### PR TITLE
Cleanup toolbar filters in preperation for advanced filter support

### DIFF
--- a/frontend/awx/access/roles/Roles.tsx
+++ b/frontend/awx/access/roles/Roles.tsx
@@ -14,7 +14,7 @@ export function useRolesFilters() {
         label: t('Role'),
         type: 'string',
         query: 'role_field__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
     ],
     [t]

--- a/frontend/awx/access/users/hooks/useUsersFilters.tsx
+++ b/frontend/awx/access/users/hooks/useUsersFilters.tsx
@@ -22,7 +22,7 @@ export function useUsersFilters() {
         label: t('Email'),
         type: 'string',
         query: 'email__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
     ],
     [usernameToolbarFilter, firstnameByToolbarFilter, lastnameToolbarFilter, t]

--- a/frontend/awx/administration/instance-groups/InstanceGroups.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroups.tsx
@@ -130,7 +130,7 @@ export function useInstanceGroupsFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
     ],
     [t]

--- a/frontend/awx/administration/instances/hooks/useInstancesFilter.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesFilter.tsx
@@ -11,7 +11,7 @@ export function useInstancesFilters() {
         label: t('Name'),
         type: 'string',
         query: 'hostname__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
       {
         key: 'type',

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -10,7 +10,7 @@ export function useNameToolbarFilter() {
       label: t('Name'),
       type: 'string',
       query: 'name__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -24,7 +24,7 @@ export function useDescriptionToolbarFilter() {
       label: t('Description'),
       type: 'string',
       query: 'description__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -38,7 +38,7 @@ export function useOrganizationToolbarFilter() {
       label: t('Organization'),
       type: 'string',
       query: 'organization__name__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -52,7 +52,7 @@ export function useCreatedByToolbarFilter() {
       label: t('Created by'),
       type: 'string',
       query: 'created_by__username__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -66,7 +66,7 @@ export function useModifiedByToolbarFilter() {
       label: t('Modified by'),
       type: 'string',
       query: 'modified_by__username__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -80,7 +80,7 @@ export function useUsernameToolbarFilter() {
       label: t('Username'),
       type: 'string',
       query: 'username__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -94,7 +94,7 @@ export function useFirstNameToolbarFilter() {
       label: t('First name'),
       type: 'string',
       query: 'first_name__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -108,7 +108,7 @@ export function useLastNameToolbarFilter() {
       label: t('Last name'),
       type: 'string',
       query: 'last_name__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );
@@ -122,7 +122,7 @@ export function useEmailToolbarFilter() {
       label: t('Email'),
       type: 'string',
       query: 'email__icontains',
-      placeholder: t('contains'),
+      comparison: 'contains',
     }),
     [t]
   );

--- a/frontend/awx/dashboard/AwxDashboard.tsx
+++ b/frontend/awx/dashboard/AwxDashboard.tsx
@@ -1,15 +1,18 @@
 /* eslint-disable i18next/no-literal-string */
 import { Banner, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
+import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import { PageHeader, PageLayout, usePageDialog } from '../../../framework';
 import { PageDashboard } from '../../../framework/PageDashboard/PageDashboard';
 import { ItemsResponse } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
+import { useAwxConfig } from '../common/useAwxConfig';
 import { ExecutionEnvironment } from '../interfaces/ExecutionEnvironment';
 import { Job } from '../interfaces/Job';
 import { useAwxView } from '../useAwxView';
+import { WelcomeModal } from './WelcomeModal';
 import { AwxGettingStartedCard } from './cards/AwxGettingStartedCard';
 import { AwxHostsCard } from './cards/AwxHostsCard';
 import { AwxInventoriesCard } from './cards/AwxInventoriesCard';
@@ -17,9 +20,6 @@ import { AwxJobActivityCard } from './cards/AwxJobActivityCard';
 import { AwxProjectsCard } from './cards/AwxProjectsCard';
 import { AwxRecentJobsCard } from './cards/AwxRecentJobsCard';
 import { AwxRecentProjectsCard } from './cards/AwxRecentProjectsCard';
-import { WelcomeModal } from './WelcomeModal';
-import { useEffect } from 'react';
-import { useAwxConfig } from '../common/useAwxConfig';
 
 const HIDE_WELCOME_MESSAGE = 'hide-welcome-message';
 
@@ -30,6 +30,7 @@ export function AwxDashboard() {
   const [_, setDialog] = usePageDialog();
   const welcomeMessageSetting = sessionStorage.getItem(HIDE_WELCOME_MESSAGE);
   const hideWelcomeMessage = welcomeMessageSetting ? welcomeMessageSetting === 'true' : false;
+
   useEffect(() => {
     if (config?.ui_next && !hideWelcomeMessage) {
       setDialog(<WelcomeModal />);

--- a/frontend/awx/views/jobs/hooks/useHostMetricsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useHostMetricsFilters.tsx
@@ -1,6 +1,6 @@
-import { IToolbarFilter } from '../../../../../framework';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { IToolbarFilter } from '../../../../../framework';
 
 export function useHostMetricsFilters() {
   const { t } = useTranslation();
@@ -11,7 +11,7 @@ export function useHostMetricsFilters() {
         label: t('Hostname'),
         type: 'string',
         query: 'hostname__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
     ],
     [t]

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -14,14 +14,14 @@ export function useJobsFilters() {
         label: t('ID'),
         type: 'string',
         query: 'id',
-        placeholder: t('equals'),
+        comparison: 'equals',
       },
       {
         key: 'labels__name__icontains',
         label: t('Label name'),
         type: 'string',
         query: 'labels__name__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
       {
         key: 'type',
@@ -43,7 +43,7 @@ export function useJobsFilters() {
         label: t('Launched by (Username)'),
         type: 'string',
         query: 'created_by__username__icontains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
       {
         key: 'status',
@@ -67,7 +67,7 @@ export function useJobsFilters() {
         label: t('Limit'),
         type: 'string',
         query: 'job__limit',
-        placeholder: t('equals'),
+        comparison: 'equals',
       },
     ],
     [nameToolbarFilter, t]

--- a/frontend/eda/Resources/credentials/hooks/useCredentialFilters.tsx
+++ b/frontend/eda/Resources/credentials/hooks/useCredentialFilters.tsx
@@ -11,7 +11,7 @@ export function useCredentialFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/Resources/decision-environments/hooks/useDecisionEnvironmentFilters.tsx
+++ b/frontend/eda/Resources/decision-environments/hooks/useDecisionEnvironmentFilters.tsx
@@ -11,7 +11,7 @@ export function useDecisionEnvironmentFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/Resources/inventories/hooks/useInventoryFilters.tsx
+++ b/frontend/eda/Resources/inventories/hooks/useInventoryFilters.tsx
@@ -11,7 +11,7 @@ export function useInventoriesFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/Resources/projects/hooks/useProjectFilters.tsx
+++ b/frontend/eda/Resources/projects/hooks/useProjectFilters.tsx
@@ -11,7 +11,7 @@ export function useProjectFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/UserAccess/Groups/hooks/useGroupFilters.tsx
+++ b/frontend/eda/UserAccess/Groups/hooks/useGroupFilters.tsx
@@ -11,7 +11,7 @@ export function useGroupFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/UserAccess/Users/hooks/useControllerTokenFilters.tsx
+++ b/frontend/eda/UserAccess/Users/hooks/useControllerTokenFilters.tsx
@@ -11,7 +11,7 @@ export function useControllerFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/UserAccess/Users/hooks/useUserFilters.tsx
+++ b/frontend/eda/UserAccess/Users/hooks/useUserFilters.tsx
@@ -11,7 +11,7 @@ export function useUserFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationFilters.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationFilters.tsx
@@ -11,7 +11,7 @@ export function useRulebookActivationFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/rulebooks/hooks/useRulebookFilters.tsx
+++ b/frontend/eda/rulebooks/hooks/useRulebookFilters.tsx
@@ -11,7 +11,7 @@ export function useRulebookFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/rulebooks/hooks/useRulesetFilters.tsx
+++ b/frontend/eda/rulebooks/hooks/useRulesetFilters.tsx
@@ -11,7 +11,7 @@ export function useRulesetFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/rules/hooks/useRuleFilters.tsx
+++ b/frontend/eda/rules/hooks/useRuleFilters.tsx
@@ -11,7 +11,7 @@ export function useRuleFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditActionsFilters.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditActionsFilters.tsx
@@ -11,7 +11,7 @@ export function useRuleAuditActionsFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditEventsFilters.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditEventsFilters.tsx
@@ -11,7 +11,7 @@ export function useRuleAuditEventsFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditFilters.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditFilters.tsx
@@ -11,7 +11,7 @@ export function useRuleAuditFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/hub/administration/approvals/hooks/useApprovalFilters.tsx
+++ b/frontend/hub/administration/approvals/hooks/useApprovalFilters.tsx
@@ -11,14 +11,14 @@ export function useApprovalFilters() {
         label: t('Collection'),
         type: 'string',
         query: 'name',
-        placeholder: t('Enter collection'),
+        comparison: 'contains',
       },
       {
         key: 'namespace',
         label: t('Namespace'),
         type: 'string',
         query: 'namespace',
-        placeholder: t('Enter namespace'),
+        comparison: 'contains',
       },
       {
         key: 'status',

--- a/frontend/hub/administration/remote-registries/hooks/useRemoteRegistryFilters.tsx
+++ b/frontend/hub/administration/remote-registries/hooks/useRemoteRegistryFilters.tsx
@@ -6,7 +6,7 @@ export function useRemoteRegistryFilters() {
   const { t } = useTranslation();
   const toolbarFilters = useMemo<IToolbarFilter[]>(
     () => [
-      { key: 'name', label: t('Name'), type: 'string', query: 'name', placeholder: 'starts with' },
+      { key: 'name', label: t('Name'), type: 'string', query: 'name', comparison: 'startsWith' },
     ],
     [t]
   );

--- a/frontend/hub/administration/tasks/Tasks.tsx
+++ b/frontend/hub/administration/tasks/Tasks.tsx
@@ -114,14 +114,14 @@ export function useTaskFilters() {
         label: t('Task name'),
         type: 'string',
         query: 'name__contains',
-        placeholder: t('contains'),
+        comparison: 'contains',
       },
       {
         key: 'status',
         label: t('Status'),
         type: 'string',
         query: 'state',
-        placeholder: t('equals'),
+        comparison: 'equals',
       },
     ],
     [t]

--- a/frontend/hub/automation-content/collections/hooks/useCollectionFilters.tsx
+++ b/frontend/hub/automation-content/collections/hooks/useCollectionFilters.tsx
@@ -11,14 +11,14 @@ export function useCollectionFilters() {
         label: t('Keywords'),
         type: 'string',
         query: 'keywords',
-        placeholder: t('Enter keywords'),
+        comparison: 'contains',
       },
       {
         key: 'namespace',
         label: t('Namespace'),
         type: 'string',
         query: 'namespace',
-        placeholder: t('Enter namespace'),
+        comparison: 'contains',
       },
       {
         key: 'repository',
@@ -38,7 +38,7 @@ export function useCollectionFilters() {
         label: t('Tags'),
         type: 'string',
         query: 'tags',
-        placeholder: t('Enter tags'),
+        comparison: 'contains',
       },
       {
         key: 'type',

--- a/frontend/hub/automation-content/execution-environments/hooks/useExecutionEnvironmentFilters.tsx
+++ b/frontend/hub/automation-content/execution-environments/hooks/useExecutionEnvironmentFilters.tsx
@@ -11,7 +11,7 @@ export function useExecutionEnvironmentFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/hub/automation-content/namespaces/hooks/useNamespaceFilters.tsx
+++ b/frontend/hub/automation-content/namespaces/hooks/useNamespaceFilters.tsx
@@ -11,7 +11,7 @@ export function useNamespaceFilters() {
         label: t('Keywords'),
         type: 'string',
         query: 'keywords',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]

--- a/frontend/hub/automation-content/signature-keys/SignatureKeys.tsx
+++ b/frontend/hub/automation-content/signature-keys/SignatureKeys.tsx
@@ -101,7 +101,7 @@ export function useSignatureKeyFilters() {
         label: t('Name'),
         type: 'string',
         query: 'name',
-        placeholder: t('starts with'),
+        comparison: 'startsWith',
       },
     ],
     [t]


### PR DESCRIPTION
Cleanup toolbar filters to have a common base interface.

Biggest change here is adding a comparison type to 
```
export interface IToolbarTextFilter extends ToolbarFilterCommon {
  /** Filter for filtering by user text input. */
  type: 'string';

  /** The comparison to use when filtering. */
  comparison: 'contains' | 'startsWith' | 'endsWith' | 'equals';
}
```

Which will need to be expanded on later when advanced filters need to use those.