### PR TITLE
Update command for creating AWX job template

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -427,7 +427,7 @@ Cypress.Commands.add(
   }
 );
 
-/** Interface for tracking created resources that will need to be delete 
+/** Interface for tracking created resources that will need to be delete
 at the end of testing using cy.deleteAwxResources*/
 export interface IAwxResources {
   jobTemplate?: JobTemplate;
@@ -437,19 +437,20 @@ Cypress.Commands.add('deleteAwxResources', (resources?: IAwxResources) => {
   if (resources?.jobTemplate) cy.deleteAwxJobTemplate(resources.jobTemplate);
 });
 
-Cypress.Commands.add(
-  'createAwxJobTemplate',
-  (project: Project, inventory: Inventory, jobTemplate?: Partial<JobTemplate>) => {
-    cy.awxRequestPost<JobTemplate>('/api/v2/job_templates/', {
-      name: 'E2E Job Template ' + randomString(4),
-      playbook: 'hello_world.yml',
-      project: project.id.toString(),
-      inventory: inventory.id,
-      organization: project.organization,
-      ...jobTemplate,
-    }).then((jobTemplate) => jobTemplate);
-  }
-);
+Cypress.Commands.add('createAwxJobTemplate', () => {
+  cy.createAwxOrganization().then((organization) => {
+    cy.createAwxProject({ organization: organization.id }).then((project) => {
+      cy.createAwxInventory().then((inventory) => {
+        cy.requestPost<JobTemplate>('/api/v2/job_templates/', {
+          name: 'E2E Job Template ' + randomString(4),
+          playbook: 'hello_world.yml',
+          project: project.id.toString(),
+          inventory: inventory.id,
+        }).then((jobTemplate) => jobTemplate);
+      });
+    });
+  });
+});
 
 Cypress.Commands.add(
   'createEdaAwxJobTemplate',

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -248,11 +248,7 @@ declare global {
         organization: Organization;
       }>;
 
-      createAwxJobTemplate(
-        project: Project,
-        inventory: Inventory,
-        jobTemplate?: Partial<JobTemplate>
-      ): Chainable<JobTemplate>;
+      createAwxJobTemplate(): Chainable<JobTemplate>;
       /**
        * This command creates a job template with specific variables that will work in conjunction with
        * an EDA project and rulebook activation.


### PR DESCRIPTION
This test fails often in the CI checks: `jobs > deletes a job from the jobs list toolbar`

<img width="750" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/18d74e18-bf61-4212-87c2-a3ad8c6efc03">

1. One issue was that we had switched to using the wrong support command for creating the job template resource (we were creating a template specific to EDA using an EDA specific playbook in an AWX specific test). We needed to switch this back to  creating a template using the hello_world playbook for AWX.
2. Regardless of the playbook being used, the launch job appears to terminate in `Error` with a one-line "Finished" job output. Does anyone have more information on why this would happen? I recreated this issue with a manually created template "Test Template" on our E2E server.
Since the failing test (delete job) does not require the job to be in success state (just that it should not be running), I have tweaked the test to proceed with deletion as long as the job is not running.

