### PR TITLE
Create eda user and set permissions to enable deploying to Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,27 @@ COPY ${NGINX_CONF} ${NGINX_CONFIGURATION_PATH}
 RUN mkdir -p ${DIST_UI}/
 COPY --from=eda-ui-builder /ansible-ui/build/eda/ ${DIST_UI}
 
+# Set up permissions
+ARG USER_ID=${USER_ID:-1001}
+RUN adduser -S eda -u "$USER_ID" -G root
+
+# Pre-create things we need to access
+USER 0
+
+RUN for dir in \
+      ${DIST_UI}/ \
+      ${NGINX_CONF} \
+      ${NGINX_CONFIGURATION_PATH} \
+      /var/cache/nginx \
+      /var/log/nginx \
+      /var/lib/nginx ; \
+    do mkdir -m 0775 -p $dir ; chmod g+rwx $dir ; chgrp root $dir ; done && \
+    for file in \
+      /var/run/nginx.pid ; \
+    do touch $file ; chmod g+rw $file ; done
+
+USER "$USER_ID"
+
 # ansible-ui-builder
 FROM --platform=${TARGETPLATFORM:-linux/amd64} dependencies as ansible-ui-builder
 COPY . .


### PR DESCRIPTION
### Summary

Currently, the eda-ui image build target results in an image that cannot be used in Openshift deployments because of how Openshift injects a non-root uid.

This PR makes the necessary changes so that the container is run as a non-root use, and that user (`eda`) has access to the files needed to bring up the UI.


