### PR TITLE
Disable health check action for non-execution nodes

### DIFF
--- a/frontend/awx/administration/instances/Instances.tsx
+++ b/frontend/awx/administration/instances/Instances.tsx
@@ -86,6 +86,12 @@ export function Instances() {
         isPinned: true,
         icon: HeartbeatIcon,
         label: t('Run health check'),
+        isDisabled: (instance) => {
+          if (instance.node_type === 'execution') {
+            return undefined;
+          }
+          return t('Health checks cannot be run on instances of this type');
+        },
         onClick: (instance) => {
           const alert: AlertProps = {
             variant: 'info',


### PR DESCRIPTION
Disables health check row action for non-execution nodes

![Screenshot 2023-05-09 at 10 27 23 AM](https://github.com/ansible/ansible-ui/assets/410794/dd759e2f-d7db-43d8-a5bd-aa3df56476f7)
