### PR TITLE
AWX Dashboard Jobs Chart support showing canceled and error jobs.

### DIFF
--- a/frontend/awx/dashboard/charts/JobsChart.tsx
+++ b/frontend/awx/dashboard/charts/JobsChart.tsx
@@ -1,13 +1,18 @@
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import useSWR from 'swr';
-import { pfDanger, pfSuccess } from '../../../../framework';
+import { useSettings } from '../../../../framework';
 import { PageDashboardChart } from '../../../../framework/PageDashboard/PageDashboardChart';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
 
 export type UnifiedJobSummary = Pick<UnifiedJob, 'id' | 'finished' | 'failed'>;
 
 interface IJobChartData {
-  jobs: { failed: [number, number][]; successful: [number, number][] };
+  jobs: {
+    failed: [number, number][];
+    successful: [number, number][];
+    canceled: [number, number][];
+    error: [number, number][];
+  };
 }
 
 export type DashboardJobPeriod = 'month' | 'two_weeks' | 'week' | 'day';
@@ -25,13 +30,6 @@ export function JobsChart(props: {
     (url: string) => fetch(url).then((r) => r.json())
   );
 
-  if (isLoading)
-    return (
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    );
-
   const reducer = (tuple: [number, number]) => {
     const date = new Date(tuple[0] * 1000);
     let label: string;
@@ -47,11 +45,33 @@ export function JobsChart(props: {
 
   const failed = data?.jobs.failed.map(reducer) ?? [];
   const successful = data?.jobs.successful.map(reducer) ?? [];
+  const canceled = data?.jobs.canceled.map(reducer) ?? [];
+  const error = data?.jobs.error.map(reducer) ?? [];
+
+  const { activeTheme } = useSettings();
+  let successfulColor = 'var(--pf-chart-color-green-300)';
+  if (activeTheme === 'dark') successfulColor = 'var(--pf-chart-color-green-300)';
+  let failedColor = 'var(--pf-chart-color-red-200)';
+  if (activeTheme === 'dark') failedColor = 'var(--pf-chart-color-red-300)';
+  let errorColor = 'var(--pf-chart-color-red-100)';
+  if (activeTheme === 'dark') errorColor = 'var(--pf-chart-color-red-200)';
+  let canceledColor = 'var(--pf-chart-color-black-400)';
+  if (activeTheme === 'dark') canceledColor = 'var(--pf-chart-color-black-400)';
+
+  if (isLoading)
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+
   return (
     <PageDashboardChart
       groups={[
-        { color: pfDanger, values: failed },
-        { color: pfSuccess, values: successful },
+        { color: successfulColor, values: successful },
+        { color: failedColor, values: failed },
+        { color: errorColor, values: error },
+        { color: canceledColor, values: canceled },
       ]}
     />
   );

--- a/frontend/awx/dashboard/charts/JobsChart.tsx
+++ b/frontend/awx/dashboard/charts/JobsChart.tsx
@@ -10,8 +10,8 @@ interface IJobChartData {
   jobs: {
     failed: [number, number][];
     successful: [number, number][];
-    canceled: [number, number][];
-    error: [number, number][];
+    canceled?: [number, number][];
+    error?: [number, number][];
   };
 }
 
@@ -45,8 +45,8 @@ export function JobsChart(props: {
 
   const failed = data?.jobs.failed.map(reducer) ?? [];
   const successful = data?.jobs.successful.map(reducer) ?? [];
-  const canceled = data?.jobs.canceled.map(reducer) ?? [];
-  const error = data?.jobs.error.map(reducer) ?? [];
+  const canceled = data?.jobs.canceled?.map(reducer) ?? [];
+  const error = data?.jobs.error?.map(reducer) ?? [];
 
   const { activeTheme } = useSettings();
   let successfulColor = 'var(--pf-chart-color-green-300)';

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -1,5 +1,7 @@
 // import '@patternfly/react-core/dist/styles/base.css'
 import '@patternfly/patternfly/patternfly-base.css';
+import '@patternfly/patternfly/patternfly-charts.css';
+
 import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 
 import { Suspense } from 'react';


### PR DESCRIPTION
Currently the job chart does not show canceled and error jobs because the AWX server does not return that data.
The recent jobs card shows these and it feels to the user like there is a disconnect.

I have the changes needed for AWX and will see about getting them in. If that goes in, we can merge this and have the right support.