### PR TITLE
Decision Environment CRUD tests

### DIFF
--- a/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
+++ b/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
@@ -1,27 +1,71 @@
 //Tests a user's ability to create, edit, and delete an decision environment in the EDA UI.
-
+import { randomString } from '../../../../framework/utils/random-string';
 describe('EDA decision environment- Create, Edit, Delete', () => {
   before(() => {
     cy.edaLogin();
   });
 
-  it.skip('can create an decision environment and assert the information showing on the details page', () => {
-    //write test here
+  it('can create an decision environment and assert the information showing on the details page', () => {
+    const de_name = 'E2E Decision Environment ' + randomString(4);
+    cy.navigateTo(/^Decision environments$/);
+    cy.get('h1').should('contain', 'DecisionEnvironments');
+    cy.clickButton(/^Create decision environment$/);
+    cy.typeInputByLabel(/^Name$/, de_name);
+    cy.typeInputByLabel(/^Registry URL$/, 'quay.io/ansible/ansible-rulebook:main');
+    cy.clickButton(/^Create decision environment$/);
+    cy.hasTitle(de_name);
+    cy.getEdaDecisionEnvironmentByName(de_name).then((de) => {
+      cy.wrap(de).should('not.be.undefined');
+      if (de) cy.deleteEdaDecisionEnvironment(de);
+    });
   });
 
   it.skip('can create an decision environment and test the connection', () => {
     //write test here
   });
 
-  it.skip('can verify edit functionality of a decision environment', () => {
-    //write test here
+  it('can verify edit functionality of a decision environment', () => {
+    cy.createEdaDecisionEnvironment().then((edaDE) => {
+      cy.navigateTo(/^Decision environments$/);
+      cy.get('h1').should('contain', 'DecisionEnvironments');
+      /*
+      DE's are displayed by default in card view hence clickTableRow() doesn't work 
+      cy.clickTableRow(edaDE.name);
+      */
+      cy.get('button[aria-label="table view"]').click();
+      cy.contains('td', edaDE.name).within(() => {
+        cy.get('a').click();
+      });
+      cy.clickPageAction(/^Edit decision environment$/);
+      cy.hasTitle(/^Edit decision environment$/);
+      cy.typeInputByLabel(/^Name$/, edaDE.name + 'edited');
+      cy.clickButton(/^Save decision environment$/);
+      cy.hasTitle(`${edaDE.name}edited`);
+      cy.deleteEdaDecisionEnvironment(edaDE);
+    });
   });
 
   it.skip('can sync a decision environment to Controller', () => {
     //should this test be in this repo, or should it be moved to a private repo?
   });
 
-  it.skip('can delete a decision environment', () => {
-    //should this test be in this repo, or should it be moved to a private repo?
+  it('can delete a decision environment from the details page', () => {
+    cy.createEdaDecisionEnvironment().then((edaDE) => {
+      cy.navigateTo(/^Decision environments$/);
+      cy.get('h1').should('contain', 'DecisionEnvironments');
+      cy.get('button[aria-label="table view"]').click();
+      cy.contains('td', edaDE.name).within(() => {
+        cy.get('a').click();
+      });
+      cy.hasTitle(edaDE.name);
+      cy.intercept('DELETE', `/api/eda/v1/decision-environments/${edaDE.id}/`).as('deleteDE');
+      cy.clickPageAction(/^Delete decision environment$/);
+      cy.clickModalConfirmCheckbox();
+      cy.clickModalButton('Delete decision environments');
+      cy.wait('@deleteDE').then((deleteDE) => {
+        expect(deleteDE?.response?.statusCode).to.eql(204);
+        cy.hasTitle(/^DecisionEnvironments$/);
+      });
+    });
   });
 });

--- a/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
+++ b/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
@@ -5,6 +5,11 @@ describe('EDA decision environment- Create, Edit, Delete', () => {
     cy.edaLogin();
   });
 
+  it('can render the decision environments list page', () => {
+    cy.navigateTo(/^Decision environments$/);
+    cy.hasTitle(/^DecisionEnvironments$/);
+  });
+
   it('can create an decision environment and assert the information showing on the details page', () => {
     const de_name = 'E2E Decision Environment ' + randomString(4);
     cy.navigateTo(/^Decision environments$/);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -393,9 +393,7 @@ Cypress.Commands.add('selectToolbarFilterType', (text: string | RegExp) => {
 });
 
 Cypress.Commands.add('filterTableByText', (text: string) => {
-  cy.get('#filter-input').within(() => {
-    cy.get('input').clear().type(text, { delay: 0 });
-  });
+  cy.get('#filter-input').clear().type(text, { delay: 0 });
   cy.get('[aria-label="apply filter"]').click();
 });
 


### PR DESCRIPTION
## Description
This PR is for [ticket](https://issues.redhat.com/browse/AAP-11009)

## Acceptance Criteria
- [x] adds custom commands  `createEdaDecisionEnvironment` `getEdaDecisionEnvironment` `getEdaDecisionEnvironmentByName` `deleteEdaDecisionEnvironment`
- [x] can render the decision environments list page
- [x] can create a decision environment and assert the information showing on the details page
- [x] can verify the edit functionality of a decision environment
- [x] can delete a decision environment from the details page