### PR TITLE
Formatting job 'started' and 'finished' times

### DIFF
--- a/framework/PageCells/DateTimeCell.tsx
+++ b/framework/PageCells/DateTimeCell.tsx
@@ -2,6 +2,7 @@ import { Button, Split, SplitItem } from '@patternfly/react-core';
 import { DateTime } from 'luxon';
 import { useEffect, useState } from 'react';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { formatDateString } from '../utils/formatDateString';
 
 export function DateCell(props: { value: number | string }) {
   const date = new Date(props.value);
@@ -16,26 +17,32 @@ export function DateCell(props: { value: number | string }) {
 export function SinceCell(props: {
   value: string | number | undefined | null;
   author?: string;
+  format?: 'since' | 'date-time';
   onClick?: () => void;
 }) {
   const [translations] = useFrameworkTranslations();
   const { author, onClick } = props;
   const [dateTime, setDateTime] = useState<string | null>(null);
   useEffect(() => {
-    if (typeof props.value === 'number') {
-      setDateTime(DateTime.fromMillis(props.value).toRelative());
-    } else if (props.value) {
-      setDateTime(DateTime.fromISO(props.value).toRelative());
-    }
-    const timeout = setInterval(() => {
+    if (props.format === 'date-time' && typeof props.value === 'string') {
+      setDateTime(formatDateString(props.value));
+      return;
+    } else {
       if (typeof props.value === 'number') {
         setDateTime(DateTime.fromMillis(props.value).toRelative());
       } else if (props.value) {
         setDateTime(DateTime.fromISO(props.value).toRelative());
       }
-    }, 1000);
-    return () => clearTimeout(timeout);
-  }, [props.value]);
+      const timeout = setInterval(() => {
+        if (typeof props.value === 'number') {
+          setDateTime(DateTime.fromMillis(props.value).toRelative());
+        } else if (props.value) {
+          setDateTime(DateTime.fromISO(props.value).toRelative());
+        }
+      }, 1000);
+      return () => clearTimeout(timeout);
+    }
+  }, [props.format, props.value]);
   if (props.value === undefined) return <></>;
   return (
     <span style={{ whiteSpace: 'nowrap' }}>

--- a/framework/PageCells/DateTimeCell.tsx
+++ b/framework/PageCells/DateTimeCell.tsx
@@ -14,7 +14,7 @@ export function DateCell(props: { value: number | string }) {
   );
 }
 
-export function SinceCell(props: {
+export function DateTimeCell(props: {
   value: string | number | undefined | null;
   author?: string;
   format?: 'since' | 'date-time';

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { SinceCell } from '../PageCells/DateTimeCell';
+import { DateTimeCell } from '../PageCells/DateTimeCell';
 import { LabelsCell } from '../PageCells/LabelsCell';
 import { TextCell } from '../PageCells/TextCell';
 
@@ -80,7 +80,7 @@ export function TableColumnCell<T extends object>(props: { item: T; column?: ITa
     case 'count':
       return <>{column.value(item) ?? '-'}</>;
     case 'datetime':
-      return <SinceCell value={column.value(item)} />;
+      return <DateTimeCell format="since" value={column.value(item)} />;
     default:
       return <>{column.cell(item)}</>;
   }

--- a/frontend/awx/access/organizations/OrganizationPage/OrganizationDetails.tsx
+++ b/frontend/awx/access/organizations/OrganizationPage/OrganizationDetails.tsx
@@ -1,7 +1,7 @@
 import { Label, LabelGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { PageDetail, PageDetails, SinceCell } from '../../../../../framework';
+import { PageDetail, PageDetails, DateTimeCell } from '../../../../../framework';
 import { useGet } from '../../../../common/crud/useGet';
 import { RouteObj } from '../../../../Routes';
 import { CredentialLabel } from '../../../common/CredentialLabel';
@@ -51,7 +51,8 @@ export function OrganizationDetails(props: { organization: Organization }) {
           project, job template or workflow level.`}
       />
       <PageDetail label={t('Created')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={organization.created}
           author={organization.summary_fields?.created_by?.username}
           onClick={() =>
@@ -65,7 +66,8 @@ export function OrganizationDetails(props: { organization: Organization }) {
         />
       </PageDetail>
       <PageDetail label={t('Last modified')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={organization.modified}
           author={organization.summary_fields?.modified_by?.username}
           onClick={() =>

--- a/frontend/awx/access/teams/TeamPage/TeamDetails.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamDetails.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { PageDetail, PageDetails, SinceCell, TextCell } from '../../../../../framework';
+import { PageDetail, PageDetails, DateTimeCell, TextCell } from '../../../../../framework';
 import { RouteObj } from '../../../../Routes';
 import { Team } from '../../../interfaces/Team';
 
@@ -23,7 +23,8 @@ export function TeamDetails(props: { team: Team }) {
         />
       </PageDetail>
       <PageDetail label={t('Created')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={team.created}
           author={team.summary_fields?.created_by?.username}
           onClick={() =>
@@ -37,7 +38,8 @@ export function TeamDetails(props: { team: Team }) {
         />
       </PageDetail>
       <PageDetail label={t('Last modified')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={team.modified}
           author={team.summary_fields?.modified_by?.username}
           onClick={() =>

--- a/frontend/awx/access/users/UserPage/UserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/UserDetails.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { PageDetail, PageDetails, SinceCell } from '../../../../../framework';
+import { PageDetail, PageDetails, DateTimeCell } from '../../../../../framework';
 import { User } from '../../../interfaces/User';
 import { AuthenticationType } from '../components/AuthenticationType';
 import { UserType } from '../components/UserType';
@@ -32,13 +32,13 @@ export function UserDetails(props: { user: User }) {
           <AuthenticationType user={user} />
         </PageDetail>
         <PageDetail label={t('Created')}>
-          <SinceCell value={user.created} />
+          <DateTimeCell format="since" value={user.created} />
         </PageDetail>
         <PageDetail label={t('Modified')}>
-          <SinceCell value={user.modified} />
+          <DateTimeCell format="since" value={user.modified} />
         </PageDetail>
         <PageDetail label={t('Last login')}>
-          <SinceCell value={user.last_login} />
+          <DateTimeCell format="since" value={user.last_login} />
         </PageDetail>
       </PageDetails>
     </>

--- a/frontend/awx/access/users/hooks/useUsersColumns.tsx
+++ b/frontend/awx/access/users/hooks/useUsersColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
+import { ITableColumn, DateTimeCell, TextCell } from '../../../../../framework';
 import { RouteObj } from '../../../../Routes';
 import { User } from '../../../interfaces/User';
 import { UserType } from '../components/UserType';
@@ -48,7 +48,7 @@ export function useUsersColumns(_options?: { disableLinks?: boolean; disableSort
       },
       {
         header: t('Created'),
-        cell: (item) => <SinceCell value={item.created} />,
+        cell: (item) => <DateTimeCell format="since" value={item.created} />,
         card: 'hidden',
         list: 'secondary',
       },

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -13,7 +13,7 @@ import {
   PageDetails,
   PageHeader,
   PageLayout,
-  SinceCell,
+  DateTimeCell,
 } from '../../../../framework';
 import { LoadingPage } from '../../../../framework/components/LoadingPage';
 import { useGetItem } from '../../../common/crud/useGetItem';
@@ -105,13 +105,13 @@ function InstanceDetailsTab(props: { instance: Instance }) {
         <BytesCell bytes={instance.memory} />
       </PageDetail>
       <PageDetail label={t('Last health check')}>
-        <SinceCell value={instance.last_health_check} />
+        <DateTimeCell format="since" value={instance.last_health_check} />
       </PageDetail>
       <PageDetail label={t('Created')}>
-        <SinceCell value={instance.created} />
+        <DateTimeCell format="since" value={instance.created} />
       </PageDetail>
       <PageDetail label={t('Modified')}>
-        <SinceCell value={instance.modified} />
+        <DateTimeCell format="since" value={instance.modified} />
       </PageDetail>
     </PageDetails>
   );

--- a/frontend/awx/administration/instances/Instances.tsx
+++ b/frontend/awx/administration/instances/Instances.tsx
@@ -13,7 +13,7 @@ import {
   PageHeader,
   PageLayout,
   PageTable,
-  SinceCell,
+  DateTimeCell,
   TextCell,
 } from '../../../../framework';
 import { Dotted } from '../../../../framework/components/Dotted';
@@ -219,7 +219,7 @@ export function useInstancesColumns(options?: { disableSort?: boolean; disableLi
       },
       {
         header: t('Last health check'),
-        cell: (instance) => <SinceCell value={instance.last_health_check} />,
+        cell: (instance) => <DateTimeCell format="since" value={instance.last_health_check} />,
         card: 'hidden',
       },
       createdColumn,

--- a/frontend/awx/resources/credentials/CredentialPage/CredentialDetails.tsx
+++ b/frontend/awx/resources/credentials/CredentialPage/CredentialDetails.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { PageDetail, PageDetails, SinceCell, TextCell } from '../../../../../framework';
+import { PageDetail, PageDetails, DateTimeCell, TextCell } from '../../../../../framework';
 import { RouteObj } from '../../../../Routes';
 import { Credential } from '../../../interfaces/Credential';
 
@@ -32,7 +32,8 @@ export function CredentialDetails(props: { credential: Credential }) {
         />
       </PageDetail>
       <PageDetail label={t('Created')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={credential.created}
           author={credential.summary_fields?.created_by?.username}
           onClick={() =>
@@ -46,7 +47,8 @@ export function CredentialDetails(props: { credential: Credential }) {
         />
       </PageDetail>
       <PageDetail label={t('Last modified')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={credential.modified}
           author={credential.summary_fields?.modified_by?.username}
           onClick={() =>

--- a/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { CopyCell, PageDetail, PageDetails, SinceCell, TextCell } from '../../../../../framework';
+import {
+  CopyCell,
+  PageDetail,
+  PageDetails,
+  DateTimeCell,
+  TextCell,
+} from '../../../../../framework';
 import { RouteObj } from '../../../../Routes';
 import { Project } from '../../../interfaces/Project';
 import { ScmType } from '../../../../common/scm';
@@ -71,7 +77,8 @@ export function ProjectDetails(props: { project: Project }) {
         {project.local_path}
       </PageDetail>
       <PageDetail label={t('Created')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={project.created}
           author={project.summary_fields?.created_by?.username}
           onClick={() =>
@@ -85,7 +92,8 @@ export function ProjectDetails(props: { project: Project }) {
         />
       </PageDetail>
       <PageDetail label={t('Last modified')}>
-        <SinceCell
+        <DateTimeCell
+          format="since"
           value={project.modified}
           author={project.summary_fields?.modified_by?.username}
           onClick={() =>

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
+import { ITableColumn, DateTimeCell, TextCell } from '../../../../../framework';
 import { ElapsedTimeCell } from '../../../../../framework/PageCells/ElapsedTimeCell';
 import { StatusCell } from '../../../../common/StatusCell';
 import { getJobOutputUrl } from '../jobUtils';
@@ -63,7 +63,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       {
         header: t('Started'),
         cell: (job: UnifiedJob) =>
-          job.started && <SinceCell format="date-time" value={job.started} />,
+          job.started && <DateTimeCell format="date-time" value={job.started} />,
         sort: 'started',
         list: 'secondary',
         defaultSortDirection: 'desc',
@@ -71,7 +71,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       {
         header: t('Finished'),
         cell: (job: UnifiedJob) =>
-          job.finished && <SinceCell format="date-time" value={job.started} />,
+          job.finished && <DateTimeCell format="date-time" value={job.started} />,
         sort: 'finished',
         card: 'hidden',
         list: 'secondary',

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -5,6 +5,7 @@ import { ElapsedTimeCell } from '../../../../../framework/PageCells/ElapsedTimeC
 import { StatusCell } from '../../../../common/StatusCell';
 import { getJobOutputUrl } from '../jobUtils';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
+import { formatDateString } from '../../../../../framework/utils/formatDateString';
 
 export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -62,14 +63,14 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Started'),
-        cell: (job: UnifiedJob) => job.started && <SinceCell value={job.started} />,
+        cell: (job: UnifiedJob) => job.started && <p>{formatDateString(job.started)}</p>,
         sort: 'started',
         list: 'secondary',
         defaultSortDirection: 'desc',
       },
       {
         header: t('Finished'),
-        cell: (job: UnifiedJob) => job.finished && <SinceCell value={job.finished} />,
+        cell: (job: UnifiedJob) => job.finished && <p>{formatDateString(job.finished)}</p>,
         sort: 'finished',
         card: 'hidden',
         list: 'secondary',

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
+import { ITableColumn, TextCell } from '../../../../../framework';
 import { ElapsedTimeCell } from '../../../../../framework/PageCells/ElapsedTimeCell';
 import { StatusCell } from '../../../../common/StatusCell';
 import { getJobOutputUrl } from '../jobUtils';

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, TextCell } from '../../../../../framework';
+import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
 import { ElapsedTimeCell } from '../../../../../framework/PageCells/ElapsedTimeCell';
 import { StatusCell } from '../../../../common/StatusCell';
 import { getJobOutputUrl } from '../jobUtils';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
-import { formatDateString } from '../../../../../framework/utils/formatDateString';
 
 export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -63,14 +62,16 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Started'),
-        cell: (job: UnifiedJob) => job.started && <p>{formatDateString(job.started)}</p>,
+        cell: (job: UnifiedJob) =>
+          job.started && <SinceCell format="date-time" value={job.started} />,
         sort: 'started',
         list: 'secondary',
         defaultSortDirection: 'desc',
       },
       {
         header: t('Finished'),
-        cell: (job: UnifiedJob) => job.finished && <p>{formatDateString(job.finished)}</p>,
+        cell: (job: UnifiedJob) =>
+          job.finished && <SinceCell format="date-time" value={job.started} />,
         sort: 'finished',
         card: 'hidden',
         list: 'secondary',

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { ITableColumn, SinceCell, TextCell } from '../../framework';
+import { ITableColumn, DateTimeCell, TextCell } from '../../framework';
 import { RouteObj } from '../Routes';
 
 export function useIdColumn<T extends { name: string; id: number }>() {
@@ -76,7 +76,8 @@ export function useCreatedColumn(options?: { disableSort?: boolean; disableLinks
       cell: (item) => {
         if (!item.created) return <></>;
         return (
-          <SinceCell
+          <DateTimeCell
+            format="since"
             value={item.created}
             author={
               'summary_fields' in item ? item.summary_fields?.created_by?.username : undefined
@@ -120,7 +121,8 @@ export function useModifiedColumn(options?: { disableSort?: boolean; disableLink
       cell: (item) => {
         if (!item.modified) return <></>;
         return (
-          <SinceCell
+          <DateTimeCell
+            format="since"
             value={item.modified}
             author={
               'summary_fields' in item ? item.summary_fields?.modified_by?.username : undefined

--- a/frontend/hub/administration/approvals/hooks/useApprovalsColumns.tsx
+++ b/frontend/hub/administration/approvals/hooks/useApprovalsColumns.tsx
@@ -1,7 +1,7 @@
 import { ExclamationTriangleIcon, ThumbsUpIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, PFColorE, SinceCell, TextCell } from '../../../../../framework';
+import { ITableColumn, PFColorE, DateTimeCell, TextCell } from '../../../../../framework';
 import { Approval } from '../Approval';
 
 export function useApprovalsColumns(_options?: { disableSort?: boolean; disableLinks?: boolean }) {
@@ -43,7 +43,7 @@ export function useApprovalsColumns(_options?: { disableSort?: boolean; disableL
       },
       {
         header: t('Created'),
-        cell: (approval) => <SinceCell value={approval.created_at} />,
+        cell: (approval) => <DateTimeCell format="since" value={approval.created_at} />,
         card: 'hidden',
         list: 'secondary',
       },

--- a/frontend/hub/administration/remote-registries/hooks/useRemoteRegistriesColumns.tsx
+++ b/frontend/hub/administration/remote-registries/hooks/useRemoteRegistriesColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, SinceCell, TextCell } from '../../../../../framework';
+import { ITableColumn, DateTimeCell, TextCell } from '../../../../../framework';
 import { RemoteRegistry } from '../RemoteRegistry';
 
 export function useRemoteRegistriesColumns(_options?: {
@@ -16,7 +16,7 @@ export function useRemoteRegistriesColumns(_options?: {
       },
       {
         header: t('Created'),
-        cell: (remoteRegistry) => <SinceCell value={remoteRegistry.created_at} />,
+        cell: (remoteRegistry) => <DateTimeCell format="since" value={remoteRegistry.created_at} />,
       },
       {
         header: t('Registry URL'),

--- a/frontend/hub/administration/repositories/Repositories.tsx
+++ b/frontend/hub/administration/repositories/Repositories.tsx
@@ -11,7 +11,7 @@ import {
   PageTab,
   PageTable,
   PageTabs,
-  SinceCell,
+  DateTimeCell,
   TextCell,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
@@ -80,7 +80,9 @@ export function useLocalRepositoriesColumns(_options?: {
       },
       {
         header: 'Modified',
-        cell: (repository) => <SinceCell value={repository.repository.pulp_last_updated} />,
+        cell: (repository) => (
+          <DateTimeCell format="since" value={repository.repository.pulp_last_updated} />
+        ),
       },
     ],
     []
@@ -152,15 +154,17 @@ export function useRemoteRepositoriesColumns(_options?: {
       },
       {
         header: t('Last sync'),
-        cell: (repository) => <SinceCell value={repository.last_sync_task.finished_at} />,
+        cell: (repository) => (
+          <DateTimeCell format="since" value={repository.last_sync_task.finished_at} />
+        ),
       },
       {
         header: t('Last modified'),
-        cell: (repository) => <SinceCell value={repository.updated_at} />,
+        cell: (repository) => <DateTimeCell format="since" value={repository.updated_at} />,
       },
       {
         header: t('Created'),
-        cell: (repository) => <SinceCell value={repository.created_at} />,
+        cell: (repository) => <DateTimeCell format="since" value={repository.created_at} />,
       },
     ],
     [t]

--- a/frontend/hub/administration/tasks/TaskDetails.tsx
+++ b/frontend/hub/administration/tasks/TaskDetails.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { PageDetails, PageHeader, PageLayout, SinceCell } from '../../../../framework';
+import { PageDetails, PageHeader, PageLayout, DateTimeCell } from '../../../../framework';
 import { LoadingPage } from '../../../../framework/components/LoadingPage';
 import { PageDetail } from '../../../../framework/PageDetails/PageDetail';
 import { AwxError } from '../../../awx/common/AwxError';
@@ -33,13 +33,13 @@ export function TaskDetails() {
           <StatusCell status={task?.state} />
         </PageDetail>
         <PageDetail label={t('Started')}>
-          <SinceCell value={task?.finished_at} />
+          <DateTimeCell format="since" value={task?.finished_at} />
         </PageDetail>
         <PageDetail label={t('Finished')}>
-          <SinceCell value={task?.finished_at} />
+          <DateTimeCell format="since" value={task?.finished_at} />
         </PageDetail>
         <PageDetail label={t('Created')}>
-          <SinceCell value={task?.pulp_created} />
+          <DateTimeCell format="since" value={task?.pulp_created} />
         </PageDetail>
       </PageDetails>
     </PageLayout>

--- a/frontend/hub/administration/tasks/Tasks.tsx
+++ b/frontend/hub/administration/tasks/Tasks.tsx
@@ -8,7 +8,7 @@ import {
   PageHeader,
   PageLayout,
   PageTable,
-  SinceCell,
+  DateTimeCell,
   TextCell,
 } from '../../../../framework';
 import { useInMemoryView } from '../../../../framework/useInMemoryView';
@@ -81,20 +81,20 @@ export function useTasksColumns(_options?: { disableSort?: boolean; disableLinks
       },
       {
         header: t('Started'),
-        cell: (task) => <SinceCell value={task.started_at} />,
+        cell: (task) => <DateTimeCell format="since" value={task.started_at} />,
         sort: 'started_at',
         list: 'secondary',
       },
       {
         header: t('Finished'),
-        cell: (task) => <SinceCell value={task.finished_at} />,
+        cell: (task) => <DateTimeCell format="since" value={task.finished_at} />,
         sort: 'finished_at',
         card: 'hidden',
         list: 'secondary',
       },
       {
         header: t('Created'),
-        cell: (task) => <SinceCell value={task.pulp_created} />,
+        cell: (task) => <DateTimeCell format="since" value={task.pulp_created} />,
         sort: 'pulp_created',
         card: 'hidden',
         list: 'secondary',

--- a/frontend/hub/automation-content/signature-keys/SignatureKeys.tsx
+++ b/frontend/hub/automation-content/signature-keys/SignatureKeys.tsx
@@ -11,7 +11,7 @@ import {
   PageHeader,
   PageLayout,
   PageTable,
-  SinceCell,
+  DateTimeCell,
   TextCell,
 } from '../../../../framework';
 import { downloadTextFile } from '../../../../framework/utils/download-file';
@@ -79,7 +79,7 @@ export function useSignatureKeysColumns(_options?: {
       },
       {
         header: t('Created'),
-        cell: (signatureKey) => <SinceCell value={signatureKey.pulp_created} />,
+        cell: (signatureKey) => <DateTimeCell format="since" value={signatureKey.pulp_created} />,
         card: 'hidden',
         list: 'secondary',
       },


### PR DESCRIPTION
Following UXD recommendation, the format for the "started" and "finished" times is updated to the MM/DD/YYYY, hh:mm:ss AM/PM format. 

Note: In the future we may provide a setting for users to select the format for dates.

<img width="1452" alt="Screenshot 2023-04-03 at 11 46 43 AM" src="https://user-images.githubusercontent.com/43621546/229562384-dfe4ea2e-1c77-4714-816e-5a57112bdfd3.png">
