### PR TITLE
Refactor StatusCell and add useStatusColumn hook

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -517,7 +517,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('tableHasRowWithSuccess', (name: string | RegExp, filter?: boolean) => {
   cy.getTableRowByText(name, filter).within(() => {
-    cy.get('.pf-c-alert__title').should('contain', 'Successful');
+    cy.get('[data-label="Status"]').should('contain', 'Successful');
   });
 });
 

--- a/framework/PageCells/TextCell.tsx
+++ b/framework/PageCells/TextCell.tsx
@@ -15,7 +15,6 @@ export interface TextCellProps {
   maxWidth?: number;
   disableLinks?: boolean;
 }
-
 export function TextCell(props: TextCellProps) {
   const navigate = usePageNavigate();
   return (
@@ -44,6 +43,9 @@ export function TextCell(props: TextCellProps) {
           >
             {!props.disableLinks && (props.to || props.onClick) ? (
               <a
+                style={{
+                  color: props.color ? getPatternflyColor(props.color) : undefined,
+                }}
                 href={props.to}
                 onClick={(e) => {
                   e.preventDefault();

--- a/framework/components/pfcolors.tsx
+++ b/framework/components/pfcolors.tsx
@@ -30,28 +30,38 @@ export function getPatternflyColor(color: PFColor) {
     case 'default':
       return undefined;
     case 'green':
+      return pfSuccess200;
     case 'success':
       return pfSuccess;
     case 'red':
+      return pfDanger200;
     case 'danger':
       return pfDanger;
     case 'yellow':
+      return pfWarning200;
     case 'warning':
       return pfWarning;
     case 'blue':
+      return pfInfo200;
     case 'info':
       return pfInfo;
     case 'grey':
+      return pfDisabled200;
     case 'disabled':
       return pfDisabled;
   }
 }
 
 export const pfSuccess = 'var(--pf-global--success-color--100)';
+export const pfSuccess200 = 'var(--pf-global--success-color--200)';
 export const pfDanger = 'var(--pf-global--danger-color--100)';
+export const pfDanger200 = 'var(--pf-global--danger-color--200)';
 export const pfWarning = 'var(--pf-global--warning-color--100)';
+export const pfWarning200 = 'var(--pf-global--warning-color--200)';
 export const pfInfo = 'var(--pf-global--info-color--100)';
+export const pfInfo200 = 'var(--pf-global--info-color-200)';
 export const pfDisabled = 'var(--pf-global--disabled-color--100)';
+export const pfDisabled200 = 'var(--pf-global--disabled-color--200)';
 export const pfLink = 'var(--pf-global--link--Color)';
 
 export enum LabelColorE {

--- a/frontend/awx/resources/projects/hooks/useProjectStatusColumn.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectStatusColumn.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Tooltip } from '@patternfly/react-core';
+import { ITableColumn } from '../../../../../framework';
+import { StatusCell } from '../../../../common/StatusCell';
+import { RouteObj } from '../../../../Routes';
+
+export function useProjectStatusColumn(options?: {
+  tooltip?: string;
+  tooltipAlt?: string;
+  disableLinks?: boolean;
+  disableSort?: boolean;
+}) {
+  const { t } = useTranslation();
+  const column: ITableColumn<{
+    type?: string;
+    status?: string;
+    summary_fields?: {
+      last_job?: {
+        id?: number;
+      };
+      current_job?: {
+        id?: number;
+      };
+    };
+  }> = useMemo(
+    () => ({
+      header: t('Status'),
+      cell: (item) =>
+        item.summary_fields?.current_job || item.summary_fields?.last_job ? (
+          <Tooltip content={options?.tooltip ?? ''} position="top">
+            <StatusCell
+              status={item.status}
+              to={RouteObj.JobOutput.replace(':job_type', item.type ? item.type : '').replace(
+                ':id',
+                (
+                  item.summary_fields?.current_job?.id ??
+                  item.summary_fields?.last_job?.id ??
+                  ''
+                ).toString()
+              )}
+              disableLinks={options?.disableLinks}
+            />
+          </Tooltip>
+        ) : (
+          <Tooltip content={options?.tooltipAlt ?? ''} position="top">
+            <StatusCell status={item.status} />
+          </Tooltip>
+        ),
+      sort: options?.disableSort ? undefined : 'status',
+    }),
+    [options?.disableSort, options?.disableLinks, options?.tooltip, options?.tooltipAlt, t]
+  );
+  return column;
+}

--- a/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
@@ -2,13 +2,13 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ScmType } from '../../../../common/scm';
-import { StatusCell } from '../../../../common/StatusCell';
 import { CopyCell, ITableColumn } from '../../../../../framework';
 import {
   useCreatedColumn,
   useModifiedColumn,
   useNameColumn,
   useOrganizationNameColumn,
+  useStatusColumn,
 } from '../../../../common/columns';
 import { RouteObj } from '../../../../Routes';
 import { Project } from '../../../interfaces/Project';
@@ -24,13 +24,14 @@ export function useProjectsColumns(options?: { disableSort?: boolean; disableLin
   const organizationColumn = useOrganizationNameColumn(options);
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);
+  const statusColumn = useStatusColumn({
+    ...options,
+    tooltip: t`Click to view latest project sync job`,
+  });
   const tableColumns = useMemo<ITableColumn<Project>[]>(
     () => [
       nameColumn,
-      {
-        header: t('Status'),
-        cell: (project) => <StatusCell status={project.status} />,
-      },
+      statusColumn,
       {
         header: t('Type'),
         cell: (project) => <ScmType scmType={project.scm_type} />,
@@ -44,7 +45,7 @@ export function useProjectsColumns(options?: { disableSort?: boolean; disableLin
       createdColumn,
       modifiedColumn,
     ],
-    [nameColumn, t, organizationColumn, createdColumn, modifiedColumn]
+    [nameColumn, t, organizationColumn, createdColumn, modifiedColumn, statusColumn]
   );
   return tableColumns;
 }

--- a/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
@@ -27,6 +27,7 @@ export function useProjectsColumns(options?: { disableSort?: boolean; disableLin
   const statusColumn = useStatusColumn({
     ...options,
     tooltip: t`Click to view latest project sync job`,
+    tooltipAlt: t`Unable to load latest project sync job`,
   });
   const tableColumns = useMemo<ITableColumn<Project>[]>(
     () => [

--- a/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
@@ -8,8 +8,8 @@ import {
   useModifiedColumn,
   useNameColumn,
   useOrganizationNameColumn,
-  useStatusColumn,
 } from '../../../../common/columns';
+import { useProjectStatusColumn } from './useProjectStatusColumn';
 import { RouteObj } from '../../../../Routes';
 import { Project } from '../../../interfaces/Project';
 
@@ -24,7 +24,7 @@ export function useProjectsColumns(options?: { disableSort?: boolean; disableLin
   const organizationColumn = useOrganizationNameColumn(options);
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);
-  const statusColumn = useStatusColumn({
+  const statusColumn = useProjectStatusColumn({
     ...options,
     tooltip: t`Click to view latest project sync job`,
     tooltipAlt: t`Unable to load latest project sync job`,

--- a/frontend/common/StatusCell.tsx
+++ b/frontend/common/StatusCell.tsx
@@ -1,54 +1,159 @@
-import { BanIcon, ClockIcon } from '@patternfly/react-icons';
+import {
+  BanIcon,
+  ClockIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { Alert } from '@patternfly/react-core';
-import { PFColorE, RunningIcon } from '../../framework';
+import { RunningIcon, TextCell } from '../../framework';
 
-export function StatusCell(props: { status?: string }) {
+export function StatusCell(props: { status?: string; disableLinks?: boolean; to?: string }) {
   const { t } = useTranslation();
   switch (props.status) {
     case 'disabled':
       return (
-        <Alert
-          customIcon={<BanIcon color={PFColorE.Grey} />}
-          title={<div style={{ color: PFColorE.Grey }}>{t('Disabled')}</div>}
-          isInline
-          isPlain
+        <TextCell
+          text={t`Disabled`}
+          color={'grey'}
+          iconColor={'disabled'}
+          icon={<BanIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
         />
       );
     case 'healthy':
-      return <Alert variant="success" title={t('Healthy')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Healthy`}
+          color={'green'}
+          iconColor={'success'}
+          icon={<CheckCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'completed':
-      return <Alert variant="success" title={t('Completed')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Completed`}
+          color={'green'}
+          iconColor={'success'}
+          icon={<CheckCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'successful':
-      return <Alert variant="success" title={t('Successful')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Successful`}
+          color={'green'}
+          iconColor={'success'}
+          icon={<CheckCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'failed':
-      return <Alert variant="danger" title={t('Failed')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Failed`}
+          color={'red'}
+          iconColor={'danger'}
+          icon={<ExclamationCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'error':
-      return <Alert variant="danger" title={t('Error')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Error`}
+          color={'red'}
+          iconColor={'danger'}
+          icon={<ExclamationCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'waiting':
       return (
-        <Alert
-          customIcon={<ClockIcon color={PFColorE.Grey} />}
-          title={<div style={{ color: PFColorE.Grey }}>{t('Waiting')}</div>}
-          isInline
-          isPlain
+        <TextCell
+          text={t`Waiting`}
+          color={'grey'}
+          iconColor={'disabled'}
+          icon={<ClockIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
         />
       );
     case 'pending':
       return (
-        <Alert customIcon={<ClockIcon />} title={t('Pending')} variant="info" isPlain isInline />
+        <TextCell
+          text={t`Pending`}
+          color={'blue'}
+          iconColor={'info'}
+          icon={<ClockIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
       );
     case 'new':
-      return <Alert variant="info" title={t('Pending')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Pending`}
+          color={'blue'}
+          iconColor={'info'}
+          icon={<InfoCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'running':
       return (
-        <Alert customIcon={<RunningIcon />} title={t('Running')} variant="info" isPlain isInline />
+        <TextCell
+          text={t`Running`}
+          color={'blue'}
+          iconColor={'info'}
+          icon={<RunningIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
       );
     case 'canceled':
-      return <Alert variant="warning" title={t('Canceled')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Canceled`}
+          color={'yellow'}
+          iconColor={'warning'}
+          icon={<ExclamationTriangleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     case 'never-updated':
-      return <Alert variant="info" title={t('Never updated')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Never updated`}
+          color={'blue'}
+          iconColor={'info'}
+          icon={<InfoCircleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
     default:
-      return <Alert variant="warning" title={t('Unknown')} isPlain isInline />;
+      return (
+        <TextCell
+          text={t`Unknown`}
+          color={'yellow'}
+          iconColor={'warning'}
+          icon={<ExclamationTriangleIcon />}
+          to={props.to}
+          disableLinks={props.disableLinks}
+        />
+      );
   }
 }

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -189,6 +189,7 @@ export function useOrganizationNameColumn(options?: {
 }
 export function useStatusColumn(options?: {
   tooltip?: string;
+  tooltipAlt?: string;
   disableLinks?: boolean;
   disableSort?: boolean;
 }) {
@@ -207,25 +208,30 @@ export function useStatusColumn(options?: {
   }> = useMemo(
     () => ({
       header: t('Status'),
-      cell: (item) => (
-        <Tooltip content={options?.tooltip ?? ''} position="top">
-          <StatusCell
-            status={item.status}
-            to={RouteObj.JobOutput.replace(':job_type', item.type ? item.type : '').replace(
-              ':id',
-              (
-                item.summary_fields?.current_job?.id ??
-                item.summary_fields?.last_job?.id ??
-                ''
-              ).toString()
-            )}
-            disableLinks={options?.disableLinks}
-          />
-        </Tooltip>
-      ),
+      cell: (item) =>
+        item.summary_fields?.current_job || item.summary_fields?.last_job ? (
+          <Tooltip content={options?.tooltip ?? ''} position="top">
+            <StatusCell
+              status={item.status}
+              to={RouteObj.JobOutput.replace(':job_type', item.type ? item.type : '').replace(
+                ':id',
+                (
+                  item.summary_fields?.current_job?.id ??
+                  item.summary_fields?.last_job?.id ??
+                  ''
+                ).toString()
+              )}
+              disableLinks={options?.disableLinks}
+            />
+          </Tooltip>
+        ) : (
+          <Tooltip content={options?.tooltipAlt ?? ''} position="top">
+            <StatusCell status={item.status} />
+          </Tooltip>
+        ),
       sort: options?.disableSort ? undefined : 'status',
     }),
-    [options?.disableSort, options?.disableLinks, options?.tooltip, t]
+    [options?.disableSort, options?.disableLinks, options?.tooltip, options?.tooltipAlt, t]
   );
   return column;
 }

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { Tooltip } from '@patternfly/react-core';
 import { ColumnTableOption, DateTimeCell, ITableColumn, TextCell } from '../../framework';
+import { StatusCell } from './StatusCell';
 import { RouteObj } from '../Routes';
 
 export function useIdColumn<T extends { name: string; id: number }>() {
@@ -182,6 +184,48 @@ export function useOrganizationNameColumn(options?: {
       sort: options?.disableSort ? undefined : 'organization',
     }),
     [options?.disableLinks, options?.disableSort, t]
+  );
+  return column;
+}
+export function useStatusColumn(options?: {
+  tooltip?: string;
+  disableLinks?: boolean;
+  disableSort?: boolean;
+}) {
+  const { t } = useTranslation();
+  const column: ITableColumn<{
+    type?: string;
+    status?: string;
+    summary_fields?: {
+      last_job?: {
+        id?: number;
+      };
+      current_job?: {
+        id?: number;
+      };
+    };
+  }> = useMemo(
+    () => ({
+      header: t('Status'),
+      cell: (item) => (
+        <Tooltip content={options?.tooltip ?? ''} position="top">
+          <StatusCell
+            status={item.status}
+            to={RouteObj.JobOutput.replace(':job_type', item.type ? item.type : '').replace(
+              ':id',
+              (
+                item.summary_fields?.current_job?.id ??
+                item.summary_fields?.last_job?.id ??
+                ''
+              ).toString()
+            )}
+            disableLinks={options?.disableLinks}
+          />
+        </Tooltip>
+      ),
+      sort: options?.disableSort ? undefined : 'status',
+    }),
+    [options?.disableSort, options?.disableLinks, options?.tooltip, t]
   );
   return column;
 }

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { Tooltip } from '@patternfly/react-core';
 import { ColumnTableOption, DateTimeCell, ITableColumn, TextCell } from '../../framework';
-import { StatusCell } from './StatusCell';
 import { RouteObj } from '../Routes';
 
 export function useIdColumn<T extends { name: string; id: number }>() {
@@ -184,54 +182,6 @@ export function useOrganizationNameColumn(options?: {
       sort: options?.disableSort ? undefined : 'organization',
     }),
     [options?.disableLinks, options?.disableSort, t]
-  );
-  return column;
-}
-export function useStatusColumn(options?: {
-  tooltip?: string;
-  tooltipAlt?: string;
-  disableLinks?: boolean;
-  disableSort?: boolean;
-}) {
-  const { t } = useTranslation();
-  const column: ITableColumn<{
-    type?: string;
-    status?: string;
-    summary_fields?: {
-      last_job?: {
-        id?: number;
-      };
-      current_job?: {
-        id?: number;
-      };
-    };
-  }> = useMemo(
-    () => ({
-      header: t('Status'),
-      cell: (item) =>
-        item.summary_fields?.current_job || item.summary_fields?.last_job ? (
-          <Tooltip content={options?.tooltip ?? ''} position="top">
-            <StatusCell
-              status={item.status}
-              to={RouteObj.JobOutput.replace(':job_type', item.type ? item.type : '').replace(
-                ':id',
-                (
-                  item.summary_fields?.current_job?.id ??
-                  item.summary_fields?.last_job?.id ??
-                  ''
-                ).toString()
-              )}
-              disableLinks={options?.disableLinks}
-            />
-          </Tooltip>
-        ) : (
-          <Tooltip content={options?.tooltipAlt ?? ''} position="top">
-            <StatusCell status={item.status} />
-          </Tooltip>
-        ),
-      sort: options?.disableSort ? undefined : 'status',
-    }),
-    [options?.disableSort, options?.disableLinks, options?.tooltip, options?.tooltipAlt, t]
   );
   return column;
 }

--- a/frontend/common/scm.tsx
+++ b/frontend/common/scm.tsx
@@ -1,13 +1,11 @@
-import { GitAltIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import { ReactNode } from 'react';
-import { pfWarning, TextCell } from '../../framework';
+import { TextCell } from '../../framework';
 
 export function getScmType(scm_type: string): { text: string; icon?: ReactNode } {
   switch (scm_type) {
     case 'git':
       return {
         text: 'Git',
-        icon: <GitAltIcon color="#F1502F" />,
       };
     case 'svn':
       return {
@@ -28,7 +26,6 @@ export function getScmType(scm_type: string): { text: string; icon?: ReactNode }
     default:
       return {
         text: 'Unknown',
-        icon: <QuestionCircleIcon color={pfWarning} />,
       };
   }
 }


### PR DESCRIPTION
Based on suggestions and meetings with UXD and the feedback given, this PR:

- refactors our `StatusCell` component to use the `Textcell` component instead of PF's `Alert` component
- adds a new hook for the status column, `useStatusColumn` that takes props for tooltips and redirect handling
- updates the Projects List status column to use the new hook and redirects the user to the current or last project sync job.
- removes the Github and Unknown icons from the `Scm` component.

<img width="1608" alt="Screenshot 2023-04-11 at 12 05 34 PM" src="https://user-images.githubusercontent.com/2293210/231287638-39926c1e-497f-4c90-aa37-1b95e9956d98.png">
