### PR TITLE
Update titles and breadcrumbs on Edit pages 

### DIFF
--- a/cypress/e2e/eda/Credentials/credentials-crud.cy.ts
+++ b/cypress/e2e/eda/Credentials/credentials-crud.cy.ts
@@ -79,7 +79,7 @@ describe('EDA Credentials- Create, Edit, Delete', () => {
       cy.get('h1').should('contain', 'Credentials');
       cy.clickTableRow(edaCredential.name);
       cy.clickPageAction(/^Edit credential$/);
-      cy.hasTitle(/^Edit Credential$/);
+      cy.hasTitle(`Edit ${edaCredential.name}`);
       cy.typeInputByLabel(/^Name$/, edaCredential.name + 'lalala');
       cy.typeInputByLabel(/^Description$/, 'this credential type has been changed');
       cy.selectDropdownOptionByLabel(/^Type$/, 'GitHub personal access token');

--- a/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
+++ b/cypress/e2e/eda/Decision-Environments/decision-env-crud.cy.ts
@@ -42,7 +42,7 @@ describe('EDA decision environment- Create, Edit, Delete', () => {
         cy.get('a').click();
       });
       cy.clickPageAction(/^Edit decision environment$/);
-      cy.hasTitle(/^Edit Decision Environment$/);
+      cy.hasTitle(`Edit ${edaDE.name}`);
       cy.typeInputByLabel(/^Name$/, edaDE.name + 'edited');
       cy.clickButton(/^Save decision environment$/);
       cy.hasTitle(`${edaDE.name}edited`);

--- a/cypress/e2e/eda/Users/users-crud-cy.ts
+++ b/cypress/e2e/eda/Users/users-crud-cy.ts
@@ -48,7 +48,7 @@ describe('EDA Users- Create, Edit, Delete', () => {
       cy.get('h1').should('contain', 'Users');
       cy.clickTableRow(edaUser.username);
       cy.clickPageAction(/^Edit user$/);
-      cy.hasTitle(`/^Edit User$/`);
+      cy.hasTitle(`Edit ${edaUser.username}`);
       cy.typeInputByLabel(/^Username$/, edaUser.username);
       cy.typeInputByLabel(/^First name$/, edaUser.username + 'edited firstname');
       cy.typeInputByLabel(/^Last name$/, edaUser.username + 'edited lastname');

--- a/frontend/eda/Resources/credentials/EditCredential.tsx
+++ b/frontend/eda/Resources/credentials/EditCredential.tsx
@@ -115,10 +115,10 @@ export function EditCredential() {
       return (
         <PageLayout>
           <PageHeader
-            title={t('Edit Credential')}
+            title={`${t('Edit')} ${credential?.name || t('Credential')}`}
             breadcrumbs={[
               { label: t('Credentials'), to: RouteObj.EdaCredentials },
-              { label: t('Edit Credential') },
+              { label: `${t('Edit')} ${credential?.name || t('Credential')}` },
             ]}
           />
           <PageForm

--- a/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
+++ b/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
@@ -109,10 +109,10 @@ export function EditDecisionEnvironment() {
       return (
         <PageLayout>
           <PageHeader
-            title={t('Edit Decision Environment')}
+            title={`${t('Edit')} ${decisionEnvironment?.name || t('Decision Environment')}`}
             breadcrumbs={[
               { label: t('Decision Environments'), to: RouteObj.EdaDecisionEnvironments },
-              { label: t('Edit Decision Environment') },
+              { label: `${t('Edit')} ${decisionEnvironment?.name || t('Decision Environment')}` },
             ]}
           />
           <PageForm

--- a/frontend/eda/UserAccess/Users/EditUser.tsx
+++ b/frontend/eda/UserAccess/Users/EditUser.tsx
@@ -112,8 +112,11 @@ export function EditUser() {
   return (
     <PageLayout>
       <PageHeader
-        title={t('Edit User')}
-        breadcrumbs={[{ label: t('Users'), to: RouteObj.EdaUsers }, { label: t('Edit User') }]}
+        title={`${t('Edit')} ${user?.username || t('User')}`}
+        breadcrumbs={[
+          { label: t('Users'), to: RouteObj.EdaUsers },
+          { label: `${t('Edit')} ${user?.username || t('Credential')}` },
+        ]}
       />
       <PageForm<IUserInput>
         submitText={t('Save user')}


### PR DESCRIPTION
Update titles and breadcrumbs on Edit pages for User, Credential and Decision Environment
![Screenshot from 2023-04-25 17-54-24](https://user-images.githubusercontent.com/12769982/234413375-51a14578-88b5-4206-92d5-4d2bdfb89152.png)
![Screenshot from 2023-04-25 17-53-57](https://user-images.githubusercontent.com/12769982/234413376-d1b46a8d-da64-4471-a0ad-bd730b1168f5.png)
![Screenshot from 2023-04-25 17-53-46](https://user-images.githubusercontent.com/12769982/234413380-30f93ce5-d7dd-4b9b-9be5-178af93186f6.png)
![Screenshot from 2023-04-25 17-50-43](https://user-images.githubusercontent.com/12769982/234413382-f96180da-62b5-4c37-a911-c85ef56e9888.png)
