### PR TITLE
Cypress eslint rule to check for .only and streamline selectByLabel to auto detect search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "i18next"],
+  "plugins": ["@typescript-eslint", "i18next", "no-only-tests"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
@@ -18,6 +18,7 @@
     "plugin:i18next/recommended"
   ],
   "rules": {
+    "no-only-tests/no-only-tests": "error",
     "react/react-in-jsx-scope": "off",
     "no-console": "error",
     "jsx-a11y/no-autofocus": "off",

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -43,7 +43,7 @@ describe('credentials', () => {
     cy.clickButton(/^Create credential$/);
     cy.typeByLabel(/^Name$/, credentialName);
     cy.typeByLabel(/^Organization$/, organization.name);
-    cy.selectByLabel(/^Credential type$/, 'Amazon Web Services', { disableSearch: true });
+    cy.selectByLabel(/^Credential type$/, 'Amazon Web Services');
     cy.clickButton(/^Create credential$/);
     cy.hasTitle(credentialName);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
         "eslint-plugin-i18next": "6.0.0-8",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-jsx-a11y": "6.7.1",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
@@ -17580,6 +17581,15 @@
       "version": "9.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true,
+      "engines": {
+        "node": ">=5.0.0"
+      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -42408,6 +42418,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "eslint-plugin-i18next": "6.0.0-8",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jsx-a11y": "6.7.1",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",


### PR DESCRIPTION
- QE wanted an eslint rule that makes sure .only is never checked in.
- The selectByLabel commend now detects if there is a search in the dropdown and only then uses it.