### PR TITLE
Page Table Toolbar Sorting Support

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -64,6 +64,7 @@ import { PageTableList } from './PageTableList';
 import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
 import { PageTableToolbar } from './PageToolbar';
 import { IToolbarFilter } from './PageToolbarFilter';
+import { usePageToolbarSortOptionsFromColumns } from './PageToolbarSort';
 
 const ScrollDiv = styled.div`
   height: 100%;
@@ -279,6 +280,8 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
 
   const usePadding = useBreakpoint('md') && disableBodyPadding !== true;
 
+  const sortOptions = usePageToolbarSortOptionsFromColumns(props.tableColumns);
+
   if (error) {
     return (
       <EmptyStateDiv>
@@ -347,6 +350,7 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
         viewType={viewType}
         setViewType={setViewType}
         bottomBorder
+        sortOptions={sortOptions}
       />
       {viewType === PageTableViewTypeE.Table && (
         <PageBody disablePadding={disableBodyPadding}>

--- a/framework/PageTable/PageToolbar.css
+++ b/framework/PageTable/PageToolbar.css
@@ -1,5 +1,6 @@
 .pf-c-toolbar__content-section {
   row-gap: 16px !important;
+  justify-content: end;
 }
 
 .pf-c-toolbar__expandable-content.pf-m-expanded {

--- a/framework/PageTable/PageToolbar.tsx
+++ b/framework/PageTable/PageToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Flex,
   OnPerPageSelect,
   OnSetPage,
   Pagination,
@@ -175,92 +176,97 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
           />
         </ToolbarGroup>
         <FlexGrowDiv />
-        <PageTableToolbarSort
-          sort={sort}
-          setSort={setSort}
-          sortDirection={sortDirection}
-          setSortDirection={setSortDirection}
-          sortOptions={sortOptions}
-        />
-        <ToolbarGroup variant="button-group" style={{ justifyContent: 'end' }}>
-          {!props.disableColumnManagement && openColumnModal && viewType === 'table' && (
-            <ToolbarItem>
-              <Tooltip content={'Manage columns'}>
-                <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
-              </Tooltip>
-            </ToolbarItem>
-          )}
-          {viewTypeCount > 1 && (
-            <ToolbarItem>
-              <ToggleGroup aria-label="table view toggle">
-                {[
-                  !props.disableTableView && PageTableViewTypeE.Table,
-                  !props.disableListView && PageTableViewTypeE.List,
-                  !props.disableCardView && PageTableViewTypeE.Cards,
-                ]
-                  .filter((i) => i)
-                  .map((vt) => {
-                    switch (vt) {
-                      case PageTableViewTypeE.Cards:
-                        return (
-                          <Tooltip
-                            content={'Card view'}
-                            key={vt}
-                            position="top-end"
-                            enableFlip={false}
-                          >
-                            <ToggleGroupItem
-                              icon={<ThLargeIcon />}
-                              isSelected={viewType === PageTableViewTypeE.Cards}
-                              onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
-                              aria-label="card view"
-                            />
-                          </Tooltip>
-                        );
-                      case PageTableViewTypeE.List:
-                        return (
-                          <Tooltip
-                            content={'List view'}
-                            key={vt}
-                            position="top-end"
-                            enableFlip={false}
-                          >
-                            <ToggleGroupItem
-                              icon={<ListIcon />}
-                              isSelected={viewType === PageTableViewTypeE.List}
-                              onClick={() => setViewType?.(PageTableViewTypeE.List)}
-                              aria-label="list view"
-                            />
-                          </Tooltip>
-                        );
-                      case PageTableViewTypeE.Table:
-                        return (
-                          <Tooltip
-                            content={'Table view'}
-                            key={vt}
-                            position="top-end"
-                            enableFlip={false}
-                          >
-                            <ToggleGroupItem
-                              icon={<TableIcon />}
-                              isSelected={viewType === PageTableViewTypeE.Table}
-                              onClick={() => setViewType?.(PageTableViewTypeE.Table)}
-                              aria-label="table view"
-                            />
-                          </Tooltip>
-                        );
-                    }
-                  })}
-              </ToggleGroup>
-            </ToolbarItem>
-          )}
-        </ToolbarGroup>
+        <Flex>
+          <PageTableToolbarSort
+            sort={sort}
+            setSort={setSort}
+            sortDirection={sortDirection}
+            setSortDirection={setSortDirection}
+            sortOptions={sortOptions}
+          />
+          <ToolbarGroup variant="button-group" style={{ justifyContent: 'end' }}>
+            {!props.disableColumnManagement && openColumnModal && viewType === 'table' && (
+              <ToolbarItem>
+                <Tooltip content={'Manage columns'}>
+                  <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
+                </Tooltip>
+              </ToolbarItem>
+            )}
+            {viewTypeCount > 1 && (
+              <ToolbarItem>
+                <ToggleGroup aria-label="table view toggle">
+                  {[
+                    !props.disableTableView && PageTableViewTypeE.Table,
+                    !props.disableListView && PageTableViewTypeE.List,
+                    !props.disableCardView && PageTableViewTypeE.Cards,
+                  ]
+                    .filter((i) => i)
+                    .map((vt) => {
+                      switch (vt) {
+                        case PageTableViewTypeE.Cards:
+                          return (
+                            <Tooltip
+                              content={'Card view'}
+                              key={vt}
+                              position="top-end"
+                              enableFlip={false}
+                            >
+                              <ToggleGroupItem
+                                icon={<ThLargeIcon />}
+                                isSelected={viewType === PageTableViewTypeE.Cards}
+                                onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
+                                aria-label="card view"
+                              />
+                            </Tooltip>
+                          );
+                        case PageTableViewTypeE.List:
+                          return (
+                            <Tooltip
+                              content={'List view'}
+                              key={vt}
+                              position="top-end"
+                              enableFlip={false}
+                            >
+                              <ToggleGroupItem
+                                icon={<ListIcon />}
+                                isSelected={viewType === PageTableViewTypeE.List}
+                                onClick={() => setViewType?.(PageTableViewTypeE.List)}
+                                aria-label="list view"
+                              />
+                            </Tooltip>
+                          );
+                        case PageTableViewTypeE.Table:
+                          return (
+                            <Tooltip
+                              content={'Table view'}
+                              key={vt}
+                              position="top-end"
+                              enableFlip={false}
+                            >
+                              <ToggleGroupItem
+                                icon={<TableIcon />}
+                                isSelected={viewType === PageTableViewTypeE.Table}
+                                onClick={() => setViewType?.(PageTableViewTypeE.Table)}
+                                aria-label="table view"
+                              />
+                            </Tooltip>
+                          );
+                      }
+                    })}
+                </ToggleGroup>
+              </ToolbarItem>
+            )}
+          </ToolbarGroup>
+        </Flex>
 
         {/* {toolbarButtonActions.length > 0 && <ToolbarGroup variant="button-group">{toolbarActionButtons}</ToolbarGroup>} */}
         {/* <ToolbarGroup variant="button-group">{toolbarActionDropDownItems}</ToolbarGroup> */}
 
         {/* Pagination */}
-        <ToolbarItem visibility={{ default: 'hidden', '2xl': 'visible' }}>
+        <ToolbarItem
+          visibility={{ default: 'hidden', '2xl': 'visible' }}
+          style={{ marginLeft: 24 }}
+        >
           <Pagination
             variant={PaginationVariant.top}
             isCompact

--- a/framework/PageTable/PageToolbar.tsx
+++ b/framework/PageTable/PageToolbar.tsx
@@ -23,8 +23,9 @@ import { useBreakpoint } from '../components/useBreakPoint';
 import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
 import './PageToolbar.css';
 import { IToolbarFilter, PageTableToolbarFilters } from './PageToolbarFilter';
+import { PageTableSortOption, PageTableToolbarSort } from './PageToolbarSort';
 
-const ToolbarGroupsDiv = styled.div`
+const FlexGrowDiv = styled.div`
   flex-grow: 1;
 `;
 
