### PR TITLE
Routed tabs (with URLs)

### DIFF
--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -56,7 +56,7 @@ describe('users', () => {
     cy.navigateTo(/^Users$/);
     cy.clickRow(user.username);
     cy.hasTitle(user.username);
-    cy.clickButton(/^Details$/);
+    cy.clickLink(/^Details$/);
     cy.contains('#username', user.username);
   });
 

--- a/framework/RoutedTabs.tsx
+++ b/framework/RoutedTabs.tsx
@@ -1,0 +1,170 @@
+import { Children, isValidElement, ReactNode, useCallback, useState, useMemo } from 'react';
+import { Routes, Route, useParams, useNavigate } from 'react-router-dom';
+import {
+  Divider,
+  Flex,
+  FlexItem,
+  PageSection,
+  PageSectionTypes,
+  Skeleton,
+  Tab,
+  Tabs,
+  TabsComponent,
+} from '@patternfly/react-core';
+
+interface RoutedTabProps {
+  label?: string;
+  url: string;
+  children: ReactNode;
+}
+
+function replaceRouteParams(path: string, params: { [key: string]: string | undefined }) {
+  let newPath = path;
+  Object.keys(params).forEach((key) => {
+    newPath = newPath.replace(`:${key}`, params[key] ?? `:${key}`);
+  });
+  return newPath;
+}
+
+export function RoutedTabs(props: {
+  baseUrl: string;
+  children: ReactNode;
+  preComponents?: ReactNode;
+  postComponents?: ReactNode;
+  initialTabIndex?: number;
+  isLoading?: boolean;
+}) {
+  const params = useParams<{ [key: string]: string | undefined }>();
+  const { isLoading } = props;
+  const baseUrl = replaceRouteParams(props.baseUrl, params);
+  const children = useMemo(
+    () =>
+      Children.toArray(props.children).filter(
+        (child) => isValidElement(child) && child.type === RoutedTab
+      ),
+    [props.children]
+  );
+  const [activeKey, setActiveKey] = useState<number>(props?.initialTabIndex ?? 0);
+  const navigate = useNavigate();
+
+  const handleSelect = useCallback(
+    (event: React.MouseEvent<HTMLElement, MouseEvent>, key: number) => {
+      // const match = tabsArray.find((tab) => tab.id === eventKey);
+      const match = children[key];
+      if (match) {
+        event.preventDefault();
+        setActiveKey(key);
+        const url = match.props.url;
+        navigate(replaceRouteParams(url, params));
+      }
+    },
+    [setActiveKey, navigate, children, params]
+  );
+  const tabs = children.map((child, index) => {
+    const { label, url } = child.props as RoutedTabProps;
+    return (
+      <Tab
+        key={label ?? index}
+        title={label ? label : <Skeleton width="60px" />}
+        eventKey={index}
+        href={replaceRouteParams(url, params)}
+      />
+    );
+  });
+  const routes = children.map((child, index) => {
+    const { label, url = '', children } = child.props as RoutedTabProps;
+    return (
+      <Route
+        key={label ?? index}
+        path={url.replace(props.baseUrl.replace('*', ''), '')}
+        element={children}
+      />
+    );
+  });
+  console.log(routes);
+
+  if (isLoading) {
+    return (
+      <RoutedTabs baseUrl={baseUrl}>
+        <RoutedTab url="#">
+          <PageSection variant="light">
+            <Skeleton />
+          </PageSection>
+        </RoutedTab>
+      </RoutedTabs>
+    );
+  }
+
+  return (
+    <>
+      <Tabs
+        activeKey={activeKey}
+        onSelect={handleSelect}
+        inset={
+          props.preComponents
+            ? undefined
+            : {
+                default: 'insetNone',
+                sm: 'insetNone',
+                md: 'insetNone',
+                lg: 'insetNone',
+                xl: 'insetSm',
+                ['2xl']: 'insetSm',
+              }
+        }
+        hasBorderBottom={false}
+        component={TabsComponent.nav}
+      >
+        {tabs}
+      </Tabs>
+      <Routes>{routes}</Routes>
+    </>
+  );
+
+  return (
+    <>
+      <PageSection type={PageSectionTypes.tabs} className="border-bottom">
+        <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+          {props.preComponents && (
+            <>
+              <FlexItem>{props.preComponents}</FlexItem>
+              <Divider orientation={{ default: 'vertical' }} component="div" />
+            </>
+          )}
+          <FlexItem grow={{ default: 'grow' }}>
+            <Tabs
+              activeKey={activeKey}
+              onSelect={onSelect}
+              inset={
+                props.preComponents
+                  ? undefined
+                  : {
+                      default: 'insetNone',
+                      sm: 'insetNone',
+                      md: 'insetNone',
+                      lg: 'insetNone',
+                      xl: 'insetSm',
+                      ['2xl']: 'insetSm',
+                    }
+              }
+              hasBorderBottom={false}
+            >
+              {tabs}
+            </Tabs>
+          </FlexItem>
+          {props.postComponents && (
+            <>
+              <Divider orientation={{ default: 'vertical' }} />
+              <FlexItem style={{ paddingRight: 16 }}>{props.postComponents}</FlexItem>
+            </>
+          )}
+        </Flex>
+      </PageSection>
+      {content}
+    </>
+  );
+}
+
+export function RoutedTab(props: RoutedTabProps) {
+  return <>{props.children}</>;
+}

