### PR TITLE
[AAP-11556] Update activation id in activation instance records. 

### DIFF
--- a/frontend/eda/interfaces/EdaActivationInstance.ts
+++ b/frontend/eda/interfaces/EdaActivationInstance.ts
@@ -10,7 +10,7 @@ export interface EdaActivationInstance {
   name?: string;
   description?: string;
   status?: string;
-  activation: string;
+  activation_id: string;
   activation_name: string;
   started_at: string;
   ended_at?: string;

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -38,7 +38,7 @@ export function ActivationInstanceDetails() {
   );
 
   const { data: activation } = useGet<EdaRulebookActivation>(
-    `${API_PREFIX}/activations/${activationInstance?.activation ?? ''}/`
+    `${API_PREFIX}/activations/${activationInstance?.activation_id ?? ''}/`
   );
 
   const renderActivationDetailsTab = (
@@ -48,7 +48,7 @@ export function ActivationInstanceDetails() {
       <Scrollable>
         <PageDetails>
           <PageDetail label={t('Name')}>
-            {activationInstance?.name || `Instance ${activationInstance?.id || ''}`}
+            {`${activationInstance?.id || ''} - ${activationInstance?.name || ''}`}
           </PageDetail>
           <PageDetail label={t('Activation status')}>{activationInstance?.status || ''}</PageDetail>
           <PageDetail label={t('Start date')}>
@@ -81,24 +81,24 @@ export function ActivationInstanceDetails() {
   return (
     <PageLayout>
       <PageHeader
-        title={activationInstance?.name ?? `Instance ${activationInstance?.id || ''}`}
+        title={`${activationInstance?.id || ''} - ${activationInstance?.name || ''}`}
         breadcrumbs={[
           { label: t('Rulebook Activations'), to: RouteObj.EdaRulebookActivations },
           {
             label: activationInstance?.activation_name ?? (activation?.name || ''),
             to: RouteObj.EdaRulebookActivationDetails.replace(
               ':id',
-              activationInstance?.activation || ''
+              activationInstance?.activation_id || ''
             ),
           },
           {
             label: t('History'),
             to: RouteObj.EdaRulebookActivationDetailsHistory.replace(
               ':id',
-              activationInstance?.activation || ''
+              activationInstance?.activation_id || ''
             ),
           },
-          { label: activationInstance?.name ?? `Instance ${activationInstance?.id || ''}` },
+          { label: `${activationInstance?.id || ''} - ${activationInstance?.name || ''}` },
         ]}
       />
       {activationInstance ? (

--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -107,8 +107,8 @@ export function RulebookActivationInputs() {
   const query = useCallback(async () => {
     const response = await requestGet<EdaResult<EdaRulebook>>(
       projectId !== undefined
-        ? `${API_PREFIX}/rulebooks/?project_id=${projectId}`
-        : `${API_PREFIX}/rulebooks/`
+        ? `${API_PREFIX}/rulebooks/?project_id=${projectId}&page=1&page_size=200`
+        : `${API_PREFIX}/rulebooks/?page=1&page_size=200`
     );
     return Promise.resolve({
       total: response.count,

--- a/frontend/eda/rulebook-activations/hooks/useActivationHistoryColumns.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useActivationHistoryColumns.tsx
@@ -15,7 +15,7 @@ export function useActivationHistoryColumns() {
         header: t('Name'),
         cell: (instance) => (
           <TextCell
-            text={instance.name || `Instance ${instance.id}`}
+            text={`${instance?.id || ''} - ${instance?.name || ''}`}
             onClick={() =>
               navigate(RouteObj.EdaActivationInstanceDetails.replace(':id', instance.id.toString()))
             }


### PR DESCRIPTION
Update activation id in activation instance records. ( The field in the activation-instance endpoint changed to activation_id)
Updated Instance names to <instance> - Activation name
Update page size for the rulebooks query on the Create activation form

![Screenshot from 2023-04-26 13-56-49](https://user-images.githubusercontent.com/12769982/234662775-a5c81628-5c3e-451e-b3cd-a6d414409405.png)

![Screenshot from 2023-04-26 13-56-58](https://user-images.githubusercontent.com/12769982/234662789-a82ebc53-687b-424d-ac88-8652a829c538.png)

