### PR TITLE
Adds rbac parameters to user add, edit and delete buttons in user list

### DIFF
--- a/frontend/awx/access/users/UserPage/UserTeams.tsx
+++ b/frontend/awx/access/users/UserPage/UserTeams.tsx
@@ -33,7 +33,7 @@ export function UserTeams(props: { user: User }) {
   const selectTeamsAddUsers = useSelectTeamsAddUsers(view.selectItemsAndRefresh);
   const removeTeamsFromUsers = useRemoveTeamsFromUsers(view.unselectItemsAndRefresh);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>('/api/v2/users/');
-  const canCreateUser = Boolean(data && data.actions && data.actions['POST']);
+  const canAddUserToTeam = Boolean(data && data.actions && data.actions['POST']);
 
   const toolbarActions = useMemo<IPageAction<Team>[]>(
     () => [
@@ -42,7 +42,7 @@ export function UserTeams(props: { user: User }) {
         variant: ButtonVariant.primary,
         icon: PlusIcon,
         label: t('Add user to teams'),
-        isDisabled: canCreateUser
+        isDisabled: canAddUserToTeam
           ? undefined
           : t(
               'You do not have permissions to add this user to a team. Please contact your Organization Administrator if there is an issue with your access.'
@@ -56,7 +56,7 @@ export function UserTeams(props: { user: User }) {
         onClick: () => removeTeamsFromUsers([user], view.selectedItems),
       },
     ],
-    [t, canCreateUser, selectTeamsAddUsers, user, removeTeamsFromUsers, view.selectedItems]
+    [t, canAddUserToTeam, selectTeamsAddUsers, user, removeTeamsFromUsers, view.selectedItems]
   );
   const rowActions = useMemo<IPageAction<Team>[]>(
     () => [
@@ -81,21 +81,21 @@ export function UserTeams(props: { user: User }) {
         rowActions={rowActions}
         errorStateTitle={t('Error loading teams')}
         emptyStateTitle={
-          canCreateUser
+          canAddUserToTeam
             ? t('This user currently does not belong to any teams.')
             : t('You do not have permissions to add this user to a team.')
         }
         emptyStateDescription={
-          canCreateUser
+          canAddUserToTeam
             ? t('Please add a team by using the button below.')
             : t(
                 'Please contact your Organization Administrator if there is an issue with your access.'
               )
         }
-        emptyStateIcon={canCreateUser ? undefined : CubesIcon}
-        emptyStateButtonText={canCreateUser ? t('Add team') : undefined}
-        emptyStateButtonIcon={canCreateUser ? <PlusIcon /> : null}
-        emptyStateButtonClick={canCreateUser ? () => selectTeamsAddUsers([user]) : undefined}
+        emptyStateIcon={canAddUserToTeam ? undefined : CubesIcon}
+        emptyStateButtonText={canAddUserToTeam ? t('Add team') : undefined}
+        emptyStateButtonIcon={canAddUserToTeam ? <PlusIcon /> : null}
+        emptyStateButtonClick={canAddUserToTeam ? () => selectTeamsAddUsers([user]) : undefined}
         {...view}
       />
     </>

--- a/frontend/awx/access/users/UserPage/UserTeams.tsx
+++ b/frontend/awx/access/users/UserPage/UserTeams.tsx
@@ -33,7 +33,7 @@ export function UserTeams(props: { user: User }) {
   const selectTeamsAddUsers = useSelectTeamsAddUsers(view.selectItemsAndRefresh);
   const removeTeamsFromUsers = useRemoveTeamsFromUsers(view.unselectItemsAndRefresh);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>('/api/v2/users/');
-  const canAddTeam = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateUser = Boolean(data && data.actions && data.actions['POST']);
 
   const toolbarActions = useMemo<IPageAction<Team>[]>(
     () => [
@@ -42,7 +42,7 @@ export function UserTeams(props: { user: User }) {
         variant: ButtonVariant.primary,
         icon: PlusIcon,
         label: t('Add user to teams'),
-        isDisabled: canAddTeam
+        isDisabled: canCreateUser
           ? undefined
           : t(
               'You do not have permissions to add this user to a team. Please contact your Organization Administrator if there is an issue with your access.'
@@ -56,7 +56,7 @@ export function UserTeams(props: { user: User }) {
         onClick: () => removeTeamsFromUsers([user], view.selectedItems),
       },
     ],
-    [t, canAddTeam, selectTeamsAddUsers, user, removeTeamsFromUsers, view.selectedItems]
+    [t, canCreateUser, selectTeamsAddUsers, user, removeTeamsFromUsers, view.selectedItems]
   );
   const rowActions = useMemo<IPageAction<Team>[]>(
     () => [
@@ -81,21 +81,21 @@ export function UserTeams(props: { user: User }) {
         rowActions={rowActions}
         errorStateTitle={t('Error loading teams')}
         emptyStateTitle={
-          canAddTeam
+          canCreateUser
             ? t('This user currently does not belong to any teams.')
             : t('You do not have permissions to add this user to a team.')
         }
         emptyStateDescription={
-          canAddTeam
+          canCreateUser
             ? t('Please add a team by using the button below.')
             : t(
                 'Please contact your Organization Administrator if there is an issue with your access.'
               )
         }
-        emptyStateIcon={canAddTeam ? undefined : CubesIcon}
-        emptyStateButtonText={canAddTeam ? t('Add team') : undefined}
-        emptyStateButtonIcon={canAddTeam ? <PlusIcon /> : null}
-        emptyStateButtonClick={canAddTeam ? () => selectTeamsAddUsers([user]) : undefined}
+        emptyStateIcon={canCreateUser ? undefined : CubesIcon}
+        emptyStateButtonText={canCreateUser ? t('Add team') : undefined}
+        emptyStateButtonIcon={canCreateUser ? <PlusIcon /> : null}
+        emptyStateButtonClick={canCreateUser ? () => selectTeamsAddUsers([user]) : undefined}
         {...view}
       />
     </>

--- a/frontend/awx/access/users/hooks/useDeleteUsers.tsx
+++ b/frontend/awx/access/users/hooks/useDeleteUsers.tsx
@@ -30,7 +30,7 @@ export function useDeleteUsers(onComplete: (users: User[]) => void) {
     bulkAction({
       title: t('Permanently delete users', { count: users.length }),
       confirmText: t('Yes, I confirm that I want to delete these {{count}} users.', {
-        count: undeletableUsers.length,
+        count: users.length - undeletableUsers.length,
       }),
       actionButtonText: t('Delete users', { count: users.length }),
       items: users.sort((l, r) => compareStrings(l.username, r.username)),

--- a/frontend/awx/access/users/hooks/useDeleteUsers.tsx
+++ b/frontend/awx/access/users/hooks/useDeleteUsers.tsx
@@ -18,15 +18,34 @@ export function useDeleteUsers(onComplete: (users: User[]) => void) {
     [t]
   );
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
+  const cannotDeleteUser = (user: User) => {
+    return user?.summary_fields?.user_capabilities?.delete
+      ? undefined
+      : t('The user cannot be deleted due to insufficient permissions.');
+  };
   const bulkAction = useBulkConfirmation<User>();
   const deleteUsers = (users: User[]) => {
+    const undeletableUsers = users.filter(cannotDeleteUser);
+
     bulkAction({
       title: t('Permanently delete users', { count: users.length }),
       confirmText: t('Yes, I confirm that I want to delete these {{count}} users.', {
-        count: users.length,
+        count: undeletableUsers.length,
       }),
       actionButtonText: t('Delete users', { count: users.length }),
       items: users.sort((l, r) => compareStrings(l.username, r.username)),
+      alertPrompts:
+        undeletableUsers.length > 0
+          ? [
+              t(
+                '{{count}} of the selected users cannot be deleted due to insufficient permissions.',
+                {
+                  count: undeletableUsers.length,
+                }
+              ),
+            ]
+          : undefined,
+      isItemNonActionable: cannotDeleteUser,
       keyFn: getItemKey,
       isDanger: true,
       confirmationColumns,


### PR DESCRIPTION
<img width="1463" alt="Screenshot 2023-03-22 at 1 59 42 PM" src="https://user-images.githubusercontent.com/9889020/226996129-ffaf9c4e-0261-4b6b-b8aa-bc7efeccc615.png">
<img width="1356" alt="Screenshot 2023-03-22 at 1 59 30 PM" src="https://user-images.githubusercontent.com/9889020/226996135-ec530ae4-a168-4d0c-a93b-e8b320c91fd5.png">
<img width="984" alt="Screenshot 2023-03-22 at 1 59 14 PM" src="https://user-images.githubusercontent.com/9889020/226996138-b1578d07-129d-480c-bfb1-ce8de2b05fc9.png">

The actions around adding/remove from teams and orgs is _much_ more complicated from an RBAC perspective so I left that alone for now.
