### PR TITLE
Update rule audit to read activation_instance data

### DIFF
--- a/frontend/eda/interfaces/generated/eda-api.ts
+++ b/frontend/eda/interfaces/generated/eda-api.ts
@@ -228,7 +228,10 @@ export interface AuditRule {
   ruleset_uuid?: string | null;
   /** Name of the related ruleset */
   ruleset_name?: string;
-  activation_instance_id: number | null;
+  activation_instance?: {
+    id: number | null;
+    name: string;
+  };
   job_instance_id: number | null;
   definition?: Record<string, any>;
 }
@@ -252,8 +255,10 @@ export interface AuditRuleOut {
    * @format date-time
    */
   created_at: string;
-  /** ID of the related Activation */
-  activation_id: number;
+  activation_instance?: {
+    id: number | null;
+    name: string;
+  };
   /** Name of the related Activation */
   activation_name: string;
 }

--- a/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
+++ b/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
@@ -48,17 +48,17 @@ export function RuleAuditDetails() {
             label={t('Rulebook activation')}
             helpText={t`Rulebook activations are rulebooks that have been activated to run.`}
           >
-            {ruleAudit && ruleAudit.activation_id ? (
+            {ruleAudit && ruleAudit.activation_instance?.id ? (
               <Link
                 to={RouteObj.EdaRulebookActivationDetails.replace(
                   ':id',
-                  `${ruleAudit.activation_id || ''}`
+                  `${ruleAudit.activation_instance?.id || ''}`
                 )}
               >
-                {ruleAudit?.activation_name}
+                {ruleAudit?.activation_instance?.name}
               </Link>
             ) : (
-              ruleAudit?.activation_name || ''
+              ruleAudit?.activation_instance?.name || ''
             )}
           </PageDetail>
           <PageDetail label={t('Created')}>

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
@@ -34,9 +34,9 @@ export function useRuleAuditColumns() {
       {
         header: t('Rulebook activation'),
         cell: (ruleAudit) =>
-          ruleAudit?.activation_instance ? (
+          ruleAudit?.activation_instance?.id ? (
             <TextCell
-              text={ruleAudit?.activation_name}
+              text={ruleAudit?.activation_instance?.name || ''}
               onClick={() =>
                 navigate(
                   RouteObj.EdaRulebookActivationDetails.replace(

--- a/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
+++ b/frontend/eda/views/RuleAudit/hooks/useRuleAuditColumns.tsx
@@ -34,20 +34,20 @@ export function useRuleAuditColumns() {
       {
         header: t('Rulebook activation'),
         cell: (ruleAudit) =>
-          ruleAudit?.activation_id ? (
+          ruleAudit?.activation_instance ? (
             <TextCell
               text={ruleAudit?.activation_name}
               onClick={() =>
                 navigate(
                   RouteObj.EdaRulebookActivationDetails.replace(
                     ':id',
-                    ruleAudit?.activation_id.toString() || ''
+                    ruleAudit?.activation_instance?.id?.toString() || ''
                   )
                 )
               }
             />
           ) : (
-            <TextCell text={ruleAudit?.activation_name || ''} />
+            <TextCell text={ruleAudit?.activation_instance?.name || ''} />
           ),
         modal: ColumnModalOption.Hidden,
       },


### PR DESCRIPTION
Update the interface for rule audits to use the activation_instance data field that's being added to the API

* depends on https://github.com/ansible/aap-eda/pull/260 *