### PR TITLE
Styled components in framework pages

### DIFF
--- a/framework/BulkConfirmationDialog.tsx
+++ b/framework/BulkConfirmationDialog.tsx
@@ -134,6 +134,13 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
   borderTop: 'thin solid var(--pf-global--BorderColor--100)'
   `;
 
+  const ConfirmBoxDiv = styled.div`
+    margin-left: 32;
+    height: 64;
+    display: 'flex';
+    alignitems: 'center';
+  `;
+
   return (
     <Modal
       titleIconVariant={isDanger ? 'warning' : undefined}
@@ -187,14 +194,14 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
             />
           </ModalBodyDiv>
           {confirmText && actionableItems.length > 0 && (
-            <div style={{ marginLeft: 32, height: 64, display: 'flex', alignItems: 'center' }}>
+            <ConfirmBoxDiv>
               <Checkbox
                 id="confirm"
                 label={confirmText}
                 isChecked={confirmed}
                 onChange={setConfirmed}
               />
-            </div>
+            </ConfirmBoxDiv>
           )}
         </ModalBoxBody>
       )}

--- a/framework/BulkConfirmationDialog.tsx
+++ b/framework/BulkConfirmationDialog.tsx
@@ -18,6 +18,20 @@ import { useFrameworkTranslations } from './useFrameworkTranslations';
 import { compareStrings } from './utils/compare';
 import styled from 'styled-components';
 
+const ModalBodyDiv = styled.div`
+  display: flex,
+  flex-direction: column,
+  max-height: 560px,
+  overflow: hidden,
+  border-top: thin solid var(--pf-global--BorderColor--100)
+`;
+const ConfirmBoxDiv = styled.div`
+  margin-left: 32px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+`;
+
 export interface BulkConfirmationDialog<T extends object> {
   /** The title of the model.
    * @link https://www.patternfly.org/v4/components/modal/design-guidelines#confirmation-dialogs
@@ -125,21 +139,6 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
     }
     return items;
   }, [isItemNonActionable, items]);
-
-  const ModalBodyDiv = styled.div`
-  display: 'flex',
-  flexDirection: 'column',
-  maxHeight: 560,
-  overflow: 'hidden',
-  borderTop: 'thin solid var(--pf-global--BorderColor--100)'
-  `;
-
-  const ConfirmBoxDiv = styled.div`
-    margin-left: 32;
-    height: 64;
-    display: 'flex';
-    alignitems: 'center';
-  `;
 
   return (
     <Modal

--- a/framework/BulkConfirmationDialog.tsx
+++ b/framework/BulkConfirmationDialog.tsx
@@ -16,6 +16,7 @@ import { ITableColumn, PageTable } from './PageTable/PageTable';
 import { usePaged } from './PageTable/useTableItems';
 import { useFrameworkTranslations } from './useFrameworkTranslations';
 import { compareStrings } from './utils/compare';
+import styled from 'styled-components';
 
 export interface BulkConfirmationDialog<T extends object> {
   /** The title of the model.
@@ -125,6 +126,14 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
     return items;
   }, [isItemNonActionable, items]);
 
+  const ModalBodyDiv = styled.div`
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: 560,
+  overflow: 'hidden',
+  borderTop: 'thin solid var(--pf-global--BorderColor--100)'
+  `;
+
   return (
     <Modal
       titleIconVariant={isDanger ? 'warning' : undefined}
@@ -154,15 +163,7 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
     >
       {items.length > 0 && (
         <ModalBoxBody style={{ paddingLeft: 0, paddingRight: 0 }}>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              maxHeight: 560,
-              overflow: 'hidden',
-              borderTop: 'thin solid var(--pf-global--BorderColor--100)',
-            }}
-          >
+          <ModalBodyDiv>
             {alertPrompts &&
               alertPrompts.length > 0 &&
               alertPrompts.map((alertPrompt, i) => (
@@ -184,7 +185,7 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
               autoHidePagination={true}
               disableBodyPadding
             />
-          </div>
+          </ModalBodyDiv>
           {confirmText && actionableItems.length > 0 && (
             <div style={{ marginLeft: 32, height: 64, display: 'flex', alignItems: 'center' }}>
               <Checkbox

--- a/framework/BulkConfirmationDialog.tsx
+++ b/framework/BulkConfirmationDialog.tsx
@@ -19,11 +19,11 @@ import { compareStrings } from './utils/compare';
 import styled from 'styled-components';
 
 const ModalBodyDiv = styled.div`
-  display: flex,
-  flex-direction: column,
-  max-height: 560px,
-  overflow: hidden,
-  border-top: thin solid var(--pf-global--BorderColor--100)
+  display: flex;
+  flex-direction: column;
+  max-height: 560px;
+  overflow: hidden;
+  border-top: thin solid var(--pf-global--BorderColor--100);
 `;
 const ConfirmBoxDiv = styled.div`
   margin-left: 32px;


### PR DESCRIPTION
Hello Zita!!

Things are looking much more copacetic now that the `,` has been replaced with the `;`. Thank you for the review!

After changes: 
<img width="562" alt="Screenshot 2023-03-08 at 11 44 39 AM" src="https://user-images.githubusercontent.com/64337863/223775542-27e1fa5e-fba7-4d3e-b9cf-9684882f48f6.png">


Before: 
<img width="561" alt="Screenshot 2023-03-07 at 3 08 54 PM" src="https://user-images.githubusercontent.com/64337863/223540718-28c2df4e-4114-42fd-87ad-5def8c5cba42.png">


