### PR TITLE
Adds last login and authentication type to user details

### DIFF
--- a/frontend/awx/access/users/UserPage/UserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/UserDetails.tsx
@@ -3,11 +3,13 @@ import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { PageDetail, PageDetails, SinceCell } from '../../../../../framework';
 import { User } from '../../../interfaces/User';
+import { AuthenticationType } from '../components/AuthenticationType';
 import { UserType } from '../components/UserType';
 
 export function UserDetails(props: { user: User }) {
   const { t } = useTranslation();
   const { user } = props;
+
   return (
     <>
       {user.is_superuser && (
@@ -26,11 +28,17 @@ export function UserDetails(props: { user: User }) {
         <PageDetail label={t('User type')}>
           <UserType user={user} />
         </PageDetail>
+        <PageDetail label={t('Authentication type')}>
+          <AuthenticationType user={user} />
+        </PageDetail>
         <PageDetail label={t('Created')}>
           <SinceCell value={user.created} />
         </PageDetail>
         <PageDetail label={t('Modified')}>
           <SinceCell value={user.modified} />
+        </PageDetail>
+        <PageDetail label={t('Last login')}>
+          <SinceCell value={user.last_login} />
         </PageDetail>
       </PageDetails>
     </>

--- a/frontend/awx/access/users/components/AuthenticationType.tsx
+++ b/frontend/awx/access/users/components/AuthenticationType.tsx
@@ -1,0 +1,15 @@
+import { Label } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { User } from '../../../interfaces/User';
+
+export function AuthenticationType(props: { user: User }) {
+  const { user } = props;
+  const { t } = useTranslation();
+  if (user.ldap_dn) {
+    return <Label>{t('LDAP')}</Label>;
+  }
+  if (user.auth.length > 0) {
+    return <Label>{t('Social')}</Label>;
+  }
+  return <Label>{t('Local')}</Label>;
+}

--- a/frontend/awx/interfaces/User.ts
+++ b/frontend/awx/interfaces/User.ts
@@ -40,4 +40,5 @@ export interface User extends Omit<SwaggerUser, 'id' | 'username' | 'summary_fie
   };
   user_roles?: AccessRole[];
   team_roles?: AccessRole[];
+  auth: string[];
 }


### PR DESCRIPTION
These two fields were missing from the user details.  Last login displays the time since the user last logged in.  Authentication type should be displayed when the user is either an LDAP user or a social auth user.  Here's what it looks like in action:

<img width="1725" alt="Screenshot 2023-03-21 at 8 59 29 PM" src="https://user-images.githubusercontent.com/9889020/226774764-a3cf0ac8-65c6-40cc-a14f-21b373d4803a.png">

I coded the behavior of the Authentication type field to match the existing AWX behavior.  We have outstanding enhancement requests to show something more specific than `SOCIAL` since we have the auth provider name in the user.auth array but we should talk through the UX there before implementing.