### PR TITLE
AAP-9339: Make table view match width of list and card views

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -233,20 +233,14 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
       )}
       {viewType === PageTableViewTypeE.List && (
         <Scrollable>
-          <PageSection padding={{ default: 'noPadding', md: 'padding' }}>
-            <div
-              style={{
-                borderLeft: usePadding
-                  ? 'thin solid var(--pf-global--BorderColor--100)'
-                  : undefined,
-                borderRight: usePadding
-                  ? 'thin solid var(--pf-global--BorderColor--100)'
-                  : undefined,
-              }}
-            >
-              <PageTableList {...props} showSelect={showSelect} />
-            </div>
-          </PageSection>
+          <div
+            style={{
+              borderLeft: usePadding ? 'thin solid var(--pf-global--BorderColor--100)' : undefined,
+              borderRight: usePadding ? 'thin solid var(--pf-global--BorderColor--100)' : undefined,
+            }}
+          >
+            <PageTableList {...props} showSelect={showSelect} />
+          </div>
         </Scrollable>
       )}
       {viewType === PageTableViewTypeE.Cards && (

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -218,7 +218,7 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
   }
 
   return (
-    <>
+    <PageSection>
       <PageTableToolbar
         {...props}
         openColumnModal={openColumnModal}
@@ -258,7 +258,7 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
         <PagePagination {...props} />
       )}
       {columnModal}
-    </>
+    </PageSection>
   );
 }
 

--- a/framework/PageTable/PageTableCards.tsx
+++ b/framework/PageTable/PageTableCards.tsx
@@ -51,5 +51,9 @@ export function PageTableCards<T extends object>(props: PageTableCardsProps<T>) 
     defaultCardSubtitle,
   ]);
 
-  return <PageSection style={{ flexGrow: 1 }}>{catalogCards}</PageSection>;
+  return (
+    <PageSection style={{ flexGrow: 1, paddingLeft: 0, paddingRight: 0 }}>
+      {catalogCards}
+    </PageSection>
+  );
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9339

The toolbar should be attached to the table/list. In the card view there is a separation between the toolbars and the cards.

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/43621546/222249142-c2e00ae7-1be3-4e44-8253-785d517deade.png">

<img width="1073" alt="image (14)" src="https://user-images.githubusercontent.com/43621546/222260052-f3a2b759-2c52-4f32-b559-12ef154e180d.png">

<img width="1073" alt="image (16)" src="https://user-images.githubusercontent.com/43621546/222259953-b199fd39-499f-43de-9e9c-40e8b57ba0a7.png">
