### PR TITLE
Conditionally show extra var section.

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -195,8 +195,8 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
                 : ''}
             </PageDetail>
           </PageDetails>
-          <PageDetailsSection>
-            {rulebookActivation?.extra_var?.id && (
+          {rulebookActivation?.extra_var?.id && (
+            <PageDetailsSection>
               <PageDetail
                 label={t('Variables')}
                 helpText={t(
@@ -205,8 +205,8 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
               >
                 <EdaExtraVarsCell id={rulebookActivation.extra_var.id} />
               </PageDetail>
-            )}
-          </PageDetailsSection>
+            </PageDetailsSection>
+          )}
         </PageSection>
       </Scrollable>
     );


### PR DESCRIPTION
Remove empty block for extra var section in Rulebook Activations details view:

Before:
<img width="1815" alt="ra-before" src="https://user-images.githubusercontent.com/2293210/236061209-c43e8ecf-9ec0-4651-904d-add8ed451f32.png">

After:
<img width="1815" alt="Screenshot 2023-05-03 at 3 09 14 PM" src="https://user-images.githubusercontent.com/2293210/236061227-aaac8af1-b9aa-4d69-9f2c-df44fbacbb4f.png">
