### PR TITLE
EDA disable onboarding E2E tests that assume the E2E server has no data.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -210,6 +210,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+      - name: Setup EDA Server
+        run: |
+          mkdir eda
+          cd eda
+          echo "${{ secrets.EDA_DOCKER_COMPOSE }}" > docker-compose.yaml
+          docker compose up -d --quiet-pull
       - uses: actions/download-artifact@v3
         with:
           name: ansible-ui.tar

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -210,12 +210,6 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Setup EDA Server
-        run: |
-          mkdir eda
-          cd eda
-          echo "${{ secrets.EDA_DOCKER_COMPOSE }}" > docker-compose.yaml
-          docker compose up -d --quiet-pull
       - uses: actions/download-artifact@v3
         with:
           name: ansible-ui.tar

--- a/cypress/e2e/eda/Decision-Environments/decision-tabs.cy.ts
+++ b/cypress/e2e/eda/Decision-Environments/decision-tabs.cy.ts
@@ -1,20 +1,16 @@
 //Tests a user's ability to perform certain actions on the tabs inside a decision environment in the EDA UI.
 
-describe('EDA decision environment Access Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
+before(() => {
+  cy.edaLogin();
+});
 
+describe('EDA decision environment Access Tab', () => {
   it.skip('can view the users who have access to the decision environment', () => {
     //write test here
   });
 });
 
 describe('EDA decision environment Instances Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
-
   it.skip('can view the instances associated with the decision environment', () => {
     //change test stub name to stipulate what the specific criteria is
   });
@@ -25,10 +21,6 @@ describe('EDA decision environment Instances Tab', () => {
 });
 
 describe('EDA decision environment Repositories Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
-
   it.skip('can view the repositories associated with the decision environment', () => {
     //change test stub name to stipulate what the specific criteria is
   });
@@ -39,10 +31,6 @@ describe('EDA decision environment Repositories Tab', () => {
 });
 
 describe('EDA decision environment Collections Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
-
   it.skip('can add a Collection on the decision environment Collections tab and then view it on the list', () => {
     //use mock data to test search
   });
@@ -53,10 +41,6 @@ describe('EDA decision environment Collections Tab', () => {
 });
 
 describe('EDA decision environment Contents Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
-
   it.skip('can view the Contents associated with the decision environment', () => {
     //change test stub name to stipulate what the specific criteria is
   });
@@ -67,10 +51,6 @@ describe('EDA decision environment Contents Tab', () => {
 });
 
 describe('EDA decision environment Dependencies Tab', () => {
-  before(() => {
-    cy.edaLogin();
-  });
-
   it.skip('can view the Dependencies associated with the decision environment', () => {
     //change test stub name to stipulate what the specific criteria is
   });

--- a/cypress/e2e/eda/General-UI/dashboard.cy.ts
+++ b/cypress/e2e/eda/General-UI/dashboard.cy.ts
@@ -136,11 +136,12 @@ describe('EDA Dashboard', () => {
 });
 
 describe('dashboard checks when resources before any resources are created', () => {
-  it('checks instruction guide link works in the Getting Started section of the Dashboard page', () => {
-    cy.navigateTo(/^Dashboard$/);
-    cy.hasTitle(/^Getting Started$/).should('be.visible');
-    cy.checkAnchorLinks('check out our instruct guides');
-  });
+  // THIS NEEDS TO BE MOVED TO A COMPONENT TEST AS THE STATE OF THE E2E SERVER IS UNKNOWN AND THIS MAY NOT SHOW UP
+  // it('checks instruction guide link works in the Getting Started section of the Dashboard page', () => {
+  //   cy.navigateTo(/^Dashboard$/);
+  //   cy.hasTitle(/^Getting Started$/).should('be.visible');
+  //   cy.checkAnchorLinks('check out our instruct guides');
+  // });
 
   it('checks the dashboard landing page titles ', () => {
     cy.navigateTo(/^Dashboard$/);
@@ -157,16 +158,17 @@ describe('dashboard checks when resources before any resources are created', () 
     cy.contains('small', 'Recently updated environments').should('be.visible');
   });
 
-  it('checks resource creation links work in the Getting Started section of the Dashboard page', () => {
-    const resources = ['Project', 'Decision Environment', 'Rulebook Activation'];
-    cy.navigateTo(/^Dashboard$/);
-    cy.hasTitle(/^Getting Started$/).should('be.visible');
-    cy.get('ol.pf-c-progress-stepper').within(() => {
-      resources.forEach((resource) => {
-        cy.checkAnchorLinks(resource);
-      });
-    });
-  });
+  // THIS NEEDS TO BE MOVED TO A COMPONENT TEST AS THE STATE OF THE E2E SERVER IS UNKNOWN AND THIS MAY NOT SHOW UP
+  // it('checks resource creation links work in the Getting Started section of the Dashboard page', () => {
+  //   const resources = ['Project', 'Decision Environment', 'Rulebook Activation'];
+  //   cy.navigateTo(/^Dashboard$/);
+  //   cy.hasTitle(/^Getting Started$/).should('be.visible');
+  //   cy.get('ol.pf-c-progress-stepper').within(() => {
+  //     resources.forEach((resource) => {
+  //       cy.checkAnchorLinks(resource);
+  //     });
+  //   });
+  // });
 
   it('user can navigate to the Projects page using the link from the Dashboard', () => {
     cy.navigateTo(/^Dashboard$/);


### PR DESCRIPTION
Disable E2E tests that assume the E2E server has no data.
These tests need to be moved to component tests where the state of the data can be controlled.