### PR TITLE
Update EDA details views to re-query data on a 10 second interval

### DIFF
--- a/frontend/common/crud/useGet.tsx
+++ b/frontend/common/crud/useGet.tsx
@@ -5,7 +5,8 @@ import { useGetRequest } from './useGetRequest';
 /** useGet - returns data from a url. */
 export function useGet<T>(
   url: string | undefined,
-  query?: Record<string, string | number | boolean>
+  query?: Record<string, string | number | boolean>,
+  refreshInterval?: number
 ) {
   const getRequest = useGetRequest<T>();
 
@@ -23,7 +24,10 @@ export function useGet<T>(
     url += '?' + new URLSearchParams(normalizedQuery).toString();
   }
 
-  const response = useSWR<T>(url, getRequest, { dedupingInterval: 0 });
+  const response = useSWR<T>(url, getRequest, {
+    dedupingInterval: 0,
+    ...(refreshInterval && { refreshInterval }),
+  });
 
   const refresh = useCallback(() => {
     void response.mutate();

--- a/frontend/eda/Resources/credentials/CredentialDetails.tsx
+++ b/frontend/eda/Resources/credentials/CredentialDetails.tsx
@@ -18,7 +18,7 @@ import {
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaCredential } from '../../interfaces/EdaCredential';
 import { CredentialOptions } from './EditCredential';
 import { useDeleteCredentials } from './hooks/useDeleteCredentials';
@@ -28,7 +28,9 @@ export function CredentialDetails() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: credential } = useGet<EdaCredential>(
-    `${API_PREFIX}/credentials/${params.id ?? ''}/`
+    `${API_PREFIX}/credentials/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const deleteCredentials = useDeleteCredentials((deleted) => {

--- a/frontend/eda/Resources/decision-environments/DecisionEnvironmentDetails.tsx
+++ b/frontend/eda/Resources/decision-environments/DecisionEnvironmentDetails.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaCredential } from '../../interfaces/EdaCredential';
 import { EdaDecisionEnvironment } from '../../interfaces/EdaDecisionEnvironment';
 import { useDeleteDecisionEnvironments } from './hooks/useDeleteDecisionEnvironments';
@@ -27,7 +27,9 @@ export function DecisionEnvironmentDetails() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: decisionEnvironment } = useGet<EdaDecisionEnvironment>(
-    `${API_PREFIX}/decision-environments/${params.id ?? ''}/`
+    `${API_PREFIX}/decision-environments/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const { data: credential } = useGet<EdaCredential>(

--- a/frontend/eda/Resources/inventories/InventoryDetails.tsx
+++ b/frontend/eda/Resources/inventories/InventoryDetails.tsx
@@ -28,7 +28,7 @@ import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
 import { PageDetailsSection } from '../../common/PageDetailSection';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaInventory } from '../../interfaces/EdaInventory';
 import { useDeleteInventories } from './hooks/useDeleteInventories';
 
@@ -36,7 +36,11 @@ export function InventoryDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data: inventory } = useGet<EdaInventory>(`${API_PREFIX}/inventory/${params.id ?? ''}/`);
+  const { data: inventory } = useGet<EdaInventory>(
+    `${API_PREFIX}/inventory/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
   const [copied, setCopied] = React.useState(false);
 
   const clipboardCopyFunc = (event: React.MouseEvent, text: { toString: () => string }) => {

--- a/frontend/eda/Resources/projects/ProjectDetails.tsx
+++ b/frontend/eda/Resources/projects/ProjectDetails.tsx
@@ -22,7 +22,7 @@ import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { RouteObj } from '../../../Routes';
 import { StatusCell } from '../../../common/StatusCell';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaProject } from '../../interfaces/EdaProject';
 import { useDeleteProjects } from './hooks/useDeleteProjects';
 import { postRequest } from '../../../common/crud/Data';
@@ -34,7 +34,9 @@ export function ProjectDetails() {
   const alertToaster = usePageAlertToaster();
 
   const { data: project, refresh } = useGet<EdaProject>(
-    `${API_PREFIX}/projects/${params.id ?? ''}/`
+    `${API_PREFIX}/projects/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
   const syncProject = useCallback(
     (project: EdaProject) =>

--- a/frontend/eda/UserAccess/Groups/GroupDetails.tsx
+++ b/frontend/eda/UserAccess/Groups/GroupDetails.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaGroup } from '../../interfaces/EdaGroup';
 import { useDeleteGroups } from './hooks/useDeleteGroup';
 import { useGroupColumns } from './hooks/useGroupColumns';
@@ -23,7 +23,11 @@ export function GroupDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data: group } = useGet<EdaGroup>(`${API_PREFIX}/groups/${params.id ?? ''}/`);
+  const { data: group } = useGet<EdaGroup>(
+    `${API_PREFIX}/groups/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
   const tableColumns = useGroupColumns();
 
   const deleteGroups = useDeleteGroups((deleted) => {

--- a/frontend/eda/UserAccess/Roles/RoleDetails.tsx
+++ b/frontend/eda/UserAccess/Roles/RoleDetails.tsx
@@ -3,13 +3,17 @@ import { useParams } from 'react-router-dom';
 import { PageDetail, PageDetails, PageHeader, PageLayout, Scrollable } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaRole } from '../../interfaces/EdaRole';
 
 export function RoleDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { data: role } = useGet<EdaRole>(`${API_PREFIX}/roles/${params.id ?? ''}/`);
+  const { data: role } = useGet<EdaRole>(
+    `${API_PREFIX}/roles/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
 
   return (
     <PageLayout>

--- a/frontend/eda/UserAccess/Users/EdaUserDetails.tsx
+++ b/frontend/eda/UserAccess/Users/EdaUserDetails.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaUser } from '../../interfaces/EdaUser';
 import { useDeleteUsers } from './hooks/useDeleteUser';
 import { EdaUserInfo } from '../../../common/Masthead';
@@ -36,7 +36,11 @@ export function EdaUserDetails({ initialTabIndex = 0 }) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data: user } = useGet<EdaUser>(`${API_PREFIX}/users/${params.id ?? ''}/`);
+  const { data: user } = useGet<EdaUser>(
+    `${API_PREFIX}/users/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
 
   const me = EdaUserInfo();
   const deleteUsers = useDeleteUsers((deleted) => {

--- a/frontend/eda/constants.ts
+++ b/frontend/eda/constants.ts
@@ -1,1 +1,2 @@
 export const API_PREFIX = '/api/eda/v1';
+export const SWR_REFRESH_INTERVAL = 10 * 1000;

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -15,7 +15,7 @@ import { RouteObj } from '../../Routes';
 import { ItemsResponse } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
 import { PageDetailsSection } from '../common/PageDetailsSection';
-import { API_PREFIX } from '../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
 import { EdaActivationInstanceLog } from '../interfaces/EdaActivationInstanceLog';
 import { EdaRulebookActivation } from '../interfaces/EdaRulebookActivation';
@@ -24,21 +24,29 @@ export function ActivationInstanceDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data: activationInstance } = useGet<EdaActivationInstance>(
-    `${API_PREFIX}/activation-instances/${params.id ?? ''}/`
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const { data: activationInstanceLogInfo } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
-    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=1`
+    `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=1`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const { data: activationInstanceLog } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
     `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=${
       activationInstanceLogInfo?.count || 10
-    }`
+    }`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const { data: activation } = useGet<EdaRulebookActivation>(
-    `${API_PREFIX}/activations/${activationInstance?.activation_id ?? ''}/`
+    `${API_PREFIX}/activations/${activationInstance?.activation_id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const renderActivationDetailsTab = (

--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -26,7 +26,7 @@ import { StatusCell } from '../../common/StatusCell';
 import { postRequest } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
 import { EdaProjectCell } from '../Resources/projects/components/EdaProjectCell';
-import { API_PREFIX } from '../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
 import { EdaRulebookActivation } from '../interfaces/EdaRulebookActivation';
 import { useEdaView } from '../useEventDrivenView';
@@ -44,7 +44,9 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
   const alertToaster = usePageAlertToaster();
 
   const { data: rulebookActivation, refresh } = useGet<EdaRulebookActivation>(
-    `${API_PREFIX}/activations/${params.id ?? ''}/`
+    `${API_PREFIX}/activations/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
   );
 
   const restartRulebookActivation = useRestartRulebookActivations((restarted) => {

--- a/frontend/eda/rulebooks/RulebookDetails.tsx
+++ b/frontend/eda/rulebooks/RulebookDetails.tsx
@@ -15,7 +15,7 @@ import {
 import { formatDateString } from '../../../framework/utils/formatDateString';
 import { RouteObj } from '../../Routes';
 import { useGet } from '../../common/crud/useGet';
-import { API_PREFIX } from '../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaResult } from '../interfaces/EdaResult';
 import { EdaRulebook } from '../interfaces/EdaRulebook';
 import { EdaRuleset } from '../interfaces/EdaRuleset';
@@ -25,7 +25,11 @@ import { useRulesetFilters } from './hooks/useRulesetFilters';
 export function RulebookDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { data: rulebook } = useGet<EdaRulebook>(`${API_PREFIX}/rulebooks/${params.id ?? ''}/`);
+  const { data: rulebook } = useGet<EdaRulebook>(
+    `${API_PREFIX}/rulebooks/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
 
   const renderRulebookDetailsTab = (rulebook: EdaRulebook | undefined): JSX.Element => {
     return (

--- a/frontend/eda/rules/RuleDetails.tsx
+++ b/frontend/eda/rules/RuleDetails.tsx
@@ -23,14 +23,18 @@ import { RouteObj } from '../../Routes';
 import { useGet } from '../../common/crud/useGet';
 import { EdaProjectCell } from '../Resources/projects/components/EdaProjectCell';
 import { PageDetailsSection } from '../common/PageDetailsSection';
-import { API_PREFIX } from '../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaRule } from '../interfaces/EdaRule';
 import { EdaRulebookCell } from '../rulebooks/components/EdaRulebookCell';
 
 export function RuleDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { data: rule } = useGet<EdaRule>(`${API_PREFIX}/rules/${params.id ?? ''}/`);
+  const { data: rule } = useGet<EdaRule>(
+    `${API_PREFIX}/rules/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
   const [copied, setCopied] = React.useState(false);
 
   const clipboardCopyFunc = (event: React.MouseEvent, text: { toString: () => string }) => {

--- a/frontend/eda/useEventDrivenView.tsx
+++ b/frontend/eda/useEventDrivenView.tsx
@@ -4,6 +4,7 @@ import useSWR from 'swr';
 import { ISelected, ITableColumn, IToolbarFilter, useSelected } from '../../framework';
 import { IView, useView } from '../../framework/useView';
 import { ItemsResponse, getItemKey, swrOptions, useFetcher } from '../common/crud/Data';
+import { SWR_REFRESH_INTERVAL } from './constants';
 
 export type IEdaView<T extends { id: number | string }> = IView &
   ISelected<T> & {
@@ -95,7 +96,7 @@ export function useEdaView<T extends { id: number | string }>(options: {
   const fetcher = useFetcher();
   const response = useSWR<ItemsResponse<T>>(url, fetcher, {
     ...swrOptions,
-    refreshInterval: 10 * 1000,
+    refreshInterval: SWR_REFRESH_INTERVAL,
   });
   const { data, mutate } = response;
   const [refreshing, setRefreshing] = useState(false);

--- a/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
+++ b/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
@@ -16,7 +16,7 @@ import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { RouteObj } from '../../../Routes';
 import { StatusCell } from '../../../common/StatusCell';
 import { useGet } from '../../../common/crud/useGet';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaRuleAudit } from '../../interfaces/EdaRuleAudit';
 import { EdaRuleAuditAction } from '../../interfaces/EdaRuleAuditAction';
 import { EdaRuleAuditEvent } from '../../interfaces/EdaRuleAuditEvent';
@@ -30,7 +30,11 @@ export function RuleAuditDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
-  const { data: ruleAudit } = useGet<EdaRuleAudit>(`${API_PREFIX}/audit-rules/${params.id ?? ''}/`);
+  const { data: ruleAudit } = useGet<EdaRuleAudit>(
+    `${API_PREFIX}/audit-rules/${params.id ?? ''}/`,
+    undefined,
+    SWR_REFRESH_INTERVAL
+  );
 
   const renderRuleAuditDetailsTab = (ruleAudit: EdaRuleAudit | undefined): JSX.Element => {
     return (


### PR DESCRIPTION
I noticed that we were already using a 10 second refresh interval on list pages. So I chose the same refresh interval for details pages as well. 
@lgalis  @jamestalton Let me know if you think we should be selecting different intervals in different views. Thanks!