### PR TITLE
Updated implementation for removing users from a team

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -67,6 +67,24 @@ describe('teams', () => {
     cy.hasTitle(teamName);
   });
 
+  it('team: remove users from team', () => {
+    cy.requestPost<User>(`/api/v2/users/${user1.id.toString()}/roles/`, {
+      id: team.summary_fields.object_roles.member_role.id,
+    });
+    cy.requestPost<User>(`/api/v2/users/${user2.id.toString()}/roles/`, {
+      id: team.summary_fields.object_roles.member_role.id,
+    });
+    cy.navigateTo(/^Teams$/, true);
+    cy.clickRowAction(team.name, /^Remove users from team$/);
+    cy.selectRowInDialog(user1.username);
+    cy.selectRowInDialog(user2.username);
+    cy.get('#confirm').click();
+    cy.get('#confirm').click();
+    cy.clickButton(/^Remove user/);
+    cy.contains(/^Success$/);
+    cy.clickButton(/^Close$/);
+  });
+
   it('edit team', () => {
     cy.navigateTo(/^Teams$/, true);
     cy.clickRow(team.name);

--- a/framework/useSelectMultipleDialog.tsx
+++ b/framework/useSelectMultipleDialog.tsx
@@ -35,6 +35,7 @@ export function SelectMultipleDialog<T extends object>(props: SelectMultipleDial
         <Button
           key="confirm"
           variant="primary"
+          id="confirm"
           onClick={() => {
             onClose();
             onSelect(view.selectedItems);

--- a/frontend/awx/access/common/ResourceAccessList.tsx
+++ b/frontend/awx/access/common/ResourceAccessList.tsx
@@ -128,7 +128,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
         },
       },
     ],
-    [canAddAndRemoveUsers, removeUsersFromResource, t, view.unselectItemsAndRefresh]
+    [canAddAndRemoveUsers, removeUsersFromResource, resource, t, view.unselectItemsAndRefresh]
   );
 
   const navigate = useNavigate();

--- a/frontend/awx/access/common/ResourceAccessList.tsx
+++ b/frontend/awx/access/common/ResourceAccessList.tsx
@@ -63,7 +63,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
    */
   const selectUsersAddTeams = useSelectUsersAddTeams(() => void view.refresh());
 
-  const removeUsersFromResource = useRemoveUsersFromResource(resource);
+  const removeUsersFromResource = useRemoveUsersFromResource();
 
   const toolbarActions = useMemo<IPageAction<User>[]>(
     () => [
@@ -89,7 +89,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
           : t(
               'You do not have permission to remove users. Please contact your Organization Administrator if there is an issue with your access.'
             ),
-        onClick: (users) => removeUsersFromResource(users, view.unselectItemsAndRefresh),
+        onClick: (users) => removeUsersFromResource(users, resource, view.unselectItemsAndRefresh),
       },
     ],
     [
@@ -108,7 +108,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
         type: PageActionType.single,
         icon: MinusCircleIcon,
         label: t('Remove user'),
-        onClick: (user) => removeUsersFromResource([user], view.unselectItemsAndRefresh),
+        onClick: (user) => removeUsersFromResource([user], resource, view.unselectItemsAndRefresh),
         isDisabled: (user: User) => {
           if (user.is_superuser) {
             return t('System administrators have unrestricted access to all resources.');

--- a/frontend/awx/access/teams/TeamPage/TeamAccess.cy.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamAccess.cy.tsx
@@ -114,7 +114,7 @@ describe('TeamAccess', () => {
         .first()
         .click();
       cy.contains(`Are you sure you want to remove ${role.name} access from user-2?`).should(
-        'be.visible'
+        'exist'
       );
     });
   });

--- a/frontend/awx/access/teams/hooks/useTeamActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamActions.tsx
@@ -9,6 +9,7 @@ import { Team } from '../../../interfaces/Team';
 import { useSelectUsersAddTeams } from '../../users/hooks/useSelectUsersAddTeams';
 import { useSelectAndRemoveUsersFromTeam } from '../../users/hooks/useSelectAndRemoveUsersFromTeam';
 import { useDeleteTeams } from './useDeleteTeams';
+import { useActiveUser } from '../../../../common/useActiveUser';
 
 export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => void }) {
   const { onTeamsDeleted } = options;
@@ -17,16 +18,29 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
   const deleteTeams = useDeleteTeams(onTeamsDeleted);
   const selectUsersAddTeams = useSelectUsersAddTeams();
   const selectAndRemoveUsersFromTeam = useSelectAndRemoveUsersFromTeam();
+  const activeUser = useActiveUser();
 
   return useMemo<IPageAction<Team>[]>(() => {
     const cannotDeleteTeam = (team: Team) =>
       team?.summary_fields?.user_capabilities?.delete
         ? ''
-        : t(`The team cannot be deleted due to insufficient permission`);
+        : t(`The team cannot be deleted due to insufficient permissions.`);
     const cannotEditTeam = (team: Team) =>
       team?.summary_fields?.user_capabilities?.edit
         ? ''
-        : t(`The team cannot be edited due to insufficient permission`);
+        : t(`The team cannot be edited due to insufficient permissions.`);
+    const cannotRemoveUsers = (team: Team) =>
+      activeUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
+        ? ''
+        : t(
+            `You do not have permission to remove users. Please contact your Organization Administrator if there is an issue with your access.`
+          );
+    const cannotAddUsers = (team: Team) =>
+      activeUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
+        ? ''
+        : t(
+            `You do not have permission to add users. Please contact your Organization Administrator if there is an issue with your access.`
+          );
 
     return [
       {
@@ -42,12 +56,14 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
         type: PageActionType.single,
         icon: PlusCircleIcon,
         label: t('Add users to team'),
+        isDisabled: (team: Team) => cannotAddUsers(team),
         onClick: (team) => selectUsersAddTeams([team]),
       },
       {
         type: PageActionType.single,
         icon: MinusCircleIcon,
         label: t('Remove users from team'),
+        isDisabled: (team: Team) => cannotRemoveUsers(team),
         onClick: (team) => selectAndRemoveUsersFromTeam(team),
       },
       { type: PageActionType.seperator },
@@ -60,5 +76,12 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
         isDanger: true,
       },
     ];
-  }, [deleteTeams, navigate, selectAndRemoveUsersFromTeam, selectUsersAddTeams, t]);
+  }, [
+    activeUser?.is_superuser,
+    deleteTeams,
+    navigate,
+    selectAndRemoveUsersFromTeam,
+    selectUsersAddTeams,
+    t,
+  ]);
 }

