### PR TITLE
E2E login updates for testing EDA

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -5,6 +5,7 @@
   "EDA_SERVER": "http://localhost:8000/",
   "EDA_USERNAME": "testuser",
   "EDA_PASSWORD": "testpass",
+  "TEST_STANDALONE": "false",
   "HUB_SERVER": "http://localhost:5001/",
   "HUB_USERNAME": "admin",
   "HUB_PASSWORD": "admin"

--- a/cypress/CYPRESS.md
+++ b/cypress/CYPRESS.md
@@ -40,12 +40,12 @@ graph LR;
 
    ##### EDA
 
-   | Environment Variable      | Description                                                                                                                          |
-   | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-   | `CYPRESS_EDA_SERVER`      | URL of the EDA server to run E2E tests against. `Default: <https://localhost:8000>`                                                  |
-   | `CYPRESS_EDA_USERNAME`    | username for logging into the EDA server. `Default: testuser`                                                                        |
-   | `CYPRESS_EDA_PASSWORD`    | password for logging into the EDA server. `Default: testpass`                                                                        |
-   | `CYPRESS_TEST_STANDALONE` | flag to indicate if EDA UI should be tested standalone. (Login via route `/login` instead of `/automation-servers`) `Default: false` |
+   | Environment Variable      | Description                                                                                                                      |
+   | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+   | `CYPRESS_EDA_SERVER`      | URL of the EDA server to run E2E tests against. `Default: <https://localhost:8000>`                                              |
+   | `CYPRESS_EDA_USERNAME`    | username for logging into the EDA server. `Default: testuser`                                                                    |
+   | `CYPRESS_EDA_PASSWORD`    | password for logging into the EDA server. `Default: testpass`                                                                    |
+   | `CYPRESS_TEST_STANDALONE` | flag to indicate if UI should be tested standalone. (Login via route `/login` instead of `/automation-servers`) `Default: false` |
 
 2. Run the Ansible-UI frontend and proxy
 

--- a/cypress/CYPRESS.md
+++ b/cypress/CYPRESS.md
@@ -26,8 +26,9 @@ graph LR;
 ### E2E Getting started
 
 1. Setup Environment Variables
+   <br>The E2E tests need a live API to test against. The following environment variables can be used to setup the E2E test server.
 
-   The E2E tests need a live API to test against. The following environment variables can be used to setup the E2E test server.
+   ##### AWX
 
    | Environment Variable   | Description                                                                         |
    | ---------------------- | ----------------------------------------------------------------------------------- |
@@ -36,6 +37,15 @@ graph LR;
    | `CYPRESS_AWX_PASSWORD` | password for logging into the AWX server. `Default: admin`                          |
 
    > NOTE: Running AWX API locally defaults to <https://localhost:8043> which easily allows running E2E test against it.
+
+   ##### EDA
+
+   | Environment Variable      | Description                                                                                                                          |
+   | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+   | `CYPRESS_EDA_SERVER`      | URL of the EDA server to run E2E tests against. `Default: <https://localhost:8000>`                                                  |
+   | `CYPRESS_EDA_USERNAME`    | username for logging into the EDA server. `Default: testuser`                                                                        |
+   | `CYPRESS_EDA_PASSWORD`    | password for logging into the EDA server. `Default: testpass`                                                                        |
+   | `CYPRESS_TEST_STANDALONE` | flag to indicate if EDA UI should be tested standalone. (Login via route `/login` instead of `/automation-servers`) `Default: false` |
 
 2. Run the Ansible-UI frontend and proxy
 
@@ -54,7 +64,7 @@ graph LR;
    Open the Cypress UI to run e2e tests
 
    ```
-   npm run cypress:open:e2e
+   npm run cypress:open
    ```
 
 ## Component Testing
@@ -68,7 +78,7 @@ npm run cypress:run:component
 Open the Cypress UI to run component tests
 
 ```
-npm run cypress:open:component
+npm run cypress:open
 ```
 
 ## Coverage

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -79,6 +79,18 @@ Cypress.Commands.add(
     window.localStorage.setItem('theme', 'light');
     window.localStorage.setItem('disclaimer', 'true');
 
+    if (serverType === 'EDA server' && Cypress.env('TEST_STANDALONE') === true) {
+      // Standalone EDA login
+      cy.visit(`/login`, {
+        retryOnStatusCodeFailure: true,
+        retryOnNetworkFailure: true,
+      });
+      cy.typeByLabel(/^Username$/, username);
+      cy.typeByLabel(/^Password$/, password);
+      cy.get('button[type=submit]').click();
+      return;
+    }
+
     cy.visit(`/automation-servers`, {
       retryOnStatusCodeFailure: true,
       retryOnNetworkFailure: true,


### PR DESCRIPTION
Updates the login steps for testing EDA standalone. (login via `/login` route instead of `/automation-servers)`

To test:
```bash
# EDA server & credentials
export CYPRESS_EDA_SERVER=
export CYPRESS_EDA_USERNAME=
export CYPRESS_EDA_PASSWORD=

# Base URL to test EDA frontend      
export CYPRESS_BASE_URL=
# Flag to test EDA standalone
export CYPRESS_TEST_STANDALONE=true

npm run cypress:open
```