@@ -53,8 +54,12 @@ export type PagetableToolbarProps<T extends object> = {
   selectItems?: (items: T[]) => void;
   unselectAll?: () => void;
   onSelect?: (item: T) => void;
-
   showSelect?: boolean;
+
+  sort?: string;
+  setSort?: (sort: string) => void;
+  sortDirection?: 'asc' | 'desc';
+  setSortDirection?: (sortDirection: 'asc' | 'desc') => void;
 
   viewType: PageTableViewType;
   setViewType: (viewType: PageTableViewType) => void;
@@ -64,6 +69,7 @@ export type PagetableToolbarProps<T extends object> = {
   disableCardView?: boolean;
   disableColumnManagement?: boolean;
   bottomBorder?: boolean;
+  sortOptions?: PageTableSortOption[];
 };
 
 export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<T>) {
@@ -80,6 +86,11 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
     clearAllFilters,
     openColumnModal,
     bottomBorder,
+    sort,
+    setSort,
+    sortDirection,
+    setSortDirection,
+    sortOptions,
   } = props;
 
   const sm = useBreakpoint('md');
@@ -142,7 +153,7 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
         borderBottom: bottomBorder ? 'thin solid var(--pf-global--BorderColor--100)' : undefined,
       }}
     >
-      <ToolbarContent>
+      <ToolbarContent style={{ justifyContent: 'end', justifyItems: 'end' }}>
         {showSelect && (
           <ToolbarGroup>
             <ToolbarItem variant="bulk-select">
@@ -163,9 +174,15 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
             wrapper={ToolbarItem}
           />
         </ToolbarGroup>
-        <ToolbarGroupsDiv />
-
-        <ToolbarGroup variant="button-group">
+        <FlexGrowDiv />
+        <PageTableToolbarSort
+          sort={sort}
+          setSort={setSort}
+          sortDirection={sortDirection}
+          setSortDirection={setSortDirection}
+          sortOptions={sortOptions}
+        />
+        <ToolbarGroup variant="button-group" style={{ justifyContent: 'end' }}>
           {!props.disableColumnManagement && openColumnModal && viewType === 'table' && (
             <ToolbarItem>
               <Tooltip content={'Manage columns'}>

--- a/framework/PageTable/PageToolbar.tsx
+++ b/framework/PageTable/PageToolbar.tsx
@@ -1,30 +1,26 @@
 import {
-  Button,
   Flex,
   OnPerPageSelect,
   OnSetPage,
   Pagination,
   PaginationVariant,
   Skeleton,
-  ToggleGroup,
-  ToggleGroupItem,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Tooltip,
 } from '@patternfly/react-core';
-import { ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
 import { Dispatch, Fragment, SetStateAction, useCallback } from 'react';
 import styled from 'styled-components';
 import { IPageAction, PageActionSelection } from '../PageActions/PageAction';
 import { PageActions } from '../PageActions/PageActions';
 import { BulkSelector } from '../components/BulkSelector';
 import { useBreakpoint } from '../components/useBreakPoint';
-import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
+import { PageTableViewType } from './PageTableViewType';
 import './PageToolbar.css';
-import { IToolbarFilter, PageTableToolbarFilters } from './PageToolbarFilter';
-import { PageTableSortOption, PageTableToolbarSort } from './PageToolbarSort';
+import { IToolbarFilter, PageToolbarFilters } from './PageToolbarFilter';
+import { PageTableSortOption, PageToolbarSort } from './PageToolbarSort';
+import { PageToolbarView } from './PageToolbarView';
 
 const FlexGrowDiv = styled.div`
   flex-grow: 1;
@@ -119,12 +115,6 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
       ));
 
   const showToolbar = showSelect || showSearchAndFilters || showToolbarActions;
-
-  let viewTypeCount = 0;
-  if (!props.disableTableView) viewTypeCount++;
-  if (!props.disableCardView) viewTypeCount++;
-  if (!props.disableListView) viewTypeCount++;
-
   if (!showToolbar) {
     return <Fragment />;
   }
@@ -155,6 +145,7 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
       }}
     >
       <ToolbarContent style={{ justifyContent: 'end', justifyItems: 'end' }}>
+        {/* Selection */}
         {showSelect && (
           <ToolbarGroup>
             <ToolbarItem variant="bulk-select">
@@ -162,12 +153,15 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
             </ToolbarItem>
           </ToolbarGroup>
         )}
-        <PageTableToolbarFilters
+
+        {/* Filters */}
+        <PageToolbarFilters
           toolbarFilters={toolbarFilters}
           filters={filters}
           setFilters={setFilters}
         />
-        {/* Action Buttons */}
+
+        {/* Actions */}
         <ToolbarGroup variant="button-group">
           <PageActions
             actions={toolbarActions}
@@ -175,92 +169,32 @@ export function PageTableToolbar<T extends object>(props: PagetableToolbarProps<
             wrapper={ToolbarItem}
           />
         </ToolbarGroup>
+
+        {/* Spacing */}
         <FlexGrowDiv />
+
+        {/* The flex below is needed to make the toolbar wrap elements properly */}
         <Flex>
-          <PageTableToolbarSort
+          {/* Sort */}
+          <PageToolbarSort
             sort={sort}
             setSort={setSort}
             sortDirection={sortDirection}
             setSortDirection={setSortDirection}
             sortOptions={sortOptions}
           />
-          <ToolbarGroup variant="button-group" style={{ justifyContent: 'end' }}>
-            {!props.disableColumnManagement && openColumnModal && viewType === 'table' && (
-              <ToolbarItem>
-                <Tooltip content={'Manage columns'}>
-                  <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
-                </Tooltip>
-              </ToolbarItem>
-            )}
-            {viewTypeCount > 1 && (
-              <ToolbarItem>
-                <ToggleGroup aria-label="table view toggle">
-                  {[
-                    !props.disableTableView && PageTableViewTypeE.Table,
-                    !props.disableListView && PageTableViewTypeE.List,
-                    !props.disableCardView && PageTableViewTypeE.Cards,
-                  ]
-                    .filter((i) => i)
-                    .map((vt) => {
-                      switch (vt) {
-                        case PageTableViewTypeE.Cards:
-                          return (
-                            <Tooltip
-                              content={'Card view'}
-                              key={vt}
-                              position="top-end"
-                              enableFlip={false}
-                            >
-                              <ToggleGroupItem
-                                icon={<ThLargeIcon />}
-                                isSelected={viewType === PageTableViewTypeE.Cards}
-                                onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
-                                aria-label="card view"
-                              />
-                            </Tooltip>
-                          );
-                        case PageTableViewTypeE.List:
-                          return (
-                            <Tooltip
-                              content={'List view'}
-                              key={vt}
-                              position="top-end"
-                              enableFlip={false}
-                            >
-                              <ToggleGroupItem
-                                icon={<ListIcon />}
-                                isSelected={viewType === PageTableViewTypeE.List}
-                                onClick={() => setViewType?.(PageTableViewTypeE.List)}
-                                aria-label="list view"
-                              />
-                            </Tooltip>
-                          );
-                        case PageTableViewTypeE.Table:
-                          return (
-                            <Tooltip
-                              content={'Table view'}
-                              key={vt}
-                              position="top-end"
-                              enableFlip={false}
-                            >
-                              <ToggleGroupItem
-                                icon={<TableIcon />}
-                                isSelected={viewType === PageTableViewTypeE.Table}
-                                onClick={() => setViewType?.(PageTableViewTypeE.Table)}
-                                aria-label="table view"
-                              />
-                            </Tooltip>
-                          );
-                      }
-                    })}
-                </ToggleGroup>
-              </ToolbarItem>
-            )}
-          </ToolbarGroup>
-        </Flex>
 
-        {/* {toolbarButtonActions.length > 0 && <ToolbarGroup variant="button-group">{toolbarActionButtons}</ToolbarGroup>} */}
-        {/* <ToolbarGroup variant="button-group">{toolbarActionDropDownItems}</ToolbarGroup> */}
+          {/* View */}
+          <PageToolbarView
+            disableTableView={props.disableTableView}
+            disableListView={props.disableListView}
+            disableCardView={props.disableCardView}
+            disableColumnManagement={props.disableColumnManagement}
+            viewType={viewType}
+            setViewType={setViewType}
+            openColumnModal={openColumnModal}
+          />
+        </Flex>
 
         {/* Pagination */}
         <ToolbarItem

--- a/framework/PageTable/PageToolbarFilter.tsx
+++ b/framework/PageTable/PageToolbarFilter.tsx
@@ -65,6 +65,8 @@ export function PageTableToolbarFilters(props: PageTableToolbarFiltersProps) {
     toolbarFilters ? (toolbarFilters?.length > 0 ? toolbarFilters[0].key : '') : ''
   );
 
+  const [translations] = useFrameworkTranslations();
+
   const showFilterLabel = !useBreakpoint('md');
 
   if (!toolbarFilters) return <></>;
@@ -73,7 +75,7 @@ export function PageTableToolbarFilters(props: PageTableToolbarFiltersProps) {
   return (
     <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
       <ToolbarGroup variant="filter-group">
-        {showFilterLabel && <ToolbarItem variant="label">Filter</ToolbarItem>}
+        {showFilterLabel && <ToolbarItem variant="label">{translations.filter}</ToolbarItem>}
         <ToolbarItem>
           <Split>
             <SplitItem>

--- a/framework/PageTable/PageToolbarFilter.tsx
+++ b/framework/PageTable/PageToolbarFilter.tsx
@@ -6,6 +6,8 @@ import {
   SelectOption,
   SelectOptionObject,
   SelectVariant,
+  Split,
+  SplitItem,
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
@@ -16,8 +18,8 @@ import {
 } from '@patternfly/react-core';
 import { ArrowRightIcon, FilterIcon, TimesIcon } from '@patternfly/react-icons';
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
-import styled from 'styled-components';
 import { FormGroupSelect } from '../PageForm/Inputs/FormGroupSelect';
+import { useBreakpoint } from '../components/useBreakPoint';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 
 export const enum PageFilterTypeE {
@@ -63,78 +65,85 @@ export function PageTableToolbarFilters(props: PageTableToolbarFiltersProps) {
     toolbarFilters ? (toolbarFilters?.length > 0 ? toolbarFilters[0].key : '') : ''
   );
 
+  const showFilterLabel = !useBreakpoint('md');
+
   if (!toolbarFilters) return <></>;
   if (toolbarFilters.length === 0) return <></>;
 
   return (
     <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
       <ToolbarGroup variant="filter-group">
+        {showFilterLabel && <ToolbarItem variant="label">Filter</ToolbarItem>}
         <ToolbarItem>
-          <InputGroup style={{ zIndex: 400 }}>
-            {toolbarFilters.length === 1 ? (
-              <>
-                <InputGroupText
-                  style={{
-                    border: 0,
-                    paddingLeft: 12,
-                    paddingRight: 2,
-                    color: 'inherit',
-                    borderRadius: '4px 0px 0px 4px',
-                  }}
-                >
-                  <FilterIcon />
-                </InputGroupText>
-                <InputGroupText style={{ border: 0, padding: '6px 8px', color: 'inherit' }}>
-                  {toolbarFilters[0].label}
-                </InputGroupText>
-              </>
-            ) : (
-              <>
-                <InputGroupText
-                  style={{
-                    border: 0,
-                    paddingLeft: 12,
-                    paddingRight: 12,
-                    color: 'inherit',
-                    borderRadius: '4px 0px 0px 4px',
-                  }}
-                >
-                  <FilterIcon />
-                </InputGroupText>
-                <FormGroupSelect
-                  id="filter"
-                  onSelect={(_, v) => setSeletedFilter(v.toString())}
-                  value={selectedFilter}
-                  placeholderText=""
-                >
-                  {toolbarFilters.map((filter) => (
-                    <SelectOption key={filter.key} value={filter.key}>
-                      {filter.label}
-                    </SelectOption>
-                  ))}
-                </FormGroupSelect>
-              </>
-            )}
-          </InputGroup>
-        </ToolbarItem>
-        <ToolbarItem>
-          <ToolbarFilterInput
-            id="filter-input"
-            filter={toolbarFilters.find((filter) => filter.key === selectedFilter)}
-            addFilter={(value: string) => {
-              let values = filters?.[selectedFilter];
-              if (!values) values = [];
-              if (!values.includes(value)) values.push(value);
-              setFilters?.({ ...filters, [selectedFilter]: values });
-            }}
-            removeFilter={(value: string) => {
-              let values = filters?.[selectedFilter];
-              if (!values) values = [];
-              values = values.filter((v) => v !== value);
-              setFilters?.({ ...filters, [selectedFilter]: values });
-            }}
-            values={filters?.[selectedFilter] ?? []}
-          />
+          <Split>
+            <SplitItem>
+              <InputGroup style={{ zIndex: 400 }}>
+                {toolbarFilters.length === 1 ? (
+                  <>
+                    <InputGroupText
+                      style={{
+                        border: 0,
+                        paddingLeft: 12,
+                        paddingRight: 2,
+                        color: 'inherit',
+                        borderRadius: '4px 0px 0px 4px',
+                      }}
+                    >
+                      <FilterIcon />
+                    </InputGroupText>
+                    <InputGroupText style={{ border: 0, padding: '6px 8px', color: 'inherit' }}>
+                      {toolbarFilters[0].label}
+                    </InputGroupText>
+                  </>
+                ) : (
+                  <>
+                    <InputGroupText
+                      style={{
+                        border: 0,
+                        paddingLeft: 12,
+                        paddingRight: 12,
+                        color: 'inherit',
+                        borderRadius: '4px 0px 0px 4px',
+                      }}
+                    >
+                      <FilterIcon />
+                    </InputGroupText>
+                    <FormGroupSelect
+                      id="filter"
+                      onSelect={(_, v) => setSeletedFilter(v.toString())}
+                      value={selectedFilter}
+                      placeholderText=""
+                    >
+                      {toolbarFilters.map((filter) => (
+                        <SelectOption key={filter.key} value={filter.key}>
+                          {filter.label}
+                        </SelectOption>
+                      ))}
+                    </FormGroupSelect>
+                  </>
+                )}
+              </InputGroup>
+            </SplitItem>
+            <SplitItem isFilled>
+              <ToolbarFilterInput
+                id="filter-input"
+                filter={toolbarFilters.find((filter) => filter.key === selectedFilter)}
+                addFilter={(value: string) => {
+                  let values = filters?.[selectedFilter];
+                  if (!values) values = [];
+                  if (!values.includes(value)) values.push(value);
+                  setFilters?.({ ...filters, [selectedFilter]: values });
+                }}
+                removeFilter={(value: string) => {
+                  let values = filters?.[selectedFilter];
+                  if (!values) values = [];
+                  values = values.filter((v) => v !== value);
+                  setFilters?.({ ...filters, [selectedFilter]: values });
+                }}
+                values={filters?.[selectedFilter] ?? []}
+              />
+            </SplitItem>
+          </Split>
         </ToolbarItem>
         {toolbarFilters.map((filter) => {
           const values = filters?.[filter.key] ?? [];
@@ -285,15 +294,10 @@ function ToolbarSelectFilter(props: {
         onToggle={setOpen}
         selections={selections}
         onSelect={onSelect}
-        placeholderText={
-          values.length ? (
-            translations.selectedText
-          ) : (
-            <SelectionSpan>{props.placeholder}</SelectionSpan>
-          )
-        }
+        placeholderText={values.length ? translations.selectedText : props.placeholder}
         // ZIndex 400 is needed for PF table stick headers
         style={{ zIndex: open ? 400 : 0 }}
+        hasPlaceholderStyle
       >
         {options.map((option) => (
           <SelectOption id={option.value} key={option.value} value={option.value}>
@@ -304,7 +308,3 @@ function ToolbarSelectFilter(props: {
     </>
   );
 }
-
-const SelectionSpan = styled.span`
-  opacity: 0.7;
-`;

--- a/framework/PageTable/PageToolbarFilter.tsx
+++ b/framework/PageTable/PageToolbarFilter.tsx
@@ -52,13 +52,13 @@ export type IToolbarFilter = IToolbarStringFilter | IToolbarSelectFilter;
 
 export type IFilterState = Record<string, string[] | undefined>;
 
-export type PageTableToolbarFiltersProps = {
+export type PageToolbarFiltersProps = {
   toolbarFilters?: IToolbarFilter[];
   filters?: Record<string, string[]>;
   setFilters?: Dispatch<SetStateAction<Record<string, string[]>>>;
 };
 
-export function PageTableToolbarFilters(props: PageTableToolbarFiltersProps) {
+export function PageToolbarFilters(props: PageToolbarFiltersProps) {
   const { toolbarFilters, filters, setFilters } = props;
 
   const [selectedFilter, setSeletedFilter] = useState(() =>
@@ -77,9 +77,9 @@ export function PageTableToolbarFilters(props: PageTableToolbarFiltersProps) {
       <ToolbarGroup variant="filter-group">
         {showFilterLabel && <ToolbarItem variant="label">{translations.filter}</ToolbarItem>}
         <ToolbarItem>
-          <Split>
+          <Split style={{ zIndex: 400 }}>
             <SplitItem>
-              <InputGroup style={{ zIndex: 400 }}>
+              <InputGroup>
                 {toolbarFilters.length === 1 ? (
                   <>
                     <InputGroupText

--- a/framework/PageTable/PageToolbarSort.tsx
+++ b/framework/PageTable/PageToolbarSort.tsx
@@ -107,6 +107,7 @@ function ToolbarSortSelect(props: {
   const onSelect = useCallback(
     (e: unknown, value: string | SelectOptionObject) => {
       setSort?.(value.toString());
+      setOpen(false);
     },
     [setSort]
   );

--- a/framework/PageTable/PageToolbarSort.tsx
+++ b/framework/PageTable/PageToolbarSort.tsx
@@ -10,7 +10,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import {
-  SortAlphaDownIcon,
+  SortAlphaDownAltIcon,
   SortAlphaUpIcon,
   SortAmountDownIcon,
   SortAmountUpIcon,
@@ -50,7 +50,7 @@ export function PageTableToolbarSort(props: PageTableToolbarSortProps) {
           case 'asc':
             return <SortAlphaUpIcon />;
           case 'desc':
-            return <SortAlphaDownIcon />;
+            return <SortAlphaDownAltIcon />;
         }
         break;
       case 'number':
@@ -137,7 +137,26 @@ export function usePageToolbarSortOptionsFromColumns<T extends object>(
     const sortOptions: PageTableSortOption[] = [];
     for (const column of tableColumns) {
       if (column.sort) {
-        sortOptions.push({ label: column.header, value: column.sort });
+        if (column.defaultSort) {
+          // Assumes the defauilt sort is a text column
+          sortOptions.push({ label: column.header, value: column.sort, type: 'text' });
+          continue;
+        }
+
+        switch (column.type) {
+          case 'datetime':
+            sortOptions.push({ label: column.header, value: column.sort });
+            break;
+          case 'count':
+            sortOptions.push({ label: column.header, value: column.sort, type: 'number' });
+            break;
+          case 'text':
+            sortOptions.push({ label: column.header, value: column.sort, type: 'text' });
+            break;
+          default:
+            sortOptions.push({ label: column.header, value: column.sort });
+            break;
+        }
       }
     }
     return sortOptions;

--- a/framework/PageTable/PageToolbarSort.tsx
+++ b/framework/PageTable/PageToolbarSort.tsx
@@ -144,9 +144,6 @@ export function usePageToolbarSortOptionsFromColumns<T extends object>(
         }
 
         switch (column.type) {
-          case 'datetime':
-            sortOptions.push({ label: column.header, value: column.sort });
-            break;
           case 'count':
             sortOptions.push({ label: column.header, value: column.sort, type: 'number' });
             break;

--- a/framework/PageTable/PageToolbarSort.tsx
+++ b/framework/PageTable/PageToolbarSort.tsx
@@ -21,7 +21,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { ITableColumn } from './PageTableColumn';
 
-export type PageTableToolbarSortProps = {
+export type PageToolbarSortProps = {
   sort?: string;
   setSort?: (sort: string) => void;
   sortDirection?: 'asc' | 'desc';
@@ -35,7 +35,7 @@ export interface PageTableSortOption {
   type?: 'text' | 'number' | undefined;
 }
 
-export function PageTableToolbarSort(props: PageTableToolbarSortProps) {
+export function PageToolbarSort(props: PageToolbarSortProps) {
   const { sort, setSort, sortDirection, setSortDirection, sortOptions } = props;
 
   const sortOption = sortOptions?.find((sortOption) => sortOption.value === sort);

--- a/framework/PageTable/PageToolbarSort.tsx
+++ b/framework/PageTable/PageToolbarSort.tsx
@@ -1,0 +1,146 @@
+import {
+  Button,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+  Split,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import {
+  SortAlphaDownIcon,
+  SortAlphaUpIcon,
+  SortAmountDownIcon,
+  SortAmountUpIcon,
+  SortNumericDownIcon,
+  SortNumericUpIcon,
+} from '@patternfly/react-icons';
+import { useCallback, useMemo, useState } from 'react';
+import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { ITableColumn } from './PageTableColumn';
+
+export type PageTableToolbarSortProps = {
+  sort?: string;
+  setSort?: (sort: string) => void;
+  sortDirection?: 'asc' | 'desc';
+  setSortDirection?: (sortDirection: 'asc' | 'desc') => void;
+  sortOptions?: PageTableSortOption[];
+};
+
+export interface PageTableSortOption {
+  label: string;
+  value: string;
+  type?: 'text' | 'number' | undefined;
+}
+
+export function PageTableToolbarSort(props: PageTableToolbarSortProps) {
+  const { sort, setSort, sortDirection, setSortDirection, sortOptions } = props;
+
+  const sortOption = sortOptions?.find((sortOption) => sortOption.value === sort);
+  const sortType = sortOption ? sortOption.type : undefined;
+
+  const [translations] = useFrameworkTranslations();
+
+  const sortDirectionIcon = useMemo(() => {
+    switch (sortType) {
+      case 'text':
+        switch (sortDirection) {
+          case 'asc':
+            return <SortAlphaUpIcon />;
+          case 'desc':
+            return <SortAlphaDownIcon />;
+        }
+        break;
+      case 'number':
+        switch (sortDirection) {
+          case 'asc':
+            return <SortNumericUpIcon />;
+          case 'desc':
+            return <SortNumericDownIcon />;
+        }
+        break;
+      default:
+        switch (sortDirection) {
+          case 'asc':
+            return <SortAmountUpIcon />;
+          case 'desc':
+            return <SortAmountDownIcon />;
+        }
+        break;
+    }
+    return <></>;
+  }, [sortDirection, sortType]);
+
+  if (!sortOptions || sortOptions.length <= 1) return <></>;
+
+  return (
+    <ToolbarToggleGroup breakpoint="md" toggleIcon={undefined}>
+      <ToolbarGroup variant="filter-group">
+        <ToolbarItem variant="label">{translations.sort}</ToolbarItem>
+        <ToolbarItem>
+          <Split>
+            <ToolbarSortSelect sortOptions={sortOptions} sort={sort} setSort={setSort} />
+            <Button
+              variant="control"
+              icon={sortDirectionIcon}
+              onClick={() => {
+                if (sortDirection === 'asc') setSortDirection?.('desc');
+                else setSortDirection?.('asc');
+              }}
+            />
+          </Split>
+        </ToolbarItem>
+      </ToolbarGroup>
+    </ToolbarToggleGroup>
+  );
+}
+
+function ToolbarSortSelect(props: {
+  sort?: string;
+  setSort?: (sort: string) => void;
+  sortOptions: PageTableSortOption[];
+}) {
+  const { sortOptions: options, sort, setSort } = props;
+  const [open, setOpen] = useState(false);
+  const onSelect = useCallback(
+    (e: unknown, value: string | SelectOptionObject) => {
+      setSort?.(value.toString());
+    },
+    [setSort]
+  );
+  return (
+    <Select
+      variant={SelectVariant.single}
+      isOpen={open}
+      onToggle={setOpen}
+      selections={sort}
+      onSelect={onSelect}
+      // ZIndex 400 is needed for PF table sticky headers
+      style={{ zIndex: open ? 400 : 0 }}
+      hasPlaceholderStyle
+    >
+      {options.map((option) => (
+        <SelectOption id={option.value} key={option.value} value={option.value}>
+          {option.label}
+        </SelectOption>
+      ))}
+    </Select>
+  );
+}
+
+export function usePageToolbarSortOptionsFromColumns<T extends object>(
+  tableColumns: ITableColumn<T>[]
+) {
+  const sortOptions = useMemo(() => {
+    const sortOptions: PageTableSortOption[] = [];
+    for (const column of tableColumns) {
+      if (column.sort) {
+        sortOptions.push({ label: column.header, value: column.sort });
+      }
+    }
+    return sortOptions;
+  }, [tableColumns]);
+  return sortOptions;
+}

--- a/framework/PageTable/PageToolbarView.tsx
+++ b/framework/PageTable/PageToolbarView.tsx
@@ -1,0 +1,108 @@
+import {
+  Button,
+  ToggleGroup,
+  ToggleGroupItem,
+  ToolbarGroup,
+  ToolbarItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
+import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
+
+export type PageToolbarViewProps = {
+  disableTableView?: boolean;
+  disableCardView?: boolean;
+  disableListView?: boolean;
+  disableColumnManagement?: boolean;
+  openColumnModal?: () => void;
+  viewType: PageTableViewType;
+  setViewType: (viewType: PageTableViewType) => void;
+};
+
+export function PageToolbarView(props: PageToolbarViewProps) {
+  const { viewType, setViewType, openColumnModal } = props;
+
+  const [translations] = useFrameworkTranslations();
+
+  let viewTypeCount = 0;
+  if (!props.disableTableView) viewTypeCount++;
+  if (!props.disableCardView) viewTypeCount++;
+  if (!props.disableListView) viewTypeCount++;
+
+  return (
+    <ToolbarGroup variant="button-group" style={{ justifyContent: 'end' }}>
+      {!props.disableColumnManagement && openColumnModal && viewType === 'table' && (
+        <ToolbarItem>
+          <Tooltip content={translations.manageColumns}>
+            <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
+          </Tooltip>
+        </ToolbarItem>
+      )}
+      {viewTypeCount > 1 && (
+        <ToolbarItem>
+          <ToggleGroup aria-label="table view toggle">
+            {[
+              !props.disableTableView && PageTableViewTypeE.Table,
+              !props.disableListView && PageTableViewTypeE.List,
+              !props.disableCardView && PageTableViewTypeE.Cards,
+            ]
+              .filter((i) => i)
+              .map((vt) => {
+                switch (vt) {
+                  case PageTableViewTypeE.Cards:
+                    return (
+                      <Tooltip
+                        content={translations.cardView}
+                        key={vt}
+                        position="top-end"
+                        enableFlip={false}
+                      >
+                        <ToggleGroupItem
+                          icon={<ThLargeIcon />}
+                          isSelected={viewType === PageTableViewTypeE.Cards}
+                          onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
+                          aria-label="card view"
+                        />
+                      </Tooltip>
+                    );
+                  case PageTableViewTypeE.List:
+                    return (
+                      <Tooltip
+                        content={translations.listView}
+                        key={vt}
+                        position="top-end"
+                        enableFlip={false}
+                      >
+                        <ToggleGroupItem
+                          icon={<ListIcon />}
+                          isSelected={viewType === PageTableViewTypeE.List}
+                          onClick={() => setViewType?.(PageTableViewTypeE.List)}
+                          aria-label="list view"
+                        />
+                      </Tooltip>
+                    );
+                  case PageTableViewTypeE.Table:
+                    return (
+                      <Tooltip
+                        content={translations.tableView}
+                        key={vt}
+                        position="top-end"
+                        enableFlip={false}
+                      >
+                        <ToggleGroupItem
+                          icon={<TableIcon />}
+                          isSelected={viewType === PageTableViewTypeE.Table}
+                          onClick={() => setViewType?.(PageTableViewTypeE.Table)}
+                          aria-label="table view"
+                        />
+                      </Tooltip>
+                    );
+                }
+              })}
+          </ToggleGroup>
+        </ToolbarItem>
+      )}
+    </ToolbarGroup>
+  );
+}

--- a/framework/useFrameworkTranslations.tsx
+++ b/framework/useFrameworkTranslations.tsx
@@ -4,7 +4,7 @@ export interface IFrameworkTranslations {
   by: string;
   cancelText: string;
   canceledText: string;
-  filter: string;
+  cardView: string;
   clearAllFilters: string;
   clickToRefresh: string;
   closeText: string;
@@ -12,6 +12,8 @@ export interface IFrameworkTranslations {
   countMore: string;
   documentation: string;
   errorText: string;
+  filter: string;
+  listView: string;
   manageColumns: string;
   moreInformation: string;
   noItemsFound: string;
@@ -30,6 +32,7 @@ export interface IFrameworkTranslations {
   submitText: string;
   submittingText: string;
   successText: string;
+  tableView: string;
   unknownError: string;
   validating: string;
 }
@@ -38,7 +41,7 @@ const defaultTranslations: IFrameworkTranslations = {
   by: 'by',
   cancelText: 'Cancel',
   canceledText: 'Canceled',
-  filter: 'Filter',
+  cardView: 'Card view',
   clearAllFilters: 'Clear all filters',
   clickToRefresh: 'Click to refresh',
   closeText: 'Close',
@@ -46,6 +49,8 @@ const defaultTranslations: IFrameworkTranslations = {
   countMore: '{count} more',
   documentation: 'Documentation',
   errorText: 'Error',
+  filter: 'Filter',
+  listView: 'List view',
   manageColumns: 'Manage columns',
   moreInformation: 'More information',
   noItemsFound: 'No items found',
@@ -59,11 +64,12 @@ const defaultTranslations: IFrameworkTranslations = {
   processingText: 'Processing',
   selectNone: 'Select none',
   selectedText: 'Selected',
-  sort: 'Sort',
   showLess: 'Show less',
+  sort: 'Sort',
   submitText: 'Submit',
   submittingText: 'Submitting',
   successText: 'Success',
+  tableView: 'Table view',
   unknownError: 'Unknown error',
   validating: 'Validating...',
 };

--- a/framework/useFrameworkTranslations.tsx
+++ b/framework/useFrameworkTranslations.tsx
@@ -25,6 +25,7 @@ export interface IFrameworkTranslations {
   selectNone: string;
   selectedText: string;
   showLess: string;
+  sort: string;
   submitText: string;
   submittingText: string;
   successText: string;
@@ -56,6 +57,7 @@ const defaultTranslations: IFrameworkTranslations = {
   processingText: 'Processing',
   selectNone: 'Select none',
   selectedText: 'Selected',
+  sort: 'Sort',
   showLess: 'Show less',
   submitText: 'Submit',
   submittingText: 'Submitting',

--- a/framework/useFrameworkTranslations.tsx
+++ b/framework/useFrameworkTranslations.tsx
@@ -4,6 +4,7 @@ export interface IFrameworkTranslations {
   by: string;
   cancelText: string;
   canceledText: string;
+  filter: string;
   clearAllFilters: string;
   clickToRefresh: string;
   closeText: string;
@@ -37,6 +38,7 @@ const defaultTranslations: IFrameworkTranslations = {
   by: 'by',
   cancelText: 'Cancel',
   canceledText: 'Canceled',
+  filter: 'Filter',
   clearAllFilters: 'Clear all filters',
   clickToRefresh: 'Click to refresh',
   closeText: 'Close',

--- a/frontend/awx/access/users/hooks/useUsersColumns.tsx
+++ b/frontend/awx/access/users/hooks/useUsersColumns.tsx
@@ -48,7 +48,10 @@ export function useUsersColumns(options?: { disableLinks?: boolean; disableSort?
         value: (user) => user.email,
         sort: 'email',
       },
-      createdColumn,
+      {
+        ...createdColumn,
+        sort: undefined,
+      },
     ],
     [createdColumn, t]
   );

--- a/frontend/awx/views/jobs/Jobs.cy.tsx
+++ b/frontend/awx/views/jobs/Jobs.cy.tsx
@@ -75,8 +75,7 @@ describe('Jobs.cy.ts', () => {
       .should('be.an', 'array')
       .then((results: UnifiedJob[]) => {
         const job = results[4]; // job with summary_fields.user_capabilities.delete: false
-        cy.get('.pf-c-select__toggle').click();
-        cy.clickButton('ID');
+        cy.selectToolbarFilterType('ID');
         cy.selectTableRow(job.id.toString(), false);
         cy.clickToolbarKebabAction(/^Delete selected jobs$/);
         cy.contains(
@@ -146,8 +145,7 @@ describe('Jobs.cy.ts', () => {
       .should('be.an', 'array')
       .then((results: UnifiedJob[]) => {
         const job = results[0];
-        cy.get('.pf-c-select__toggle').click();
-        cy.clickButton('ID');
+        cy.selectToolbarFilterType('ID');
         cy.selectTableRow(job.id.toString(), false);
         cy.clickToolbarKebabAction(/^Cancel selected jobs$/);
         cy.contains(


### PR DESCRIPTION
![Screenshot 2023-04-27 at 10 13 45 AM](https://user-images.githubusercontent.com/6277895/234892052-e47ff570-ad2e-4c68-b8b8-96a7c03d0b6b.png)

Adds a sort component to the table toolbar.

This is needed
- for users to be able to sort on columns that are in the expandable row such as `created`.
- for the list and card views as there is no other way to sort on those views.

Changing the column header sort, updates the toolbar sort. Updating the toolbar sort, updates the column header sort.

In addition, there are enhancements to make the table toolbar properly wrap items when there are too many items on the toolbar. This is going to be important as we add support for more filters which are needed by analytics and others.