--- a/frontend/awx/access/teams/hooks/useTeamActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamActions.tsx
@@ -7,7 +7,7 @@ import { IPageAction, PageActionType } from '../../../../../framework';
 import { RouteObj } from '../../../../Routes';
 import { Team } from '../../../interfaces/Team';
 import { useSelectUsersAddTeams } from '../../users/hooks/useSelectUsersAddTeams';
-import { useSelectUsersRemoveTeams } from '../../users/hooks/useSelectUsersRemoveTeams';
+import { useSelectAndRemoveUsersFromTeam } from '../../users/hooks/useSelectAndRemoveUsersFromTeam';
 import { useDeleteTeams } from './useDeleteTeams';
 
 export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => void }) {
@@ -16,7 +16,7 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
   const navigate = useNavigate();
   const deleteTeams = useDeleteTeams(onTeamsDeleted);
   const selectUsersAddTeams = useSelectUsersAddTeams();
-  const selectUsersRemoveTeams = useSelectUsersRemoveTeams();
+  const selectAndRemoveUsersFromTeam = useSelectAndRemoveUsersFromTeam();
 
   return useMemo<IPageAction<Team>[]>(() => {
     const cannotDeleteTeam = (team: Team) =>
@@ -48,7 +48,7 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
         type: PageActionType.single,
         icon: MinusCircleIcon,
         label: t('Remove users from team'),
-        onClick: (team) => selectUsersRemoveTeams([team]),
+        onClick: (team) => selectAndRemoveUsersFromTeam(team),
       },
       { type: PageActionType.seperator },
       {
@@ -60,5 +60,5 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
         isDanger: true,
       },
     ];
-  }, [deleteTeams, navigate, selectUsersAddTeams, selectUsersRemoveTeams, t]);
+  }, [deleteTeams, navigate, selectAndRemoveUsersFromTeam, selectUsersAddTeams, t]);
 }

