### PR TITLE
Modifications to serve static files from /static/controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "npm run clean && concurrently --kill-others-on-fail npm:build:frontend npm:build:proxy --prefix-colors cyan,green,blue,magenta,gray",
     "build:proxy": "cd proxy && rollup --config rollup.config.ts --configPlugin typescript",
     "build:frontend": "webpack --mode production --env pwa",
-    "build:controller": "webpack --mode production --env controller --output-path build/controller",
+    "build:controller": "webpack --mode production --env controller --output-path build/controller && mv build/controller/index.html build/controller/index_controller.html",
     "build:hub": "webpack --mode production --env hub --output-path build/hub",
     "build:eda": "webpack --mode production --env eda --output-path build/eda",
     "clean": "rm -rf build coverage .nyc_output",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -100,7 +100,7 @@ module.exports = function (_env, argv) {
       clean: true,
       filename: isProduction ? '[contenthash].js' : undefined,
       path: path.resolve(__dirname, 'build/public'),
-      publicPath: isProduction ? '/' : '/',
+      publicPath: _env.controller ? '/static/controller/' : '/',
     },
     optimization: {
       minimizer: [


### PR DESCRIPTION
There are two areas left to change within the compiled index file to correctly reference Django's static directory cc @jamestalton :

```
<link rel="manifest" href="/manifest.webmanifest"/>
<link rel="apple-touch-icon" href="/icons/ansible192.png"/>
```

Making changes to webpack's `CopyPlugin` module does not produce what we need since it actually tries to copy the files into a directory that only exists within our Django environment. 

Sidenote: we are also referencing an asset that does not exist (`icons/ansible192.png`)