### PR TITLE
Navigate to correct UI (user details) from username dropdown in the masthead

### DIFF
--- a/frontend/common/Masthead.tsx
+++ b/frontend/common/Masthead.tsx
@@ -45,6 +45,7 @@ import { API_PREFIX } from '../eda/constants';
 import { useAnsibleAboutModal } from './AboutModal';
 import { swrOptions, useFetcher } from './crud/Data';
 import { postRequest } from './crud/usePostRequest';
+import { useActiveUser } from './useActiveUser';
 
 const MastheadBrandDiv = styled.div`
   display: flex;
@@ -292,6 +293,7 @@ function AccountDropdownInternal() {
     setOpen((open) => !open);
   }, []);
   const { t } = useTranslation();
+  const activeUser = useActiveUser();
   return (
     <Dropdown
       onSelect={onSelect}
@@ -316,8 +318,16 @@ function AccountDropdownInternal() {
           key="user-details"
           onClick={() => {
             automationServer?.type === AutomationServerType.EDA
-              ? history(RouteObj.EdaUsers)
-              : history(RouteObj.Users);
+              ? history(
+                  activeUser
+                    ? RouteObj.EdaUserDetails.replace(':id', activeUser.id.toString())
+                    : RouteObj.EdaUsers
+                )
+              : history(
+                  activeUser
+                    ? RouteObj.UserDetails.replace(':id', activeUser.id.toString())
+                    : RouteObj.Users
+                );
           }}
         >
           {t('User details')}


### PR DESCRIPTION
When the user clicks the "User details" menu item in the username dropdown in the masthead, they should be brought to their user's details page. (Currently it is brings the user to the list of users)

<img width="222" alt="image" src="https://user-images.githubusercontent.com/43621546/233198307-24a08e69-96f4-4667-af17-da48b16e7749.png">

Updated for both AWX and EDA. cc: @lgalis
