### PR TITLE
Make primary action button blue on details screens

### DIFF
--- a/framework/PageActions/PagePinnedActions.tsx
+++ b/framework/PageActions/PagePinnedActions.tsx
@@ -75,10 +75,7 @@ export function PagePinnedAction<T extends object>(props: {
       return (
         <PageButtonAction
           action={action}
-          isSecondary={
-            (selectedItems !== undefined && selectedItems.length !== 0) ||
-            selectedItem !== undefined
-          }
+          isSecondary={selectedItems !== undefined && selectedItems.length !== 0}
           iconOnly={props.iconOnly}
           wrapper={wrapper}
         />


### PR DESCRIPTION
Adjusts logic so primary action button (usually "edit") is blue on details screens

![Screenshot 2023-03-02 at 1 09 30 PM](https://user-images.githubusercontent.com/410794/222553692-f00d9868-26e5-454f-abd7-21110833eb5b.png)
