### PR TITLE
[AAP-12343] Change 'playbooks' to 'rulebooks' in EDA projects header

### DIFF
--- a/frontend/eda/Resources/projects/Projects.tsx
+++ b/frontend/eda/Resources/projects/Projects.tsx
@@ -26,7 +26,7 @@ export function Projects() {
     <PageLayout>
       <PageHeader
         title={t('Projects')}
-        description={t('Projects are a logical collection of playbooks.')}
+        description={t('Projects are a logical collection of rulebooks.')}
       />
       <PageTable
         tableColumns={tableColumns}


### PR DESCRIPTION
This fixes a simple string issue where in the Projects header section of EDA, the language needs to be changed from saying 'playbooks' to 'rulebooks'.

See https://issues.redhat.com/browse/AAP-12343 for more information