--- a/framework/index.ts
+++ b/framework/index.ts
@@ -40,6 +40,7 @@ export * from './PageTable/PageTableColumn';
 export * from './PageTable/PageToolbar';
 export * from './PageTable/useTableItems';
 export * from './PageTabs';
+export * from './RoutedTabs';
 export * from './Settings';
 export * from './components/BulkSelector';
 export * from './components/Collapse';

--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -76,7 +76,11 @@ export const RouteObj: { [key: string]: RouteType } = {
   AddRolesToTeam: `${awxRoutePrefix}/teams/:id/roles/add`,
 
   Users: `${awxRoutePrefix}/users`,
+  UserPage: `${awxRoutePrefix}/users/:id/*`,
   UserDetails: `${awxRoutePrefix}/users/:id/details`,
+  UserOrganizations: `${awxRoutePrefix}/users/:id/organizations`,
+  UserTeams: `${awxRoutePrefix}/users/:id/teams`,
+  UserRoles: `${awxRoutePrefix}/users/:id/roles`,
   CreateUser: `${awxRoutePrefix}/users/create`,
   EditUser: `${awxRoutePrefix}/users/:id/edit`,
   AddRolesToUser: `${awxRoutePrefix}/users/:id/roles/add`,

--- a/frontend/awx/AwxRouter.tsx
+++ b/frontend/awx/AwxRouter.tsx
@@ -89,7 +89,7 @@ export function AwxRouter() {
         <Route path={RouteObjWithoutPrefix.EditOrganization} element={<EditOrganization />} />
 
         <Route path={RouteObjWithoutPrefix.Users} element={<Users />} />
-        <Route path={RouteObjWithoutPrefix.UserDetails} element={<UserPage />} />
+        <Route path={RouteObjWithoutPrefix.UserPage} element={<UserPage />} />
         <Route path={RouteObjWithoutPrefix.CreateUser} element={<CreateUser />} />
         <Route path={RouteObjWithoutPrefix.EditUser} element={<EditUser />} />
         <Route path={RouteObjWithoutPrefix.AddRolesToUser} element={<AddRolesToUser />} />

--- a/frontend/awx/access/users/UserPage/UserPage.tsx
+++ b/frontend/awx/access/users/UserPage/UserPage.tsx
@@ -10,8 +10,8 @@ import {
   PageActionType,
   PageHeader,
   PageLayout,
-  PageTab,
-  PageTabs,
+  RoutedTabs,
+  RoutedTab,
 } from '../../../../../framework';
 import { LoadingPage } from '../../../../../framework/components/LoadingPage';
 import { useGetItem } from '../../../../common/crud/useGetItem';
@@ -72,20 +72,20 @@ export function UserPage() {
           />
         }
       />
-      <PageTabs>
-        <PageTab label={t('Details')}>
+      <RoutedTabs baseUrl={RouteObj.UserPage}>
+        <RoutedTab label={t('Details')} url={RouteObj.UserDetails}>
           <UserDetails user={user} />
-        </PageTab>
-        <PageTab label={t('Organizations')}>
+        </RoutedTab>
+        <RoutedTab label={t('Organizations')} url={RouteObj.UserOrganizations}>
           <UserOrganizations user={user} />
-        </PageTab>
-        <PageTab label={t('Teams')}>
+        </RoutedTab>
+        <RoutedTab label={t('Teams')} url={RouteObj.UserTeams}>
           <UserTeams user={user} />
-        </PageTab>
-        <PageTab label={t('Roles')}>
+        </RoutedTab>
+        <RoutedTab label={t('Roles')} url={RouteObj.UserRoles}>
           <UserRoles user={user} />
-        </PageTab>
-      </PageTabs>
+        </RoutedTab>
+      </RoutedTabs>
     </PageLayout>
   );
 }


### PR DESCRIPTION
Adds a RoutedTabs component. The API is very similar to PageTabs, but it uses a sub-router for URL-based routing between tabs.

AWX User page has been updated to use RoutedTabs as a proof-of-concept.