### PR TITLE
bump number of parallel test runners up for component tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1]
+        containers: [1, 2]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
We have reached that milestone where component tests are taking more than 10 minutes!
Adding a parallel builder to cut the test time down.

![Screenshot 2023-06-07 at 3 16 23 PM](https://github.com/ansible/ansible-ui/assets/6277895/a84b36d0-0dec-436a-8452-7af3b4b1d24a)
