### PR TITLE
Cypress commands for baseline resource creation/cleanup + Jobs E2E tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,8 +1,21 @@
 import codeCoverage from '@cypress/code-coverage/task';
 import { defineConfig } from 'cypress';
 import pkg from 'webpack';
+import { Inventory, JobTemplate } from './frontend/awx/interfaces/generated-from-swagger/api';
+import { Organization } from './frontend/awx/interfaces/Organization';
+import { Project } from './frontend/awx/interfaces/Project';
 
 const { DefinePlugin } = pkg;
+
+export type Resources = {
+  organization: Organization;
+  inventory?: Inventory;
+  project?: Project;
+  jobTemplate?: JobTemplate;
+  // We can expand this type to include EDA/hub resources
+};
+
+let globalResources: Resources | null;
 
 export default defineConfig({
   viewportWidth: 1600,
@@ -14,6 +27,22 @@ export default defineConfig({
     testIsolation: false,
     setupNodeEvents(on, config) {
       // implement node event listeners here
+      on('task', {
+        setBaselineResources: (resources: Resources | null) => {
+          globalResources = resources;
+          return null;
+        },
+        getBaselineResources: (): Resources | null => {
+          return globalResources ? globalResources : null;
+        },
+      });
+      on('task', {
+        log(args) {
+          // eslint-disable-next-line
+          console.log(...args);
+          return null;
+        },
+      });
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-var-requires
       codeCoverage(on, config);
       return config;

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,21 +1,8 @@
 import codeCoverage from '@cypress/code-coverage/task';
 import { defineConfig } from 'cypress';
 import pkg from 'webpack';
-import { Inventory, JobTemplate } from './frontend/awx/interfaces/generated-from-swagger/api';
-import { Organization } from './frontend/awx/interfaces/Organization';
-import { Project } from './frontend/awx/interfaces/Project';
 
 const { DefinePlugin } = pkg;
-
-export type Resources = {
-  organization: Organization;
-  inventory?: Inventory;
-  project?: Project;
-  jobTemplate?: JobTemplate;
-  // We can expand this type to include EDA/hub resources
-};
-
-let globalResources: Resources | null;
 
 export default defineConfig({
   viewportWidth: 1600,
@@ -27,15 +14,7 @@ export default defineConfig({
     testIsolation: false,
     setupNodeEvents(on, config) {
       // implement node event listeners here
-      on('task', {
-        setBaselineResources: (resources: Resources | null) => {
-          globalResources = resources;
-          return null;
-        },
-        getBaselineResources: (): Resources | null => {
-          return globalResources ? globalResources : null;
-        },
-      });
+
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-var-requires
       codeCoverage(on, config);
       return config;

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -36,13 +36,6 @@ export default defineConfig({
           return globalResources ? globalResources : null;
         },
       });
-      on('task', {
-        log(args) {
-          // eslint-disable-next-line
-          console.log(...args);
-          return null;
-        },
-      });
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-var-requires
       codeCoverage(on, config);
       return config;

--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -4,15 +4,21 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { ItemsResponse } from '../../../../frontend/Data';
+import { AwxOrgResource } from '../../../support/commands';
 
 describe('organizations', () => {
   let organization: Organization;
 
   before(() => {
     cy.awxLogin();
+
+    cy.createBaselineResourcesForAWX({ onlyCreateOrg: true }).then((resources) => {
+      organization = (resources as AwxOrgResource).organization;
+    });
   });
 
   after(() => {
+    cy.cleanupBaselineResourcesForAWX();
     // Sometimes if tests are stopped in the middle, we get left over organizations
     // Cleanup E2E organizations older than 2 hours
     cy.requestGet<ItemsResponse<Organization>>(
@@ -24,16 +30,6 @@ describe('organizations', () => {
         cy.requestDelete(`/api/v2/organizations/${organization.id}/`, true);
       }
     });
-  });
-
-  beforeEach(() => {
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Organization ' + randomString(4),
-    }).then((testOrganization) => (organization = testOrganization));
-  });
-
-  afterEach(() => {
-    cy.requestDelete(`/api/v2/organizations/${organization.id}/`, true);
   });
 
   it('renders the organizations list page', () => {
@@ -75,13 +71,18 @@ describe('organizations', () => {
   });
 
   it('deletes an organization from the details page', () => {
-    cy.navigateTo(/^Organizations$/, false);
-    cy.clickRow(organization.name);
-    cy.hasTitle(organization.name);
-    cy.clickPageAction(/^Delete organization/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete organization/);
-    cy.hasTitle(/^Organizations$/);
+    cy.requestPost<Organization>('/api/v2/organizations/', {
+      name: 'E2E Organization ' + randomString(4),
+    }).then((testOrganization) => {
+      cy.navigateTo(/^Organizations$/, false);
+      cy.clickRow(testOrganization.name);
+      cy.hasTitle(testOrganization.name);
+      cy.clickPageAction(/^Delete organization/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete organization/);
+      cy.hasTitle(/^Organizations$/);
+      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
+    });
   });
 
   it('navigates to the edit form from the organizations list row item', () => {
@@ -91,23 +92,33 @@ describe('organizations', () => {
   });
 
   it('deletes an organization from the organizations list row item', () => {
-    cy.navigateTo(/^Organizations$/, false);
-    cy.clickRowAction(organization.name, /^Delete organization$/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete organization/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
+    cy.requestPost<Organization>('/api/v2/organizations/', {
+      name: 'E2E Organization ' + randomString(4),
+    }).then((testOrganization) => {
+      cy.navigateTo(/^Organizations$/, false);
+      cy.clickRowAction(testOrganization.name, /^Delete organization$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete organization/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.clickButton(/^Clear all filters$/);
+      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
+    });
   });
 
   it('deletes an organization from the organizations list toolbar', () => {
-    cy.navigateTo(/^Organizations$/, false);
-    cy.selectRow(organization.name);
-    cy.clickToolbarAction(/^Delete selected organizations$/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete organization/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
+    cy.requestPost<Organization>('/api/v2/organizations/', {
+      name: 'E2E Organization ' + randomString(4),
+    }).then((testOrganization) => {
+      cy.navigateTo(/^Organizations$/, false);
+      cy.selectRow(testOrganization.name);
+      cy.clickToolbarAction(/^Delete selected organizations$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete organization/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.clickButton(/^Clear all filters$/);
+      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
+    });
   });
 });

--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -4,7 +4,6 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { ItemsResponse } from '../../../../frontend/Data';
-import { AwxOrgResource } from '../../../support/commands';
 
 describe('organizations', () => {
   let organization: Organization;
@@ -12,13 +11,13 @@ describe('organizations', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.createBaselineResourcesForAWX({ onlyCreateOrg: true }).then((resources) => {
-      organization = (resources as AwxOrgResource).organization;
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
     });
   });
 
   after(() => {
-    cy.cleanupBaselineResourcesForAWX();
+    cy.deleteAwxOrganization(organization);
     // Sometimes if tests are stopped in the middle, we get left over organizations
     // Cleanup E2E organizations older than 2 hours
     cy.requestGet<ItemsResponse<Organization>>(
@@ -71,9 +70,7 @@ describe('organizations', () => {
   });
 
   it('deletes an organization from the details page', () => {
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Organization ' + randomString(4),
-    }).then((testOrganization) => {
+    cy.createAwxOrganization().then((testOrganization) => {
       cy.navigateTo(/^Organizations$/, false);
       cy.clickRow(testOrganization.name);
       cy.hasTitle(testOrganization.name);
@@ -81,7 +78,6 @@ describe('organizations', () => {
       cy.get('#confirm').click();
       cy.clickButton(/^Delete organization/);
       cy.hasTitle(/^Organizations$/);
-      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
     });
   });
 
@@ -92,9 +88,7 @@ describe('organizations', () => {
   });
 
   it('deletes an organization from the organizations list row item', () => {
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Organization ' + randomString(4),
-    }).then((testOrganization) => {
+    cy.createAwxOrganization().then((testOrganization) => {
       cy.navigateTo(/^Organizations$/, false);
       cy.clickRowAction(testOrganization.name, /^Delete organization$/);
       cy.get('#confirm').click();
@@ -102,14 +96,11 @@ describe('organizations', () => {
       cy.contains(/^Success$/);
       cy.clickButton(/^Close$/);
       cy.clickButton(/^Clear all filters$/);
-      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
     });
   });
 
   it('deletes an organization from the organizations list toolbar', () => {
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Organization ' + randomString(4),
-    }).then((testOrganization) => {
+    cy.createAwxOrganization().then((testOrganization) => {
       cy.navigateTo(/^Organizations$/, false);
       cy.selectRow(testOrganization.name);
       cy.clickToolbarAction(/^Delete selected organizations$/);
@@ -118,7 +109,6 @@ describe('organizations', () => {
       cy.contains(/^Success$/);
       cy.clickButton(/^Close$/);
       cy.clickButton(/^Clear all filters$/);
-      cy.requestDelete(`/api/v2/organizations/${testOrganization.id}/`, true);
     });
   });
 });

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -12,10 +12,8 @@ describe('users', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Users ' + randomString(4),
-    }).then((testOrg) => {
-      organization = testOrg;
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
     });
   });
 
@@ -24,14 +22,11 @@ describe('users', () => {
   });
 
   beforeEach(() => {
-    cy.requestPost<User>('/api/v2/users/', {
-      username: 'E2E_User_' + randomString(4),
-      password: randomString(12),
-    }).then((testUser) => (user = testUser));
+    cy.createAwxUser(organization).then((testUser) => (user = testUser));
   });
 
   afterEach(() => {
-    cy.requestDelete(`/api/v2/users/${user.id}/`, true);
+    cy.deleteAwxUser(user);
   });
 
   it('renders the users list page', () => {

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { AwxOrgResource } from '../../../support/commands';
 
 describe('inventories', () => {
   let organization: Organization;
@@ -8,13 +7,13 @@ describe('inventories', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.createBaselineResourcesForAWX({ onlyCreateOrg: true }).then((resources) => {
-      organization = (resources as AwxOrgResource).organization;
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
     });
   });
 
   after(() => {
-    cy.cleanupBaselineResourcesForAWX();
+    cy.deleteAwxOrganization(organization);
   });
 
   it('renders the inventories list page', () => {

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-
-import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
+import { AwxOrgResource } from '../../../support/commands';
 
 describe('inventories', () => {
   let organization: Organization;
@@ -9,15 +8,13 @@ describe('inventories', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Teams ' + randomString(4),
-    }).then((testOrg) => {
-      organization = testOrg;
+    cy.createBaselineResourcesForAWX({ onlyCreateOrg: true }).then((resources) => {
+      organization = (resources as AwxOrgResource).organization;
     });
   });
 
   after(() => {
-    cy.requestDelete(`/api/v2/organizations/${organization.id}/`, true);
+    cy.cleanupBaselineResourcesForAWX();
   });
 
   it('renders the inventories list page', () => {

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -2,9 +2,6 @@ describe('Job Templates Form', () => {
   before(() => {
     cy.awxLogin();
   });
-  after(() => {
-    cy.cleanupBaselineResourcesForAWX();
-  });
 
   it('can render the templates list page', () => {
     cy.navigateTo(/^Templates$/, false);

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -1,7 +1,14 @@
+// import { JobTemplate } from '../../../../frontend/awx/interfaces/generated-from-swagger/api';
+// import { ItemsResponse } from '../../../../frontend/Data';
+
 describe('Job Templates Form', () => {
   before(() => {
     cy.awxLogin();
   });
+  after(() => {
+    cy.cleanupBaselineResourcesForAWX();
+  });
+
   it('can render the templates list page', () => {
     cy.navigateTo(/^Templates$/, false);
     cy.hasTitle(/^Templates$/);

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -1,6 +1,3 @@
-// import { JobTemplate } from '../../../../frontend/awx/interfaces/generated-from-swagger/api';
-// import { ItemsResponse } from '../../../../frontend/Data';
-
 describe('Job Templates Form', () => {
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -5,6 +5,7 @@ import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { ItemsResponse } from '../../../../frontend/Data';
+import { AwxResources } from '../../../support/commands';
 
 describe('projects', () => {
   let organization: Organization;
@@ -12,36 +13,31 @@ describe('projects', () => {
 
   before(() => {
     cy.awxLogin();
-
-    cy.requestPost<Organization>('/api/v2/organizations/', {
-      name: 'E2E Projects ' + randomString(4),
-    }).then((testOrg) => (organization = testOrg));
+    cy.createBaselineResourcesForAWX().then((resources) => {
+      organization = (resources as AwxResources).organization;
+      if ((resources as AwxResources).project) {
+        project = (resources as AwxResources).project;
+      }
+    });
   });
 
   after(() => {
-    cy.requestDelete(`/api/v2/organizations/${organization.id}/`, true);
-    // Deleting the organization does not delete the projects...
-    // So get all projects without an organization and delete them
-    // Multiple test runs could be running, so only delete projects without an organization as those are not being used.
-    // This does cleanup projects that were sync and could not be deleted by other runs, making a self cleaning E2E system for the live server.
-    cy.requestGet<ItemsResponse<Project>>(`/api/v2/projects/?limit=100&organization=null`).then(
-      (itemsResponse) => {
-        for (const project of itemsResponse.results) {
-          cy.requestDelete(`/api/v2/projects/${project.id}/`, true);
+    cy.cleanupBaselineResourcesForAWX().then(() => {
+      /**
+       * Deleting the organization does not delete the underlying projects.
+       * So get all projects without an organization and delete them. Multiple test runs
+       * could be running, so only delete projects without an organization as those are not being used.
+       * This also cleans up projects that were syncing and could not be deleted by other runs,
+       * making a self cleaning E2E system for the live server.
+       */
+      cy.requestGet<ItemsResponse<Project>>(`/api/v2/projects/?limit=100&organization=null`).then(
+        (itemsResponse) => {
+          for (const project of itemsResponse.results) {
+            cy.requestDelete(`/api/v2/projects/${project.id}/`, true);
+          }
         }
-      }
-    );
-  });
-
-  beforeEach(() => {
-    cy.requestPost<Project>('/api/v2/projects/', {
-      name: 'E2E Project ' + randomString(4),
-      organization: organization.id,
-    }).then((testProject) => (project = testProject));
-  });
-
-  afterEach(() => {
-    cy.requestDelete(`/api/v2/projects/${project.id}/`, true);
+      );
+    });
   });
 
   it('projects page', () => {
@@ -122,12 +118,13 @@ describe('projects', () => {
       organization: organization.id,
       scm_type: 'git', // Only projects with scm_type and scm_url can be copied
       scm_url: 'foo',
-    }).then((project) => {
+    }).then((testProject) => {
       cy.navigateTo(/^Projects$/, false);
-      cy.clickRow(project.name);
-      cy.hasTitle(project.name);
+      cy.clickRow(testProject.name);
+      cy.hasTitle(testProject.name);
       cy.clickPageAction(/^Copy project$/);
-      cy.hasAlert(`${project.name} copied`);
+      cy.hasAlert(`${testProject.name} copied`);
+      cy.requestDelete(`/api/v2/projects/${testProject.id}/`, true);
     });
   });
 
@@ -137,23 +134,29 @@ describe('projects', () => {
       organization: organization.id,
       scm_type: 'git', // Only projects with scm_type and scm_url can be synced
       scm_url: 'foo',
-    }).then((project) => {
+    }).then((testProject) => {
       cy.navigateTo(/^Projects$/, false);
-      cy.clickRow(project.name);
-      cy.hasTitle(project.name);
+      cy.clickRow(testProject.name);
+      cy.hasTitle(testProject.name);
       cy.clickPageAction(/^Sync project$/);
-      cy.hasAlert(`Syncing ${project.name}`);
+      cy.hasAlert(`Syncing ${testProject.name}`);
+      cy.requestDelete(`/api/v2/projects/${testProject.id}/`, true);
     });
   });
 
   it('project details delete project', () => {
-    cy.navigateTo(/^Projects$/, false);
-    cy.clickRow(project.name);
-    cy.hasTitle(project.name);
-    cy.clickPageAction(/^Delete project/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete project/);
-    cy.hasTitle(/^Projects$/);
+    cy.requestPost<Project>('/api/v2/projects/', {
+      name: 'E2E Project ' + randomString(4),
+      organization: organization.id,
+    }).then((testProject) => {
+      cy.navigateTo(/^Projects$/, false);
+      cy.clickRow(testProject.name);
+      cy.hasTitle(testProject.name);
+      cy.clickPageAction(/^Delete project/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete project/);
+      cy.hasTitle(/^Projects$/);
+    });
   });
 
   //   it('projects table row edit project', () => {
@@ -163,23 +166,33 @@ describe('projects', () => {
   //   });
 
   it('projects table row delete project', () => {
-    cy.navigateTo(/^Projects$/, false);
-    cy.clickRowAction(project.name, /^Delete project$/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete project/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
+    cy.requestPost<Project>('/api/v2/projects/', {
+      name: 'E2E Project ' + randomString(4),
+      organization: organization.id,
+    }).then((testProject) => {
+      cy.navigateTo(/^Projects$/, false);
+      cy.clickRowAction(testProject.name, /^Delete project$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete project/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.clickButton(/^Clear all filters$/);
+    });
   });
 
   it('projects toolbar delete projects', () => {
-    cy.navigateTo(/^Projects$/, false);
-    cy.selectRow(project.name);
-    cy.clickToolbarAction(/^Delete selected projects$/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete project/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
+    cy.requestPost<Project>('/api/v2/projects/', {
+      name: 'E2E Project ' + randomString(4),
+      organization: organization.id,
+    }).then((testProject) => {
+      cy.navigateTo(/^Projects$/, false);
+      cy.selectRow(testProject.name);
+      cy.clickToolbarAction(/^Delete selected projects$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete project/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.clickButton(/^Clear all filters$/);
+    });
   });
 });

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -5,7 +5,6 @@ import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { ItemsResponse } from '../../../../frontend/Data';
-import { AwxResources } from '../../../support/commands';
 
 describe('projects', () => {
   let organization: Organization;
@@ -13,16 +12,17 @@ describe('projects', () => {
 
   before(() => {
     cy.awxLogin();
-    cy.createBaselineResourcesForAWX().then((resources) => {
-      organization = (resources as AwxResources).organization;
-      if ((resources as AwxResources).project) {
-        project = (resources as AwxResources).project;
-      }
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
+    });
+    cy.createAwxProject().then((proj) => {
+      project = proj;
     });
   });
 
   after(() => {
-    cy.cleanupBaselineResourcesForAWX().then(() => {
+    cy.deleteAwxProject(project);
+    cy.deleteAwxOrganization(organization).then(() => {
       /**
        * Deleting the organization does not delete the underlying projects.
        * So get all projects without an organization and delete them. Multiple test runs

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -9,7 +9,7 @@ import { AwxResources } from '../../../support/commands';
 
 describe('jobs', () => {
   let jobTemplate: JobTemplate;
-  let job: UnifiedJobList, job1: UnifiedJobList, job2: UnifiedJobList;
+  let job: UnifiedJobList;
 
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -32,12 +32,12 @@ describe('jobs', () => {
     const jobId = job.id ? job.id.toString() : '';
     cy.requestDelete(`/api/v2/jobs/${jobId}/`, true);
     cy.cleanupBaselineResourcesForAWX();
-    cy.contains(job.name);
   });
 
   it('renders jobs list', () => {
     cy.navigateTo(/^Jobs$/, false);
     cy.hasTitle(/^Jobs$/);
+    cy.contains(job.name as string);
   });
 
   it('renders the toolbar and row actions', () => {

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -32,14 +32,15 @@ describe('jobs', () => {
     const jobId = job.id ? job.id.toString() : '';
     cy.requestDelete(`/api/v2/jobs/${jobId}/`, true);
     cy.cleanupBaselineResourcesForAWX();
+    cy.contains(job.name);
   });
 
-  it('jobs list', () => {
+  it('renders jobs list', () => {
     cy.navigateTo(/^Jobs$/, false);
     cy.hasTitle(/^Jobs$/);
   });
 
-  it('toolbar and row actions', () => {
+  it('renders the toolbar and row actions', () => {
     cy.get('.pf-c-toolbar__group button.toggle-kebab').click();
     cy.get('.pf-c-dropdown__menu').within(() => {
       cy.contains(/^Delete selected jobs$/).should('exist');
@@ -59,7 +60,7 @@ describe('jobs', () => {
       });
   });
 
-  it('filter job by id', () => {
+  it('filters jobs by id', () => {
     cy.get('.pf-c-select__toggle').click();
     cy.clickButton('ID');
     const jobId = job.id ? job.id.toString() : '';
@@ -72,7 +73,7 @@ describe('jobs', () => {
     cy.clickButton(/^Clear all filters$/);
   });
 
-  it('jobs table row: delete job', () => {
+  it('deletes a job from the jobs list row', () => {
     cy.get('.pf-c-select__toggle').click();
     cy.clickButton('ID');
     const jobTemplateId = jobTemplate.id ? jobTemplate.id.toString() : '';
@@ -98,7 +99,7 @@ describe('jobs', () => {
     });
   });
 
-  it('jobs toolbar: delete job', () => {
+  it('deletes a job from the jobs list toolbar', () => {
     cy.get('.pf-c-select__toggle').click();
     cy.clickButton('ID');
     const jobTemplateId = jobTemplate.id ? jobTemplate.id.toString() : '';

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/// <reference types="cypress" />
+
+import {
+  JobTemplate,
+  UnifiedJobList,
+} from '../../../../frontend/awx/interfaces/generated-from-swagger/api';
+import { AwxResources } from '../../../support/commands';
+
+describe('jobs', () => {
+  let jobTemplate: JobTemplate;
+  let job: UnifiedJobList;
+
+  before(() => {
+    cy.awxLogin();
+
+    cy.createBaselineResourcesForAWX().then((resources) => {
+      jobTemplate = (resources as AwxResources).jobTemplate;
+      // Launch job to populate jobs list
+      const templateId = jobTemplate.id ? jobTemplate.id.toString() : '';
+      cy.requestPost<UnifiedJobList>(
+        `/api/v2/job_templates/${templateId}/launch/`,
+        {} as UnifiedJobList
+      ).then((testJob) => {
+        job = testJob;
+      });
+    });
+  });
+
+  after(() => {
+    // Delete launched job
+    const jobId = job.id ? job.id.toString() : '';
+    cy.requestDelete(`/api/v2/jobs/${jobId}/`, true);
+  });
+
+  it('jobs list', () => {
+    cy.navigateTo(/^Jobs$/, false);
+    cy.hasTitle(/^Jobs$/);
+  });
+
+  it('toolbar and row actions', () => {
+    cy.get('pf-c-toolbar__content #toggle-kebab').click();
+    cy.get('pf-c-dropdown__menu').within(() => {
+      cy.contains('/^Delete selected jobs$/').should('be.visible');
+      cy.contains('/^Cancel selected jobs$/').should('be.visible');
+    });
+    cy.get('tr .toggle-kebab')
+      .first()
+      .within(() => {
+        cy.contains('/^Delete job$/').should('be.visible');
+        cy.contains('/^Cancel job$/').should('be.visible');
+      });
+  });
+
+  it('filter job by id', () => {
+    cy.get('.pf-c-select__toggle').click();
+    cy.clickButton('ID');
+    const jobId = job.id ? job.id.toString() : '';
+    cy.get('#filter-input').type(jobId, { delay: 0 });
+    cy.get('[aria-label="apply filter"]').click();
+    cy.get('tr').should('have.length.greaterThan', 0);
+    if (job.name) {
+      cy.contains(job.name).should('be.visible');
+    }
+  });
+
+  it('jobs table row: delete job', () => {
+    cy.get('.pf-c-select__toggle').click();
+    cy.clickButton('ID');
+    const jobTemplateId = jobTemplate.id ? jobTemplate.id.toString() : '';
+    cy.requestPost<UnifiedJobList>(
+      `/api/v2/job_templates/${jobTemplateId}/launch/`,
+      {} as UnifiedJobList
+    ).then((testJob) => {
+      cy.navigateTo(/^Jobs$/, false);
+      const jobId = testJob.id ? testJob.id.toString() : '';
+      cy.clickRowAction(jobId, /^Delete job$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete job/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.getRowFromList(jobId).should('not.exist');
+      cy.clickButton(/^Clear all filters$/);
+    });
+  });
+
+  it('jobs toolbar: delete job', () => {
+    cy.get('.pf-c-select__toggle').click();
+    cy.clickButton('ID');
+    const jobTemplateId = jobTemplate.id ? jobTemplate.id.toString() : '';
+    cy.requestPost<UnifiedJobList>(
+      `/api/v2/job_templates/${jobTemplateId}/launch/`,
+      {} as UnifiedJobList
+    ).then((testJob) => {
+      cy.navigateTo(/^Jobs$/, false);
+      const jobId = testJob.id ? testJob.id.toString() : '';
+      cy.selectRow(jobId);
+      cy.clickToolbarAction(/^Delete selected jobs$/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete job/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.getRowFromList(jobId).should('not.exist');
+      cy.clickButton(/^Clear all filters$/);
+    });
+  });
+});

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -5,7 +5,6 @@ import {
   JobTemplate,
   UnifiedJobList,
 } from '../../../../frontend/awx/interfaces/generated-from-swagger/api';
-import { AwxResources } from '../../../support/commands';
 
 describe('jobs', () => {
   let jobTemplate: JobTemplate;
@@ -14,8 +13,8 @@ describe('jobs', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.createBaselineResourcesForAWX().then((resources) => {
-      jobTemplate = (resources as AwxResources).jobTemplate;
+    cy.createAwxJobTemplate().then((template) => {
+      jobTemplate = template;
       // Launch job to populate jobs list
       const templateId = jobTemplate.id ? jobTemplate.id.toString() : '';
       cy.requestPost<UnifiedJobList>(
@@ -31,7 +30,7 @@ describe('jobs', () => {
     // Delete launched job
     const jobId = job.id ? job.id.toString() : '';
     cy.requestDelete(`/api/v2/jobs/${jobId}/`, true);
-    cy.cleanupBaselineResourcesForAWX();
+    cy.deleteAwxJobTemplate(jobTemplate);
   });
 
   it('renders jobs list', () => {

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -9,7 +9,7 @@ import { AwxResources } from '../../../support/commands';
 
 describe('jobs', () => {
   let jobTemplate: JobTemplate;
-  let job: UnifiedJobList;
+  let job: UnifiedJobList, job1: UnifiedJobList, job2: UnifiedJobList;
 
   before(() => {
     cy.awxLogin();
@@ -31,6 +31,7 @@ describe('jobs', () => {
     // Delete launched job
     const jobId = job.id ? job.id.toString() : '';
     cy.requestDelete(`/api/v2/jobs/${jobId}/`, true);
+    cy.cleanupBaselineResourcesForAWX();
   });
 
   it('jobs list', () => {
@@ -39,16 +40,21 @@ describe('jobs', () => {
   });
 
   it('toolbar and row actions', () => {
-    cy.get('pf-c-toolbar__content #toggle-kebab').click();
-    cy.get('pf-c-dropdown__menu').within(() => {
-      cy.contains('/^Delete selected jobs$/').should('be.visible');
-      cy.contains('/^Cancel selected jobs$/').should('be.visible');
+    cy.get('.pf-c-toolbar__group button.toggle-kebab').click();
+    cy.get('.pf-c-dropdown__menu').within(() => {
+      cy.contains(/^Delete selected jobs$/).should('exist');
+      cy.contains(/^Cancel selected jobs$/).should('exist');
     });
-    cy.get('tr .toggle-kebab')
-      .first()
+    cy.contains('td', job.name)
+      .parent()
       .within(() => {
-        cy.contains('/^Delete job$/').should('be.visible');
-        cy.contains('/^Cancel job$/').should('be.visible');
+        cy.get('.pf-c-dropdown__toggle').click();
+        cy.get('.pf-c-dropdown__menu-item')
+          .contains(/^Delete job$/)
+          .should('exist');
+        cy.get('.pf-c-dropdown__menu-item')
+          .contains(/^Cancel job$/)
+          .should('exist');
       });
   });
 
@@ -62,6 +68,7 @@ describe('jobs', () => {
     if (job.name) {
       cy.contains(job.name).should('be.visible');
     }
+    cy.clickButton(/^Clear all filters$/);
   });
 
   it('jobs table row: delete job', () => {
@@ -74,6 +81,11 @@ describe('jobs', () => {
     ).then((testJob) => {
       cy.navigateTo(/^Jobs$/, false);
       const jobId = testJob.id ? testJob.id.toString() : '';
+      cy.contains('td', testJob.name)
+        .parent()
+        .within(() => {
+          cy.contains('.pf-c-alert__title', 'Successful');
+        });
       cy.clickRowAction(jobId, /^Delete job$/);
       cy.get('#confirm').click();
       cy.clickButton(/^Delete job/);
@@ -94,6 +106,11 @@ describe('jobs', () => {
     ).then((testJob) => {
       cy.navigateTo(/^Jobs$/, false);
       const jobId = testJob.id ? testJob.id.toString() : '';
+      cy.contains('td', testJob.name)
+        .parent()
+        .within(() => {
+          cy.contains('.pf-c-alert__title', 'Successful');
+        });
       cy.selectRow(jobId);
       cy.clickToolbarAction(/^Delete selected jobs$/);
       cy.get('#confirm').click();

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -45,7 +45,8 @@ describe('jobs', () => {
       cy.contains(/^Delete selected jobs$/).should('exist');
       cy.contains(/^Cancel selected jobs$/).should('exist');
     });
-    cy.contains('td', job.name)
+    const jobName = job.name ? job.name : '';
+    cy.contains('td', jobName)
       .parent()
       .within(() => {
         cy.get('.pf-c-dropdown__toggle').click();
@@ -81,7 +82,8 @@ describe('jobs', () => {
     ).then((testJob) => {
       cy.navigateTo(/^Jobs$/, false);
       const jobId = testJob.id ? testJob.id.toString() : '';
-      cy.contains('td', testJob.name)
+      const jobName = testJob.name ? testJob.name : '';
+      cy.contains('td', jobName)
         .parent()
         .within(() => {
           cy.contains('.pf-c-alert__title', 'Successful');
@@ -106,7 +108,8 @@ describe('jobs', () => {
     ).then((testJob) => {
       cy.navigateTo(/^Jobs$/, false);
       const jobId = testJob.id ? testJob.id.toString() : '';
-      cy.contains('td', testJob.name)
+      const jobName = job.name ? job.name : '';
+      cy.contains('td', jobName)
         .parent()
         .within(() => {
           cy.contains('.pf-c-alert__title', 'Successful');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -409,15 +409,3 @@ Cypress.Commands.add(
     });
   }
 );
-
-Cypress.Commands.overwrite('log', function (log, ...args) {
-  if (Cypress.browser.isHeadless) {
-    return cy.task('log', args, { log: false }).then(() => {
-      return log(...args);
-    });
-  } else {
-    // eslint-disable-next-line
-    console.log(...args);
-    return log(...args);
-  }
-});

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cypress:run": "concurrently npm:cypress:run:e2e npm:cypress:run:component --prefix-colors cyan,blue",
     "cypress:run:e2e": "cypress run --e2e",
     "cypress:run:component": "cypress run --component",
-    "cypress:open": "cypress open",
+    "cypress:open": "cypress open --e2e --browser chrome",
     "coverage": "open coverage/lcov-report/index.html",
     "cypress:check": "npx nyc report --check-coverage --statements 20 --branches 20 --functions 19 --lines 20 --report-dir ./coverage --temp-dir .nyc_output --reporter=text-summary --exclude-after-remap false",
     "prepare": "husky install",


### PR DESCRIPTION
New Cypress commands:
1. `createBaselineResourcesForAWX`: Create either just an org, or an org + inventory + project + job template
    - polls projects API to wait till project has synced
2. `cleanupBaselineResourcesForAWX`: Cleans up baselines resources created

Initial tests for jobs UI