--- a/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
@@ -1,11 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import {
-  MinusCircleIcon,
-  PlusCircleIcon,
-  PlusIcon,
-  SyncIcon,
-  TrashIcon,
-} from '@patternfly/react-icons';
+import { PlusCircleIcon, PlusIcon, SyncIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -15,7 +9,7 @@ import { RouteObj } from '../../../../Routes';
 import { Team } from '../../../interfaces/Team';
 import { IAwxView } from '../../../useAwxView';
 import { useSelectUsersAddTeams } from '../../users/hooks/useSelectUsersAddTeams';
-import { useSelectUsersRemoveTeams } from '../../users/hooks/useSelectUsersRemoveTeams';
+// import { useSelectUsersRemoveTeams } from '../../users/hooks/useSelectUsersRemoveTeams';
 import { useDeleteTeams } from './useDeleteTeams';
 import { OptionsResponse, ActionsResponse } from '../../../interfaces/OptionsResponse';
 
@@ -24,7 +18,7 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
   const navigate = useNavigate();
   const deleteTeams = useDeleteTeams(view.unselectItemsAndRefresh);
   const selectUsersAddTeams = useSelectUsersAddTeams();
-  const selectUsersRemoveTeams = useSelectUsersRemoveTeams();
+  // const selectUsersRemoveTeams = useSelectUsersRemoveTeams();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>({ url: '/api/v2/teams/' });
   const canCreateTeam = Boolean(data && data.actions && data.actions['POST']);
 
@@ -49,12 +43,18 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
         label: t('Add users to selected teams'),
         onClick: () => selectUsersAddTeams(view.selectedItems),
       },
-      {
-        type: PageActionType.bulk,
-        icon: MinusCircleIcon,
-        label: t('Remove users from selected teams'),
-        onClick: () => selectUsersRemoveTeams(view.selectedItems),
-      },
+      /**
+       * TODO: This feature is being hidden for the time being as it is not implemented accurately
+       * at the moment. It is also not a feature in the awx UI.
+       * With each team having its own access_list of users, we will need to design an experience
+       * and implementation to handle removal of users from multiple teams.
+       */
+      // {
+      //   type: PageActionType.bulk,
+      //   icon: MinusCircleIcon,
+      //   label: t('Remove users from selected teams'),
+      //   onClick: () => selectUsersRemoveTeams(view.selectedItems), // This hook has been repurposed as useSelectAndRemoveUsersFromTeam to handle removing users from a single team
+      // },
       { type: PageActionType.seperator },
       {
         type: PageActionType.bulk,
@@ -71,6 +71,6 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
         onClick: () => void view.refresh(),
       },
     ],
-    [canCreateTeam, deleteTeams, navigate, selectUsersAddTeams, selectUsersRemoveTeams, t, view]
+    [canCreateTeam, deleteTeams, navigate, selectUsersAddTeams, t, view]
   );
 }

--- a/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
+++ b/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Team } from '../../../interfaces/Team';
+import { User } from '../../../interfaces/User';
+import { useRemoveUsersFromResource } from '../../common/useRemoveUserFromResource';
+import { useSelectUsers } from './useSelectUsers';
+
+export function useSelectAndRemoveUsersFromTeam(onClose?: (users: User[]) => void) {
+  const { t } = useTranslation();
+  const selectUsers = useSelectUsers();
+  const removeUsersFromTeams = useRemoveUsersFromResource();
+
+  const selectUsersRemoveTeams = useCallback(
+    (team: Team) => {
+      selectUsers(
+        t('Remove users from team'),
+        (users: User[]) => {
+          removeUsersFromTeams(users, team, onClose);
+        },
+        `/api/v2/teams/${team.id}/access_list/`
+      );
+    },
+    [removeUsersFromTeams, onClose, selectUsers, t]
+  );
+  return selectUsersRemoveTeams;
+}

--- a/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
+++ b/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
@@ -17,6 +17,7 @@ export function useSelectAndRemoveUsersFromTeam(onClose?: (users: User[]) => voi
         (users: User[]) => {
           removeUsersFromTeams(users, team, onClose);
         },
+        t('Remove user(s)'),
         `/api/v2/teams/${team.id}/access_list/`
       );
     },

--- a/frontend/awx/access/users/hooks/useSelectUsers.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsers.tsx
@@ -3,11 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { usePageDialog } from '../../../../../framework';
 import { SelectMultipleDialog } from '../../../../../framework/useSelectMultipleDialog';
 import { User } from '../../../interfaces/User';
+<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
 import { useAwxView } from '../../../useAwxView';
