### PR TITLE
[EDA] [QE] Credentials CRUD Tests

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -64,7 +64,7 @@ describe('organizations', () => {
     cy.hasTitle(organization.name);
     cy.clickButton(/^Edit organization$/);
     cy.hasTitle(/^Edit organization$/);
-    cy.typeByLabel(/^Name$/, 'a');
+    cy.typeByLabel(/^Name$/, organization.name + 'a');
     cy.clickButton(/^Save organization$/);
     cy.hasTitle(`${organization.name}a`);
   });

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -82,7 +82,7 @@ describe('teams', () => {
     cy.clickRow(team.name);
     cy.clickButton(/^Edit team$/);
     cy.hasTitle(/^Edit team$/);
-    cy.typeByLabel(/^Name$/, 'a');
+    cy.typeByLabel(/^Name$/, team.name + 'a');
     cy.clickButton(/^Save team$/);
     cy.hasTitle(`${team.name}a`);
   });

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -66,7 +66,7 @@ describe('users', () => {
     cy.hasTitle(user.username);
     cy.clickButton(/^Edit user$/);
     cy.hasTitle(/^Edit user$/);
-    cy.typeByLabel(/^Username$/, 'a');
+    cy.typeByLabel(/^Username$/, user.username + 'a');
     cy.clickButton(/^Save user$/);
     cy.hasTitle(`${user.username}a`);
   });

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -52,7 +52,7 @@ describe('credentials', () => {
     cy.clickRow(credential.name);
     cy.clickButton(/^Edit credential$/);
     cy.hasTitle(/^Edit credential$/);
-    cy.typeByLabel(/^Name$/, 'a');
+    cy.typeByLabel(/^Name$/, credential.name + 'a');
     cy.clickButton(/^Save credential$/);
     cy.hasTitle(`${credential.name}a`);
   });
@@ -69,7 +69,7 @@ describe('credentials', () => {
     cy.hasTitle(credential.name);
     cy.clickButton(/^Edit credential$/);
     cy.hasTitle(/^Edit credential$/);
-    cy.typeByLabel(/^Name$/, 'a');
+    cy.typeByLabel(/^Name$/, credential.name + 'a');
     cy.clickButton(/^Save credential$/);
     cy.hasTitle(`${credential.name}a`);
   });

--- a/cypress/e2e/eda/Credentials/credentials-crud.cy.ts
+++ b/cypress/e2e/eda/Credentials/credentials-crud.cy.ts
@@ -1,24 +1,112 @@
 //Tests a user's ability to create, edit, and delete a Credential in the EDA UI.
 //Do we want to add create tests for all credential types now or wait until next release cycle?
