### PR TITLE
Update edit forms to correctly display errors from the API

### DIFF
--- a/frontend/eda/Resources/credentials/EditCredential.tsx
+++ b/frontend/eda/Resources/credentials/EditCredential.tsx
@@ -10,11 +10,11 @@ import {
   PageLayout,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
-import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { API_PREFIX } from '../../constants';
 import { EdaCredential } from '../../interfaces/EdaCredential';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 export function CredentialOptions(t: TFunction<'translation'>) {
   return [
@@ -91,10 +91,11 @@ export function EditCredential() {
 
   const { cache } = useSWRConfig();
   const postRequest = usePostRequest<Partial<EdaCredential>, EdaCredential>();
+  const patchRequest = usePatchRequest<Partial<EdaCredential>, EdaCredential>();
 
   const onSubmit: PageFormSubmitHandler<EdaCredential> = async (credential) => {
     if (Number.isInteger(id)) {
-      await requestPatch<EdaCredential>(`${API_PREFIX}/credentials/${id}/`, credential);
+      await patchRequest(`${API_PREFIX}/credentials/${id}/`, credential);
       (cache as unknown as { clear: () => void }).clear?.();
       navigate(-1);
     } else {

--- a/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
+++ b/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
@@ -10,13 +10,13 @@ import {
   PageLayout,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
-import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { API_PREFIX } from '../../constants';
 import { EdaCredential } from '../../interfaces/EdaCredential';
 import { EdaDecisionEnvironment } from '../../interfaces/EdaDecisionEnvironment';
 import { EdaResult } from '../../interfaces/EdaResult';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 function DecisionEnvironmentInputs() {
   const { t } = useTranslation();
@@ -83,13 +83,11 @@ export function EditDecisionEnvironment() {
   );
   const { cache } = useSWRConfig();
   const postRequest = usePostRequest<Partial<EdaDecisionEnvironment>, EdaDecisionEnvironment>();
+  const patchRequest = usePatchRequest<Partial<EdaDecisionEnvironment>, EdaDecisionEnvironment>();
 
   const onSubmit: PageFormSubmitHandler<EdaDecisionEnvironment> = async (decisionEnvironment) => {
     if (Number.isInteger(id)) {
-      await requestPatch<EdaDecisionEnvironment>(
-        `${API_PREFIX}/decision-environments/${id}/`,
-        decisionEnvironment
-      );
+      await patchRequest(`${API_PREFIX}/decision-environments/${id}/`, decisionEnvironment);
       (cache as unknown as { clear: () => void }).clear?.();
       navigate(-1);
     } else {

--- a/frontend/eda/Resources/projects/EditProject.tsx
+++ b/frontend/eda/Resources/projects/EditProject.tsx
@@ -10,7 +10,6 @@ import {
   PageLayout,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
-import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { useIsValidUrl } from '../../../common/validation/useIsValidUrl';
@@ -18,6 +17,7 @@ import { API_PREFIX } from '../../constants';
 import { EdaProject } from '../../interfaces/EdaProject';
 import { EdaResult } from '../../interfaces/EdaResult';
 import { EdaCredential } from '../../interfaces/EdaCredential';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 function ProjectCreateInputs() {
   const { t } = useTranslation();
@@ -125,10 +125,11 @@ export function EditProject() {
 
   const { cache } = useSWRConfig();
   const postRequest = usePostRequest<Partial<EdaProject>, EdaProject>();
+  const patchRequest = usePatchRequest<Partial<EdaProject>, EdaProject>();
 
   const onSubmit: PageFormSubmitHandler<EdaProject> = async (project) => {
     if (Number.isInteger(id)) {
-      await requestPatch<EdaProject>(`${API_PREFIX}/projects/${id}/`, project);
+      await patchRequest(`${API_PREFIX}/projects/${id}/`, project);
       (cache as unknown as { clear: () => void }).clear?.();
       navigate(-1);
     } else {

--- a/frontend/eda/UserAccess/Groups/EditGroup.tsx
+++ b/frontend/eda/UserAccess/Groups/EditGroup.tsx
@@ -8,12 +8,12 @@ import {
   PageLayout,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
-import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { useInvalidateCacheOnUnmount } from '../../../common/useInvalidateCache';
 import { API_PREFIX } from '../../constants';
 import { EdaGroup } from '../../interfaces/EdaGroup';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 export function EditGroup() {
   const { t } = useTranslation();
@@ -25,10 +25,11 @@ export function EditGroup() {
   useInvalidateCacheOnUnmount();
 
   const postRequest = usePostRequest<Partial<EdaGroup>, EdaGroup>();
+  const patchRequest = usePatchRequest<Partial<EdaGroup>, EdaGroup>();
 
   const onSubmit: PageFormSubmitHandler<EdaGroup> = async (Group) => {
     if (Number.isInteger(id)) {
-      Group = await requestPatch<EdaGroup>(`${API_PREFIX}/groups/${id}/`, Group);
+      Group = await patchRequest(`${API_PREFIX}/groups/${id}/`, Group);
       navigate(-1);
     } else {
       const newGroup = await postRequest(`${API_PREFIX}/groups/`, Group);

--- a/frontend/eda/UserAccess/Roles/EditRole.tsx
+++ b/frontend/eda/UserAccess/Roles/EditRole.tsx
@@ -8,12 +8,12 @@ import {
   PageLayout,
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
-import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { useInvalidateCacheOnUnmount } from '../../../common/useInvalidateCache';
 import { API_PREFIX } from '../../constants';
 import { EdaRole } from '../../interfaces/EdaRole';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 export function EditRole() {
   const { t } = useTranslation();
@@ -25,10 +25,11 @@ export function EditRole() {
   useInvalidateCacheOnUnmount();
 
   const postRequest = usePostRequest<Partial<EdaRole>, EdaRole>();
+  const patchRequest = usePatchRequest<Partial<EdaRole>, EdaRole>();
 
   const onSubmit: PageFormSubmitHandler<EdaRole> = async (Role) => {
     if (Number.isInteger(id)) {
-      Role = await requestPatch<EdaRole>(`${API_PREFIX}/roles/${id}/`, Role);
+      Role = await patchRequest(`${API_PREFIX}/roles/${id}/`, Role);
       navigate(-1);
     } else {
       const newRole = await postRequest(`${API_PREFIX}/roles/`, Role);

--- a/frontend/eda/rules/EditRule.tsx
+++ b/frontend/eda/rules/EditRule.tsx
@@ -9,11 +9,11 @@ import {
   PageLayout,
 } from '../../../framework';
 import { RouteObj } from '../../Routes';
-import { requestPatch } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
 import { usePostRequest } from '../../common/crud/usePostRequest';
 import { API_PREFIX } from '../constants';
 import { EdaRule } from '../interfaces/EdaRule';
+import { usePatchRequest } from '../../common/crud/usePatchRequest';
 
 export function EditRule() {
   const { t } = useTranslation();
@@ -25,10 +25,11 @@ export function EditRule() {
   const { cache } = useSWRConfig();
 
   const postRequest = usePostRequest<Partial<EdaRule>, EdaRule>();
+  const patchRequest = usePatchRequest<Partial<EdaRule>, EdaRule>();
 
   const onSubmit: PageFormSubmitHandler<EdaRule> = async (rule) => {
     if (Number.isInteger(id)) {
-      rule = await requestPatch<EdaRule>(`${API_PREFIX}/rules/${id}/`, rule);
+      rule = await patchRequest(`${API_PREFIX}/rules/${id}/`, rule);
       (cache as unknown as { clear: () => void }).clear?.();
       navigate(-1);
     } else {


### PR DESCRIPTION
Updates "edit resource" forms (rules, groups, projects, credentials, roles & decision environments) to use the `usePatchRequest` hook so that error messages received from the API call can be correctly displayed on the form.

![image](https://user-images.githubusercontent.com/43621546/236486219-c9a78af2-3b49-4ef3-a5a9-c9d42f07e6ba.png)
