### PR TITLE
Adds AWX inventory details view

### DIFF
--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 
 describe('inventories', () => {
   let organization: Organization;
+  let inventory: Inventory;
 
   before(() => {
     cy.awxLogin();
@@ -10,15 +12,49 @@ describe('inventories', () => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
     });
+
+    cy.createAwxInventory().then((inv) => {
+      inventory = inv;
+    });
   });
 
   after(() => {
     cy.deleteAwxOrganization(organization);
+    cy.deleteAwxInventory(inventory);
   });
 
   it('renders the inventories list page', () => {
     cy.navigateTo(/^Inventories$/, false);
     cy.hasTitle(/^Inventories$/);
+  });
+
+  it('renders the inventory details page', () => {
+    cy.navigateTo(/^Inventories$/, false);
+    cy.clickRow(inventory.name);
+    cy.hasTitle(inventory.name);
+    cy.clickButton(/^Details$/);
+    cy.contains('#name', inventory.name);
+  });
+
+  it('deletes an inventory from the details page', () => {
+    cy.createAwxInventory().then((testInventory) => {
+      cy.navigateTo(/^Inventories$/, false);
+      cy.clickRow(testInventory.name);
+      cy.hasTitle(testInventory.name);
+      cy.clickPageAction(/^Delete inventory/);
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete inventory/);
+      cy.hasTitle(/^Inventories$/);
+      cy.requestDelete(`/api/v2/organizations/${testInventory.organization}/`, true);
+    });
+  });
+
+  it('copies an inventory from the details page', () => {
+    cy.navigateTo(/^Inventories$/, false);
+    cy.clickRow(inventory.name);
+    cy.hasTitle(inventory.name);
+    cy.clickPageAction(/^Copy inventory/);
+    cy.hasAlert(`${inventory.name} copied`);
   });
 
   it('test inventory with host and group', () => {

--- a/cypress/fixtures/inventory.json
+++ b/cypress/fixtures/inventory.json
@@ -1,0 +1,104 @@
+{
+  "id": 9,
+  "type": "inventory",
+  "url": "/api/v2/inventories/9/",
+  "related": {
+    "created_by": "/api/v2/users/1/",
+    "modified_by": "/api/v2/users/1/",
+    "hosts": "/api/v2/inventories/9/hosts/",
+    "groups": "/api/v2/inventories/9/groups/",
+    "root_groups": "/api/v2/inventories/9/root_groups/",
+    "variable_data": "/api/v2/inventories/9/variable_data/",
+    "script": "/api/v2/inventories/9/script/",
+    "tree": "/api/v2/inventories/9/tree/",
+    "inventory_sources": "/api/v2/inventories/9/inventory_sources/",
+    "update_inventory_sources": "/api/v2/inventories/9/update_inventory_sources/",
+    "activity_stream": "/api/v2/inventories/9/activity_stream/",
+    "job_templates": "/api/v2/inventories/9/job_templates/",
+    "ad_hoc_commands": "/api/v2/inventories/9/ad_hoc_commands/",
+    "access_list": "/api/v2/inventories/9/access_list/",
+    "object_roles": "/api/v2/inventories/9/object_roles/",
+    "instance_groups": "/api/v2/inventories/9/instance_groups/",
+    "copy": "/api/v2/inventories/9/copy/",
+    "labels": "/api/v2/inventories/9/labels/",
+    "organization": "/api/v2/organizations/1/"
+  },
+  "summary_fields": {
+    "organization": {
+      "id": 1,
+      "name": "Default",
+      "description": ""
+    },
+    "created_by": {
+      "id": 1,
+      "username": "awx",
+      "first_name": "",
+      "last_name": ""
+    },
+    "modified_by": {
+      "id": 1,
+      "username": "awx",
+      "first_name": "",
+      "last_name": ""
+    },
+    "object_roles": {
+      "admin_role": {
+        "description": "Can manage all aspects of the inventory",
+        "name": "Admin",
+        "id": 483
+      },
+      "update_role": {
+        "description": "May update the inventory",
+        "name": "Update",
+        "id": 484
+      },
+      "adhoc_role": {
+        "description": "May run ad hoc commands on the inventory",
+        "name": "Ad Hoc",
+        "id": 485
+      },
+      "use_role": {
+        "description": "Can use the inventory in a job template",
+        "name": "Use",
+        "id": 486
+      },
+      "read_role": {
+        "description": "May view settings for the inventory",
+        "name": "Read",
+        "id": 487
+      }
+    },
+    "user_capabilities": {
+      "edit": true,
+      "delete": true,
+      "copy": true,
+      "adhoc": true
+    },
+    "labels": {
+      "count": 0,
+      "results": [
+        {
+          "id": 1,
+          "name": "test label"
+        }
+      ]
+    }
+  },
+  "created": "2023-02-08T21:10:41.447053Z",
+  "modified": "2023-02-08T21:10:41.447067Z",
+  "name": "test inventory",
+  "description": "",
+  "organization": 1,
+  "kind": "",
+  "host_filter": null,
+  "variables": "---",
+  "has_active_failures": false,
+  "total_hosts": 1,
+  "hosts_with_active_failures": 0,
+  "total_groups": 0,
+  "has_inventory_sources": false,
+  "total_inventory_sources": 0,
+  "inventory_sources_with_failures": 0,
+  "pending_deletion": false,
+  "prevent_instance_group_fallback": false
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,14 +6,10 @@ import 'cypress-network-idle';
 import { randomString } from '../../framework/utils/random-string';
 import { Organization } from '../../frontend/awx/interfaces/Organization';
 import { Project } from '../../frontend/awx/interfaces/Project';
+import { Inventory } from '../../frontend/awx/interfaces/Inventory';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { User } from '../../frontend/awx/interfaces/User';
-import {
-  Group,
-  Host,
-  Inventory,
-  JobTemplate,
-} from '../../frontend/awx/interfaces/generated-from-swagger/api';
+import { Group, Host, JobTemplate } from '../../frontend/awx/interfaces/generated-from-swagger/api';
 import { EdaProject } from '../../frontend/eda/interfaces/EdaProject';
 import { EdaResult } from '../../frontend/eda/interfaces/EdaResult';
 import { EdaRulebook } from '../../frontend/eda/interfaces/EdaRulebook';

--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -50,7 +50,7 @@ export const RouteObj: { [key: string]: RouteType } = {
   EditProject: `${awxRoutePrefix}/projects/edit/:id`,
 
   Inventories: `${awxRoutePrefix}/inventories`,
-  InventoryDetails: `${awxRoutePrefix}/inventories/details/:id`,
+  InventoryDetails: `${awxRoutePrefix}/inventories/:inventory_type/details/:id`,
   CreateInventory: `${awxRoutePrefix}/inventories/create`,
   EditInventory: `${awxRoutePrefix}/inventories/edit/:id`,
 

--- a/frontend/awx/AwxRouter.tsx
+++ b/frontend/awx/AwxRouter.tsx
@@ -25,6 +25,7 @@ import { CreateCredential, EditCredential } from './resources/credentials/Creden
 import { CredentialPage } from './resources/credentials/CredentialPage/CredentialPage';
 import { Credentials } from './resources/credentials/Credentials';
 import { Hosts } from './resources/hosts/Hosts';
+import { InventoryPage } from './resources/inventories/InventoryPage/InventoryPage';
 import { Inventories } from './resources/inventories/Inventories';
 import { ProjectPage } from './resources/projects/ProjectPage/ProjectPage';
 import { Projects } from './resources/projects/Projects';
@@ -78,6 +79,7 @@ export function AwxRouter() {
         {/* <Route path={RouteObjWithoutPrefix.ProjectEdit} element={<ProjectEdit />} /> */}
 
         <Route path={RouteObjWithoutPrefix.Inventories} element={<Inventories />} />
+        <Route path={RouteObjWithoutPrefix.InventoryDetails} element={<InventoryPage />} />
 
         <Route path={RouteObjWithoutPrefix.Hosts} element={<Hosts />} />
 

--- a/frontend/awx/common/useVerbosityString.tsx
+++ b/frontend/awx/common/useVerbosityString.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+
+export function useVerbosityString(value: number | undefined) {
+  const { t } = useTranslation();
+
+  switch (value) {
+    case 0:
+      return t('0 (Normal)');
+    case 1:
+      return t('1 (Verbose)');
+    case 2:
+      return t('2 (More Verbose)');
+    case 3:
+      return t('3 (Debug)');
+    case 4:
+      return t('4 (Connection Debug)');
+    case 5:
+      return t('5 (WinRM Debug)');
+    default:
+      return '';
+  }
+}

--- a/frontend/awx/interfaces/Inventory.ts
+++ b/frontend/awx/interfaces/Inventory.ts
@@ -1,6 +1,78 @@
 import { Inventory as SwaggerInventory } from './generated-from-swagger/api';
+import {
+  SummaryFieldsByUser,
+  SummaryFieldsOrganization,
+  SummeryFieldObjectRole,
+} from './summary-fields/summary-fields';
+import { Label } from './Label';
 
-export interface Inventory extends Omit<SwaggerInventory, 'id' | 'name' | 'summary_fields'> {
+export interface CommonInventory
+  extends Omit<
+    SwaggerInventory,
+    'id' | 'name' | 'type' | 'kind' | 'summary_fields' | 'organization'
+  > {
   id: number;
   name: string;
+  type: 'inventory';
+  summary_fields: {
+    organization: SummaryFieldsOrganization;
+    created_by: SummaryFieldsByUser;
+    modified_by: SummaryFieldsByUser;
+    object_roles: {
+      admin_role: SummeryFieldObjectRole;
+      update_role: SummeryFieldObjectRole;
+      adhoc_role: SummeryFieldObjectRole;
+      use_role: SummeryFieldObjectRole;
+      read_role: SummeryFieldObjectRole;
+    };
+    user_capabilities: {
+      edit: boolean;
+      delete: boolean;
+      copy: boolean;
+      adhoc: boolean;
+    };
+  };
+  organization: number;
 }
+
+export interface ConstructedInventory extends CommonInventory {
+  kind: 'constructed';
+  source_vars: string;
+  update_cache_timeout: number;
+  limit: string;
+  verbosity: number;
+  summary_fields: {
+    organization: SummaryFieldsOrganization;
+    created_by: SummaryFieldsByUser;
+    modified_by: SummaryFieldsByUser;
+    object_roles: {
+      admin_role: SummeryFieldObjectRole;
+      update_role: SummeryFieldObjectRole;
+      adhoc_role: SummeryFieldObjectRole;
+      use_role: SummeryFieldObjectRole;
+      read_role: SummeryFieldObjectRole;
+    };
+    user_capabilities: {
+      edit: boolean;
+      delete: boolean;
+      copy: boolean;
+      adhoc: boolean;
+    };
+    labels: {
+      count: number;
+      results: Label[];
+    };
+  };
+}
+
+export interface RegularInventory extends CommonInventory {
+  kind: '';
+  verbosity?: never;
+}
+
+export interface SmartInventory extends CommonInventory {
+  kind: 'smart';
+  verbosity?: never;
+}
+
+export type Inventory = RegularInventory | ConstructedInventory | SmartInventory;

--- a/frontend/awx/interfaces/Inventory.ts
+++ b/frontend/awx/interfaces/Inventory.ts
@@ -31,6 +31,10 @@ export interface CommonInventory
       copy: boolean;
       adhoc: boolean;
     };
+    labels: {
+      count: number;
+      results: Label[];
+    };
   };
   organization: number;
 }
@@ -41,28 +45,6 @@ export interface ConstructedInventory extends CommonInventory {
   update_cache_timeout: number;
   limit: string;
   verbosity: number;
-  summary_fields: {
-    organization: SummaryFieldsOrganization;
-    created_by: SummaryFieldsByUser;
-    modified_by: SummaryFieldsByUser;
-    object_roles: {
-      admin_role: SummeryFieldObjectRole;
-      update_role: SummeryFieldObjectRole;
-      adhoc_role: SummeryFieldObjectRole;
-      use_role: SummeryFieldObjectRole;
-      read_role: SummeryFieldObjectRole;
-    };
-    user_capabilities: {
-      edit: boolean;
-      delete: boolean;
-      copy: boolean;
-      adhoc: boolean;
-    };
-    labels: {
-      count: number;
-      results: Label[];
-    };
-  };
 }
 
 export interface RegularInventory extends CommonInventory {

--- a/frontend/awx/interfaces/WorkflowJobTemplate.ts
+++ b/frontend/awx/interfaces/WorkflowJobTemplate.ts
@@ -21,7 +21,20 @@ export interface WorkflowJobTemplate
       cloud: boolean;
       credential_type_id: number;
     };
-    inventory?: { name: string; id: number };
+    inventory?: {
+      name: string;
+      id: number;
+      description: string;
+      has_active_failures: boolean;
+      total_hosts: number;
+      hosts_with_active_failures: number;
+      total_groups: number;
+      has_inventory_sources: boolean;
+      total_inventory_sources: number;
+      inventory_sources_with_failures: number;
+      organization_id: number;
+      kind: '' | 'smart' | 'constructed';
+    };
     organization?: {
       id: string;
       name: string;

--- a/frontend/awx/resources/inventories/Inventories.tsx
+++ b/frontend/awx/resources/inventories/Inventories.tsx
@@ -107,9 +107,21 @@ export function useInventoriesFilters() {
 
 export function useInventoriesColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const navigate = useNavigate();
+
   const nameClick = useCallback(
-    (inventory: Inventory) =>
-      navigate(RouteObj.InventoryDetails.replace(':id', inventory.id.toString())),
+    (inventory: Inventory) => {
+      const kinds: { [key: string]: string } = {
+        '': 'inventory',
+        smart: 'smart_inventory',
+        constructed: 'constructed_inventory',
+      };
+      return navigate(
+        RouteObj.InventoryDetails.replace(':inventory_type', kinds[inventory.kind]).replace(
+          ':id',
+          inventory.id.toString()
+        )
+      );
+    },
     [navigate]
   );
   const nameColumn = useNameColumn({

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable i18next/no-literal-string */
+import { Inventory } from '../../../interfaces/Inventory';
+import { InventoryDetails } from './InventoryDetails';
+
+describe('InventoryDetails', () => {
+  it('Component renders and displays inventory', () => {
+    cy.fixture('inventory').then((inventory: Inventory) => {
+      cy.mount(<InventoryDetails inventory={inventory} />);
+      cy.get('#name').should('have.text', 'test inventory');
+      cy.get('#type').should('have.text', 'Inventory');
+      cy.get('#organization').should('have.text', 'Default');
+      cy.contains('a', 'Default').should('have.attr', 'href', '/ui_next/organizations/details/1');
+      cy.get('#total-hosts').should('have.text', '1');
+      cy.get('#labels').should('have.text', 'test label');
+      cy.get(
+        '#created > .pf-c-description-list__text > [style="white-space: nowrap;"] > .pf-c-button'
+      ).should('have.text', 'awx');
+      cy.get(
+        '#last-modified > .pf-c-description-list__text > [style="white-space: nowrap;"] > .pf-c-button'
+      ).should('have.text', 'awx');
+    });
+  });
+});

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
@@ -1,0 +1,183 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  Label,
+  LabelGroup,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
+import { DateTimeCell, PageDetail, PageDetails, TextCell } from '../../../../../framework';
+import { useGet } from '../../../../common/crud/useGet';
+import { RouteObj } from '../../../../Routes';
+import { InstanceGroup } from '../../../interfaces/InstanceGroup';
+import { Inventory } from '../../../interfaces/Inventory';
+import { useVerbosityString } from '../../../common/useVerbosityString';
+
+function useInstanceGroups(inventoryId: string) {
+  const { data } = useGet<{ results: InstanceGroup[] }>(
+    `/api/v2/inventories/${inventoryId}/instance_groups/`
+  );
+  return data?.results ?? [];
+}
+
+export function InventoryDetails(props: { inventory: Inventory }) {
+  const { t } = useTranslation();
+  const { inventory } = props;
+  const history = useNavigate();
+  const params = useParams<{ id: string }>();
+  const instanceGroups = useInstanceGroups(params.id || '0');
+  const verbosityString = useVerbosityString(inventory.verbosity);
+
+  const { data: inputInventories, error: inputInventoriesError } = useGet<{ results: Inventory[] }>(
+    inventory.kind === 'constructed'
+      ? `/api/v2/inventories/${inventory.id}/input_inventories/`
+      : undefined
+  );
+
+  const inventoryTypes: { [key: string]: string } = {
+    '': t('Inventory'),
+    smart: t('Smart inventory'),
+    constructed: t('Constructed inventory'),
+  };
+
+  const inventoryUrlPaths: { [key: string]: string } = {
+    '': 'inventory',
+    smart: 'smart_inventory',
+    constructed: 'constructed_inventory',
+  };
+
+  return (
+    <PageDetails>
+      <PageDetail label={t('Name')}>{inventory.name}</PageDetail>
+      <PageDetail label={t('Description')}>{inventory.description}</PageDetail>
+      <PageDetail label={t('Type')}>{inventoryTypes[inventory.kind]}</PageDetail>
+      <PageDetail label={t('Organization')}>
+        <TextCell
+          text={inventory.summary_fields?.organization?.name}
+          to={RouteObj.OrganizationDetails.replace(
+            ':id',
+            (inventory.summary_fields?.organization?.id ?? '').toString()
+          )}
+        />
+      </PageDetail>
+      <PageDetail label={t('Smart host filter')} isEmpty={inventory.kind !== 'smart'}>
+        <LabelGroup>
+          <Label>{inventory.host_filter}</Label>
+        </LabelGroup>
+      </PageDetail>
+      <PageDetail label={t('Total hosts')}>{inventory.total_hosts}</PageDetail>
+      <PageDetail label={t('Hosts with active failures')}>
+        {inventory.hosts_with_active_failures}
+      </PageDetail>
+      <PageDetail label={t('Total groups')}>{inventory.total_groups}</PageDetail>
+      <PageDetail label={t('Total inventory sources')}>
+        {inventory.total_inventory_sources}
+      </PageDetail>
+      <PageDetail label={t('Inventory sources with active failures')}>
+        {inventory.inventory_sources_with_failures}
+      </PageDetail>
+      {inventory.kind === 'constructed' && (
+        <>
+          <PageDetail label={t('Limit')}>{inventory.limit}</PageDetail>
+          <PageDetail label={t('Verbosity')}>{verbosityString}</PageDetail>
+          <PageDetail label={t('Update cache timeout')}>
+            {inventory.update_cache_timeout}
+          </PageDetail>
+        </>
+      )}
+      <PageDetail label={t`Instance groups`} isEmpty={instanceGroups.length === 0}>
+        <LabelGroup>
+          {instanceGroups.map((ig) => (
+            <Label color="blue" key={ig.id}>
+              <Link to={RouteObj.InstanceGroupDetails.replace(':id', (ig.id ?? 0).toString())}>
+                {ig.name}
+              </Link>
+            </Label>
+          ))}
+        </LabelGroup>
+      </PageDetail>
+      <PageDetail
+        label={t`Input inventories`}
+        isEmpty={
+          typeof inputInventoriesError === 'undefined' &&
+          (!inputInventories || inputInventories?.results.length === 0)
+        }
+      >
+        {inputInventoriesError ? (
+          t`There was an error fetching the input inventories`
+        ) : (
+          <LabelGroup>
+            {inputInventories?.results.map((inventory) => (
+              <Label color="blue" key={inventory.id}>
+                <Link
+                  to={RouteObj.InventoryDetails.replace(
+                    ':inventory_type',
+                    inventoryUrlPaths[inventory.kind]
+                  ).replace(':id', (inventory.id ?? 0).toString())}
+                >
+                  {inventory.name}
+                </Link>
+              </Label>
+            ))}
+          </LabelGroup>
+        )}
+      </PageDetail>
+      {inventory.kind === 'constructed' && (
+        <PageDetail
+          label={t`Labels`}
+          isEmpty={inventory.summary_fields.labels.results.length === 0}
+        >
+          <LabelGroup>
+            {inventory.summary_fields.labels.results.map((label) => (
+              <Label color="blue" key={label.id}>
+                {label.name}
+              </Label>
+            ))}
+          </LabelGroup>
+        </PageDetail>
+      )}
+      <PageDetail label={t('Created')}>
+        <DateTimeCell
+          format="since"
+          value={inventory.created}
+          author={inventory.summary_fields?.created_by?.username}
+          onClick={() =>
+            history(
+              RouteObj.UserDetails.replace(
+                ':id',
+                (inventory.summary_fields?.created_by?.id ?? 0).toString()
+              )
+            )
+          }
+        />
+      </PageDetail>
+      <PageDetail label={t('Last modified')}>
+        <DateTimeCell
+          format="since"
+          value={inventory.modified}
+          author={inventory.summary_fields?.modified_by?.username}
+          onClick={() =>
+            history(
+              RouteObj.UserDetails.replace(
+                ':id',
+                (inventory.summary_fields?.modified_by?.id ?? 0).toString()
+              )
+            )
+          }
+        />
+      </PageDetail>
+      <PageDetail label={t('Enabled options')} isEmpty={!inventory.prevent_instance_group_fallback}>
+        <TextList component={TextListVariants.ul}>
+          {inventory.prevent_instance_group_fallback && (
+            <TextListItem component={TextListItemVariants.li}>
+              {t`Prevent instance group fallback`}
+            </TextListItem>
+          )}
+        </TextList>
+      </PageDetail>
+    </PageDetails>
+  );
+}

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
@@ -125,20 +125,15 @@ export function InventoryDetails(props: { inventory: Inventory }) {
           </LabelGroup>
         )}
       </PageDetail>
-      {inventory.kind === 'constructed' && (
-        <PageDetail
-          label={t`Labels`}
-          isEmpty={inventory.summary_fields.labels.results.length === 0}
-        >
-          <LabelGroup>
-            {inventory.summary_fields.labels.results.map((label) => (
-              <Label color="blue" key={label.id}>
-                {label.name}
-              </Label>
-            ))}
-          </LabelGroup>
-        </PageDetail>
-      )}
+      <PageDetail label={t`Labels`} isEmpty={inventory.summary_fields.labels.results.length === 0}>
+        <LabelGroup>
+          {inventory.summary_fields.labels.results.map((label) => (
+            <Label color="blue" key={label.id}>
+              {label.name}
+            </Label>
+          ))}
+        </LabelGroup>
+      </PageDetail>
       <PageDetail label={t('Created')}>
         <DateTimeCell
           format="since"

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryPage.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryPage.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DropdownPosition } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PageActions, PageHeader, PageLayout, PageTab, PageTabs } from '../../../../../framework';
+import { useGet } from '../../../../common/crud/useGet';
+import { RouteObj } from '../../../../Routes';
+import { Inventory } from '../../../interfaces/Inventory';
+import { useInventoryActions } from '../hooks/useInventoryActions';
+import { InventoryDetails } from './InventoryDetails';
+
+export function InventoryPage() {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string; inventory_type: string }>();
+  const inventory = useGetInventory(params.id, params.inventory_type);
+  const navigate = useNavigate();
+  const itemActions = useInventoryActions({
+    onInventoriesDeleted: () => navigate(RouteObj.Inventories),
+  });
+  return (
+    <PageLayout>
+      <PageHeader
+        title={inventory?.name}
+        breadcrumbs={[
+          { label: t('Inventories'), to: RouteObj.Inventories },
+          { label: inventory?.name },
+        ]}
+        headerActions={
+          <PageActions<Inventory>
+            actions={itemActions}
+            position={DropdownPosition.right}
+            selectedItem={inventory}
+          />
+        }
+      />
+      <PageTabs loading={!inventory}>
+        <PageTab label={t('Details')}>
+          <InventoryDetails inventory={inventory!} />
+        </PageTab>
+        <PageTab label={t('Access')}>TODO</PageTab>
+        {inventory?.kind !== 'smart' && <PageTab label={t('Groups')}>TODO</PageTab>}
+        <PageTab label={t('Hosts')}>TODO</PageTab>
+        {inventory?.kind !== 'constructed' && <PageTab label={t('Sources')}>TODO</PageTab>}
+        <PageTab label={t('Jobs')}>TODO</PageTab>
+        <PageTab label={t('Job Templates')}>TODO</PageTab>
+      </PageTabs>
+    </PageLayout>
+  );
+}
+
+function useGetInventory(id?: string, inventory_type?: string) {
+  const path =
+    inventory_type === 'constructed_inventory' ? 'constructed_inventories' : 'inventories';
+  const { data: job } = useGet<Inventory>(id ? `/api/v2/${path}/${id}/` : '');
+  return job;
+}

--- a/frontend/awx/resources/inventories/hooks/useInventoryActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoryActions.tsx
@@ -1,0 +1,85 @@
+import { AlertProps, ButtonVariant } from '@patternfly/react-core';
+import { CopyIcon, EditIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { IPageAction, PageActionType, usePageAlertToaster } from '../../../../../framework';
+import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { RouteObj } from '../../../../Routes';
+import { Inventory } from '../../../interfaces/Inventory';
+import { useDeleteInventories } from './useDeleteInventories';
+
+export function useInventoryActions(options: {
+  onInventoriesDeleted: (inventories: Inventory[]) => void;
+}) {
+  const { onInventoriesDeleted } = options;
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const postRequest = usePostRequest();
+  const deleteInventories = useDeleteInventories(onInventoriesDeleted);
+  const alertToaster = usePageAlertToaster();
+
+  return useMemo<IPageAction<Inventory>[]>(() => {
+    const cannotDeleteInventory = (inventory: Inventory) =>
+      inventory?.summary_fields?.user_capabilities?.delete
+        ? ''
+        : t(`The inventory cannot be deleted due to insufficient permission`);
+    const cannotEditInventory = (inventory: Inventory) =>
+      inventory?.summary_fields?.user_capabilities?.edit
+        ? ''
+        : t(`The inventory cannot be edited due to insufficient permission`);
+    const cannotCopyInventory = (inventory: Inventory) =>
+      inventory?.summary_fields?.user_capabilities?.copy
+        ? ''
+        : t(`The inventory cannot be copied due to insufficient permission`);
+
+    return [
+      {
+        type: PageActionType.single,
+        variant: ButtonVariant.primary,
+        icon: EditIcon,
+        label: t('Edit inventory'),
+        isDisabled: (inventory: Inventory) => cannotEditInventory(inventory),
+        onClick: (inventory) =>
+          navigate(RouteObj.EditInventory.replace(':id', inventory.id.toString())),
+      },
+      {
+        type: PageActionType.single,
+        icon: CopyIcon,
+        label: t('Copy inventory'),
+        isDisabled: (inventory: Inventory) => cannotCopyInventory(inventory),
+        onClick: (inventory: Inventory) => {
+          const alert: AlertProps = {
+            variant: 'success',
+            title: t(`${inventory.name} copied.`),
+            timeout: 2000,
+          };
+          postRequest(`/api/v2/inventories/${inventory?.id ?? 0}/copy/`, {
+            name: `${inventory.name} @ ${new Date()
+              .toTimeString()
+              .replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1')}`,
+          })
+            .then(() => {
+              alertToaster.addAlert(alert);
+            })
+            .catch((error) => {
+              alertToaster.replaceAlert(alert, {
+                variant: 'danger',
+                title: t('Failed to copy inventory'),
+                children: error instanceof Error && error.message,
+              });
+            });
+        },
+      },
+      { type: PageActionType.seperator },
+      {
+        type: PageActionType.single,
+        icon: TrashIcon,
+        label: t('Delete inventory'),
+        isDisabled: (inventory: Inventory) => cannotDeleteInventory(inventory),
+        onClick: (inventory) => deleteInventories([inventory]),
+        isDanger: true,
+      },
+    ];
+  }, [alertToaster, deleteInventories, navigate, postRequest, t]);
+}

--- a/frontend/awx/resources/templates/TemplateDetail.tsx
+++ b/frontend/awx/resources/templates/TemplateDetail.tsx
@@ -29,6 +29,7 @@ import { useGetItem } from '../../../common/crud/useGetItem';
 import { RouteObj } from '../../../Routes';
 import { AwxError } from '../../common/AwxError';
 import { UserDateDetail } from '../../common/UserDateDetail';
+import { useVerbosityString } from '../../common/useVerbosityString';
 import { handleLaunch } from '../../common/util/launchHandlers';
 import { JobTemplate } from '../../interfaces/JobTemplate';
 import { useDeleteTemplates } from './hooks/useDeleteTemplates';
@@ -136,26 +137,6 @@ export function TemplateDetail() {
   );
 }
 
-// TODO centralize this utility somewhere
-const VERBOSITY = (t: (arg0: string) => string, value: number): string => {
-  switch (value) {
-    case 0:
-      return t('0 (Normal)');
-    case 1:
-      return t('1 (Verbose)');
-    case 2:
-      return t('2 (More Verbose)');
-    case 3:
-      return t('3 (Debug)');
-    case 4:
-      return t('4 (Connection Debug)');
-    case 5:
-      return t('5 (WinRM Debug)');
-    default:
-      return '';
-  }
-};
-
 function TemplateDetailsTab(props: { template: JobTemplate }) {
   const { t } = useTranslation();
   const { template } = props;
@@ -168,6 +149,12 @@ function TemplateDetailsTab(props: { template: JobTemplate }) {
     template.use_fact_cache ||
     template.webhook_service ||
     template.prevent_instance_group_fallback;
+
+  const inventoryUrlPaths: { [key: string]: string } = {
+    '': 'inventory',
+    smart: 'smart_inventory',
+    constructed: 'constructed_inventory',
+  };
 
   return (
     <PageDetails>
@@ -187,9 +174,9 @@ function TemplateDetailsTab(props: { template: JobTemplate }) {
       <PageDetail label={t('Inventory')} isEmpty={!summaryFields.inventory}>
         <Link
           to={RouteObj.InventoryDetails.replace(
-            ':id',
-            summaryFields.inventory?.id.toString() ?? ''
-          )}
+            ':inventory_type',
+            inventoryUrlPaths[summaryFields.inventory.kind]
+          ).replace(':id', summaryFields.inventory?.id.toString() ?? '')}
         >
           {summaryFields.inventory?.name}
         </Link>
@@ -216,7 +203,7 @@ function TemplateDetailsTab(props: { template: JobTemplate }) {
       <PageDetail label={t('Playbook')}>{template.playbook}</PageDetail>
       <PageDetail label={t('Forks')}>{template.forks || 0}</PageDetail>
       <PageDetail label={t('Limit')}>{template.limit}</PageDetail>
-      <PageDetail label={t('Verbosity')}>{VERBOSITY(t, template.verbosity)}</PageDetail>
+      <PageDetail label={t('Verbosity')}>{useVerbosityString(template.verbosity)}</PageDetail>
       <PageDetail label={t('Timeout')}>{template.timeout || 0}</PageDetail>
       <PageDetail label={t('Show changes')}>{template.diff_mode ? t`On` : t`Off`}</PageDetail>
       <PageDetail label={t('Job slicing')}>{template.job_slice_count}</PageDetail>

--- a/frontend/awx/resources/templates/WorkflowJobTemplateDetail.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateDetail.tsx
@@ -124,6 +124,12 @@ function TemplateDetailsTab(props: { template: WorkflowJobTemplate }) {
 
   const showOptionsField = template.allow_simultaneous || template.webhook_service;
 
+  const inventoryUrlPaths: { [key: string]: string } = {
+    '': 'inventory',
+    smart: 'smart_inventory',
+    constructed: 'constructed_inventory',
+  };
+
   return (
     <PageDetails>
       <PageDetail label={t('Name')}>{template.name}</PageDetail>
@@ -142,9 +148,9 @@ function TemplateDetailsTab(props: { template: WorkflowJobTemplate }) {
       <PageDetail label={t('Inventory')} isEmpty={!summaryFields.inventory}>
         <Link
           to={RouteObj.InventoryDetails.replace(
-            ':id',
-            summaryFields.inventory?.id.toString() ?? ''
-          )}
+            ':inventory_type',
+            inventoryUrlPaths[summaryFields.inventory?.kind || '']
+          ).replace(':id', summaryFields.inventory?.id.toString() ?? '')}
         >
           {summaryFields.inventory?.name}
         </Link>

--- a/frontend/awx/views/jobs/JobExpanded.tsx
+++ b/frontend/awx/views/jobs/JobExpanded.tsx
@@ -33,6 +33,11 @@ export function JobExpanded(job: UnifiedJob) {
     () => (job.summary_fields?.schedule ? getScheduleUrl(job) ?? '' : ''),
     [job]
   );
+  const inventoryUrlPaths: { [key: string]: string } = {
+    '': 'inventory',
+    smart: 'smart_inventory',
+    constructed: 'constructed_inventory',
+  };
 
   return (
     <PageDetails disablePadding>
@@ -89,13 +94,12 @@ export function JobExpanded(job: UnifiedJob) {
         </PageDetail>
       )}
       {job.summary_fields?.inventory && (
-        // TODO - update route to inventory details based on inventory kind (smart/constructed)
         <PageDetail label={t`Inventory`}>
           <Link
             to={RouteObj.InventoryDetails.replace(
-              ':id',
-              job.summary_fields?.inventory.id.toString()
-            )}
+              ':inventory_type',
+              inventoryUrlPaths[job.summary_fields?.inventory.kind]
+            ).replace(':id', job.summary_fields?.inventory.id.toString())}
           >
             {job.summary_fields?.inventory.name}
           </Link>


### PR DESCRIPTION
Add support for inventory details view in AWX.  Currently missing from the implementation is:

1) The Variables detail which will come in a follow-on PR

Regular inventory:
<img width="1722" alt="Screenshot 2023-03-31 at 10 41 48 AM" src="https://user-images.githubusercontent.com/9889020/229152188-5b53ed54-a414-4e34-8ca6-dc23d788d6ca.png">

Smart inventory:
<img width="1726" alt="Screenshot 2023-03-31 at 10 42 10 AM" src="https://user-images.githubusercontent.com/9889020/229152269-e828dfae-32cf-45db-bcca-e714c9564cc5.png">

Constructed inventory:
<img width="1728" alt="Screenshot 2023-03-31 at 10 42 35 AM" src="https://user-images.githubusercontent.com/9889020/229152374-219394fb-4f27-4e9f-ab72-a1687176ff7e.png">

One open question that I had was around handling the replacing the :inventory_type in the route.  I copy/pasted the mapping in several places but wasn't sure if that was a best practice or if there was a way to make that generic and reusable.