### PR TITLE
Fix GitHub Actions unit test failure

### DIFF
--- a/frontend/controller/access/teams/Teams.cy.tsx
+++ b/frontend/controller/access/teams/Teams.cy.tsx
@@ -45,9 +45,11 @@ describe('Jobs.cy.ts', () => {
         <Teams />
       </MemoryRouter>
     );
-    cy.get('button[id="create-team"]')
-      .contains('Create team')
-      .should('have.attr', 'aria-disabled', 'true');
+    cy.contains('button[id="create-team"]', 'Create team').should(
+      'have.attr',
+      'aria-disabled',
+      'true'
+    );
   });
   it('Create Team button is enabled if the user has permission to create teams', () => {
     cy.intercept(
@@ -78,8 +80,10 @@ describe('Jobs.cy.ts', () => {
         <Teams />
       </MemoryRouter>
     );
-    cy.get('button[id="create-team"]')
-      .contains('Create team')
-      .should('have.attr', 'aria-disabled', 'false');
+    cy.contains('button[id="create-team"]', 'Create team').should(
+      'have.attr',
+      'aria-disabled',
+      'false'
+    );
   });
 });


### PR DESCRIPTION
As noted by @jamestalton the following test fails on GitHub Actions:
```
  1) Create Team button is enabled if the user has permission to create teams
     CypressError: Timed out retrying after 30000ms: `cy.should()` failed because this element is detached from the DOM.
```
This PR should address that.