### PR TITLE
UI updates to teams list edit action button + E2E tests

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -231,7 +231,7 @@ describe('teams', () => {
 
   it('teams table row edit team', () => {
     cy.navigateTo(/^Teams$/, true);
-    cy.get('#edit-team').click();
+    cy.clickRowAction(team.name, /^Edit team$/);
     cy.hasTitle(/^Edit team$/);
   });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -214,7 +214,9 @@ Cypress.Commands.add('hasAlert', (label: string | RegExp) => {
 });
 
 Cypress.Commands.add('clickToolbarAction', (label: string | RegExp) => {
-  cy.get('#toggle-kebab').click().get('.pf-c-dropdown__menu-item').contains(label).click();
+  cy.get('.page-table-toolbar').within(() => {
+    cy.get('.toggle-kebab').click().get('.pf-c-dropdown__menu-item').contains(label).click();
+  });
 });
 
 Cypress.Commands.add('clickRow', (name: string | RegExp, filter?: boolean) => {
@@ -274,5 +276,5 @@ Cypress.Commands.add('selectRowInDialog', (name: string | RegExp, filter?: boole
 });
 
 Cypress.Commands.add('clickPageAction', (label: string | RegExp) => {
-  cy.get('#toggle-kebab').click().get('.pf-c-dropdown__menu-item').contains(label).click();
+  cy.get('.toggle-kebab').click().get('.pf-c-dropdown__menu-item').contains(label).click();
 });

--- a/framework/PageActions/PageDropdownAction.tsx
+++ b/framework/PageActions/PageDropdownAction.tsx
@@ -73,7 +73,7 @@ export function PageDropdownAction<T extends object>(props: {
       </DropdownToggle>
     ) : (
       <KebabToggle
-        id="toggle-kebab"
+        className="toggle-kebab"
         isDisabled={isDisabled}
         onToggle={() => setDropdownOpen(!dropdownOpen)}
         toggleVariant={isPrimary ? 'primary' : undefined}

--- a/framework/PageTable/PageToolbar.tsx
+++ b/framework/PageTable/PageToolbar.tsx
@@ -207,7 +207,7 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
   return (
     <Toolbar
       clearAllFilters={clearAllFilters}
-      className="dark-2"
+      className="dark-2 page-table-toolbar"
       style={{
         paddingBottom: sm ? undefined : 8,
         paddingTop: sm ? undefined : 8,

--- a/frontend/awx/access/teams/TeamPage/TeamAccess.cy.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamAccess.cy.tsx
@@ -150,7 +150,7 @@ describe('TeamAccess', () => {
         .click();
       cy.contains(
         `Are you sure you want to remove ${role.name} access from Team 2 Org 0? Doing so affects all members of the team.`
-      ).should('be.visible');
+      ).should('exist');
     });
   });
   it('If one/more selected users cannot be deleted, bulk confirmation dialog highlights this with a warning', () => {

--- a/frontend/awx/access/teams/TeamPage/TeamPage.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamPage.tsx
@@ -17,7 +17,10 @@ export function TeamPage() {
   const params = useParams<{ id: string }>();
   const team = useItem<Team>('/api/v2/teams', params.id ?? '0');
   const navigate = useNavigate();
-  const itemActions = useTeamActions({ onTeamsDeleted: () => navigate(RouteObj.Teams) });
+  const itemActions = useTeamActions({
+    onTeamsDeleted: () => navigate(RouteObj.Teams),
+    isDetailsPageAction: true,
+  });
   const viewActivityStreamAction = useViewActivityStream('team');
   const pageActions = [...viewActivityStreamAction, ...itemActions];
   return (

--- a/frontend/awx/access/teams/Teams.cy.tsx
+++ b/frontend/awx/access/teams/Teams.cy.tsx
@@ -59,7 +59,7 @@ describe('Teams.cy.ts', () => {
         </MemoryRouter>
       );
       cy.get('[type="checkbox"][id="select-all"]').check();
-      cy.get('#toggle-kebab').click();
+      cy.get('.toggle-kebab').click();
       cy.contains('a[role="menuitem"]', 'Delete selected teams').click();
       cy.contains(
         '{{count}} of the selected teams cannot be deleted due to insufficient permissions.'

--- a/frontend/awx/access/teams/Teams.cy.tsx
+++ b/frontend/awx/access/teams/Teams.cy.tsx
@@ -59,8 +59,7 @@ describe('Teams.cy.ts', () => {
         </MemoryRouter>
       );
       cy.get('[type="checkbox"][id="select-all"]').check();
-      cy.get('.toggle-kebab').click();
-      cy.contains('a[role="menuitem"]', 'Delete selected teams').click();
+      cy.clickToolbarAction(/^Delete selected teams$/);
       cy.contains(
         '{{count}} of the selected teams cannot be deleted due to insufficient permissions.'
       ).should('be.visible');

--- a/frontend/awx/access/teams/hooks/useTeamActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamActions.tsx
@@ -11,8 +11,11 @@ import { useSelectAndRemoveUsersFromTeam } from '../../users/hooks/useSelectAndR
 import { useDeleteTeams } from './useDeleteTeams';
 import { useActiveUser } from '../../../../common/useActiveUser';
 
-export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => void }) {
-  const { onTeamsDeleted } = options;
+export function useTeamActions(options: {
+  onTeamsDeleted: (teams: Team[]) => void;
+  isDetailsPageAction?: boolean;
+}) {
+  const { onTeamsDeleted, isDetailsPageAction } = options;
   const { t } = useTranslation();
   const navigate = useNavigate();
   const deleteTeams = useDeleteTeams(onTeamsDeleted);
@@ -45,7 +48,7 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
     return [
       {
         type: PageActionType.single,
-        variant: ButtonVariant.primary,
+        variant: isDetailsPageAction ? ButtonVariant.primary : undefined, // Edit Team shows up as a primary button on the details page, but as a kebab menu option on a row
         icon: EditIcon,
         label: t('Edit team'),
         isDisabled: (team: Team) => cannotEditTeam(team),
@@ -79,6 +82,7 @@ export function useTeamActions(options: { onTeamsDeleted: (teams: Team[]) => voi
   }, [
     activeUser?.is_superuser,
     deleteTeams,
+    isDetailsPageAction,
     navigate,
     selectAndRemoveUsersFromTeam,
     selectUsersAddTeams,

--- a/frontend/awx/resources/templates/TemplateDetail.cy.tsx
+++ b/frontend/awx/resources/templates/TemplateDetail.cy.tsx
@@ -39,7 +39,7 @@ describe('TemplateDetails', () => {
         <TemplateDetail />
       </MemoryRouter>
     );
-    cy.get('button#toggle-kebab').click();
+    cy.get('button.toggle-kebab').click();
     cy.contains('a', 'Launch template').click();
 
     cy.wait('@getLaunchConfig');


### PR DESCRIPTION
1. The "edit" row action is part of a kebab menu in all the lists except "Teams" where it shows up as an icon outside the kebab menu. This PR moves the row action for editing teams into the kebab menu to be consistent with other lists.
2. The dropdown actions that fall under a kebab menu have a static `toggle-kebab` id that is repeated on the page when there are multiple kebab menus (for instance on each row of a list), making the id non-unique. The id was being set in the framework component for the dropdown action. Since the framework component could apply to any type of resource/object, I've replaced the `id` attribute with `className` and updated the tests accordingly.

@mabashian Thanks for catching these issues!