### PR TITLE
Add an AWX config provider and point to the correct doc links

### DIFF
--- a/frontend/awx/Awx.tsx
+++ b/frontend/awx/Awx.tsx
@@ -4,14 +4,17 @@ import { ActiveUserProvider } from '../common/useActiveUser';
 import { AwxRouter } from './AwxRouter';
 import { AwxSidebar } from './AwxSidebar';
 import { WebSocketProvider } from './common/useAwxWebSocket';
+import { AwxConfigProvider } from './common/useAwxConfig';
 
 export function AWX() {
   return (
     <WebSocketProvider>
       <ActiveUserProvider>
-        <Page header={<AnsibleMasthead />} sidebar={<AwxSidebar />}>
-          <AwxRouter />
-        </Page>
+        <AwxConfigProvider>
+          <Page header={<AnsibleMasthead />} sidebar={<AwxSidebar />}>
+            <AwxRouter />
+          </Page>
+        </AwxConfigProvider>
       </ActiveUserProvider>
     </WebSocketProvider>
   );

--- a/frontend/awx/access/organizations/Organizations.tsx
+++ b/frontend/awx/access/organizations/Organizations.tsx
@@ -40,12 +40,15 @@ import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { useSelectUsersAddOrganizations } from '../users/hooks/useSelectUsersAddOrganizations';
 import { useSelectUsersRemoveOrganizations } from '../users/hooks/useSelectUsersRemoveOrganizations';
 import { useDeleteOrganizations } from './hooks/useDeleteOrganizations';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function Organizations() {
   const { t } = useTranslation();
   const product: string = process.env.PRODUCT ?? t('AWX');
   const navigate = useNavigate();
   usePersistentFilters('organizations');
+  const config = useAwxConfig();
 
   const toolbarFilters = useOrganizationsFilters();
 
@@ -155,7 +158,7 @@ export function Organizations() {
           `An Organization is a logical collection of Users, Teams, Projects, and Inventories, and is the highest level in the {{product}} object hierarchy.`,
           { product }
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/organizations.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/organizations.html`}
         description={t(
           `An Organization is a logical collection of Users, Teams, Projects, and Inventories, and is the highest level in the {{product}} object hierarchy.`,
           { product }

--- a/frontend/awx/access/teams/Teams.tsx
+++ b/frontend/awx/access/teams/Teams.tsx
@@ -13,6 +13,8 @@ import { useTeamActions } from './hooks/useTeamActions';
 import { useTeamToolbarActions } from './hooks/useTeamToolbarActions';
 import { useTeamsColumns } from './hooks/useTeamsColumns';
 import { useTeamsFilters } from './hooks/useTeamsFilters';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function Teams() {
   const { t } = useTranslation();
@@ -25,6 +27,7 @@ export function Teams() {
   const { data } = useOptions<OptionsResponse<ActionsResponse>>('/api/v2/teams/');
   const canCreateTeam = Boolean(data && data.actions && data.actions['POST']);
   usePersistentFilters('teams');
+  const config = useAwxConfig();
 
   return (
     <PageLayout>
@@ -42,7 +45,7 @@ export function Teams() {
             'For instance, permissions may be granted to a whole Team rather than each user on the Team.'
           ),
         ]}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/teams.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/teams.html`}
         description={t(
           'A Team is a subdivision of an organization with associated users, projects, credentials, and permissions.'
         )}

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -32,12 +32,15 @@ import { useSelectTeamsRemoveUsers } from '../teams/hooks/useSelectTeamsRemoveUs
 import { useDeleteUsers } from './hooks/useDeleteUsers';
 import { useUsersColumns } from './hooks/useUsersColumns';
 import { useUsersFilters } from './hooks/useUsersFilters';
+import { useAwxConfig } from '../../common/useAwxConfig';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
 
 export function Users() {
   const { t } = useTranslation();
   const product: string = process.env.PRODUCT ?? t('AWX');
   const navigate = useNavigate();
   usePersistentFilters('users');
+  const config = useAwxConfig();
 
   const toolbarFilters = useUsersFilters();
 
@@ -204,7 +207,7 @@ export function Users() {
           `A user is someone who has access to {{product}} with associated permissions and credentials.`,
           { product }
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/users.html`}
         description={t(
           `A user is someone who has access to {{product}} with associated permissions and credentials.`,
           { product }

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -32,10 +32,13 @@ import { ExecutionEnvironment } from '../../interfaces/ExecutionEnvironment';
 import { useAwxView } from '../../useAwxView';
 
 import { useDeleteExecutionEnvironments } from './hooks/useDeleteExecutionEnvironments';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function ExecutionEnvironments() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const config = useAwxConfig();
   const toolbarFilters = useExecutionEnvironmentsFilters();
   const tableColumns = useExecutionEnvironmentsColumns();
   const view = useAwxView<ExecutionEnvironment>({
@@ -98,7 +101,7 @@ export function ExecutionEnvironments() {
     <PageLayout>
       <PageHeader
         title={t('Execution Environments')}
-        titleDocLink="https://docs.ansible.com/automation-controller/latest/html/userguide/execution_environments.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/execution_environments.html`}
       />
       <PageTable<ExecutionEnvironment>
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -101,6 +101,13 @@ export function ExecutionEnvironments() {
     <PageLayout>
       <PageHeader
         title={t('Execution Environments')}
+        description={t(
+          'An execution environment allows you to have a customized image to run jobs.'
+        )}
+        titleHelpTitle={t('Execution Environments')}
+        titleHelp={t(
+          'Execution environments are container images that make it possible to incorporate system-level dependencies and collection-based content. Each execution environment allows you to have a customized image to run jobs, and each of them contain only what you need when running the job, nothing more.'
+        )}
         titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/execution_environments.html`}
       />
       <PageTable<ExecutionEnvironment>

--- a/frontend/awx/common/ExecutionEnvironmentDetail.tsx
+++ b/frontend/awx/common/ExecutionEnvironmentDetail.tsx
@@ -7,6 +7,8 @@ import { PageDetail } from '../../../framework';
 import { RouteObj } from '../../Routes';
 import { ExecutionEnvironment } from '../interfaces/ExecutionEnvironment';
 import { SummaryFieldsExecutionEnvironment } from '../interfaces/summary-fields/summary-fields';
+import getDocsBaseUrl from './util/getDocsBaseUrl';
+import { useAwxConfig } from './useAwxConfig';
 
 const ExclamationTriangleIcon = styled(PFExclamationTriangleIcon)`
   color: var(--pf-global--warning-color--100);
@@ -37,9 +39,8 @@ function ExecutionEnvironmentDetail(props: {
     helpText,
   } = props;
   const { t } = useTranslation();
-  // TODO: use config context to generate the base docs URL
-  const docsBaseUrl = 'https://docs.ansible.com/automation-controller/latest';
-  const docsLink = `${docsBaseUrl}/html/upgrade-migration-guide/upgrade_to_ees.html`;
+  const config = useAwxConfig();
+  const docsLink = `${getDocsBaseUrl(config)}/html/upgrade-migration-guide/upgrade_to_ees.html`;
   const label = isDefaultEnvironment
     ? t('Default execution environment')
     : t('Execution environment');

--- a/frontend/awx/common/useAwxConfig.tsx
+++ b/frontend/awx/common/useAwxConfig.tsx
@@ -1,0 +1,24 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { Config } from '../interfaces/Config';
+import { useGet } from '../../common/crud/useGet';
+
+const AwxConfigContext = createContext<Config | null | undefined>(undefined);
+
+/**
+ * Get the AWX configuration settings
+ * @returns undefined while querying, null if no data was retrieved, otherwise the configuration.
+ */
+export function useAwxConfig() {
+  return useContext(AwxConfigContext);
+}
+
+export function AwxConfigProvider(props: { children?: ReactNode }) {
+  const [config, setConfig] = useState<Config | null | undefined>(undefined);
+  const configResponse = useGet<Config>('/api/v2/config/');
+  useEffect(() => {
+    if (configResponse.data) {
+      setConfig(configResponse.data ?? null);
+    }
+  }, [configResponse.data]);
+  return <AwxConfigContext.Provider value={config}>{props.children}</AwxConfigContext.Provider>;
+}

--- a/frontend/awx/common/util/getDocsBaseUrl.ts
+++ b/frontend/awx/common/util/getDocsBaseUrl.ts
@@ -1,0 +1,10 @@
+import { Config } from '../../interfaces/Config';
+
+export default function getDocsBaseUrl(config: Config | null | undefined) {
+  let version = 'latest';
+  const licenseType = config?.license_info?.license_type;
+  if (licenseType && licenseType !== 'open') {
+    version = config?.version ? config.version.split('-')[0] : 'latest';
+  }
+  return `https://docs.ansible.com/automation-controller/${version}`;
+}

--- a/frontend/awx/dashboard/AwxDashboard.tsx
+++ b/frontend/awx/dashboard/AwxDashboard.tsx
@@ -19,15 +19,14 @@ import { AwxRecentJobsCard } from './cards/AwxRecentJobsCard';
 import { AwxRecentProjectsCard } from './cards/AwxRecentProjectsCard';
 import { WelcomeModal } from './WelcomeModal';
 import { useEffect } from 'react';
+import { useAwxConfig } from '../common/useAwxConfig';
 
 const HIDE_WELCOME_MESSAGE = 'hide-welcome-message';
 
 export function AwxDashboard() {
   const { t } = useTranslation();
   const product: string = process.env.PRODUCT ?? t('AWX');
-  const { data: config } = useSWR<IConfigData>(`/api/v2/config/`, (url: string) =>
-    fetch(url).then((r) => r.json())
-  );
+  const config = useAwxConfig();
   const [_, setDialog] = usePageDialog();
   const welcomeMessageSetting = sessionStorage.getItem(HIDE_WELCOME_MESSAGE);
   const hideWelcomeMessage = welcomeMessageSetting ? welcomeMessageSetting === 'true' : false;
@@ -106,9 +105,6 @@ function DashboardInternal() {
   );
 }
 
-interface IConfigData {
-  ui_next: boolean;
-}
 interface IDashboardData {
   inventories: {
     url: string;

--- a/frontend/awx/interfaces/Config.ts
+++ b/frontend/awx/interfaces/Config.ts
@@ -84,6 +84,7 @@ export interface Config {
     };
   };
   become_methods: string[][];
+  ui_next?: boolean;
   project_base_dir: string;
   project_local_paths: unknown[];
   custom_virtualenvs: unknown[];

--- a/frontend/awx/resources/credentials/Credentials.tsx
+++ b/frontend/awx/resources/credentials/Credentials.tsx
@@ -9,6 +9,8 @@ import { useCredentialActions } from './hooks/useCredentialActions';
 import { useCredentialToolbarActions } from './hooks/useCredentialToolbarActions';
 import { useCredentialsColumns } from './hooks/useCredentialsColumns';
 import { useCredentialsFilters } from './hooks/useCredentialsFilters';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function Credentials() {
   const { t } = useTranslation();
@@ -24,6 +26,8 @@ export function Credentials() {
   });
   const toolbarActions = useCredentialToolbarActions(view);
   const rowActions = useCredentialActions({ onDeleted: () => void view.refresh() });
+  const config = useAwxConfig();
+
   return (
     <PageLayout>
       <PageHeader
@@ -33,7 +37,7 @@ export function Credentials() {
           `Credentials are utilized by {{product}} for authentication when launching Jobs against machines, synchronizing with inventory sources, and importing project content from a version control system. You can grant users and teams the ability to use these credentials, without actually exposing the credential to the user. If you have a user move to a different team or leave the organization, you don’t have to re-key all of your systems just because that credential was available in {{product}}.`,
           { product }
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/credentials.html`}
         description={t(
           `Credentials are utilized by {{product}} for authentication when launching Jobs against machines, synchronizing with inventory sources, and importing project content from a version control system.`,
           { product }

--- a/frontend/awx/resources/hosts/Hosts.tsx
+++ b/frontend/awx/resources/hosts/Hosts.tsx
@@ -29,6 +29,8 @@ import {
 import { AwxHost } from '../../interfaces/AwxHost';
 import { useAwxView } from '../../useAwxView';
 import { useDeleteHosts } from './useDeleteHosts';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function Hosts() {
   const { t } = useTranslation();
@@ -38,6 +40,7 @@ export function Hosts() {
   const tableColumns = useHostsColumns();
   const view = useAwxView<AwxHost>({ url: '/api/v2/hosts/', toolbarFilters, tableColumns });
   const deleteHosts = useDeleteHosts(view.unselectItemsAndRefresh);
+  const config = useAwxConfig();
 
   const toolbarActions = useMemo<IPageAction<AwxHost>[]>(
     () => [
@@ -103,7 +106,7 @@ export function Hosts() {
             'Ansible works against multiple managed nodes or “hosts” in your infrastructure at the same time, using a list or group of lists known as inventory. Once your inventory is defined, you use patterns to select the hosts or groups you want Ansible to run against.'
           ),
         ]}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/hosts.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/hosts.html`}
       />
       <PageTable<AwxHost>
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/resources/inventories/Inventories.tsx
+++ b/frontend/awx/resources/inventories/Inventories.tsx
@@ -12,6 +12,8 @@ import { useInventoriesColumns } from './hooks/useInventoriesColumns';
 import { useInventoriesFilters } from './hooks/useInventoriesFilters';
 import { useInventoriesToolbarActions } from './hooks/useInventoriesToolbarActions';
 import { useInventoryActions } from './hooks/useInventoryActions';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export type WebSocketInventory = {
   status: string;
@@ -42,6 +44,7 @@ export function Inventories() {
     onInventoryCopied: view.refresh,
   });
   usePersistentFilters('inventories');
+  const config = useAwxConfig();
 
   const handleWebSocketMessage = useCallback(
     (message?: WebSocketMessage) => {
@@ -94,7 +97,7 @@ export function Inventories() {
         titleHelp={t(
           'An inventory defines the hosts and groups of hosts upon which commands, modules, and tasks in a playbook operate.'
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/inventories.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/inventories.html`}
         description={t(
           'An inventory defines the hosts and groups of hosts upon which commands, modules, and tasks in a playbook operate.'
         )}

--- a/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
@@ -9,7 +9,6 @@ import {
 import { useCallback } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import useSWR from 'swr';
 import {
   CopyCell,
   DateTimeCell,
@@ -26,17 +25,14 @@ import { CredentialLabel } from '../../../common/CredentialLabel';
 import { ExecutionEnvironmentDetail } from '../../../common/ExecutionEnvironmentDetail';
 import { useAwxWebSocketSubscription } from '../../../common/useAwxWebSocket';
 import { Project } from '../../../interfaces/Project';
+import { useAwxConfig } from '../../../common/useAwxConfig';
+import getDocsBaseUrl from '../../../common/util/getDocsBaseUrl';
 
 export function ProjectDetails(props: { project: Project }) {
   const { t } = useTranslation();
   const { project } = props;
   const history = useNavigate();
-  {
-    /* TODO config provider */
-  }
-  const { data: config } = useSWR<IConfigData>(`/api/v2/config/`, (url: string) =>
-    fetch(url).then((r) => r.json())
-  );
+  const config = useAwxConfig();
   const view = useGet<Project>(`/api/v2/projects/${project.id}/`);
   const { refresh } = view;
   const handleWebSocketMessage = useCallback(
@@ -104,9 +100,9 @@ export function ProjectDetails(props: { project: Project }) {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href={
-          'https://docs.ansible.com/automation-controller/latest/html/userguide/projects.html#manage-playbooks-using-source-control'
-        }
+        href={`${getDocsBaseUrl(
+          config
+        )}/html/userguide/projects.html#manage-playbooks-using-source-control`}
       >
         {t`Documentation.`}
       </a>
@@ -199,10 +195,6 @@ export function ProjectDetails(props: { project: Project }) {
       )}
     </TextList>
   );
-
-  interface IConfigData {
-    project_base_dir: string | null;
-  }
 
   return (
     <PageDetails>

--- a/frontend/awx/resources/projects/Projects.tsx
+++ b/frontend/awx/resources/projects/Projects.tsx
@@ -14,6 +14,8 @@ import { useProjectActions } from './hooks/useProjectActions';
 import { useProjectToolbarActions } from './hooks/useProjectToolbarActions';
 import { useProjectsColumns } from './hooks/useProjectsColumns';
 import { useProjectsFilters } from './hooks/useProjectsFilters';
+import { useAwxConfig } from '../../common/useAwxConfig';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
 
 export function Projects() {
   const { t } = useTranslation();
@@ -58,6 +60,7 @@ export function Projects() {
     { control: ['limit_reached_1'], jobs: ['status_changed'] },
     handleWebSocketMessage as (data: unknown) => void
   );
+  const config = useAwxConfig();
 
   return (
     <PageLayout>
@@ -68,7 +71,7 @@ export function Projects() {
           `A Project is a logical collection of Ansible playbooks, represented in {{product}}. You can manage playbooks and playbook directories by either placing them manually under the Project Base Path on your {{product}} server, or by placing your playbooks into a source code management (SCM) system supported by {{product}}, including Git, Subversion, Mercurial, and Red Hat Insights.`,
           { product }
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/projects.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/projects.html`}
         description={t(
           `A Project is a logical collection of Ansible playbooks, represented in {{product}}.`,
           { product }

--- a/frontend/awx/resources/templates/Templates.tsx
+++ b/frontend/awx/resources/templates/Templates.tsx
@@ -32,6 +32,8 @@ import { JobTemplate } from '../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../interfaces/WorkflowJobTemplate';
 import { useAwxView } from '../../useAwxView';
 import { useDeleteTemplates } from './hooks/useDeleteTemplates';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../../common/useAwxConfig';
 
 export function Templates() {
   const { t } = useTranslation();
@@ -47,6 +49,7 @@ export function Templates() {
     },
   });
   usePersistentFilters('templates');
+  const config = useAwxConfig();
 
   const deleteTemplates = useDeleteTemplates(view.unselectItemsAndRefresh);
 
@@ -115,7 +118,7 @@ export function Templates() {
         titleHelp={t(
           'A job template is a definition and set of parameters for running an Ansible job. Job templates are useful to execute the same job many times. Job templates also encourage the reuse of Ansible playbook content and collaboration between teams.'
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/job_templates.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/job_templates.html`}
         description={t(
           'A job template is a definition and set of parameters for running an Ansible job.'
         )}

--- a/frontend/awx/views/jobs/Jobs.tsx
+++ b/frontend/awx/views/jobs/Jobs.tsx
@@ -13,6 +13,8 @@ import { useJobRowActions } from './hooks/useJobRowActions';
 import { useJobToolbarActions } from './hooks/useJobToolbarActions';
 import { useJobsColumns } from './hooks/useJobsColumns';
 import { useJobsFilters } from './hooks/useJobsFilters';
+import { useAwxConfig } from '../../common/useAwxConfig';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
 
 export default function Jobs() {
   const { t } = useTranslation();
@@ -30,6 +32,7 @@ export default function Jobs() {
   const toolbarActions = useJobToolbarActions(view.unselectItemsAndRefresh);
   const rowActions = useJobRowActions(view.unselectItemsAndRefresh);
   usePersistentFilters('jobs');
+  const config = useAwxConfig();
 
   const [showGraph] = useState(false);
 
@@ -68,7 +71,7 @@ export default function Jobs() {
           `A job is an instance of {{product}} launching an Ansible playbook against an inventory of hosts.`,
           { product }
         )}
-        titleDocLink="https://docs.ansible.com/ansible-tower/latest/html/userguide/jobs.html"
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/jobs.html`}
         description={t(
           `A job is an instance of {{product}} launching an Ansible playbook against an inventory of hosts.`,
           { product }

--- a/frontend/common/Masthead.tsx
+++ b/frontend/common/Masthead.tsx
@@ -50,6 +50,8 @@ import { swrOptions, useFetcher } from './crud/Data';
 import { postRequest } from './crud/usePostRequest';
 import { shouldShowAutmationServers } from './should-show-autmation-servers';
 import { useActiveUser } from './useActiveUser';
+import getDocsBaseUrl from '../awx/common/util/getDocsBaseUrl';
+import { useAwxConfig } from '../awx/common/useAwxConfig';
 
 const MastheadBrandDiv = styled.div`
   display: flex;
@@ -88,7 +90,7 @@ export function AnsibleMasthead(props: { hideLogin?: boolean }) {
   const brand: string = process.env.BRAND ?? '';
   const product: string = process.env.PRODUCT ?? t('Ansible');
   const { automationServer } = useAutomationServers();
-
+  const config = useAwxConfig();
   const navBar = usePageNavSideBar();
 
   return (
@@ -206,7 +208,7 @@ export function AnsibleMasthead(props: { hideLogin?: boolean }) {
                           open(
                             isEdaServer(automationServer)
                               ? 'https://www.redhat.com/en/engage/event-driven-ansible-20220907'
-                              : 'https://docs.ansible.com/automation-controller/4.2.0/html/userguide/index.html',
+                              : `${getDocsBaseUrl(config)}/html/userguide/index.html`,
                             '_blank'
                           );
                         }}


### PR DESCRIPTION
- Adds an AWX configuration provider. Components can get access to the config settings via the `useAwxConfig` hook.
- Adds a `getDocsBaseUrl` utility to get the base URL for docs based on the AWX version