### PR TITLE
[AAP-13182] Fix the link to the Activation Instance details page from the rule audit details page

### DIFF
--- a/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
+++ b/frontend/eda/views/RuleAudit/RuleAuditDetails.tsx
@@ -50,7 +50,7 @@ export function RuleAuditDetails() {
           >
             {ruleAudit && ruleAudit.activation_instance?.id ? (
               <Link
-                to={RouteObj.EdaRulebookActivationDetails.replace(
+                to={RouteObj.EdaActivationInstanceDetails.replace(
                   ':id',
                   `${ruleAudit.activation_instance?.id || ''}`
                 )}


### PR DESCRIPTION
Fix the link in the Audit details page to point to the corresponding Activation instance details page 
