### PR TITLE
Get page size for the activation instance output and read all records

### DIFF
--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -27,8 +27,14 @@ export function ActivationInstanceDetails() {
     `${API_PREFIX}/activation-instances/${params.id ?? ''}/`
   );
 
+  const { data: activationInstanceLogInfo } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=1`
+  );
+
   const { data: activationInstanceLog } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
-    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/`
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=${
+      activationInstanceLogInfo?.count || 10
+    }`
   );
 
   const { data: activation } = useGet<EdaRulebookActivation>(


### PR DESCRIPTION
**Alternative for #457** 
Get page size for the activation instance output and read all records

![Screenshot from 2023-04-25 15-36-56](https://user-images.githubusercontent.com/12769982/234384666-686b6de0-00c2-4f1b-b9f3-29761518fcca.png)
