### PR TITLE
Fix for translation interpolation bug in Team Access UI

### DIFF
--- a/frontend/awx/access/common/DeleteRoleConfirmation.tsx
+++ b/frontend/awx/access/common/DeleteRoleConfirmation.tsx
@@ -31,8 +31,13 @@ export function DeleteRoleConfirmation(props: DeleteRoleConfirmationProps) {
   return (
     <Modal
       titleIconVariant="danger"
-      // TODO `${sourceOfRole()}` breaks translations
-      title={title ? title : t(`Remove ${sourceOfRole()} access`)}
+      title={
+        title
+          ? title
+          : typeof role.team_id !== 'undefined'
+          ? t(`Remove team access`)
+          : t(`Remove user access`)
+      }
       variant={ModalVariant.small}
       isOpen
       onClose={onCloseClicked}


### PR DESCRIPTION
The interpolation as it is currently implemented will not work with i18next: 
```
title={title ? title : t(`Remove ${sourceOfRole()} access`)}
```
This PR fixes the interpolation to work correctly with i18-next.

Thanks for reporting the issue @jamestalton 

