### PR TITLE
Random E2E Failure - AWX Job Template Form

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -1,5 +1,5 @@
 # Ansible UI Framework
 
-A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers
+A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers.
 
 [Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework)


### PR DESCRIPTION
  Should create job template with all fields except for prompt on launch values:
     AssertionError: Timed out retrying after 30000ms: Expected to find element: `div[data-ouia-component-type="PF4/ModalContent"]`, but never found it.
      at Context.eval (webpack:///./cypress/support/awx-commands.ts:259:5)
      
  Suspect the use of the deprecated hook `useSelect`.