### PR TITLE
Update page size for the activation instance logs

### DIFF
--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -28,7 +28,7 @@ export function ActivationInstanceDetails() {
   );
 
   const { data: activationInstanceLog } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
-    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/`
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page=1&page_size=300`
   );
 
   const { data: activation } = useGet<EdaRulebookActivation>(


### PR DESCRIPTION
Update page size for the activation instance logs

![Screenshot from 2023-04-25 14-52-17](https://user-images.githubusercontent.com/12769982/234375080-d8a0a202-10a0-418a-97e4-8026a8dba07f.png)
