### PR TITLE
Fix job relaunch redirect and handle 202 responses

### DIFF
--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -57,31 +57,30 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
       ) {
         // TODO: If password is needed for relaunch, handle with dialog
       } else {
+        let relaunchJob;
         switch (job.type) {
           case 'ad_hoc_command': {
-            await postRequest(relaunchEndpoint, {} as AdHocCommandRelaunch);
+            relaunchJob = await postRequest(relaunchEndpoint, {} as AdHocCommandRelaunch);
             break;
           }
           case 'workflow_job': {
-            await postRequest(relaunchEndpoint, {} as WorkflowJobRelaunch);
+            relaunchJob = await postRequest(relaunchEndpoint, {} as WorkflowJobRelaunch);
             break;
           }
           case 'job': {
-            await postRequest(relaunchEndpoint, {
+            relaunchJob = await postRequest(relaunchEndpoint, {
               ...jobRelaunchParams,
             } as JobRelaunch);
             break;
           }
           case 'inventory_update':
-            await postRequest(relaunchEndpoint, {} as InventorySourceUpdate);
+            relaunchJob = await postRequest(relaunchEndpoint, {} as InventorySourceUpdate);
             break;
           case 'project_update':
-            await postRequest(relaunchEndpoint, {} as ProjectUpdateView);
+            relaunchJob = await postRequest(relaunchEndpoint, {} as ProjectUpdateView);
             break;
         }
-
-        // Navigate to Job Output UI
-        navigate(getJobOutputUrl(job));
+        navigate(getJobOutputUrl(relaunchJob as UnifiedJob));
       }
     } catch (error) {
       alertToaster.addAlert({

--- a/frontend/common/crud/usePostRequest.tsx
+++ b/frontend/common/crud/usePostRequest.tsx
@@ -29,7 +29,6 @@ export function usePostRequest<RequestBody = object, ResponseBody = RequestBody>
       },
       signal: signal ?? abortSignalRef.current.signal,
     });
-
     if (!response.ok) {
       if (response.status === 401) {
         navigate(RouteObj.Login + '?navigate-back=true');
@@ -46,11 +45,15 @@ export function usePostRequest<RequestBody = object, ResponseBody = RequestBody>
     }
 
     switch (response.status) {
-      case 202: // No Content
-      case 204: // Accepted
+      case 204: // No Content
         return null as ResponseBody;
     }
-    return (await response.json()) as ResponseBody;
+
+    try {
+      return (await response.json()) as ResponseBody;
+    } catch {
+      return null as ResponseBody;
+    }
   };
 }
 


### PR DESCRIPTION
Currently when relaunching a job the UI redirects to the old job output and not the job output that has been relaunched/is underway. This PR fixes the redirect.

![job_redirect](https://github.com/ansible/ansible-ui/assets/2293210/97e1b3ea-3e66-49cd-ad83-1754bc0a70b7)


Concurrently, I also discovered that the API on occasion will return a `202` with a response body (example POST request to `resource/id/update` endpoint). This PR handles the two cases where:
1. `202` with no body -> return `null`
2. `202` with response body -> return `response.json()`