### PR TITLE
Align dropdown item text when switches are present

### DIFF
--- a/framework/PageActions/PageActionDropdown.tsx
+++ b/framework/PageActions/PageActionDropdown.tsx
@@ -19,6 +19,14 @@ import styled from 'styled-components';
 const IconSpan = styled.span`
   padding-right: 4px;
 `;
+const StyledDropdownItem = styled.div<{ hasSwitches: boolean; isDanger: boolean }>`
+  --pf-c-dropdown__menu-item-icon--Width: ${({ hasSwitches }) =>
+    hasSwitches ? '40px' : undefined};
+  --pf-c-dropdown__menu-item-icon--MarginRight: ${({ hasSwitches }) =>
+    hasSwitches ? '16px' : undefined};
+  --pf-c-dropdown__menu-item--Color: ${({ isDanger }) =>
+    isDanger ? 'var(--pf-global--danger-color--100)' : undefined};
+`;
 
 interface PageActionDropdownProps<T extends object> {
   actions: IPageAction<T>[];
@@ -64,6 +72,14 @@ export function PageActionDropdown<T extends object>(props: PageActionDropdownPr
     () =>
       actions.find(
         (action) => action.type !== PageActionType.Seperator && action.icon !== undefined
+      ) !== undefined,
+    [actions]
+  );
+  const hasSwitches = useMemo(
+    () =>
+      actions.find(
+        (action) =>
+          action.type !== PageActionType.Seperator && action.type === PageActionType.Switch
       ) !== undefined,
     [actions]
   );
@@ -123,6 +139,7 @@ export function PageActionDropdown<T extends object>(props: PageActionDropdownPr
           selectedItems={selectedItems ?? []}
           selectedItem={selectedItem}
           hasIcons={hasIcons}
+          hasSwitches={hasSwitches}
           index={index}
         />
       ))}
@@ -145,9 +162,10 @@ function PageDropdownActionItem<T extends object>(props: {
   selectedItems: T[];
   selectedItem?: T;
   hasIcons: boolean;
+  hasSwitches: boolean;
   index: number;
 }): JSX.Element {
-  const { action, selectedItems, selectedItem, hasIcons, index } = props;
+  const { action, selectedItems, selectedItem, hasIcons, hasSwitches, index } = props;
   const isPageActionDisabled = usePageActionDisabled<T>();
   const isDisabled = isPageActionDisabled(action, selectedItem, selectedItems);
 
@@ -163,37 +181,33 @@ function PageDropdownActionItem<T extends object>(props: {
       }
       return (
         <Tooltip key={action.label} content={tooltip} trigger={tooltip ? undefined : 'manual'}>
-          <DropdownItem
-            icon={
-              Icon ? (
-                <IconSpan>
-                  <Icon />
-                </IconSpan>
-              ) : undefined
-            }
-            onClick={() => {
-              switch (action.selection) {
-                case PageActionSelection.None:
-                  action.onClick();
-                  break;
-                case PageActionSelection.Single:
-                  if (selectedItem) action.onClick(selectedItem);
-                  break;
-                case PageActionSelection.Multiple:
-                  if (selectedItems) action.onClick(selectedItems);
-                  break;
+          <StyledDropdownItem hasSwitches={hasSwitches} isDanger={Boolean(action.isDanger)}>
+            <DropdownItem
+              icon={
+                Icon ? (
+                  <IconSpan>
+                    <Icon />
+                  </IconSpan>
+                ) : undefined
               }
-            }}
-            isAriaDisabled={isButtonDisabled}
-            style={{
-              color:
-                action.isDanger && !isButtonDisabled
-                  ? 'var(--pf-global--danger-color--100)'
-                  : undefined,
-            }}
-          >
-            {action.label}
-          </DropdownItem>
+              onClick={() => {
+                switch (action.selection) {
+                  case PageActionSelection.None:
+                    action.onClick();
+                    break;
+                  case PageActionSelection.Single:
+                    if (selectedItem) action.onClick(selectedItem);
+                    break;
+                  case PageActionSelection.Multiple:
+                    if (selectedItems) action.onClick(selectedItems);
+                    break;
+                }
+              }}
+              isAriaDisabled={isButtonDisabled}
+            >
+              {action.label}
+            </DropdownItem>
+          </StyledDropdownItem>
         </Tooltip>
       );
     }


### PR DESCRIPTION
Detects when a switch is present in the dropdown and applies custom spacing to vertically align text. 

_Dropdown with switch_
![Screenshot 2023-04-27 at 7 00 37 PM](https://user-images.githubusercontent.com/15881645/235192611-eba14856-69a2-4560-8970-c89abf661ea7.png)

_Dropdown without switch_
<img width="260" alt="Screenshot 2023-04-28 at 11 38 56 AM" src="https://user-images.githubusercontent.com/15881645/235192618-854c7b9d-cd14-4b0a-8ef7-bc66c4338f38.png">
