### PR TITLE
[EDA] Fix broken user details and user tokens views for non-admins and non-auditors

### DIFF
--- a/cypress/e2e/eda/Users/users-list.cy.ts
+++ b/cypress/e2e/eda/Users/users-list.cy.ts
@@ -1,7 +1,7 @@
 //Tests a user's ability to perform certain actions on the Users list in the EDA UI.
 
 describe('EDA Users List', () => {
-  let roleIDs: string[];
+  let roleIDs: { [key: string]: string };
   let editorRoleID: string;
   let _contributorRoleID: string;
   let auditorRoleID: string;
@@ -10,12 +10,16 @@ describe('EDA Users List', () => {
   before(() => {
     cy.edaLogin();
     cy.getEdaRoles().then((rolesArray) => {
-      roleIDs = rolesArray.map((role) => role.id);
-      _contributorRoleID = roleIDs[0];
-      viewerRoleID = roleIDs[1];
-      editorRoleID = roleIDs[2];
-      auditorRoleID = roleIDs[4];
-      operatorRoleID = roleIDs[5];
+      roleIDs = rolesArray.reduce((acc, role) => {
+        const { name, id } = role;
+        return { ...acc, [name]: id };
+      }, {});
+
+      _contributorRoleID = roleIDs.Contributor;
+      viewerRoleID = roleIDs.Viewer;
+      editorRoleID = roleIDs.Editor;
+      auditorRoleID = roleIDs.Auditor;
+      operatorRoleID = roleIDs.Operator;
     });
   });
 

--- a/frontend/Routes.ts
+++ b/frontend/Routes.ts
@@ -274,6 +274,9 @@ export const RouteObj = {
   EdaRoleDetails: `${edaRoutePrefix}/roles/details/:id`,
   EditEdaRole: `${edaRoutePrefix}/roles/edit/:id`,
   CreateEdaControllerToken: `${edaRoutePrefix}/users/tokens/create`,
+
+  EdaMyDetails: `${edaRoutePrefix}/users/me`,
+  EdaMyTokens: `${edaRoutePrefix}/users/me/tokens`,
 };
 
 export function useRoutesWithoutPrefix(prefix: string) {

--- a/frontend/common/Masthead.tsx
+++ b/frontend/common/Masthead.tsx
@@ -52,6 +52,7 @@ import { swrOptions, useFetcher } from './crud/Data';
 import { postRequest } from './crud/usePostRequest';
 import { shouldShowAutmationServers } from './should-show-autmation-servers';
 import { useActiveUser } from './useActiveUser';
+import { EdaUser } from '../eda/interfaces/EdaUser';
 
 const MastheadBrandDiv = styled.div`
   display: flex;
@@ -290,11 +291,7 @@ function AccountDropdown() {
 
 export function EdaUserInfo() {
   const fetcher = useFetcher();
-  const meResponse = useSWR<{ id: number; username: string }>(
-    `${API_PREFIX}/users/me/`,
-    fetcher,
-    swrOptions
-  );
+  const meResponse = useSWR<EdaUser>(`${API_PREFIX}/users/me/`, fetcher, swrOptions);
   return meResponse?.data;
 }
 
@@ -348,11 +345,7 @@ function AccountDropdownInternal() {
           key="user-details"
           onClick={() => {
             isEdaServer(automationServer)
-              ? history(
-                  edaActiveUser
-                    ? RouteObj.EdaUserDetails.replace(':id', `${edaActiveUser?.id || ''}`)
-                    : RouteObj.EdaUsers
-                )
+              ? history(edaActiveUser ? RouteObj.EdaMyDetails : RouteObj.EdaUsers)
               : history(
                   activeUser
                     ? RouteObj.UserDetails.replace(':id', activeUser.id.toString())

--- a/frontend/eda/EventDrivenRouter.tsx
+++ b/frontend/eda/EventDrivenRouter.tsx
@@ -20,7 +20,7 @@ import { EditRole } from './UserAccess/Roles/EditRole';
 import { RoleDetails } from './UserAccess/Roles/RoleDetails';
 import { Roles } from './UserAccess/Roles/Roles';
 import { CreateControllerToken } from './UserAccess/Users/CreateControllerToken';
-import { EdaUserDetails } from './UserAccess/Users/EdaUserDetails';
+import { EdaUserDetails, EdaMyDetails } from './UserAccess/Users/EdaUserDetails';
 import { CreateUser, EditUser } from './UserAccess/Users/EditUser';
 import { Users } from './UserAccess/Users/Users';
 import { EdaDashboard } from './dashboard/EdaDashboard';
@@ -125,6 +125,11 @@ export function EventDrivenRouter() {
       <Route
         path={RouteObjWithoutPrefix.EdaUserDetailsTokens}
         element={<EdaUserDetails initialTabIndex={1} />}
+      />
+      <Route path={RouteObjWithoutPrefix.EdaMyDetails} element={<EdaMyDetails />} />
+      <Route
+        path={RouteObjWithoutPrefix.EdaMyTokens}
+        element={<EdaMyDetails initialTabIndex={1} />}
       />
 
       <Route path={RouteObjWithoutPrefix.EdaGroups} element={<Groups />} />

--- a/frontend/eda/EventDrivenSidebar.tsx
+++ b/frontend/eda/EventDrivenSidebar.tsx
@@ -5,11 +5,18 @@ import { usePageNavBarClick } from '../../framework/PageNav/PageNavSidebar';
 import { RouteObj } from '../Routes';
 import { CommonSidebar } from '../common/CommonSidebar';
 import { isRouteActive } from '../common/Masthead';
+import { EdaUserInfo } from '../common/Masthead';
 
 export function EventDrivenSidebar() {
   const { t } = useTranslation();
   const location = useLocation();
   const onClick = usePageNavBarClick();
+  const activeUser = EdaUserInfo();
+  const canViewAccess =
+    activeUser &&
+    (activeUser.is_superuser ||
+      activeUser.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor'));
+
   return (
     <CommonSidebar>
       <NavItem
@@ -66,25 +73,27 @@ export function EventDrivenSidebar() {
           {t('Credentials')}
         </NavItem>
       </NavExpandable>
-      <NavExpandable
-        key="user"
-        title={t('User Access')}
-        isExpanded
-        isActive={isRouteActive([RouteObj.EdaUsers, RouteObj.EdaRoles], location)}
-      >
-        <NavItem
-          isActive={isRouteActive(RouteObj.EdaUsers, location)}
-          onClick={() => onClick(RouteObj.EdaUsers)}
+      {canViewAccess ? (
+        <NavExpandable
+          key="user"
+          title={t('User Access')}
+          isExpanded
+          isActive={isRouteActive([RouteObj.EdaUsers, RouteObj.EdaRoles], location)}
         >
-          {t('Users')}
-        </NavItem>
-        <NavItem
-          isActive={isRouteActive(RouteObj.EdaRoles, location)}
-          onClick={() => onClick(RouteObj.EdaRoles)}
-        >
-          {t('Roles')}
-        </NavItem>
-      </NavExpandable>
+          <NavItem
+            isActive={isRouteActive(RouteObj.EdaUsers, location)}
+            onClick={() => onClick(RouteObj.EdaUsers)}
+          >
+            {t('Users')}
+          </NavItem>
+          <NavItem
+            isActive={isRouteActive(RouteObj.EdaRoles, location)}
+            onClick={() => onClick(RouteObj.EdaRoles)}
+          >
+            {t('Roles')}
+          </NavItem>
+        </NavExpandable>
+      ) : null}
     </CommonSidebar>
   );
 }

--- a/frontend/eda/UserAccess/Users/CreateControllerToken.tsx
+++ b/frontend/eda/UserAccess/Users/CreateControllerToken.tsx
@@ -50,27 +50,31 @@ export function CreateControllerToken() {
 
   const onSubmit: PageFormSubmitHandler<EdaControllerTokenCreate> = async (token) => {
     await postRequest(`${API_PREFIX}/users/me/awx-tokens/`, token);
-    navigate(RouteObj.EdaUserDetailsTokens.replace(':id', `${user?.id || ''}`));
+    navigate(RouteObj.EdaMyTokens);
   };
   const onCancel = () => navigate(-1);
 
+  const canViewUsers = user?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
+  const breadcrumbs = [
+    ...(canViewUsers ? [{ label: t('Users'), to: RouteObj.EdaUsers }] : []),
+    {
+      label: user?.username ?? '',
+      to: canViewUsers
+        ? RouteObj.EdaUserDetails.replace(':id', `${user?.id || ''}`)
+        : RouteObj.EdaMyDetails,
+    },
+    {
+      label: t('Controller tokens'),
+      to: canViewUsers
+        ? RouteObj.EdaUserDetailsTokens.replace(':id', `${user?.id || ''}`)
+        : RouteObj.EdaMyTokens,
+    },
+    { label: user?.username ?? '' },
+  ];
+
   return (
     <PageLayout>
-      <PageHeader
-        title={t('Create Controller Token')}
-        breadcrumbs={[
-          { label: t('Users'), to: RouteObj.EdaUsers },
-          {
-            label: user?.username ?? '',
-            to: RouteObj.EdaUserDetails.replace(':id', `${user?.id || ''}`),
-          },
-          {
-            label: t('Controller tokens'),
-            to: RouteObj.EdaUserDetailsTokens.replace(':id', `${user?.id || ''}`),
-          },
-          { label: user?.username ?? '' },
-        ]}
-      />
+      <PageHeader title={t('Create Controller Token')} breadcrumbs={breadcrumbs} />
       <PageForm
         submitText={t('Create controller token')}
         onSubmit={onSubmit}


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-11573

* Fix bug where users without admin or auditor roles could not create or view their tokens
* Fix bug where users without admin or auditor roles could not view their details via the masthead dropdown
* Add `/users/me` and `/users/me/tokens` EDA routes

**When user does not have Admin role:**
* Hide user details edit and delete actions

**When user does not have Admin or Auditor roles:** 
* Hide Access sidebar group
* Hide users breadcrumb route
* GET user details from `api/eda/v1/users/me` instead of `api/eda/v1/users/:id`

**When user is viewing self** 
* Show Controller Tokens tab 

![permissions](https://github.com/ansible/ansible-ui/assets/15881645/4d7c57a1-6d47-41d3-9c48-5f9ebceaf091)

**Note**
Ideally I would've moved user, roles, and permissions into a context provider that wrapped the EventDriven page. Adding that new functionality would've remove duplicate calls to `EdaUserInfo()`, but it was not necessary for this bug fix and it bloated the PR. 