### PR TITLE
add default selection support

### DIFF
--- a/framework/PageTable/useTableItems.tsx
+++ b/framework/PageTable/useTableItems.tsx
@@ -90,9 +90,15 @@ export interface ISelected<T extends object> {
   keyFn: (item: T) => string | number;
 }
 
+/** Hook to track selection from a list of items. */
 export function useSelected<T extends object>(
+  /** The items in which selections are being tracked. Used to update the selected items when an item changes.  */
   items: T[],
+
+  /** A function that returns a unique key for each item, used to track selection. */
   keyFn: (item: T) => string | number,
+
+  /** The default items that should be initially selected. */
   defaultSelection?: T[]
 ): ISelected<T> {
   const [selectedMap, setSelectedMap] = useState<Record<string | number, T>>(() => {

--- a/framework/PageTable/useTableItems.tsx
+++ b/framework/PageTable/useTableItems.tsx
@@ -92,9 +92,19 @@ export interface ISelected<T extends object> {
 
 export function useSelected<T extends object>(
   items: T[],
-  keyFn: (item: T) => string | number
+  keyFn: (item: T) => string | number,
+  defaultSelection?: T[]
 ): ISelected<T> {
-  const [selectedMap, setSelectedMap] = useState<Record<string | number, T>>({});
+  const [selectedMap, setSelectedMap] = useState<Record<string | number, T>>(() => {
+    if (defaultSelection) {
+      return defaultSelection.reduce<Record<string | number, T>>((selectedMap, item) => {
+        selectedMap[keyFn(item)] = item;
+        return selectedMap;
+      }, {});
+    } else {
+      return {};
+    }
+  });
 
   useEffect(() => {
     setSelectedMap((selectedMap) => {

--- a/frontend/awx/useAwxView.tsx
+++ b/frontend/awx/useAwxView.tsx
@@ -26,11 +26,22 @@ function getQueryString(queryParams: QueryParams) {
 }
 
 export function useAwxView<T extends { id: number }>(options: {
+  /** The base url for the view. */
   url: string;
+
+  /** The filters for the view. Used to manage the keys used in the brower querystrings which store the filter results. */
   toolbarFilters?: IToolbarFilter[];
+
+  /** The table columns for the view. Used to determine the default sort. */
   tableColumns?: ITableColumn<T>[];
+
+  /** Extra querystring params passed to the backed API.  */
   queryParams?: QueryParams;
+
+  /** Disable the brower querystring updating. Used when a table is in a details page or modal. */
   disableQueryString?: boolean;
+
+  /** The default items that should be initially selected. */
   defaultSelection?: T[];
 }): IAwxView<T> {
   let { url } = options;

--- a/frontend/awx/useAwxView.tsx
+++ b/frontend/awx/useAwxView.tsx
@@ -31,6 +31,7 @@ export function useAwxView<T extends { id: number }>(options: {
   tableColumns?: ITableColumn<T>[];
   queryParams?: QueryParams;
   disableQueryString?: boolean;
+  defaultSelection?: T[];
 }): IAwxView<T> {
   let { url } = options;
   const { toolbarFilters, tableColumns, disableQueryString } = options;
@@ -110,7 +111,7 @@ export function useAwxView<T extends { id: number }>(options: {
     }
   }
 
-  const selection = useSelected(data?.results ?? [], getItemKey);
+  const selection = useSelected(data?.results ?? [], getItemKey, options.defaultSelection);
 
   if (data?.count !== undefined) {
     itemCountRef.current.itemCount = data?.count;


### PR DESCRIPTION
Support for a view to have default selection

This is not hoked up to any dialogs yet, this is in preparation for future work.

In the case where you are opening a dialog from say the Teams view,
you create an AWXView for the dialogs table with the currently selected items using useAwxView({ defaultSelections: view.selected })

Or from a PageFormSelect where the current value in the select is passed to a SelectDialog by creating a new AwxView with the current item as the defaultSelections