### PR TITLE
Add PR label automation for AWX, EDA and framework labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+AWX:
+  - frontend/awx/**/*
+
+EDA:
+  - frontend/eda/**/*
+
+framework:
+  - framework/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4


### PR DESCRIPTION
Leverages https://github.com/marketplace/actions/labeler to apply `AWX`, `EDA` and `framework` labels to PRs based on the files touched in a particular PR.