### PR TITLE
Random E2E Failure - AWX Teams Remove Users

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -1,5 +1,5 @@
 # Ansible UI Framework
 
-A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers
+A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers.
 
 [Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework)


### PR DESCRIPTION
can remove users from the team via the team access tab toolbar:
     CypressError: `cy.type()` failed because it targeted a disabled element.