### PR TITLE
Remove link to project from project select

### DIFF
--- a/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
+++ b/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
@@ -31,7 +31,7 @@ export function PageFormProjectSelect<
       name={name}
       label={t('Project')}
       placeholder={t('Add project')}
-      selectTitle={t('Select an project')}
+      selectTitle={t('Select a project')}
       labelHelpTitle={t('Project')}
       labelHelp={t('Select the project containing the playbook you want this job to execute.')}
       selectValue={(project: Project) => project.name}

--- a/frontend/awx/resources/projects/hooks/useProjectNameColumn.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectNameColumn.tsx
@@ -1,16 +1,16 @@
 import { Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ITableColumn } from '../../../../../framework';
 import { IconWrapper } from '../../../../../framework/components/IconWrapper';
-import { usePageNavigate } from '../../../../../framework/components/usePageNavigate';
 import { RouteObj } from '../../../../Routes';
 import { Project } from '../../../interfaces/Project';
 
-export function useProjectNameColumn() {
+export function useProjectNameColumn(options?: { disableLinks?: boolean }) {
   const { t } = useTranslation();
-  const navigate = usePageNavigate();
+  const { disableLinks } = options ?? {};
   const column = useMemo<ITableColumn<Project>>(
     () => ({
       header: t('Name'),
@@ -26,15 +26,13 @@ export function useProjectNameColumn() {
                   overflow: 'hidden',
                 }}
               >
-                <a
-                  href={RouteObj.ProjectDetails.replace(':id', project.id.toString())}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    navigate(RouteObj.ProjectDetails.replace(':id', project.id.toString()));
-                  }}
-                >
-                  {project.name}
-                </a>
+                {disableLinks ? (
+                  project.name
+                ) : (
+                  <Link to={RouteObj.ProjectDetails.replace(':id', project.id.toString())}>
+                    {project.name}
+                  </Link>
+                )}
               </div>
             </SplitItem>
             <SplitItem>
@@ -57,15 +55,13 @@ export function useProjectNameColumn() {
               overflow: 'hidden',
             }}
           >
-            <a
-              href={RouteObj.ProjectDetails.replace(':id', project.id.toString())}
-              onClick={(e) => {
-                e.preventDefault();
-                navigate(RouteObj.ProjectDetails.replace(':id', project.id.toString()));
-              }}
-            >
-              {project.name}
-            </a>
+            {disableLinks ? (
+              project.name
+            ) : (
+              <Link to={RouteObj.ProjectDetails.replace(':id', project.id.toString())}>
+                {project.name}
+              </Link>
+            )}
           </div>
         ),
       sort: 'name',
@@ -73,7 +69,7 @@ export function useProjectNameColumn() {
       list: 'name',
       defaultSort: true,
     }),
-    [navigate, t]
+    [t, disableLinks]
   );
   return column;
 }

--- a/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsColumns.tsx
@@ -16,7 +16,7 @@ import { useProjectNameColumn } from './useProjectNameColumn';
 
 export function useProjectsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
-  const nameColumn = useProjectNameColumn();
+  const nameColumn = useProjectNameColumn({ disableLinks: options?.disableLinks });
   const descriptionColumn = useDescriptionColumn();
   const organizationColumn = useOrganizationNameColumn(options);
   const createdColumn = useCreatedColumn(options);


### PR DESCRIPTION
Removes the link from table of projects in the project select modal. This prevents the user from accidentally navigating away from the form when trying to select a project.

![Screenshot 2023-06-07 at 2 44 09 PM](https://github.com/ansible/ansible-ui/assets/410794/b3f08cad-8935-4bec-a5ac-54e8306c7824)
