### PR TITLE
[AAP-11816] Add description to Users, Roles and Rule audit page headers

### DIFF
--- a/frontend/eda/UserAccess/Roles/Roles.tsx
+++ b/frontend/eda/UserAccess/Roles/Roles.tsx
@@ -14,7 +14,12 @@ export function Roles() {
   });
   return (
     <PageLayout>
-      <PageHeader title={t('Roles')} />
+      <PageHeader
+        title={t('Roles')}
+        description={t(
+          'A role is a set of permissions that can be assigned to users based on their role within an organization.'
+        )}
+      />
       <PageTable
         tableColumns={tableColumns}
         errorStateTitle={t('Error loading roles')}

--- a/frontend/eda/UserAccess/Users/Users.tsx
+++ b/frontend/eda/UserAccess/Users/Users.tsx
@@ -24,7 +24,12 @@ export function Users() {
   const rowActions = useUserActions(view);
   return (
     <PageLayout>
-      <PageHeader title={t('Users')} />
+      <PageHeader
+        title={t('Users')}
+        description={t(
+          'A user is someone who has access to EDA with associated permissions and credentials.'
+        )}
+      />
       <PageTable
         tableColumns={tableColumns}
         toolbarActions={toolbarActions}

--- a/frontend/eda/views/RuleAudit/RuleAudit.tsx
+++ b/frontend/eda/views/RuleAudit/RuleAudit.tsx
@@ -21,7 +21,12 @@ export function RuleAudit() {
 
   return (
     <PageLayout>
-      <PageHeader title={`Rule Audit`} />
+      <PageHeader
+        title={`Rule Audit`}
+        description={t(
+          'Rule audit allows auditing of rules which have been triggered by incoming events.'
+        )}
+      />
       <PageTable
         tableColumns={tableColumns}
         toolbarFilters={toolbarFilters}


### PR DESCRIPTION
Add description to Users, Roles and Rule audit page headers

![Screenshot from 2023-05-07 12-56-25](https://user-images.githubusercontent.com/12769982/236691484-590aae10-bd22-4ae8-889e-e85e37f18deb.png)
![Screenshot from 2023-05-07 12-56-12](https://user-images.githubusercontent.com/12769982/236691487-5e3fce98-d205-4eef-801a-991f66a878b6.png)
![Screenshot from 2023-05-07 12-56-08](https://user-images.githubusercontent.com/12769982/236691488-73c65a66-37bf-483e-b909-3826c8aaffea.png)
