### PR TITLE
Clean up translations.

### DIFF
--- a/frontend/awx/dashboard/AwxDashboard.tsx
+++ b/frontend/awx/dashboard/AwxDashboard.tsx
@@ -40,12 +40,13 @@ export function AwxDashboard() {
     <PageLayout>
       {config?.ui_next && (
         <Banner variant="info">
-          <Trans>
-            <p>
-              <InfoCircleIcon /> You are currently viewing a tech preview of the new {product} user
-              interface. To return to the original interface, click <a href="/">here</a>.
-            </p>
-          </Trans>
+          <p>
+            <InfoCircleIcon />{' '}
+            <Trans>
+              You are currently viewing a tech preview of the new {{ product }} user interface. To
+              return to the original interface, click <a href="/">here</a>.
+            </Trans>
+          </p>
         </Banner>
       )}
       <PageHeader

--- a/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
@@ -109,32 +109,35 @@ export function ProjectDetails(props: { project: Project }) {
     </span>
   );
   const basePathHelpBlock = (
-    <Trans i18nKey="basePathHelpBlock">
+    <>
       <p>
-        Base path used for locating playbooks. Directories found inside this path will be listed in
-        the playbook directory drop-down. Together the base path and selected playbook directory
-        provide the full path used to locate playbooks.
+        {t(
+          'Base path used for locating playbooks. Directories found inside this path will be listed in the playbook directory drop-down. Together the base path and selected playbook directory provide the full path used to locate playbooks.'
+        )}
       </p>
       <br></br>
       <p>
-        Change PROJECTS_ROOT when deploying {product} {brand} to change this location.
+        <Trans>
+          Change PROJECTS_ROOT when deploying {{ product }} {{ brand }} to change this location.
+        </Trans>
       </p>
-    </Trans>
+    </>
   );
   const scmUrlHelpBlock = (
-    <Trans i18nKey="scmUrlHelpBlock">
-      <p>Example URLs for GIT Source Control include:</p>
-      <code>
-        https://github.com/ansible/ansible.git git@github.com:ansible/ansible.git
-        git://servername.example.com/ansible.git
-      </code>
+    <>
+      <p>{t('Example URLs for GIT Source Control include:')}</p>
+      <Trans>
+        <code>
+          https://github.com/ansible/ansible.git git@github.com:ansible/ansible.git
+          git://servername.example.com/ansible.git
+        </code>
+      </Trans>
       <p>
-        Note: When using SSH protocol for GitHub or Bitbucket, enter an SSH key only, do not enter a
-        username (other than git). Additionally, GitHub and Bitbucket do not support password
-        authentication when using SSH. GIT read only protocol (git://) does not use username or
-        password information.
+        {t(
+          'Note: When using SSH protocol for GitHub or Bitbucket, enter an SSH key only, do not enter a username (other than git). Additionally, GitHub and Bitbucket do not support password authentication when using SSH. GIT read only protocol (git://) does not use username or password information.'
+        )}
       </p>
-    </Trans>
+    </>
   );
   const renderOptions = (options: Project) => (
     <TextList component={TextListVariants.ul}>

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { Banner } from '@patternfly/react-core';
-import { Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Job } from '../../../interfaces/Job';
 import './JobOutput.css';
 import { JobOutputLoadingRow } from './JobOutputLoadingRow';
@@ -19,6 +19,7 @@ export interface ICollapsed {
 const runningJobTypes: string[] = ['new', 'pending', 'waiting', 'running'];
 
 export function JobOutputEvents(props: { job: Job }) {
+  const { t } = useTranslation();
   const { job } = props;
   // TODO set job status on ws event change
   const isJobRunning = !job.status || runningJobTypes.includes(job.status);
@@ -82,12 +83,11 @@ export function JobOutputEvents(props: { job: Job }) {
       <Divider /> */}
       {isJobRunning ? (
         <Banner variant="warning">
-          <Trans>
-            <p>
-              This job is currently running. Live event streaming has not been added yet to the tech
-              preview.
-            </p>
-          </Trans>
+          <p>
+            {t(
+              'This job is currently running. Live event streaming has not been added yet to the tech preview.'
+            )}
+          </p>
         </Banner>
       ) : null}
       <div

--- a/frontend/eda/Resources/credentials/CredentialDetails.tsx
+++ b/frontend/eda/Resources/credentials/CredentialDetails.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
-import { TFunction, Trans, useTranslation } from 'react-i18next';
+import { TFunction, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   IPageAction,
@@ -32,14 +32,14 @@ import { useDeleteCredentials } from './hooks/useDeleteCredentials';
 export function CredentialDetails() {
   const { t } = useTranslation();
   const credentialTypeHelpBlock = (
-    <Trans i18nKey="credentialTypeHelpBlock">
-      <p>The credential type defines what the credential will be used for.</p>
+    <>
+      <p>{t('The credential type defines what the credential will be used for.')}</p>
       <br />
-      <p>There are three types:</p>
-      <p>GitHub Personal Access Token</p>
-      <p>GitLab Personal Access Token</p>
-      <p>Container Registry</p>
-    </Trans>
+      <p>{t('There are three types:')}</p>
+      <p>{t('GitHub Personal Access Token')}</p>
+      <p>{t('GitLab Personal Access Token')}</p>
+      <p>{t('Container Registry')}</p>
+    </>
   );
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();

--- a/frontend/eda/Resources/credentials/EditCredential.tsx
+++ b/frontend/eda/Resources/credentials/EditCredential.tsx
@@ -1,4 +1,4 @@
-import { TFunction, Trans, useTranslation } from 'react-i18next';
+import { TFunction, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
 import {
@@ -38,14 +38,14 @@ export function CredentialOptions(t: TFunction<'translation'>) {
 function CredentialInputs() {
   const { t } = useTranslation();
   const credentialTypeHelpBlock = (
-    <Trans i18nKey="credentialTypeHelpBlock">
-      <p>The credential type defines what the credential will be used for.</p>
+    <>
+      <p>{t('The credential type defines what the credential will be used for.')}</p>
       <br />
-      <p>There are three types:</p>
-      <p>GitHub Personal Access Token</p>
-      <p>GitLab Personal Access Token</p>
-      <p>Container Registry</p>
-    </Trans>
+      <p>{t('There are three types:')}</p>
+      <p>{t('GitHub Personal Access Token')}</p>
+      <p>{t('GitLab Personal Access Token')}</p>
+      <p>{t('Container Registry')}</p>
+    </>
   );
   return (
     <>

--- a/frontend/eda/Resources/decision-environments/DecisionEnvironmentDetails.tsx
+++ b/frontend/eda/Resources/decision-environments/DecisionEnvironmentDetails.tsx
@@ -34,12 +34,18 @@ export function DecisionEnvironmentDetails() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
   const imageHelpBlock = (
-    <Trans i18nKey="imageHelpBlock">
-      <p>The full image location, including the container registry, image name, and version tag.</p>
+    <>
+      <p>
+        {t(
+          'The full image location, including the container registry, image name, and version tag.'
+        )}
+      </p>
       <br />
-      <p>Examples:</p>
-      <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
-    </Trans>
+      <p>{t('Examples:')}</p>
+      <Trans>
+        <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
+      </Trans>
+    </>
   );
   const { data: decisionEnvironment } = useGet<EdaDecisionEnvironment>(
     `${API_PREFIX}/decision-environments/${params.id ?? ''}/`,

--- a/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
+++ b/frontend/eda/Resources/decision-environments/DecisionEnvironmentForm.tsx
@@ -22,12 +22,18 @@ function DecisionEnvironmentInputs() {
   const { t } = useTranslation();
   const { data: credentials } = useGet<EdaResult<EdaCredential>>(`${API_PREFIX}/credentials/`);
   const imageHelpBlock = (
-    <Trans i18nKey="imageHelpBlock">
-      <p>The full image location, including the container registry, image name, and version tag.</p>
+    <>
+      <p>
+        {t(
+          'The full image location, including the container registry, image name, and version tag.'
+        )}
+      </p>
       <br />
-      <p>Examples:</p>
-      <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
-    </Trans>
+      <p>{t('Examples:')}</p>
+      <Trans>
+        <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
+      </Trans>
+    </>
   );
   return (
     <>

--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -1,7 +1,7 @@
 import { DropdownPosition, PageSection, Skeleton, Stack } from '@patternfly/react-core';
 import { CubesIcon, RedoIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   IPageAction,
@@ -43,14 +43,14 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
   const restartPolicyHelpBlock = (
-    <Trans i18nKey="restartPolicyHelpBlock">
-      <p>A policy to decide when to restart a rulebook.</p>
+    <>
+      <p>{t('A policy to decide when to restart a rulebook.')}</p>
       <br />
-      <p>Policies:</p>
-      <p>Always: restarts when a rulebook finishes.</p>
-      <p>Never: never restarts a rulebook when it finishes.</p>
-      <p>On failure: only restarts when it fails.</p>
-    </Trans>
+      <p>{t('Policies:')}</p>
+      <p>{t('Always: restarts when a rulebook finishes.')}</p>
+      <p>{t('Never: never restarts a rulebook when it finishes.')}</p>
+      <p>{t('On failure: only restarts when it fails.')}</p>
+    </>
   );
 
   const { data: rulebookActivation, refresh } = useGet<EdaRulebookActivation>(

--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useWatch } from 'react-hook-form';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   PageForm,
@@ -87,14 +87,14 @@ export function CreateRulebookActivation() {
 export function RulebookActivationInputs() {
   const { t } = useTranslation();
   const restartPolicyHelpBlock = (
-    <Trans i18nKey="restartPolicyHelpBlock">
-      <p>A policy to decide when to restart a rulebook.</p>
+    <>
+      <p>{t('A policy to decide when to restart a rulebook.')}</p>
       <br />
-      <p>Policies:</p>
-      <p>Always: restarts when a rulebook finishes.</p>
-      <p>Never: never restarts a rulebook when it finishes.</p>
-      <p>On failure: only restarts when it fails.</p>
-    </Trans>
+      <p>{t('Policies:')}</p>
+      <p>{t('Always: restarts when a rulebook finishes.')}</p>
+      <p>{t('Never: never restarts a rulebook when it finishes.')}</p>
+      <p>{t('On failure: only restarts when it fails.')}</p>
+    </>
   );
   const { data: projects } = useGet<EdaResult<EdaProject>>(
     `${API_PREFIX}/projects/?page=1&page_size=200`


### PR DESCRIPTION
The original cause of the bug was due to an `i18nKey` prop being provided to a block of text that was wrapped in the `<Trans>` component without its corresponding entry in translations.json. Upon further reading of the docs, it is stated that the `<Trans>` component is [rarely needed](https://react.i18next.com/latest/trans-component#important-note), and that most strings can be marked for translation using the provided `t` macro.


This PR cleans up some translations and help text blocks. Previously, the `<Trans>` component was used to wrap long help text blocks with formatting. I have used the `t` macro in areas where possible, and in other areas where strings include HTML text formatting, I have wrapped using the provided `<Trans>` component.