### PR TITLE
E2E tests: Address issue with filter selection failing randomly

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -70,7 +70,9 @@ Cypress.Commands.add('selectDropdownOptionByLabel', (label: string | RegExp, tex
 
 Cypress.Commands.add('selectToolbarFilterType', (text: string | RegExp) => {
   cy.get('#filter-form-group').within(() => {
-    cy.get('.pf-c-select').should('not.be.disabled').click();
+    cy.get('.pf-c-select button').as('filterTypeBtn');
+    cy.get('@filterTypeBtn').should('not.be.disabled');
+    cy.get('@filterTypeBtn').click();
     cy.get('.pf-c-select__menu').within(() => {
       cy.clickButton(text);
     });


### PR DESCRIPTION
Fix for the following error that appears randomly on the "selectToolbarFilterType" Cypress command in `cypress/support/awx-commands.ts`:
![image](https://github.com/ansible/ansible-ui/assets/43621546/e63e3c69-d1c0-47ed-8bd8-11e21e3d85f5)
