### PR TITLE
Add missing job template details

### DIFF
--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -33,11 +33,10 @@ export const RouteObj: { [key: string]: RouteType } = {
   Templates: `${awxRoutePrefix}/templates`,
   JobTemplateDetails: `${awxRoutePrefix}/job_template/details/:id`,
   WorkflowJobTemplateDetails: `${awxRoutePrefix}/workflow_job_template/details/:id`,
-  WorkflowJobTemplateEdit: `${awxRoutePrefix}/workflow_job_template/edit/:id`,
-  JobTemplateEdit: `${awxRoutePrefix}/job_template/edit/:id`,
   CreateWorkflowJobTemplate: `${awxRoutePrefix}/workflow_job_template/create`,
   CreateJobTemplate: `${awxRoutePrefix}/job_template/create`,
-  EditTemplate: `${awxRoutePrefix}/templates/edit/:id`,
+  EditJobTemplate: `${awxRoutePrefix}/job_template/edit/:id`,
+  EditWorkflowJobTemplate: `${awxRoutePrefix}/workflow_job_template/edit/:id`,
 
   Credentials: `${awxRoutePrefix}/credentials`,
   CredentialDetails: `${awxRoutePrefix}/credentials/details/:id`,

--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -88,7 +88,7 @@ export const RouteObj: { [key: string]: RouteType } = {
   ManagementJobs: `${awxRoutePrefix}/management-jobs`,
 
   InstanceGroups: `${awxRoutePrefix}/instance-groups`,
-  InstanceGroupDetails: `${awxRoutePrefix}/instance-groups/details/:id`,
+  InstanceGroupDetails: `${awxRoutePrefix}/instance-groups/:id/details`,
   CreateInstanceGroup: `${awxRoutePrefix}/instance-groups/create`,
   EditInstanceGroup: `${awxRoutePrefix}/instance-groups/edit/:id`,
 

--- a/frontend/awx/AwxRouter.tsx
+++ b/frontend/awx/AwxRouter.tsx
@@ -38,6 +38,7 @@ import { JobPage } from './views/jobs/JobPage';
 import Jobs from './views/jobs/Jobs';
 import Reports from './analytics/Reports/Reports';
 import { PageNotFound } from '../common/PageNotFound';
+import { PageNotImplemented } from '../common/PageNotImplemented';
 
 export function AwxRouter() {
   const RouteObjWithoutPrefix = useRoutesWithoutPrefix(RouteObj.AWX);
@@ -68,6 +69,7 @@ export function AwxRouter() {
           element={<WorkflowJobTemplateDetail />}
         />
         <Route path={RouteObjWithoutPrefix.CreateJobTemplate} element={<CreateJobTemplate />} />
+        <Route path={RouteObjWithoutPrefix.EditJobTemplate} element={<PageNotImplemented />} />
         <Route path={RouteObjWithoutPrefix.Credentials} element={<Credentials />} />
         <Route path={RouteObjWithoutPrefix.CredentialDetails} element={<CredentialPage />} />
         <Route path={RouteObjWithoutPrefix.CreateCredential} element={<CreateCredential />} />

--- a/frontend/awx/AwxRouter.tsx
+++ b/frontend/awx/AwxRouter.tsx
@@ -99,6 +99,7 @@ export function AwxRouter() {
         {/* <Route path={RouteObjWithoutPrefix.Notifications} element={<Notifications />} /> */}
         {/* <Route path={RouteObjWithoutPrefix.ManagementJobs} element={<ManagementJobs />} /> */}
         <Route path={RouteObjWithoutPrefix.InstanceGroups} element={<InstanceGroups />} />
+        <Route path={RouteObjWithoutPrefix.InstanceGroupDetails} element={<PageNotImplemented />} />
         <Route path={RouteObjWithoutPrefix.Instances} element={<Instances />} />
         <Route path={RouteObjWithoutPrefix.InstanceDetails} element={<InstanceDetails />} />
         <Route path={RouteObjWithoutPrefix.EditInstance} element={<EditInstance />} />

--- a/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
@@ -3,19 +3,34 @@ import {
   TextListItem,
   TextListItemVariants,
   TextListVariants,
+  LabelGroup,
+  Label,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { PageDetail, PageDetails } from '../../../../../framework';
+import { useGet } from '../../../../common/crud/useGet';
 import { RouteObj } from '../../../../Routes';
 import { UserDateDetail } from '../../../common/UserDateDetail';
+import { CredentialLabel } from '../../../common/CredentialLabel';
 import { useVerbosityString } from '../../../common/useVerbosityString';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
+import { InstanceGroup } from '../../../interfaces/InstanceGroup';
+
+function useInstanceGroups(templateId: string) {
+  const { data } = useGet<{ results: InstanceGroup[] }>(
+    `/api/v2/job_templates/${templateId}/instance_groups/`
+  );
+  return data?.results ?? [];
+}
 
 export function TemplateDetails(props: { template: JobTemplate }) {
   const { t } = useTranslation();
   const { template } = props;
+  const params = useParams<{ id: string }>();
   const { summary_fields: summaryFields } = template;
+
+  const instanceGroups = useInstanceGroups(params.id || '0');
 
   const showOptionsField =
     template.become_enabled ||
@@ -76,6 +91,28 @@ export function TemplateDetails(props: { template: JobTemplate }) {
       </PageDetail>
       <PageDetail label={t('Source control branch')}>{template.scm_branch}</PageDetail>
       <PageDetail label={t('Playbook')}>{template.playbook}</PageDetail>
+      <PageDetail label={t('Credentials')} isEmpty={!summaryFields.credentials.length}>
+        <LabelGroup>
+          {summaryFields.credentials.map((credential) => (
+            <CredentialLabel credential={credential} key={credential.id} />
+          ))}
+        </LabelGroup>
+      </PageDetail>
+      <PageDetail
+        label={t`Instance Groups`}
+        helpText={t`The Instance Groups for this Job Template to run on.`}
+        isEmpty={instanceGroups.length === 0}
+      >
+        <LabelGroup>
+          {instanceGroups.map((ig) => (
+            <Label color="blue" key={ig.id}>
+              <Link to={RouteObj.InstanceGroupDetails.replace(':id', (ig.id ?? 0).toString())}>
+                {ig.name}
+              </Link>
+            </Label>
+          ))}
+        </LabelGroup>
+      </PageDetail>
       <PageDetail label={t('Forks')}>{template.forks || 0}</PageDetail>
       <PageDetail label={t('Limit')}>{template.limit}</PageDetail>
       <PageDetail label={t('Verbosity')}>{useVerbosityString(template.verbosity)}</PageDetail>
@@ -139,6 +176,27 @@ export function TemplateDetails(props: { template: JobTemplate }) {
             </TextListItem>
           )}
         </TextList>
+      </PageDetail>
+      <PageDetail label={t('Labels')} isEmpty={!summaryFields.labels?.results?.length}>
+        <LabelGroup>
+          {summaryFields.labels.results.map((label) => (
+            <Label key={label.id}>{label.name}</Label>
+          ))}
+        </LabelGroup>
+      </PageDetail>
+      <PageDetail label={t('Job tags')} isEmpty={!template.job_tags}>
+        <LabelGroup>
+          {template.job_tags.split(',').map((tag) => (
+            <Label key={tag}>{tag}</Label>
+          ))}
+        </LabelGroup>
+      </PageDetail>
+      <PageDetail label={t('Skip tags')} isEmpty={!template.skip_tags}>
+        <LabelGroup>
+          {template.skip_tags.split(',').map((tag) => (
+            <Label key={tag}>{tag}</Label>
+          ))}
+        </LabelGroup>
       </PageDetail>
     </PageDetails>
   );

--- a/frontend/awx/resources/templates/Templates.tsx
+++ b/frontend/awx/resources/templates/Templates.tsx
@@ -85,12 +85,11 @@ export function Templates() {
   const rowActions = useMemo<IPageAction<JobTemplate | WorkflowJobTemplate>[]>(
     () => [
       {
-        type: PageActionType.Button,
+        type: PageActionType.Link,
         selection: PageActionSelection.Single,
         icon: EditIcon,
         label: t(`Edit Template`),
-        onClick: (template) =>
-          navigate(RouteObj.JobTemplateEdit.replace(':id', template.id.toString())),
+        href: (template) => RouteObj.EditJobTemplate.replace(':id', template.id.toString()),
       },
       {
         type: PageActionType.Button,
@@ -100,7 +99,7 @@ export function Templates() {
         onClick: (template) => deleteTemplates([template]),
       },
     ],
-    [navigate, deleteTemplates, t]
+    [deleteTemplates, t]
   );
   return (
     <PageLayout>

--- a/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
@@ -1,4 +1,3 @@
-import { ButtonVariant } from '@patternfly/react-core';
 import { EditIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,15 +21,13 @@ export function useTemplateActions(options: {
   return useMemo<IPageAction<JobTemplate>[]>(() => {
     const itemActions: IPageAction<JobTemplate>[] = [
       {
-        type: PageActionType.Button,
+        type: PageActionType.Link,
         selection: PageActionSelection.Single,
-        variant: ButtonVariant.primary,
         isPinned: true,
         icon: EditIcon,
         label: t('Edit template'),
         ouiaId: 'job-template-detail-edit-button',
-        onClick: (template) =>
-          navigate(RouteObj.EditTemplate.replace(':id', template?.id.toString() ?? '')),
+        href: (template) => RouteObj.EditJobTemplate.replace(':id', template?.id.toString() ?? ''),
       },
       {
         type: PageActionType.Button,


### PR DESCRIPTION
Adds to JobTemplateDetails:

* Credentials
* Labels
* Instance groups
* Job tags
* Skip tags

Also adds the "page not implemented" screen to the instance group details route