+import { randomString } from '../../../../framework/utils/random-string';
 
 describe('EDA Credentials- Create, Edit, Delete', () => {
   before(() => {
     cy.edaLogin();
   });
 
-  it.skip('can create a machine credential, and assert the information showing on the details page', () => {
-    //write test here
+  it('can create a container registry credential, and assert the information showing on the details page', () => {
+    const name = 'E2E Credential ' + randomString(4);
+    cy.navigateTo(/^Credentials$/);
+    cy.get('h1').should('contain', 'Credentials');
+    cy.clickButton(/^Create credential$/);
+    cy.typeByLabel(/^Name$/, name);
+    cy.typeByLabel(/^Description$/, 'This is a Container Registry Credential.');
+    cy.selectByLabel(/^Type$/, 'Container Registry');
+    cy.typeByLabel(/^User name$/, 'admin');
+    cy.clickButton(/^Create credential$/);
+    cy.hasDetail('Name', name);
+    cy.hasDetail('Description', 'This is a Container Registry Credential.');
+    cy.hasDetail('Credential type', 'Container Registry');
+    cy.hasDetail('Username', 'admin');
+    cy.getEdaCredentialByName(name).then((credential) => {
+      cy.wrap(credential).should('not.be.undefined');
+      if (credential) {
+        cy.deleteEdaCredential(credential);
+      }
+    });
   });
 
-  it.skip('can create a source control credential', () => {
-    //write test here
+  it('can create a GitHub token credential, and assert the information showing on the details page', () => {
+    const name = 'E2E Credential ' + randomString(4);
+    cy.navigateTo(/^Credentials$/);
+    cy.get('h1').should('contain', 'Credentials');
+    cy.clickButton(/^Create credential$/);
+    cy.typeByLabel(/^Name$/, name);
+    cy.typeByLabel(/^Description$/, 'This is a GitHub Credential.');
+    cy.selectByLabel(/^Type$/, 'GitHub Personal Access Token');
+    cy.typeByLabel(/^User name$/, 'admin');
+    cy.clickButton(/^Create credential$/);
+    cy.hasDetail('Name', name);
+    cy.hasDetail('Description', 'This is a GitHub Credential.');
+    cy.hasDetail('Credential type', 'GitHub Personal Access Token');
+    cy.hasDetail('Username', 'admin');
+    cy.getEdaCredentialByName(name).then((credential) => {
+      cy.wrap(credential).should('not.be.undefined');
+      if (credential) {
+        cy.deleteEdaCredential(credential);
+      }
+    });
   });
 
-  it.skip('can edit a credential but cannot edit the type of credential', () => {
-    //write test here
+  it('can create a GitLab token credential, and assert the information showing on the details page', () => {
+    const name = 'E2E Credential ' + randomString(4);
+    cy.navigateTo(/^Credentials$/);
+    cy.get('h1').should('contain', 'Credentials');
+    cy.clickButton(/^Create credential$/);
+    cy.typeByLabel(/^Name$/, name);
+    cy.typeByLabel(/^Description$/, 'This is a GitLab Credential.');
+    cy.selectByLabel(/^Type$/, 'GitLab Personal Access Token');
+    cy.typeByLabel(/^User name$/, 'admin');
+    cy.clickButton(/^Create credential$/);
+    cy.hasDetail('Name', name);
+    cy.hasDetail('Description', 'This is a GitLab Credential.');
+    cy.hasDetail('Credential type', 'GitLab Personal Access Token');
+    cy.hasDetail('Username', 'admin');
+    cy.getEdaCredentialByName(name).then((credential) => {
+      cy.wrap(credential).should('not.be.undefined');
+      if (credential) {
+        cy.deleteEdaCredential(credential);
+      }
+    });
   });
 
-  it.skip('can delete a credential', () => {
-    //write test here
+  it('can edit a credential', () => {
+    cy.createEdaCredential().then((edaCredential) => {
+      cy.navigateTo(/^Credentials$/);
+      cy.get('h1').should('contain', 'Credentials');
+      cy.clickRow(edaCredential.name);
+      cy.clickPageAction(/^Edit credential$/);
+      cy.hasTitle(/^Edit credential$/);
+      cy.typeByLabel(/^Name$/, edaCredential.name + 'lalala');
+      cy.typeByLabel(/^Description$/, 'this credential type has been changed');
+      cy.selectByLabel(/^Type$/, 'GitHub Personal Access Token');
+      cy.typeByLabel(/^User name$/, 'velveeta');
+      cy.clickButton(/^Save credential$/);
+      cy.hasDetail('Name', edaCredential.name + 'lalala');
+      cy.hasDetail('Description', 'this credential type has been changed');
+      cy.hasDetail('Credential type', 'GitHub Personal Access Token');
+      cy.hasDetail('Username', 'velveeta');
+      cy.navigateTo(/^Credentials$/);
+      cy.deleteEdaCredential(edaCredential);
+    });
+  });
+
+  it('can delete a credential', () => {
+    cy.createEdaCredential().then((edaCredential) => {
+      cy.navigateTo(/^Credentials$/);
+      cy.get('h1').should('contain', 'Credentials');
+      cy.clickRow(edaCredential.name);
+      cy.hasTitle(edaCredential.name);
+      cy.intercept('DELETE', `/api/eda/v1/credentials/${edaCredential.id}/`).as('deleted');
+      cy.clickPageAction(/^Delete credential$/);
+      cy.confirmModalAction('Delete credential');
+      cy.wait('@deleted').then((deleted) => {
+        expect(deleted?.response?.statusCode).to.eql(204);
+        cy.hasTitle(/^Credentials$/);
+      });
+    });
   });
 });

--- a/cypress/e2e/eda/Projects/projects-crud.cy.ts
+++ b/cypress/e2e/eda/Projects/projects-crud.cy.ts
@@ -9,7 +9,7 @@ describe('EDA Projects CRUD', () => {
   before(() => cy.edaLogin());
 
   it('can create a Project, sync it, and assert the information showing on the details page', () => {
-    const name = 'E2E Team ' + randomString(4);
+    const name = 'E2E Project ' + randomString(4);
     cy.navigateTo(/^Projects$/);
     cy.get('h1').should('contain', 'Projects');
     cy.clickButton(/^Create project$/);

--- a/cypress/e2e/eda/Projects/projects-crud.cy.ts
+++ b/cypress/e2e/eda/Projects/projects-crud.cy.ts
@@ -30,7 +30,7 @@ describe('EDA Projects CRUD', () => {
       cy.clickRow(edaProject.name);
       cy.clickPageAction(/^Edit project$/);
       cy.hasTitle(/^Edit project$/);
-      cy.typeByLabel(/^Name$/, 'a');
+      cy.typeByLabel(/^Name$/, edaProject.name + 'a');
       cy.clickButton(/^Save project$/);
       cy.hasTitle(`${edaProject.name}a`);
       cy.deleteEdaProject(edaProject);


### PR DESCRIPTION
This PR:

Adds Credentials CRUD tests 
- creates 3 different kinds of credentials
- edits a credential
- deletes a credential

Adds custom commands for Credentials
- cy.createEdaCredential()
- cy.deleteEdaCredential()
- cy.getEdaCredentialByName()

Fixes a typo in projects-crud.cy.ts