### PR TITLE
Make user roles tab match existing UI

### DIFF
--- a/frontend/awx/access/users/UserPage/UserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/UserDetails.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Alert } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { PageDetail, PageDetails, DateTimeCell } from '../../../../../framework';
 import { User } from '../../../interfaces/User';
@@ -12,14 +11,6 @@ export function UserDetails(props: { user: User }) {
 
   return (
     <>
-      {user.is_superuser && (
-        <Alert
-          variant="info"
-          title={t('System administrators have unrestricted access to all resources.')}
-          isInline
-          style={{ border: 0 }}
-        />
-      )}
       <PageDetails>
         <PageDetail label={t('Username')}>{user.username}</PageDetail>
         <PageDetail label={t('First name')}>{user.first_name}</PageDetail>

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Alert, ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import {
+  ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { CubesIcon, PlusIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -15,6 +22,12 @@ import { Role } from '../../../interfaces/Role';
 import { User } from '../../../interfaces/User';
 import { useAwxView } from '../../../useAwxView';
 import { useRolesColumns, useRolesFilters } from '../../roles/Roles';
+import styled from 'styled-components';
+
+const EmptyStateDiv = styled.div`
+  height: 100%;
+  background-color: var(--pf-global--BackgroundColor--100);
+`;
 
 export function UserRoles(props: { user: User }) {
   const { user } = props;
@@ -63,24 +76,29 @@ export function UserRoles(props: { user: User }) {
     ],
     [t]
   );
+  const isSysAdmin =
+    view?.pageItems && view.pageItems.length > 0
+      ? view.pageItems.some((role) => role.name === 'System Administrator')
+      : false;
+
+  if (isSysAdmin) {
+    return (
+      <EmptyStateDiv>
+        <EmptyState variant={EmptyStateVariant.small} style={{ paddingTop: 48 }}>
+          <EmptyStateIcon icon={CubesIcon} />
+          <Title headingLevel="h2" size="lg">
+            {t(`System Administrator`)}
+          </Title>
+          <EmptyStateBody>
+            {t(`System administrators have unrestricted access to all resources.`)}
+          </EmptyStateBody>
+        </EmptyState>
+      </EmptyStateDiv>
+    );
+  }
+
   return (
     <>
-      {user.is_superuser && (
-        <Alert
-          variant="warning"
-          title={t('System administrators have unrestricted access to all resources.')}
-          isInline
-          style={{ border: 0 }}
-        />
-      )}
-      {user.is_system_auditor && (
-        <Alert
-          variant="warning"
-          title={t('System auditor have unrestricted access to all resources.')}
-          isInline
-          style={{ border: 0 }}
-        />
-      )}
       <PageTable<Role>
         toolbarFilters={toolbarFilters}
         tableColumns={tableColumns}


### PR DESCRIPTION
#### UXD recommendation:
In the Users section, Admin users do not require the banner `"System administrators have unrestricted access to all resources"` that shows up in the User details tab for a system admin. The UX should mirror the flow in the existing UI where it is part of the empty state message for the admin and only in the Roles tab. 


<img width="923" alt="image" src="https://user-images.githubusercontent.com/43621546/234918751-66a530b5-6ea4-424b-aa21-75622d2f04b4.png">
