### PR TITLE
Update projects list columns and the create/edit project pages

### DIFF
--- a/cypress/e2e/eda/Projects/projects-crud.cy.ts
+++ b/cypress/e2e/eda/Projects/projects-crud.cy.ts
@@ -13,7 +13,6 @@ describe('EDA Projects CRUD', () => {
     cy.navigateTo(/^Projects$/, false);
     cy.clickButton(/^Create project$/);
     cy.typeByLabel(/^Name$/, name);
-    cy.typeByLabel(/^SCM type$/, 'git');
     cy.typeByLabel(/^SCM URL$/, 'https://example.com');
     cy.clickButton(/^Create project$/);
     cy.hasTitle(name);

--- a/frontend/eda/Resources/projects/EditProject.tsx
+++ b/frontend/eda/Resources/projects/EditProject.tsx
@@ -1,15 +1,59 @@
-import { Static, Type } from '@sinclair/typebox';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
-import { PageForm, PageFormSubmitHandler, PageHeader, PageLayout } from '../../../../framework';
-import { PageFormSchema } from '../../../../framework/PageForm/PageFormSchema';
-import { requestPatch, requestPost } from '../../../common/crud/Data';
+import {
+  PageForm,
+  PageFormSubmitHandler,
+  PageFormTextInput,
+  PageHeader,
+  PageLayout,
+} from '../../../../framework';
+import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { RouteObj } from '../../../Routes';
 import { API_PREFIX } from '../../constants';
 import { EdaProject } from '../../interfaces/EdaProject';
+import { usePostRequest } from '../../../common/crud/usePostRequest';
+
+function ProjectInputs() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<EdaProject>
+        name="name"
+        label={t('Name')}
+        placeholder={t('Insert name here')}
+        isRequired
+        maxLength={150}
+        autoComplete="new-name"
+      />
+      <PageFormTextInput<EdaProject>
+        name="description"
+        label={t('Description')}
+        placeholder={t('Insert description here ')}
+        maxLength={150}
+      />
+      <PageFormTextInput<EdaProject>
+        name="type"
+        isReadOnly={true}
+        label={t('SCM Type')}
+        placeholder={t('Git')}
+        maxLength={150}
+      />
+      <PageFormTextInput<EdaProject>
+        name="url"
+        isRequired={true}
+        label={t('SCM URL')}
+        placeholder={t('Insert SCM URL here')}
+      />
+      <PageFormTextInput<EdaProject>
+        name="token"
+        label={t('SCM token')}
+        placeholder={t('Insert SCM token here')}
+      />
+    </>
+  );
+}
 
 export function EditProject() {
   const { t } = useTranslation();
@@ -18,54 +62,17 @@ export function EditProject() {
   const id = Number(params.id);
   const { data: project } = useGet<EdaProject>(`${API_PREFIX}/projects/${id.toString()}/`);
 
-  const ProjectSchemaType = useMemo(
-    () =>
-      Type.Object({
-        name: Type.String({
-          title: t('Name'),
-          placeholder: t('Insert name here'), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-        }),
-        description: Type.Optional(
-          Type.String({
-            title: t('Description'),
-            placeholder: t('Insert description here '), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-          })
-        ),
-        type: Type.Optional(
-          Type.String({
-            title: t('SCM type'),
-            default: 'Git',
-            placeholder: t('Select type'), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-          })
-        ),
-        url: Type.Optional(
-          Type.String({
-            title: t('SCM URL'),
-            placeholder: t('Enter the URL'), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-          })
-        ),
-        token: Type.Optional(
-          Type.String({
-            title: t('SCM token'),
-            placeholder: t('Insert token here'), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-          })
-        ),
-      }),
-    [t]
-  );
-
-  type ProjectSchema = Static<typeof ProjectSchemaType>;
-
   const { cache } = useSWRConfig();
+  const postRequest = usePostRequest<Partial<EdaProject>, EdaProject>();
 
-  const onSubmit: PageFormSubmitHandler<ProjectSchema> = async (project, setError) => {
+  const onSubmit: PageFormSubmitHandler<EdaProject> = async (project, setError) => {
     try {
       if (Number.isInteger(id)) {
         await requestPatch<EdaProject>(`${API_PREFIX}/projects/${id}/`, project);
         (cache as unknown as { clear: () => void }).clear?.();
         navigate(-1);
       } else {
-        const newProject = await requestPost<EdaProject>(`${API_PREFIX}/projects/`, project);
+        const newProject = await postRequest(`${API_PREFIX}/projects/`, project);
         (cache as unknown as { clear: () => void }).clear?.();
         navigate(RouteObj.EdaProjectDetails.replace(':id', newProject.id.toString()));
       }
@@ -98,14 +105,13 @@ export function EditProject() {
             ]}
           />
           <PageForm
-            schema={ProjectSchemaType}
             submitText={t('Save project')}
             onSubmit={onSubmit}
             cancelText={t('Cancel')}
             onCancel={onCancel}
             defaultValue={project}
           >
-            <PageFormSchema schema={ProjectSchemaType} />
+            <ProjectInputs />
           </PageForm>
         </PageLayout>
       );
@@ -121,13 +127,12 @@ export function EditProject() {
           ]}
         />
         <PageForm
-          schema={ProjectSchemaType}
           submitText={t('Create project')}
           onSubmit={onSubmit}
           cancelText={t('Cancel')}
           onCancel={onCancel}
         >
-          <PageFormSchema schema={ProjectSchemaType} />
+          <ProjectInputs />
         </PageForm>
       </PageLayout>
     );

--- a/frontend/eda/Resources/projects/ProjectDetails.tsx
+++ b/frontend/eda/Resources/projects/ProjectDetails.tsx
@@ -1,5 +1,5 @@
 import { DropdownPosition, PageSection, Skeleton, Stack } from '@patternfly/react-core';
-import { EditIcon, TrashIcon } from '@patternfly/react-icons';
+import { EditIcon, GitAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -13,6 +13,7 @@ import {
   PageLayout,
   PageTab,
   PageTabs,
+  TextCell,
 } from '../../../../framework';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { useGet } from '../../../common/crud/useGet';
@@ -59,12 +60,14 @@ export function ProjectDetails() {
       <PageDetails>
         <PageDetail label={t('Name')}>{project?.name || ''}</PageDetail>
         <PageDetail label={t('Description')}>{project?.description || ''}</PageDetail>
-        <PageDetail label={t('SCM type')}>{project?.type || t('Git')}</PageDetail>
+        <PageDetail label={t('SCM type')}>
+          <TextCell icon={<GitAltIcon color="#F1502F" />} iconSize="md" text={'Git'} />
+        </PageDetail>
         <PageDetail label={t('SCM URL')}>{project?.url || ''}</PageDetail>
         <PageDetail label={t('SCM token')}>{project?.token || ''}</PageDetail>
         <PageDetail label={t('Git hash')}>{project?.git_hash || ''}</PageDetail>
         <PageDetail label={t('Status')}>
-          <StatusLabelCell status={project?.status || ''} />
+          <StatusLabelCell status={project?.import_state || ''} />
         </PageDetail>
         <PageDetail label={t('Created')}>
           {project?.created_at ? formatDateString(project.created_at) : ''}

--- a/frontend/eda/Resources/projects/hooks/useProjectColumns.tsx
+++ b/frontend/eda/Resources/projects/hooks/useProjectColumns.tsx
@@ -28,11 +28,11 @@ export function useProjectColumns() {
       },
       {
         header: t('Status'),
-        cell: (project) => <StatusLabelCell status={project.status} />,
+        cell: (project) => <StatusLabelCell status={project.import_state} />,
       },
       {
         header: t('Revision'),
-        cell: (project) => <TextCell text={project?.revision ? project.revision : '00000'} />,
+        cell: (project) => <TextCell text={project?.git_hash ? project.git_hash : ''} />,
       },
     ],
 

--- a/frontend/eda/dashboard/hooks/useProjectColumns.tsx
+++ b/frontend/eda/dashboard/hooks/useProjectColumns.tsx
@@ -28,7 +28,7 @@ export function useProjectColumns() {
       },
       {
         header: t('Status'),
-        cell: (project) => <StatusCell status={project.status} />,
+        cell: (project) => <StatusCell status={project.import_state} />,
         sort: 'status',
         defaultSort: true,
       },

--- a/frontend/eda/interfaces/EdaProject.ts
+++ b/frontend/eda/interfaces/EdaProject.ts
@@ -13,7 +13,7 @@ export interface EdaProject {
   token?: string;
   created_at?: string;
   modified_at?: string;
-  status: string;
+  import_state: string;
   revision: string;
   url?: string;
   git_hash?: string;


### PR DESCRIPTION
- Updated Status column to the import_state. 
- Make type read only as only Git is supported as of now
- Make URL field mandatory for project Create/update.
- Status updated in the details page


![Screenshot from 2023-03-23 15-57-46](https://user-images.githubusercontent.com/12769982/227338448-94455139-d716-490d-9dcb-2655c5ae1e8a.png)

![Screenshot from 2023-03-23 15-48-49](https://user-images.githubusercontent.com/12769982/227338384-d2a044a5-38d8-4811-a869-1f0550e4bee5.png)

![Screenshot from 2023-03-23 15-57-11](https://user-images.githubusercontent.com/12769982/227338487-c9309924-ce8a-416c-8de0-fd79897c468f.png)
