### PR TITLE
Remove rogue "0" from EDA activation instance details 

### DIFF
--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -59,7 +59,7 @@ export function ActivationInstanceDetails() {
           </PageDetail>
         </PageDetails>
         <PageDetailsSection>
-          {activationInstanceLog?.results?.length && (
+          {activationInstanceLog?.results?.length ? (
             <PageDetail label={t('Output')}>
               <CodeBlock>
                 <CodeBlockCode
@@ -72,7 +72,7 @@ export function ActivationInstanceDetails() {
                 </CodeBlockCode>
               </CodeBlock>
             </PageDetail>
-          )}
+          ) : null}
         </PageDetailsSection>
       </Scrollable>
     );


### PR DESCRIPTION
##### SUMMARY
Falsy condition `activationInstanceLog?.results?.length` returned the length 0 instead of null. Swapped short-circuit for ternary operator. 

_Bug Screenshot_
![Screenshot 2023-05-02 at 5 17 54 PM](https://user-images.githubusercontent.com/15881645/236056155-9e86beba-192a-414e-b724-2bd5f7669401.png)

##### ISSUE TYPE
 - Bug Fix
 
