### PR TITLE
Fix for intermittent unit test failures

### DIFF
--- a/frontend/controller/access/teams/TeamPage/TeamPage.cy.tsx
+++ b/frontend/controller/access/teams/TeamPage/TeamPage.cy.tsx
@@ -2,7 +2,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { TeamPage } from './TeamPage';
 
 describe('TeamPage', () => {
-  before(() => {
+  beforeEach(() => {
     cy.intercept(
       {
         method: 'GET',

--- a/frontend/controller/access/teams/Teams.cy.tsx
+++ b/frontend/controller/access/teams/Teams.cy.tsx
@@ -3,7 +3,7 @@ import { PageDialogProvider } from '../../../../framework';
 import { Teams } from './Teams';
 
 describe('Jobs.cy.ts', () => {
-  before(() => {
+  beforeEach(() => {
     cy.intercept(
       {
         method: 'GET',
@@ -80,6 +80,10 @@ describe('Jobs.cy.ts', () => {
         <Teams />
       </MemoryRouter>
     );
-    cy.get('button[id="create-team"]').should('have.attr', 'aria-disabled', 'false');
+    cy.contains('button[id="create-team"]', 'Create team').should(
+      'have.attr',
+      'aria-disabled',
+      'false'
+    );
   });
 });

--- a/frontend/controller/views/jobs/Jobs.cy.tsx
+++ b/frontend/controller/views/jobs/Jobs.cy.tsx
@@ -4,7 +4,7 @@ import { ItemsResponse } from '../../../Data';
 import * as deleteJobs from './hooks/useDeleteJobs';
 
 describe('Jobs.cy.ts', () => {
-  before(() => {
+  beforeEach(() => {
     cy.intercept(
       {
         method: 'GET',


### PR DESCRIPTION
Fix for the following unit test failure that intermittently shows up in PR builds. 
```

Create Team button is enabled if the user has permission to create teams
AssertionError: Timed out retrying after 30000ms: Expected to find content: '/^Create team$/' within the selector: 'button' but never did.

```
https://github.com/ansible/ansible-ui/actions/runs/4164746504/jobs/7206880629

The issue appears to be related to the intercept clearing before the test. So instead of calling `cy.intercept` in a `before` hook it should be in a `beforeEach`.
