### PR TITLE
Use labels to indicate admin/auditor users

### DIFF
--- a/frontend/awx/access/users/components/UserType.tsx
+++ b/frontend/awx/access/users/components/UserType.tsx
@@ -1,14 +1,15 @@
-import { Text } from '@patternfly/react-core';
+import { Text, Label } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { pfWarning } from '../../../../../framework';
 import { User } from '../../../interfaces/User';
 
 export function UserType(props: { user: User }) {
   const { user } = props;
   const { t } = useTranslation();
-  if (user.is_superuser)
-    return <Text style={{ color: pfWarning }}>{t('System administrator')}</Text>;
-  if (user.is_system_auditor)
-    return <Text style={{ color: pfWarning }}>{t('System auditor')}</Text>;
+  if (user.is_superuser) {
+    return <Label>{t('System administrator')}</Label>;
+  }
+  if (user.is_system_auditor) {
+    return <Label>{t('System auditor')}</Label>;
+  }
   return <Text>{t('Normal user')}</Text>;
 }


### PR DESCRIPTION
Replaces colored text for user types and uses labels instead

![Screenshot 2023-03-06 at 12 44 07 PM](https://user-images.githubusercontent.com/410794/223226392-a582ca21-1bbf-4982-b20a-036a7f0343f0.png)
