### PR TITLE
Add welcome modal as intermediary screen when user switches to tech preview new UI

### DIFF
--- a/cypress/e2e/awx/dashboard/welcomeModal.cy.tsx
+++ b/cypress/e2e/awx/dashboard/welcomeModal.cy.tsx
@@ -1,0 +1,30 @@
+describe('dashboard: Welcome modal', () => {
+  before(() => {
+    cy.awxLogin();
+  });
+
+  it('renders the Welcome Modal on the dashboard', () => {
+    cy.visit(`/ui_next/dashboard`);
+    cy.getDialog().within(() => {
+      cy.contains('Welcome to the new Ansible user interface').should('be.visible');
+    });
+  });
+
+  it('renders the Welcome Modal on reload of the dashboard until checkbox is selected', () => {
+    cy.visit(`/ui_next/dashboard`);
+    cy.getDialog().within(() => {
+      cy.contains('Welcome to the new Ansible user interface').should('be.visible');
+    });
+    cy.clickModalButton('Close');
+    // Welcome modal continues to display on the dashboard after a reload
+    cy.reload();
+    cy.getDialog().within(() => {
+      cy.contains('Welcome to the new Ansible user interface').should('be.visible');
+    });
+    // Select option to not show the welcome message again (for the rest of the session)
+    cy.getCheckboxByLabel('Do not show this message again.').click();
+    cy.clickModalButton('Close');
+    cy.reload();
+    cy.contains('Welcome to the new Ansible user interface').should('not.exist');
+  });
+});

--- a/frontend/awx/dashboard/AwxDashboard.tsx
+++ b/frontend/awx/dashboard/AwxDashboard.tsx
@@ -3,7 +3,7 @@ import { Banner, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
-import { PageHeader, PageLayout } from '../../../framework';
+import { PageHeader, PageLayout, usePageDialog } from '../../../framework';
 import { PageDashboard } from '../../../framework/PageDashboard/PageDashboard';
 import { ItemsResponse } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
@@ -17,6 +17,10 @@ import { AwxJobActivityCard } from './cards/AwxJobActivityCard';
 import { AwxProjectsCard } from './cards/AwxProjectsCard';
 import { AwxRecentJobsCard } from './cards/AwxRecentJobsCard';
 import { AwxRecentProjectsCard } from './cards/AwxRecentProjectsCard';
+import { WelcomeModal } from './WelcomeModal';
+import { useEffect } from 'react';
+
+const HIDE_WELCOME_MESSAGE = 'hide-welcome-message';
 
 export function AwxDashboard() {
   const { t } = useTranslation();
@@ -24,6 +28,15 @@ export function AwxDashboard() {
   const { data: config } = useSWR<IConfigData>(`/api/v2/config/`, (url: string) =>
     fetch(url).then((r) => r.json())
   );
+  const [_, setDialog] = usePageDialog();
+  const welcomeMessageSetting = sessionStorage.getItem(HIDE_WELCOME_MESSAGE);
+  const hideWelcomeMessage = welcomeMessageSetting ? welcomeMessageSetting === 'true' : false;
+  useEffect(() => {
+    if (config?.ui_next && !hideWelcomeMessage) {
+      setDialog(<WelcomeModal />);
+    }
+  }, [config?.ui_next, hideWelcomeMessage, setDialog]);
+
   return (
     <PageLayout>
       {config?.ui_next && (

--- a/frontend/awx/dashboard/WelcomeModal.tsx
+++ b/frontend/awx/dashboard/WelcomeModal.tsx
@@ -54,6 +54,7 @@ export function WelcomeModal() {
           isChecked={isChecked}
           onChange={handleChange}
           name="do-not-show-welcome-modal"
+          id="welcome-modal-checkbox"
         />
       </CheckboxDiv>
     </Modal>

--- a/frontend/awx/dashboard/WelcomeModal.tsx
+++ b/frontend/awx/dashboard/WelcomeModal.tsx
@@ -1,0 +1,61 @@
+import { Button, Checkbox, Modal, ModalVariant, TextContent } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { usePageDialog } from '../../../framework';
+import { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+const CheckboxDiv = styled.div`
+  margin-left: 10px;
+`;
+
+const HIDE_WELCOME_MESSAGE = 'hide-welcome-message';
+
+export function WelcomeModal() {
+  const [_, setDialog] = usePageDialog();
+  const { t } = useTranslation();
+  const onClose = useCallback(() => {
+    setDialog(undefined);
+  }, [setDialog]);
+  const [isChecked, setIsChecked] = useState<boolean>(false);
+
+  const handleChange = (checked: boolean) => {
+    setIsChecked(checked);
+    sessionStorage.setItem(HIDE_WELCOME_MESSAGE, JSON.stringify(checked));
+  };
+
+  return (
+    <Modal
+      title={t(`Welcome to the new Ansible user interface`)}
+      variant={ModalVariant.small}
+      isOpen
+      onClose={onClose}
+      actions={[
+        <Button
+          ouiaId="welcome-modal-close-button"
+          key="close"
+          onClick={() => {
+            onClose();
+          }}
+          aria-label={t`Close`}
+        >
+          {t(`Close`)}
+        </Button>,
+      ]}
+    >
+      <TextContent>
+        {t(
+          `The new interface has been updated to provide a consistent and clean user experience. As a tech preview, not all areas within the new UI are immediately available. You can currently perform basic tasks such as create a job template and view a completed job run.`
+        )}
+      </TextContent>
+      <br />
+      <CheckboxDiv>
+        <Checkbox
+          label={t(`Do not show this message again.`)}
+          isChecked={isChecked}
+          onChange={handleChange}
+          name="do-not-show-welcome-modal"
+        />
+      </CheckboxDiv>
+    </Modal>
+  );
+}


### PR DESCRIPTION
- Welcome modal that shows up on the dashboard page
- Selecting the "Do not show this again." checkbox prevents the modal from showing up again in the session

<img width="1190" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/e35e5de8-8fa5-498c-a080-f5b5f865a9f9">

