### PR TITLE
Fix for broken Instance group and Default execution environment fields in Organization form

### DIFF
--- a/frontend/awx/access/organizations/OrganizationForm.tsx
+++ b/frontend/awx/access/organizations/OrganizationForm.tsx
@@ -132,15 +132,16 @@ export function EditOrganization() {
           onCancel={onCancel}
           defaultValue={{ organization, instanceGroups }}
         >
-          <OrganizationInputs />
+          <OrganizationInputs orgId={organization.id} />
         </PageForm>
       ) : null}
     </PageLayout>
   );
 }
 
-function OrganizationInputs() {
+function OrganizationInputs(props: { orgId?: number }) {
   const { t } = useTranslation();
+  const { orgId } = props;
   return (
     <>
       <PageFormTextInput
@@ -156,7 +157,7 @@ function OrganizationInputs() {
       />
       <PageFormInstanceGroupSelect<OrganizationFields> name="instanceGroups" />
       <PageFormExecutionEnvironmentSelect<OrganizationFields>
-        organizationId="organization.id"
+        organizationId={orgId ? orgId.toString() : undefined}
         name="organization.summary_fields.default_environment.name"
         label={t('Default execution environment')}
         executionEnvironmentPath="organization.summary_fields.default_environment"

--- a/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
+++ b/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
@@ -13,7 +13,7 @@ export function PageFormExecutionEnvironmentSelect<
   name: TFieldName;
   executionEnvironmentPath?: string;
   executionEnvironmentIdPath?: string;
-  organizationId: string;
+  organizationId?: string;
   additionalControls?: ReactElement;
   isRequired?: boolean;
   label?: string;
@@ -21,7 +21,7 @@ export function PageFormExecutionEnvironmentSelect<
   const { name, organizationId, executionEnvironmentIdPath, executionEnvironmentPath, ...rest } =
     props;
   const { t } = useTranslation();
-  const selectExecutionEnvironment = useSelectExecutionEnvironments(organizationId);
+  const selectExecutionEnvironment = useSelectExecutionEnvironments(organizationId ?? undefined);
   const { setValue } = useFormContext();
   return (
     <PageFormTextInput<TFieldValues, TFieldName, ExecutionEnvironment>
@@ -35,8 +35,8 @@ export function PageFormExecutionEnvironmentSelect<
       selectValue={(executionEnvironment: ExecutionEnvironment) => executionEnvironment.name}
       selectOpen={selectExecutionEnvironment}
       validate={async (executionEnvironmentName: string) => {
-        if (!props.isRequired) {
-          return;
+        if (!executionEnvironmentName && !props.isRequired) {
+          return undefined;
         }
         try {
           const itemsResponse = await requestGet<ItemsResponse<ExecutionEnvironment>>(

--- a/frontend/awx/administration/execution-environments/hooks/useSelectExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useSelectExecutionEnvironments.tsx
@@ -7,7 +7,7 @@ import {
   useExecutionEnvironmentsFilters,
 } from '../ExecutionEnvironments';
 
-export function useSelectExecutionEnvironments(organizationId: string) {
+export function useSelectExecutionEnvironments(organizationId?: string) {
   const { t } = useTranslation();
   const toolbarFilters = useExecutionEnvironmentsFilters();
   const tableColumns = useExecutionEnvironmentsColumns({ disableLinks: true });


### PR DESCRIPTION
Also addresses an issue with the selected Execution Environment not being correctly saved in the Template form.

![image](https://user-images.githubusercontent.com/43621546/229922656-4866126d-371c-4d6e-98a7-a8621523e616.png)

![image](https://user-images.githubusercontent.com/43621546/229922683-49ff10b2-c383-4b55-b658-e3cb934c17fe.png)

