### PR TITLE
Fix job launch redirect url

### DIFF
--- a/frontend/awx/AwxRouter.tsx
+++ b/frontend/awx/AwxRouter.tsx
@@ -57,7 +57,7 @@ export function AwxRouter() {
         {/* <Route path={RouteObjWithoutPrefix.Schedules} element={<Schedules />} /> */}
         {/* <Route path={RouteObjWithoutPrefix.ActivityStream} element={<ActivityStreeam />} /> */}
         {/* <Route path={RouteObjWithoutPrefix.WorkflowApprovals} element={<WorkflowApprovals />} /> */}
-        <Route path={RouteObjWithoutPrefix.JobDetails} element={<JobPage />} />
+        <Route path={RouteObjWithoutPrefix.JobOutput} element={<JobPage />} />
 
         <Route path={RouteObjWithoutPrefix.Templates} element={<Templates />} />
         <Route path={RouteObjWithoutPrefix.JobTemplateDetails} element={<TemplateDetail />} />

--- a/frontend/awx/resources/templates/TemplateDetail.tsx
+++ b/frontend/awx/resources/templates/TemplateDetail.tsx
@@ -32,6 +32,7 @@ import { UserDateDetail } from '../../common/UserDateDetail';
 import { handleLaunch } from '../../common/util/launchHandlers';
 import { JobTemplate } from '../../interfaces/JobTemplate';
 import { useDeleteTemplates } from './hooks/useDeleteTemplates';
+import { getJobOutputUrl } from '../../views/jobs/jobUtils';
 
 export function TemplateDetail() {
   const { t } = useTranslation();
@@ -77,10 +78,10 @@ export function TemplateDetail() {
         label: t('Launch template'),
         onClick: async (template) => {
           try {
-            const data = await handleLaunch(template?.type as string, template?.id);
-            let jobOutputRoute = RouteObj.JobOutput.replace(':job_type', data?.type as string);
-            jobOutputRoute = jobOutputRoute.replace(':id', data?.id.toString() as string);
-            navigate(jobOutputRoute);
+            const job = await handleLaunch(template?.type as string, template?.id);
+            if (job) {
+              navigate(getJobOutputUrl(job));
+            }
           } catch {
             // handle error
           }

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
+import { Banner } from '@patternfly/react-core';
+import { Trans } from 'react-i18next';
 import { Job } from '../../../interfaces/Job';
 import './JobOutput.css';
 import { JobOutputLoadingRow } from './JobOutputLoadingRow';
@@ -78,6 +80,16 @@ export function JobOutputEvents(props: { job: Job }) {
         </LabelGroup>
       </PageSection>
       <Divider /> */}
+      {isJobRunning ? (
+        <Banner variant="warning">
+          <Trans>
+            <p>
+              This job is currently running. Live event streaming has not been added yet to the tech
+              preview.
+            </p>
+          </Trans>
+        </Banner>
+      ) : null}
       <div
         ref={containerRef}
         style={{

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -7,6 +7,7 @@ import { RouteObj } from '../../../Routes';
 import { Job } from '../../interfaces/Job';
 import { JobDetails } from './JobDetails';
 import { JobOutput } from './JobOutput/JobOutput';
+import { WorkflowOutput } from './WorkflowOutput';
 
 export function JobPage() {
   const { t } = useTranslation();
@@ -21,7 +22,7 @@ export function JobPage() {
       />
       <PageTabs loading={!job}>
         <PageTab label={t('Output')}>
-          <JobOutput job={job!} />
+          {job?.type === 'workflow_job' ? <WorkflowOutput job={job} /> : <JobOutput job={job!} />}
         </PageTab>
         <PageTab label={t('Details')}>
           <JobDetails job={job!} />

--- a/frontend/awx/views/jobs/WorkflowOutput.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutput.tsx
@@ -1,0 +1,6 @@
+import { Job } from '../../interfaces/Job';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function WorkflowOutput(props: { job: Job }) {
+  return null;
+}

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
 import { ElapsedTimeCell } from '../../../../../framework/PageCells/ElapsedTimeCell';
 import { StatusCell } from '../../../../common/StatusCell';
-import { RouteObj } from '../../../../Routes';
+import { getJobOutputUrl } from '../jobUtils';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
 
 export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
@@ -21,21 +21,10 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       {
         header: t('Name'),
         cell: (job: UnifiedJob) => {
-          const paths: { [key: string]: string } = {
-            project_update: 'project',
-            inventory_update: 'inventory',
-            job: 'playbook',
-            ad_hoc_command: 'command',
-            system_job: 'management',
-            workflow_job: 'workflow',
-          };
           return (
             <TextCell
               text={job.name}
-              to={RouteObj.JobDetails.replace(':job_type', paths[job.type]).replace(
-                ':id',
-                job.id.toString()
-              )}
+              to={getJobOutputUrl(job)}
               disableLinks={options?.disableLinks}
             />
           );

--- a/frontend/awx/views/jobs/jobUtils.tsx
+++ b/frontend/awx/views/jobs/jobUtils.tsx
@@ -1,4 +1,5 @@
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
+import { RouteObj } from '../../../Routes';
 
 /** Returns the jobs API endpoint based on the job type */
 export function getJobsAPIUrl(type: string) {
@@ -37,4 +38,19 @@ export function getRelaunchEndpoint(job: UnifiedJob) {
     case 'project_update':
       return job.project ? `/api/v2/projects/${job.project}/update/` : undefined;
   }
+}
+
+const jobPaths: { [key: string]: string } = {
+  project_update: 'project',
+  inventory_update: 'inventory',
+  job: 'playbook',
+  ad_hoc_command: 'command',
+  system_job: 'management',
+  workflow_job: 'workflow',
+};
+export function getJobOutputUrl(job: UnifiedJob) {
+  return RouteObj.JobOutput.replace(':job_type', jobPaths[job.type]).replace(
+    ':id',
+    job.id.toString()
+  );
 }


### PR DESCRIPTION
* Fixes the job launch to redirect to the correct job output URL
* Adds helper util for generating job urls based on job type
* Adds a banner to the job output page if a job is running, indicating live events are not yet supported

![Screenshot 2023-03-29 at 4 03 14 PM](https://user-images.githubusercontent.com/410794/228691454-fc9699e1-6c2b-4686-a7e6-e06257716b6a.png)
