### PR TITLE
Add not__launch_type param to jobs list request and implement default sort 

### DIFF
--- a/framework/PageTable.tsx
+++ b/framework/PageTable.tsx
@@ -645,6 +645,7 @@ export interface ITableColumn<T extends object> {
 
   sort?: string
   defaultSortDirection?: 'asc' | 'desc'
+  defaultSort?: boolean
 
   /**
    * @deprecated The method should not be used

--- a/frontend/controller/views/jobs/Jobs.tsx
+++ b/frontend/controller/views/jobs/Jobs.tsx
@@ -16,6 +16,9 @@ export default function Jobs() {
   const tableColumns = useJobsColumns()
   const view = useControllerView<UnifiedJob>({
     url: '/api/v2/unified_jobs/',
+    queryParams: {
+      not__launch_type: 'sync',
+    },
     toolbarFilters,
     tableColumns,
   })

--- a/frontend/controller/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/controller/views/jobs/hooks/useJobsColumns.tsx
@@ -70,6 +70,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
         card: 'hidden',
         list: 'secondary',
         defaultSortDirection: 'desc',
+        defaultSort: true,
       },
     ],
     [options?.disableLinks, t]


### PR DESCRIPTION
- Adds ability to pass query parameters to API calls in the controller view (`not__launch_type` in case of the jobs list)
- Adds ability to set an attribute `defaultSort` on a column to indicate that the table will be sorted using this column on load
- Sorts the jobs list in descending order of "finished time"