### PR TITLE
User CRUD actions

### DIFF
--- a/cypress/e2e/eda/General-UI/login-logout.cy.ts
+++ b/cypress/e2e/eda/General-UI/login-logout.cy.ts
@@ -8,7 +8,7 @@ describe('EDA Login / Logoff', () => {
   });
 
   it('can log into the UI and view username in the top right of the Dashboard toolbar', () => {
-    cy.getEdaUser().then((edaUser) => {
+    cy.getEdaActiveUser().then((edaUser) => {
       if (Cypress.env('TEST_STANDALONE') === true) {
         cy.intercept('GET', '/api/logout/').as('loggedOut');
         cy.edaLogout();

--- a/cypress/e2e/eda/Users/users-crud.cy.ts
+++ b/cypress/e2e/eda/Users/users-crud.cy.ts
@@ -2,13 +2,23 @@
 import { randomString } from '../../../../framework/utils/random-string';
 
 describe('EDA Users- Create, Edit, Delete', () => {
+  let roleNames: string[];
+  let roleIDs: string[];
+  let editorRoleID: string;
+  let auditorRoleName: string;
   before(() => {
     cy.edaLogin();
+    cy.getEdaRoles().then((rolesArray) => {
+      roleNames = rolesArray.map((role) => role.name);
+      roleIDs = rolesArray.map((role) => role.id);
+      editorRoleID = roleIDs[2];
+      auditorRoleName = roleNames[4];
+    });
   });
 
-  it.skip('can create a User, select role(s) to add the user to, and assert the information showing on the details page', () => {
-    const userDetails = {
-      username: `E2E User ${randomString(4)}`,
+  it('can create a User, select role(s) to add the user to, and assert the information showing on the details page', () => {
+    const userInfo = {
+      username: `E2EUser${randomString(4)}`,
       FirstName: 'Firstname',
       LastName: 'Lastname',
       Email: 'first.last@redhat.com',
@@ -17,61 +27,68 @@ describe('EDA Users- Create, Edit, Delete', () => {
     cy.navigateTo(/^Users$/);
     cy.contains('h1', 'Users');
     cy.clickButton(/^Create user$/);
-    cy.typeInputByLabel(/^Username$/, userDetails.username);
-    cy.typeInputByLabel(/^First name$/, userDetails.FirstName);
-    cy.typeInputByLabel(/^Last name$/, userDetails.LastName);
-    cy.typeInputByLabel(/^Email$/, userDetails.Email);
-    cy.typeInputByLabel(/^Password$/, userDetails.Password);
-    cy.typeInputByLabel(/^Password confirmation$/, userDetails.Password);
-    // TODO: needs further work when Users page is functional
-    /*
-    Roles selection
-     */
-    cy.selectDropdownOptionByLabel(/^User type$/, 'Super user');
-    cy.selectDropdownOptionByLabel(/^Roles(s)$/, 'User Experience');
+    cy.typeInputByLabel(/^Username$/, userInfo.username);
+    cy.typeInputByLabel(/^First name$/, userInfo.FirstName);
+    cy.typeInputByLabel(/^Last name$/, userInfo.LastName);
+    cy.typeInputByLabel(/^Email$/, userInfo.Email);
+    cy.typeInputByLabel(/^Password$/, userInfo.Password);
+    cy.typeInputByLabel(/^Confirm password$/, userInfo.Password);
+    cy.get('button[aria-label="Options menu"]').click();
+    cy.contains('tbody tr', 'Contributor').within(() => {
+      cy.get('input[type="checkbox"]').check();
+    });
+    cy.contains('button', 'Confirm').should('be.enabled').click();
     cy.clickButton(/^Create user$/);
-    cy.hasDetail('First name', userDetails.FirstName);
-    cy.hasDetail('Last name', userDetails.LastName);
-    cy.hasDetail('Email', userDetails.Email);
-    cy.hasDetail('Username', userDetails.username);
-    cy.getEdaUser().then((user) => {
-      cy.wrap(user).should('not.be.undefined');
-      if (user) {
-        cy.deleteEdaUser(user);
+    cy.hasDetail('First name', userInfo.FirstName);
+    cy.hasDetail('Last name', userInfo.LastName);
+    cy.hasDetail('Email', userInfo.Email);
+    cy.hasDetail('Username', userInfo.username);
+    cy.getEdaUserByName(userInfo.username).then((username) => {
+      cy.wrap(username).should('not.be.undefined');
+      if (username) {
+        cy.deleteEdaUser(username);
       }
     });
   });
 
-  it.skip('can edit a User including the roles the user belongs to', () => {
-    cy.createEdaUser().then((edaUser) => {
+  it('can edit a User including the roles the user belongs to', () => {
+    cy.createEdaUser({
+      roles: [editorRoleID],
+    }).then((edaUser) => {
       cy.navigateTo(/^Users$/);
       cy.get('h1').should('contain', 'Users');
       cy.clickTableRow(edaUser.username);
-      cy.clickPageAction(/^Edit user$/);
+      cy.contains('button#edit-user', 'Edit user').click();
       cy.hasTitle(`Edit ${edaUser.username}`);
-      cy.typeInputByLabel(/^Username$/, edaUser.username);
-      cy.typeInputByLabel(/^First name$/, edaUser.username + 'edited firstname');
-      cy.typeInputByLabel(/^Last name$/, edaUser.username + 'edited lastname');
+      cy.typeInputByLabel(/^Username$/, `${edaUser.username}edited`);
+      cy.typeInputByLabel(/^First name$/, 'firstname-edited');
+      cy.typeInputByLabel(/^Last name$/, 'lastname-edited');
       cy.typeInputByLabel(/^Email$/, 'edited@redhat.com');
       cy.typeInputByLabel(/^Password$/, 'newpass');
-      cy.typeInputByLabel(/^Password confirmation$/, 'newpass');
-      cy.selectDropdownOptionByLabel(/^User type$/, 'Regular user');
-      cy.selectDropdownOptionByLabel(/^Roles(s)$/, 'Engineering');
+      cy.typeInputByLabel(/^Confirm password$/, 'newpass');
+      cy.get('button[aria-label="Options menu"]').click();
+      cy.contains('a', auditorRoleName)
+        .parents('td[data-label="Name"]')
+        .prev()
+        .within(() => {
+          cy.get('input[type="checkbox"]').click();
+        });
+      cy.contains('button', 'Confirm').should('be.enabled').click();
       cy.clickButton(/^Save user$/);
-      cy.hasDetail('Firstname', edaUser.username + 'edited firstname');
-      cy.hasDetail('Lastname', edaUser.username + 'edited lastname');
-      cy.hasDetail('Email', edaUser.username + 'edited lastname');
-      cy.hasDetail('First name', `${edaUser.username} edited firstname`);
-      cy.hasDetail('Last name', `${edaUser.username} edited lastname`);
-      cy.hasDetail('User type', 'Regular user');
-      cy.hasDetail('Roles(s)', 'Engineering');
+      cy.hasDetail('Username', `${edaUser.username}edited`);
+      cy.hasDetail('First name', 'firstname-edited');
+      cy.hasDetail('Last name', 'lastname-edited');
+      cy.hasDetail('Email', 'edited@redhat.com');
+      cy.get('dd[id="role(s)"] span').should('include.text', auditorRoleName).should('be.visible');
       cy.navigateTo(/^Users$/);
       cy.deleteEdaUser(edaUser);
     });
   });
 
-  it.skip('can delete a User', () => {
-    cy.createEdaUser().then((edaUser) => {
+  it('can delete a User', () => {
+    cy.createEdaUser({
+      roles: [editorRoleID],
+    }).then((edaUser) => {
       cy.navigateTo(/^Users$/);
       cy.get('h1').should('contain', 'Users');
       cy.clickTableRow(edaUser.username);
@@ -87,7 +104,20 @@ describe('EDA Users- Create, Edit, Delete', () => {
     });
   });
 
-  it.skip('can view and select from the list of available roles in the Users create form', () => {
-    //write test here
+  it('can view and select from the list of available roles in the Users create form', () => {
+    const userRoles = ['Admin', 'Viewer', 'Operator', 'Contributor', 'Editor', 'Auditor'];
+    cy.navigateTo(/^Users$/);
+    cy.contains('h1', 'Users');
+    cy.clickButton(/^Create user$/);
+    cy.get('button[aria-label="Options menu"]').click();
+    userRoles.forEach((role) => {
+      cy.contains('a', role)
+        .should('be.visible')
+        .parents('td[data-label="Name"]')
+        .prev()
+        .within(() => {
+          cy.get('input[type="checkbox"]').click();
+        });
+    });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,11 +20,12 @@ import { EdaDecisionEnvironment } from '../../frontend/eda/interfaces/EdaDecisio
 import { EdaProject } from '../../frontend/eda/interfaces/EdaProject';
 import { EdaRulebook } from '../../frontend/eda/interfaces/EdaRulebook';
 import { EdaRulebookActivation } from '../../frontend/eda/interfaces/EdaRulebookActivation';
-import { EdaUser } from '../../frontend/eda/interfaces/EdaUser';
+import { EdaUser, EdaUserCreateUpdate } from '../../frontend/eda/interfaces/EdaUser';
 import './auth';
 import './awx-commands';
 import './eda-commands';
 import './rest-commands';
+import { EdaRole } from '../../frontend/eda/interfaces/EdaRole';
 
 declare global {
   namespace Cypress {
@@ -154,7 +155,10 @@ declare global {
       // --- REST API COMMANDS ---
 
       /** Sends a request to the API to create a particular resource. */
-      requestPost<T>(url: string, data: Partial<T>): Chainable<T>;
+      requestPost<ResponseT, RequestT = ResponseT>(
+        url: string,
+        data: Partial<RequestT>
+      ): Chainable<ResponseT>;
 
       /** Sends a request to the API to get a particular resource. */
       requestGet<T>(url: string): Chainable<T>;
@@ -191,7 +195,7 @@ declare global {
       ): Chainable<{ inventory: Inventory; host: Host; group: Group }>;
 
       // --- EDA COMMANDS ---
-
+      selectUserRoleByName(roleName: string): Chainable<void>;
       checkAnchorLinks(anchorName: string): Chainable<void>;
       checkLogoSuccess(): Chainable<void>;
 
@@ -296,12 +300,15 @@ declare global {
        */
       deleteEdaCredential(credential: EdaCredential): Chainable<void>;
 
+      getEdaRoles(): Chainable<EdaRole[]>;
       /**
        * Creates an EDA user and returns the same.
        *
        * @returns {Chainable<EdaUser>}
        */
-      createEdaUser(): Chainable<EdaUser>;
+      createEdaUser(
+        user?: SetOptional<EdaUserCreateUpdate, 'username' | 'password'>
+      ): Chainable<EdaUser>;
 
       /**
        * Deletes an EDA user which is provided.
@@ -315,7 +322,9 @@ declare global {
        *
        * @returns {Chainable<EdaUser>}
        */
-      getEdaUser(): Chainable<EdaUser | undefined>;
+      getEdaActiveUser(): Chainable<EdaUser | undefined>;
+
+      getEdaUserByName(name: string): Chainable<EdaUser | undefined>;
 
       /**
        * Creates a DE and returns the same.

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -4,6 +4,7 @@ import { EdaCredential } from '../../frontend/eda/interfaces/EdaCredential';
 import { EdaDecisionEnvironment } from '../../frontend/eda/interfaces/EdaDecisionEnvironment';
 import { EdaProject } from '../../frontend/eda/interfaces/EdaProject';
 import { EdaResult } from '../../frontend/eda/interfaces/EdaResult';
+import { EdaRole } from '../../frontend/eda/interfaces/EdaRole';
 import { EdaRulebook } from '../../frontend/eda/interfaces/EdaRulebook';
 import { EdaRulebookActivation } from '../../frontend/eda/interfaces/EdaRulebookActivation';
 import { EdaUser, EdaUserCreateUpdate } from '../../frontend/eda/interfaces/EdaUser';
@@ -12,6 +13,16 @@ import './commands';
 import './rest-commands';
 
 /*  EDA related custom command implementation  */
+
+Cypress.Commands.add('selectUserRoleByName', (roleName: string) => {
+  cy.get('button[aria-label="Options menu"]').click();
+  cy.contains('a', roleName)
+    .parents('td[data-label="Name"]')
+    .prev()
+    .within(() => {
+      cy.get('input[type="checkbox"]').click();
+    });
+});
 
 Cypress.Commands.add('checkLogoSuccess', () => {
   cy.get('img').should('be.visible');
@@ -196,34 +207,64 @@ Cypress.Commands.add('getEdaCredentialByName', (edaCredentialName: string) => {
   });
 });
 
-Cypress.Commands.add('createEdaUser', () => {
-  cy.requestPost<EdaUserCreateUpdate>(`/api/eda/v1/users/`, {
-    username: `E2E User ${randomString(4)}`,
-    email: `${randomString(4)}@redhat.com`,
-    password: `${randomString(4)}`,
-  }).then((edaUser) => {
-    Cypress.log({
-      displayName: 'EDA USER CREATION :',
-      message: [`Created 👉  ${edaUser.username}`],
-    });
-    return edaUser;
+Cypress.Commands.add('getEdaRoles', () => {
+  cy.requestGet<EdaResult<EdaRole>>('/api/eda/v1/roles/').then((response) => {
+    const edaRoles = response.results;
+    return edaRoles;
   });
 });
 
+Cypress.Commands.add(
+  'createEdaUser',
+  (user?: SetOptional<EdaUserCreateUpdate, 'username' | 'password'>) => {
+    cy.requestPost<EdaUser, SetOptional<EdaUserCreateUpdate, 'username' | 'password'>>(
+      `/api/eda/v1/users/`,
+      {
+        username: `E2EUser${randomString(4)}`,
+        password: `${randomString(4)}`,
+        ...user,
+      }
+    ).then((edaUser) => {
+      Cypress.log({
+        displayName: 'EDA USER CREATION :',
+        message: [`Created 👉  ${edaUser.username}`],
+      });
+      return edaUser;
+    });
+  }
+);
+
 Cypress.Commands.add('deleteEdaUser', (user: EdaUser) => {
-  cy.requestDelete(`/api/eda/v1/credentials/${user.id}/`, true).then(() => {
+  cy.requestDelete(`/api/eda/v1/users/${user.id}/`, true).then(() => {
     Cypress.log({
-      displayName: 'EDA CREDENTIAL DELETION :',
+      displayName: 'EDA USER DELETION :',
       message: [`Deleted 👉  ${user.username}`],
     });
   });
 });
 
-Cypress.Commands.add('getEdaUser', () => {
-  cy.requestGet<EdaResult<EdaUser>>(`/api/eda/v1/users/me/`).then((result) => {
-    // This will take care of deleting the project and the associated org, inventory
-    if (Array.isArray(result?.results) && result?.results.length === 1) {
-      return result?.results[0];
+Cypress.Commands.add('getEdaActiveUser', () => {
+  cy.requestGet<EdaResult<EdaUser>>(`/api/eda/v1/users/me/`).then((response) => {
+    if (Array.isArray(response?.results) && response?.results.length > 1) {
+      Cypress.log({
+        displayName: 'EDA USER ROLE:',
+        message: [response?.results[1].roles[0].name],
+      });
+      return response?.results[1];
+    } else {
+      return undefined;
+    }
+  });
+});
+
+Cypress.Commands.add('getEdaUserByName', (edaUserName: string) => {
+  cy.requestGet<EdaResult<EdaUser>>(`/api/eda/v1/users/?name=${edaUserName}`).then((response) => {
+    if (Array.isArray(response?.results) && response?.results.length > 1) {
+      Cypress.log({
+        displayName: 'EDA USER ROLE:',
+        message: [response?.results[1].roles[0].name],
+      });
+      return response?.results[1];
     } else {
       return undefined;
     }

--- a/cypress/support/rest-commands.ts
+++ b/cypress/support/rest-commands.ts
@@ -1,10 +1,13 @@
 /// <reference types="cypress" />
 import '@cypress/code-coverage/support';
 
-Cypress.Commands.add('requestPost', function requestPost<T>(url: string, body: Partial<T>) {
+Cypress.Commands.add('requestPost', function requestPost<
+  ResponseT,
+  RequestT = ResponseT
+>(url: string, body: Partial<RequestT>) {
   cy.getCookie('csrftoken').then((cookie) =>
     cy
-      .request<T>({
+      .request<ResponseT>({
         method: 'POST',
         url,
         body,


### PR DESCRIPTION
## Description
This PR is for [ticket](https://issues.redhat.com/browse/AAP-11016) 

## Acceptance Criteria

- [x] Custom commands 
          - `getEdaRoles`
          - `createEdaUser`
          - `deleteEdaUser`
          - `getEdaActiveUser`
          - `getEdaUserByName`
- [x] can create a User, select role(s) to add the user to, and assert the information showing on the details page
- [x] can edit a User including the roles the user belongs to
- [x] can delete a user
- [x] can view and select from the list of available roles in the Users create form
- [x] Code refactoring custom command  `getEdaUser` to `getEdaActiveUser`