+=======
+import { useControllerView } from '../../../useControllerView';
+import { useUserAndTeamRolesLists } from '../../common/useUserAndTeamRolesLists';
+>>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
 import { useUsersColumns } from './useUsersColumns';
 import { useUsersFilters } from './useUsersFilters';
 
 function SelectUsers(props: {
+<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
   title: string;
   onSelect: (users: User[]) => void;
   confirmText?: string;
@@ -17,13 +23,26 @@ function SelectUsers(props: {
   const tableColumns = useUsersColumns({ disableLinks: true });
   const view = useAwxView<User>({
     url: '/api/v2/users/',
+=======
+  accessUrl?: string;
+  title: string;
+  onSelect: (users: User[]) => void;
+}) {
+  const toolbarFilters = useUsersFilters();
+  const tableColumns = useUsersColumns({ disableLinks: true });
+  const view = useControllerView<User>({
+    url: props.accessUrl ?? '/api/v2/users/',
+>>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
+  useUserAndTeamRolesLists(view.pageItems as User[]);
+
   return (
     <SelectMultipleDialog
-      {...props}
+      title={props.title}
+      onSelect={props.onSelect}
       toolbarFilters={toolbarFilters}
       tableColumns={tableColumns}
       view={view}
@@ -35,8 +54,13 @@ function SelectUsers(props: {
 export function useSelectUsers() {
   const [_, setDialog] = usePageDialog();
   const openSelectUsers = useCallback(
+<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
     (title: string, onSelect: (users: User[]) => void, confirmText?: string) => {
       setDialog(<SelectUsers title={title} onSelect={onSelect} confirmText={confirmText} />);
+=======
+    (title: string, onSelect: (users: User[]) => void, accessUrl?: string) => {
+      setDialog(<SelectUsers accessUrl={accessUrl} title={title} onSelect={onSelect} />);
+>>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
     },
     [setDialog]
   );

--- a/frontend/awx/access/users/hooks/useSelectUsers.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsers.tsx
@@ -3,17 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { usePageDialog } from '../../../../../framework';
 import { SelectMultipleDialog } from '../../../../../framework/useSelectMultipleDialog';
 import { User } from '../../../interfaces/User';
-<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
 import { useAwxView } from '../../../useAwxView';
-=======
-import { useControllerView } from '../../../useControllerView';
 import { useUserAndTeamRolesLists } from '../../common/useUserAndTeamRolesLists';
->>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
 import { useUsersColumns } from './useUsersColumns';
 import { useUsersFilters } from './useUsersFilters';
 
 function SelectUsers(props: {
-<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
+  accessUrl?: string;
   title: string;
   onSelect: (users: User[]) => void;
   confirmText?: string;
@@ -22,17 +18,7 @@ function SelectUsers(props: {
   const toolbarFilters = useUsersFilters();
   const tableColumns = useUsersColumns({ disableLinks: true });
   const view = useAwxView<User>({
-    url: '/api/v2/users/',
-=======
-  accessUrl?: string;
-  title: string;
-  onSelect: (users: User[]) => void;
-}) {
-  const toolbarFilters = useUsersFilters();
-  const tableColumns = useUsersColumns({ disableLinks: true });
-  const view = useControllerView<User>({
     url: props.accessUrl ?? '/api/v2/users/',
->>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
@@ -54,13 +40,20 @@ function SelectUsers(props: {
 export function useSelectUsers() {
   const [_, setDialog] = usePageDialog();
   const openSelectUsers = useCallback(
-<<<<<<< HEAD:frontend/awx/access/users/hooks/useSelectUsers.tsx
-    (title: string, onSelect: (users: User[]) => void, confirmText?: string) => {
-      setDialog(<SelectUsers title={title} onSelect={onSelect} confirmText={confirmText} />);
-=======
-    (title: string, onSelect: (users: User[]) => void, accessUrl?: string) => {
-      setDialog(<SelectUsers accessUrl={accessUrl} title={title} onSelect={onSelect} />);
->>>>>>> a309252 (Remove users from a team in the team list and details page):frontend/controller/access/users/hooks/useSelectUsers.tsx
+    (
+      title: string,
+      onSelect: (users: User[]) => void,
+      confirmText?: string,
+      accessUrl?: string
+    ) => {
+      setDialog(
+        <SelectUsers
+          accessUrl={accessUrl}
+          title={title}
+          onSelect={onSelect}
+          confirmText={confirmText}
+        />
+      );
     },
     [setDialog]
   );


### PR DESCRIPTION
Related: [AAP-8230](https://issues.redhat.com/browse/AAP-8230)

- Updates the implementation of the row action "Remove users from team" that appears in the teams list and in the Team Details page.
    - The dialog that opens up should only contain the users that are members of the selected team (using the access_list API)
    - After selecting the users, a confirmation dialog appears before the users are removed ( If the selected list contains specific users that cannot be removed, this will be highlighted in the confirmation)
- Removes the bulk action to remove users on multiple teams as discussed in a previous dev sync meeting. The implementation as of today is not accurate. Since we need to call the access_list API for each individual team that was selected, this implementation will need to be revisited in the future.


![image](https://user-images.githubusercontent.com/43621546/220422917-b45a21f5-5957-40e7-afa5-8d96e8373d14.png)
![image](https://user-images.githubusercontent.com/43621546/220422970-03f14697-0d82-4428-9d2e-0fd351247b74.png)
![image](https://user-images.githubusercontent.com/43621546/220423001-84546fdc-6580-41ff-bae2-bbc2ea9ec271.png)
