### PR TITLE
[AAP-10764] Add activation instance details page

### DIFF
--- a/framework/PageTabs.tsx
+++ b/framework/PageTabs.tsx
@@ -22,10 +22,11 @@ export function PageTabs(props: {
   children: ReactNode;
   preComponents?: ReactNode;
   postComponents?: ReactNode;
+  initialTabIndex?: number;
   loading?: boolean;
 }) {
   const { loading } = props;
-  const [activeKey, setActiveKey] = useState<number>(0);
+  const [activeKey, setActiveKey] = useState<number>(props?.initialTabIndex ?? 0);
   const onSelect = useCallback(
     (_: unknown, key: string | number) => setActiveKey(key as number),
     [setActiveKey]

--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -171,8 +171,10 @@ export const RouteObj: { [key: string]: RouteType } = {
 
   EdaRulebookActivations: `${edaRoutePrefix}/rulebook-activations`,
   EdaRulebookActivationDetails: `${edaRoutePrefix}/rulebook-activations/details/:id`,
+  EdaRulebookActivationDetailsHistory: `${edaRoutePrefix}/rulebook-activations/details/:id/history`,
   CreateEdaRulebookActivation: `${edaRoutePrefix}/rulebook-activations/create`,
   EditEdaRulebookActivation: `${edaRoutePrefix}/rulebook-activations/edit/:id`,
+  EdaActivationInstanceDetails: `${edaRoutePrefix}/activations-instances/details/:id`,
 
   EdaRulebooks: `${edaRoutePrefix}/rulebooks`,
   EdaRulebookDetails: `${edaRoutePrefix}/rulebooks/details/:id`,

--- a/frontend/eda/EventDrivenRouter.tsx
+++ b/frontend/eda/EventDrivenRouter.tsx
@@ -31,6 +31,7 @@ import { UserDetails } from './UserAccess/Users/UserDetails';
 import { CredentialDetails } from './Resources/credentials/CredentialDetails';
 import { EditCredential } from './Resources/credentials/EditCredential';
 import { Credentials } from './Resources/credentials/Credentials';
+import { ActivationInstanceDetails } from './rulebook-activations/ActivationInstanceDetails';
 
 export function EventDrivenRouter() {
   const RouteObjWithoutPrefix = useRoutesWithoutPrefix(RouteObj.Eda);
@@ -80,11 +81,19 @@ export function EventDrivenRouter() {
       />
       <Route
         path={RouteObjWithoutPrefix.EdaRulebookActivationDetails}
-        element={<RulebookActivationDetails />}
+        element={<RulebookActivationDetails initialTabIndex={0} />}
+      />
+      <Route
+        path={RouteObjWithoutPrefix.EdaRulebookActivationDetailsHistory}
+        element={<RulebookActivationDetails initialTabIndex={1} />}
       />
       <Route
         path={RouteObjWithoutPrefix.EdaRulebookActivations}
         element={<RulebookActivations />}
+      />
+      <Route
+        path={RouteObjWithoutPrefix.EdaActivationInstanceDetails}
+        element={<ActivationInstanceDetails />}
       />
 
       <Route path={RouteObjWithoutPrefix.CreateEdaActivity} element={<UnderDevelopment />} />

--- a/frontend/eda/dashboard/RuleAuditChartCard.tsx
+++ b/frontend/eda/dashboard/RuleAuditChartCard.tsx
@@ -31,8 +31,8 @@ const RuleAuditChart = () => {
     }
     const tickValues: string[] = [];
     data.forEach((item) => {
-      if (item.fired_date) {
-        const keyDate = new Date(item.fired_date);
+      if (item.fired_at) {
+        const keyDate = new Date(item.fired_at);
         const key = `${keyDate.getMonth()}/${keyDate.getDate()}`;
         const idx = tickValues.findIndex((tick) => tick === key);
         if (idx < 0) {

--- a/frontend/eda/interfaces/EdaActivationInstanceLog.ts
+++ b/frontend/eda/interfaces/EdaActivationInstanceLog.ts
@@ -5,12 +5,9 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export interface EdaActivationInstance {
+export interface EdaActivationInstanceLog {
   id: number;
-  name?: string;
-  status?: string;
-  activation: string;
-  activation_name: string;
-  started_at: string;
-  ended_at?: string;
+  line_number?: number;
+  log?: string;
+  activation_instance: string;
 }

--- a/frontend/eda/interfaces/EdaRuleAudit.ts
+++ b/frontend/eda/interfaces/EdaRuleAudit.ts
@@ -12,5 +12,5 @@ export interface EdaRuleAudit {
   status?: string;
   activation?: { id: number; name?: string };
   created_at?: string;
-  fired_date?: string;
+  fired_at?: string;
 }

--- a/frontend/eda/interfaces/EdaRulebookActivation.ts
+++ b/frontend/eda/interfaces/EdaRulebookActivation.ts
@@ -15,7 +15,6 @@ export interface EdaRulebookActivation {
   project?: { id: string; name: string };
   status?: string;
   is_enabled?: boolean;
-  throttle?: boolean;
   variables_template?: string;
   instances_count?: number;
   rules_count?: number;

--- a/frontend/eda/interfaces/EdaRulebookActivation.ts
+++ b/frontend/eda/interfaces/EdaRulebookActivation.ts
@@ -12,7 +12,7 @@ export interface EdaRulebookActivation {
   decision_environment?: string;
   rulebook?: { id: string; name: string };
   restart_policy?: string;
-  project?: { id: string; name: string };
+  project?: { id: string; name: string; git_hash: string };
   status?: string;
   is_enabled?: boolean;
   variables_template?: string;

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -31,7 +31,6 @@ export function ActivationInstanceDetails() {
     `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/`
   );
 
-  // TODO - remove when the endpoint return the activation name
   const { data: activation } = useGet<EdaRulebookActivation>(
     `${API_PREFIX}/activations/${activationInstance?.activation ?? ''}/`
   );

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -1,0 +1,117 @@
+import { CodeBlock, CodeBlockCode, PageSection, Skeleton, Stack } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  PageDetail,
+  PageDetails,
+  PageHeader,
+  PageLayout,
+  PageTab,
+  PageTabs,
+  Scrollable,
+} from '../../../framework';
+import { formatDateString } from '../../../framework/utils/formatDateString';
+import { useGet } from '../../common/crud/useGet';
+import { RouteObj } from '../../Routes';
+import { API_PREFIX } from '../constants';
+import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
+import { EdaActivationInstanceLog } from '../interfaces/EdaActivationInstanceLog';
+import { PageDetailsSection } from '../common/PageDetailsSection';
+import React from 'react';
+import { EdaRulebookActivation } from '../interfaces/EdaRulebookActivation';
+
+export function ActivationInstanceDetails() {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const { data: activationInstance } = useGet<EdaActivationInstance>(
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/`
+  );
+
+  const { data: activationInstanceLog } = useGet<EdaActivationInstanceLog>(
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/`
+  );
+
+  // TODO - remove when the endpoint return the activation name
+  const { data: activation } = useGet<EdaRulebookActivation>(
+    `${API_PREFIX}/activations/${activationInstance?.activation ?? ''}/`
+  );
+
+  const renderActivationDetailsTab = (
+    activationInstance: EdaActivationInstance | undefined
+  ): JSX.Element => {
+    return (
+      <Scrollable>
+        <PageDetails>
+          <PageDetail label={t('Name')}>
+            {activationInstance?.name || `Instance ${activationInstance?.id || ''}`}
+          </PageDetail>
+          <PageDetail label={t('Activation status')}>{activationInstance?.status || ''}</PageDetail>
+          <PageDetail label={t('Start date')}>
+            {activationInstance?.started_at ? formatDateString(activationInstance?.started_at) : ''}
+          </PageDetail>
+          <PageDetail label={t('End date')}>
+            {activationInstance?.ended_at ? formatDateString(activationInstance?.ended_at) : ''}
+          </PageDetail>
+        </PageDetails>
+        <PageDetailsSection>
+          <PageDetail label={t('Output')}>
+            <CodeBlock>
+              <CodeBlockCode
+                style={{
+                  minHeight: '150px',
+                }}
+                id="code-content"
+              >
+                {activationInstanceLog?.log || ''}
+              </CodeBlockCode>
+            </CodeBlock>
+          </PageDetail>
+        </PageDetailsSection>
+      </Scrollable>
+    );
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={activationInstance?.name ?? `Instance ${activationInstance?.id || ''}`}
+        breadcrumbs={[
+          { label: t('Rulebook Activations'), to: RouteObj.EdaRulebookActivations },
+          {
+            label: activationInstance?.activation_name ?? (activation?.name || ''),
+            to: RouteObj.EdaRulebookActivationDetails.replace(
+              ':id',
+              activationInstance?.activation || ''
+            ),
+          },
+          {
+            label: t('History'),
+            to: RouteObj.EdaRulebookActivationDetailsHistory.replace(
+              ':id',
+              activationInstance?.activation || ''
+            ),
+          },
+          { label: activationInstance?.name ?? `Instance ${activationInstance?.id || ''}` },
+        ]}
+      />
+      {activationInstance ? (
+        <PageTabs>
+          <PageTab label={t('Details')}>{renderActivationDetailsTab(activationInstance)}</PageTab>
+        </PageTabs>
+      ) : (
+        <PageTabs>
+          <PageTab>
+            <PageSection variant="light">
+              <Stack hasGutter>
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+              </Stack>
+            </PageSection>
+          </PageTab>
+        </PageTabs>
+      )}
+    </PageLayout>
+  );
+}

--- a/frontend/eda/rulebook-activations/EditRulebookActivation.tsx
+++ b/frontend/eda/rulebook-activations/EditRulebookActivation.tsx
@@ -29,7 +29,7 @@ export function EditRulebookActivation() {
   const { data: rulebooks } = useGet<EdaResult<EdaRulebook>>(`${API_PREFIX}/rulebooks/`);
   const { data: projects } = useGet<EdaResult<EdaProject>>(`${API_PREFIX}/projects/`);
   const { data: environments } = useGet<EdaResult<EdaDecisionEnvironment>>(
-    `${API_PREFIX}/decision_environments/`
+    `${API_PREFIX}/decision-environments/`
   );
   const { cache } = useSWRConfig();
 

--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -33,7 +33,8 @@ import { useActivationHistoryFilters } from './hooks/useActivationHistoryFilters
 import { useEdaView } from '../useEventDrivenView';
 import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
 
-export function RulebookActivationDetails() {
+// eslint-disable-next-line react/prop-types
+export function RulebookActivationDetails({ initialTabIndex = 0 }) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -128,7 +129,6 @@ export function RulebookActivationDetails() {
             <PageDetail label={t('Activation status')}>
               {rulebookActivation?.status || ''}
             </PageDetail>
-            <PageDetail label={t('Throttle')}>{rulebookActivation?.throttle || ''}</PageDetail>
             <PageDetail label={t('Variables template')}>
               {rulebookActivation?.variables_template || ''}
             </PageDetail>
@@ -200,7 +200,7 @@ export function RulebookActivationDetails() {
         }
       />
       {rulebookActivation ? (
-        <PageTabs>
+        <PageTabs initialTabIndex={initialTabIndex}>
           <PageTab label={t('Details')}>{renderActivationDetailsTab(rulebookActivation)}</PageTab>
           <PageTab label={t('History')}>
             <ActivationHistoryTab />

--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -94,18 +94,7 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
               {rulebookActivation?.decision_environment || ''}
             </PageDetail>
             <PageDetail label={t('Rulebook')}>
-              {rulebookActivation && rulebookActivation.rulebook?.id ? (
-                <Link
-                  to={RouteObj.EdaRulebookDetails.replace(
-                    ':id',
-                    `${rulebookActivation.rulebook?.id || ''}`
-                  )}
-                >
-                  {rulebookActivation?.rulebook?.name}
-                </Link>
-              ) : (
-                rulebookActivation?.rulebook?.name || ''
-              )}
+              {rulebookActivation?.rulebook?.name || ''}
             </PageDetail>
             <PageDetail label={t('Restart policy')}>
               {rulebookActivation?.restart_policy
@@ -129,8 +118,8 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
             <PageDetail label={t('Activation status')}>
               {rulebookActivation?.status || ''}
             </PageDetail>
-            <PageDetail label={t('Variables template')}>
-              {rulebookActivation?.variables_template || ''}
+            <PageDetail label={t('Project git hash')}>
+              {rulebookActivation?.project?.git_hash || ''}
             </PageDetail>
             <PageDetail label={t('Last restarted')}>
               {rulebookActivation?.last_restarted

--- a/frontend/eda/rulebook-activations/hooks/useActivationHistoryColumns.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useActivationHistoryColumns.tsx
@@ -17,7 +17,7 @@ export function useActivationHistoryColumns() {
           <TextCell
             text={instance.name || `Instance ${instance.id}`}
             onClick={() =>
-              navigate(RouteObj.EdaRulebookActivationDetails.replace(':id', instance.id.toString()))
+              navigate(RouteObj.EdaActivationInstanceDetails.replace(':id', instance.id.toString()))
             }
           />
         ),
@@ -32,14 +32,9 @@ export function useActivationHistoryColumns() {
         sort: 'status',
       },
       {
-        header: t('Activation instance'),
-        cell: (instance) => instance?.activation,
-        sort: 'rule',
-      },
-      {
         header: t('Start date'),
         cell: (instance) => <DateCell value={instance.started_at} />,
-        sort: 'fired_at',
+        sort: 'started_at',
       },
     ],
     [navigate, t]

--- a/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
+++ b/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
@@ -59,7 +59,7 @@ export function RuleAuditDetails() {
             {ruleAudit?.created_at ? formatDateString(ruleAudit?.created_at) : ''}
           </PageDetail>
           <PageDetail label={t('Fired date')}>
-            {ruleAudit?.fired_date ? formatDateString(ruleAudit?.fired_date) : ''}
+            {ruleAudit?.fired_at ? formatDateString(ruleAudit?.fired_at) : ''}
           </PageDetail>
         </PageDetails>
       </Scrollable>

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
@@ -39,7 +39,7 @@ export function useRuleAuditColumns() {
         header: t('Last fired date'),
         cell: (ruleAudit) => (
           <TextCell
-            text={ruleAudit?.fired_date ? formatDateString(new Date(ruleAudit.fired_date)) : ''}
+            text={ruleAudit?.fired_at ? formatDateString(new Date(ruleAudit.fired_at)) : ''}
           />
         ),
         sort: 'fired_at',


### PR DESCRIPTION
- Added an initialTabIndex parameter to the PageTabs to allow links to a specific tab.
- Add activation instance details page
- Activation detail page updates
     -  Add Project git hash
     -  Rulebook is display only, no link

![Screenshot from 2023-04-03 19-02-43](https://user-images.githubusercontent.com/12769982/229645942-ab662931-6408-46f2-9a69-da9ce1cc34cc.png)
![Screenshot from 2023-04-06 15-56-34](https://user-images.githubusercontent.com/12769982/230483225-4bc0473f-306a-4ce7-b9b2-5d944424ab69.png)

