### PR TITLE
Add support for href on action buttons

### DIFF
--- a/framework/PageActions/PageAction.tsx
+++ b/framework/PageActions/PageAction.tsx
@@ -21,11 +21,19 @@ export interface IPageActionSeperator {
   type: PageActionType.seperator;
 }
 
-export type IPageActionButton = IPageActionCommon & {
+type IPageActionWithLink = IPageActionCommon & {
+  type: PageActionType.button;
+  variant?: ButtonVariant;
+  href: string;
+  onClick?: never;
+};
+type IPageActionWithOnClick = IPageActionCommon & {
   type: PageActionType.button;
   variant?: ButtonVariant;
   onClick: () => void;
+  href?: never;
 };
+export type IPageActionButton = IPageActionWithLink | IPageActionWithOnClick;
 
 export type IPageBulkAction<T extends object> = IPageActionCommon & {
   type: PageActionType.bulk;
@@ -33,13 +41,25 @@ export type IPageBulkAction<T extends object> = IPageActionCommon & {
   onClick: (selectedItems: T[]) => void;
 };
 
-export type IPageSingleAction<T extends object> = IPageActionCommon & {
-  type: PageActionType.single;
+type IPageSingleActionWithLink<T extends object> = IPageActionCommon & {
+  type: PageActionType.singleLink;
   variant?: ButtonVariant;
-  onClick: (item: T) => void;
+  href: (item: T) => string;
+  onClick?: never;
   isDisabled?: (item: T) => string | undefined;
   isHidden?: (item: T) => boolean;
 };
+type IPageSingleActionWithOnClick<T extends object> = IPageActionCommon & {
+  type: PageActionType.single;
+  variant?: ButtonVariant;
+  onClick: (item: T) => void;
+  href?: never;
+  isDisabled?: (item: T) => string | undefined;
+  isHidden?: (item: T) => boolean;
+};
+export type IPageSingleAction<T extends object> =
+  | IPageSingleActionWithLink<T>
+  | IPageSingleActionWithOnClick<T>;
 
 export type IPageDropdownAction<T extends object> = IPageActionCommon & {
   type: PageActionType.dropdown;

--- a/framework/PageActions/PageActionType.tsx
+++ b/framework/PageActions/PageActionType.tsx
@@ -2,6 +2,7 @@ export enum PageActionType {
   seperator = 'seperator',
   button = 'button',
   single = 'single',
+  singleLink = 'singleLink',
   bulk = 'bulk',
   dropdown = 'dropdown',
 }

--- a/framework/PageActions/PageActions.tsx
+++ b/framework/PageActions/PageActions.tsx
@@ -95,6 +95,7 @@ export function isHiddenAction<T extends object>(
 ): boolean {
   switch (action.type) {
     case PageActionType.single:
+    case PageActionType.singleLink:
     case PageActionType.dropdown:
       return action.isHidden !== undefined && selectedItem ? action.isHidden(selectedItem) : false;
     case PageActionType.bulk:

--- a/framework/PageActions/PageButtonAction.tsx
+++ b/framework/PageActions/PageButtonAction.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { ComponentClass, Fragment, FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
 import { IPageActionButton } from './PageAction';
 
 export function PageButtonAction(props: {
@@ -28,11 +29,15 @@ export function PageButtonAction(props: {
     variant = ButtonVariant.plain;
   }
 
+  const id = props.action.label.toLowerCase().split(' ').join('-');
+  const content =
+    props.iconOnly && Icon ? <Icon /> : action.shortLabel ? action.shortLabel : action.label;
+
   return (
     <Wrapper>
       <Tooltip content={tooltip} trigger={tooltip ? undefined : 'manual'}>
         <Button
-          id={props.action.label.toLowerCase().split(' ').join('-')}
+          id={id}
           variant={variant}
           isDanger={action.isDanger}
           icon={
@@ -43,9 +48,10 @@ export function PageButtonAction(props: {
             ) : undefined
           }
           isAriaDisabled={isDisabled}
-          onClick={action.onClick}
+          onClick={action.onClick ? action.onClick : undefined}
+          component={action.href ? (props) => <Link {...props} to={action.href} /> : undefined}
         >
-          {props.iconOnly && Icon ? <Icon /> : action.shortLabel ? action.shortLabel : action.label}
+          {content}
         </Button>
       </Tooltip>
     </Wrapper>

--- a/framework/PageActions/PageDropdownAction.tsx
+++ b/framework/PageActions/PageDropdownAction.tsx
@@ -9,6 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { CircleIcon } from '@patternfly/react-icons';
 import { ComponentClass, FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { IPageAction } from './PageAction';
 import { isHiddenAction } from './PageActions';
 import { PageActionType } from './PageActionType';
@@ -114,7 +115,8 @@ function PageDropdownActionItem<T extends object>(props: {
   const { action, selectedItems, selectedItem, hasIcons, index } = props;
 
   switch (action.type) {
-    case PageActionType.single: {
+    case PageActionType.single:
+    case PageActionType.singleLink: {
       let Icon: ComponentClass | FunctionComponent | undefined = action.icon;
       if (!Icon && hasIcons) Icon = TransparentIcon;
       let tooltip = action.tooltip;
@@ -124,7 +126,16 @@ function PageDropdownActionItem<T extends object>(props: {
       return (
         <Tooltip key={action.label} content={tooltip} trigger={tooltip ? undefined : 'manual'}>
           <DropdownItem
-            onClick={() => selectedItem && action.onClick(selectedItem)}
+            onClick={
+              action.onClick ? () => selectedItem && action.onClick(selectedItem) : undefined
+            }
+            component={
+              action.href
+                ? (props: object) => (
+                    <Link {...props} to={selectedItem ? action.href(selectedItem) : ''} />
+                  )
+                : undefined
+            }
             isAriaDisabled={Boolean(isDisabled)}
             icon={
               Icon ? (
@@ -157,7 +168,10 @@ function PageDropdownActionItem<T extends object>(props: {
       return (
         <Tooltip key={action.label} content={tooltip} trigger={tooltip ? undefined : 'manual'}>
           <DropdownItem
-            onClick={() => action.onClick(selectedItems)}
+            onClick={action.onClick ? () => action.onClick(selectedItems) : undefined}
+            component={
+              !action.onClick ? (props: object) => <Link {...props} to={action.href} /> : undefined
+            }
             isAriaDisabled={isDisabled}
             icon={
               Icon ? (

--- a/framework/PageActions/PagePinnedActions.tsx
+++ b/framework/PageActions/PagePinnedActions.tsx
@@ -50,7 +50,8 @@ export function PagePinnedAction<T extends object>(props: {
     case PageActionType.seperator: {
       return <></>;
     }
-    case PageActionType.single: {
+    case PageActionType.single:
+    case PageActionType.singleLink: {
       return (
         <PageSingleAction
           action={action}

--- a/framework/PageActions/PageSingleAction.tsx
+++ b/framework/PageActions/PageSingleAction.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { ComponentClass, Fragment, FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
 import { IPageSingleAction } from './PageAction';
 
 export function PageSingleAction<T extends object>(props: {
@@ -37,7 +38,12 @@ export function PageSingleAction<T extends object>(props: {
             ) : undefined
           }
           isAriaDisabled={Boolean(isDisabled)}
-          onClick={() => selectedItem && action.onClick(selectedItem)}
+          onClick={action.onClick ? () => selectedItem && action.onClick(selectedItem) : undefined}
+          component={
+            action.href
+              ? (props) => <Link {...props} to={selectedItem && action.href(selectedItem)} />
+              : undefined
+          }
           isDanger={action.isDanger}
         >
           {props.iconOnly && Icon ? <Icon /> : action.shortLabel ? action.shortLabel : action.label}

--- a/frontend/controller/access/organizations/Organizations.tsx
+++ b/frontend/controller/access/organizations/Organizations.tsx
@@ -64,7 +64,7 @@ export function Organizations() {
         variant: ButtonVariant.primary,
         icon: PlusIcon,
         label: t('Create organization'),
-        onClick: () => navigate(RouteE.CreateOrganization),
+        href: RouteE.CreateOrganization,
       },
       { type: PageActionType.seperator },
       {
@@ -91,21 +91,21 @@ export function Organizations() {
     [
       t,
       deleteOrganizations,
-      navigate,
       selectUsersAddOrganizations,
       view.selectedItems,
       selectUsersRemoveOrganizations,
     ]
   );
 
-  const rowActions = useMemo<IPageAction<Organization>[]>(
-    () => [
+  const rowActions = useMemo<IPageAction<Organization>[]>(() => {
+    const actions: IPageAction<Organization>[] = [
       {
-        type: PageActionType.single,
+        type: PageActionType.singleLink,
         icon: EditIcon,
         label: t('Edit organization'),
-        onClick: (organization) =>
-          navigate(RouteE.EditOrganization.replace(':id', organization.id.toString())),
+        href: (organization) => {
+          return RouteE.EditOrganization.replace(':id', organization.id.toString());
+        },
       },
       { type: PageActionType.seperator },
       {
@@ -128,9 +128,9 @@ export function Organizations() {
         onClick: (organization) => deleteOrganizations([organization]),
         isDanger: true,
       },
-    ],
-    [t, navigate, selectUsersAddOrganizations, selectUsersRemoveOrganizations, deleteOrganizations]
-  );
+    ];
+    return actions;
+  }, [t, selectUsersAddOrganizations, selectUsersRemoveOrganizations, deleteOrganizations]);
 
   return (
     <PageLayout>


### PR DESCRIPTION
Adds support for actions to render as links rather than buttons by providing an `href` instead of `onClick`. For type PageActionType.button, the `href` must be a string. For single row actions, a new type PageActionType.singleLink is added where an `href` must be a function `(item: T) => string` where T is the list type.