### PR TITLE
Adds support for importing all the available locales

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -82,7 +82,7 @@ module.exports = function (env, argv) {
           : JSON.stringify('/eda'),
       }),
       isDevelopment && new ReactRefreshWebpackPlugin(),
-      ...['en', 'fr'].map((locale) => {
+      ...['en', 'es', 'fr', 'ja', 'ko', 'nl', 'zh', 'zu'].map((locale) => {
         return new MergeJsonWebpackPlugin({
           files: [`./locales/${locale}/translation.json`],
           output: {


### PR DESCRIPTION
I missed this when I added https://github.com/ansible/ansible-ui/pull/547.  Without this change we aren't able to load locales outside of `en` and `fr`
