### PR TITLE
Delete jobs test: wait for job to come out of pending state

### DIFF
--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -66,9 +66,6 @@ describe('jobs', () => {
         cy.get('#relaunch-job').should('exist');
         cy.get('.pf-c-dropdown__toggle').click();
         cy.contains('.pf-c-dropdown__menu-item', /^Delete job$/).should('exist');
-        cy.contains('.pf-c-dropdown__menu-item', /^Cancel job$/, { timeout: 60 * 1000 }).should(
-          'exist'
-        );
       });
   });
 
@@ -106,6 +103,13 @@ describe('jobs', () => {
       const jobId = testJob.id ? testJob.id.toString() : '';
       cy.filterTableByTypeAndText('ID', jobId);
       const jobName = testJob.name ? testJob.name : '';
+      cy.getTableRowByText(jobName, false).within(() => {
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 })
+          .should('not.contain', 'Running')
+          .and('not.contain', 'New')
+          .and('not.contain', 'Waiting')
+          .and('not.contain', 'Pending');
+      });
       cy.clickTableRowKebabAction(jobName, /^Delete job$/, false);
       cy.get('#confirm').click();
       cy.clickButton(/^Delete job/);
@@ -127,7 +131,11 @@ describe('jobs', () => {
       cy.filterTableByTypeAndText('ID', jobId);
       const jobName = job.name ? job.name : '';
       cy.getTableRowByText(jobName, false).within(() => {
-        cy.get('[data-label="Status"]').should('not.contain', 'Running');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 })
+          .should('not.contain', 'Running')
+          .and('not.contain', 'New')
+          .and('not.contain', 'Waiting')
+          .and('not.contain', 'Pending');
       });
       cy.selectTableRow(jobName, false);
       cy.clickToolbarKebabAction(/^Delete selected jobs$/);

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -104,11 +104,10 @@ describe('jobs', () => {
       cy.filterTableByTypeAndText('ID', jobId);
       const jobName = testJob.name ? testJob.name : '';
       cy.getTableRowByText(jobName, false).within(() => {
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 })
-          .should('not.contain', 'Running')
-          .and('not.contain', 'New')
-          .and('not.contain', 'Waiting')
-          .and('not.contain', 'Pending');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'New');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Waiting');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Pending');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Running');
       });
       cy.clickTableRowKebabAction(jobName, /^Delete job$/, false);
       cy.get('#confirm').click();
@@ -131,11 +130,10 @@ describe('jobs', () => {
       cy.filterTableByTypeAndText('ID', jobId);
       const jobName = job.name ? job.name : '';
       cy.getTableRowByText(jobName, false).within(() => {
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 })
-          .should('not.contain', 'Running')
-          .and('not.contain', 'New')
-          .and('not.contain', 'Waiting')
-          .and('not.contain', 'Pending');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'New');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Waiting');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Pending');
+        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Running');
       });
       cy.selectTableRow(jobName, false);
       cy.clickToolbarKebabAction(/^Delete selected jobs$/);


### PR DESCRIPTION
PR builds randomly fail on the following tests:
![Screenshot 2023-06-05 at 12 57 44 PM](https://github.com/ansible/ansible-ui/assets/43621546/bc020250-4cd1-4374-8733-57cc8f962762)

1. deletes a job from the jobs list row
```
Timed out retrying after 30000ms: expected '<a.pf-m-icon.pf-m-aria-disabled.pf-c-dropdown__menu-item>' not to have attribute 'aria-disabled' with the value 'true', but the value was 'true'
```
2. deletes a job from the jobs list toolbar
```
409: Conflict
Resource is being used by running jobs.
```

These are caused by the Job being stuck in "Pending" state longer than 30s. This PR updates the test to wait for 2 min until the job is not "new", "pending", "waiting" or "running" to make sure that the delete operation can work on it.
I also removed the check for the presence of the "Cancel job" row action since the job may be in running state very briefly and we may or may not see this action at the time of assertion.
