### PR TITLE
use v3 namespaces api

### DIFF
--- a/frontend/hub/namespaces/HubNamespace.tsx
+++ b/frontend/hub/namespaces/HubNamespace.tsx
@@ -1,17 +1,44 @@
+export interface LinksType {
+  name: string;
+  url: string;
+}
+
+export interface LatestMetadataType {
+  pulp_href: string;
+  name: string;
+  company: string;
+  email: string;
+  description: string;
+  resources: string;
+  links: LinksType[];
+  avatar_sha256: string | null;
+  avatar_url: string | null;
+  metadata_sha256: string;
+  groups: string[];
+  task: string | null;
+}
+
 export interface HubNamespace {
   pulp_href: string;
+  pulp_created: string;
   id: number;
   name: string;
   company: string;
   email: string;
   avatar_url: string;
   description: string;
+  num_collections: number;
   groups: [
     {
       id: number;
       name: string;
-      object_roles: string[];
+      object_permissions: string[];
+      pulp_href?: string;
     }
   ];
-  related_fields: object;
+  resources: string;
+  owners: string[];
+  links: LinksType[];
+  my_permissions: string[];
+  latest_metadata: LatestMetadataType;
 }

--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -46,7 +46,9 @@ export function AllNamespaces() {
 }
 
 export function MyNamespaces() {
-  return <CommonNamespaces url="/api/automation-hub/_ui/v1/my-namespaces/" />;
+  return (
+    <CommonNamespaces url="/api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/?my_permissions=ansible.change_ansiblenamespace" />
+  );
 }
 
 export function CommonNamespaces(props: { url: string }) {

--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { PageHeader, PageLayout, PageTab, PageTable, PageTabs } from '../../../framework';
 import { RouteObj } from '../../Routes';
-import { idKeyFn, useHubView } from '../useHubView';
+import { idKeyFn, usePulpView } from '../usePulpView';
 import { HubNamespace } from './HubNamespace';
 import { useHubNamespaceActions } from './hooks/useHubNamespaceActions';
 import { useHubNamespaceFilters } from './hooks/useHubNamespaceFilters';
@@ -56,7 +56,7 @@ export function CommonNamespaces(props: { url: string }) {
   const tableColumns = useHubNamespacesColumns();
   const toolbarActions = useHubNamespaceToolbarActions();
   const rowActions = useHubNamespaceActions();
-  const view = useHubView<HubNamespace>(props.url, idKeyFn, toolbarFilters, tableColumns);
+  const view = usePulpView<HubNamespace>(props.url, idKeyFn, toolbarFilters, tableColumns);
   return (
     <PageTable<HubNamespace>
       toolbarFilters={toolbarFilters}

--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -42,7 +42,7 @@ export function Namespaces() {
 }
 
 export function AllNamespaces() {
-  return <CommonNamespaces url="/api/automation-hub/_ui/v1/namespaces/" />;
+  return <CommonNamespaces url="/api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/" />;
 }
 
 export function MyNamespaces() {


### PR DESCRIPTION
The pr uses the new `api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/` in place of the old `/api/automation-hub/_ui/v1/namespaces/` one. 

Unfortunately, though the api at `http://localhost:5001/api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/` works fine, the UI is having trouble reading it. 

I am using:
https://github.com/ansible/galaxy_ng/pull/1705
https://github.com/pulp/pulp_ansible/pull/1437

Thanks for a quick review:)