### PR TITLE
[Analytics] Add catch in case something went wrong when reading error from API

### DIFF
--- a/frontend/awx/analytics/Reports/AutomationCalculator.tsx
+++ b/frontend/awx/analytics/Reports/AutomationCalculator.tsx
@@ -196,7 +196,8 @@ export default function AutomationCalculator(props: { schema: ChartSchemaElement
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         .then((r: { error?: { keyword?: string } }) =>
           setSpecificError(r?.error?.keyword || 'unknown')
-        );
+        )
+        .catch(() => setSpecificError('unknown'));
     }
   }, [error, optionsError]);
 

--- a/frontend/awx/analytics/Reports/Reports.tsx
+++ b/frontend/awx/analytics/Reports/Reports.tsx
@@ -52,7 +52,8 @@ export default function Reports() {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         .then((r: { error?: { keyword?: string } }) =>
           setSpecificError(r?.error?.keyword || 'unknown')
-        );
+        )
+        .catch(() => setSpecificError('unknown'));
     }
   }, [error]);
 


### PR DESCRIPTION
Steps to reproduce:
- Have a backend that's https://github.com/ansible/awx/commit/c0491a7b102f0dedc9ee8db4318854dc43ad7032 or older
- Go to Analytics -> Reports

Before:
<img width="1052" alt="Screenshot 2023-04-19 at 13 03 56" src="https://user-images.githubusercontent.com/9210860/233055739-dd74c012-4b65-44bf-b328-9a6aef9c24cb.png">

After:
<img width="1430" alt="Screenshot 2023-04-19 at 13 01 54" src="https://user-images.githubusercontent.com/9210860/233055627-bcab1f99-98f6-4e72-be1a-549696bf09c0.png">



Related to https://github.com/ansible/ansible-ui/pull/189

