### PR TITLE
[AAP-11829] Eda Dashboard - switch Audit Role and Activations card. Update Audit Rules card title

### DIFF
--- a/cypress/e2e/eda/General-UI/dashboard.cy.ts
+++ b/cypress/e2e/eda/General-UI/dashboard.cy.ts
@@ -162,7 +162,7 @@ describe('dashboard checks when resources before any resources are created', () 
       .should('be.visible');
     cy.contains('small', 'Recently updated activations').should('be.visible');
     //TO DO: change the title to Rule Audit after fix
-    cy.hasTitle(/^Rule audit$/)
+    cy.hasTitle(/^Rule Audit$/)
       .scrollIntoView()
       .should('be.visible');
     cy.contains('small', 'Recently fired rules').should('be.visible');

--- a/frontend/eda/dashboard/EdaDashboard.cy.tsx
+++ b/frontend/eda/dashboard/EdaDashboard.cy.tsx
@@ -1,5 +1,72 @@
+import { RouteObj } from '../../Routes';
+import { EdaDashboard } from './EdaDashboard';
+import { API_PREFIX } from '../constants';
+
 describe('EdaDashboard.cy.ts', () => {
-  it.skip('renders', () => {
-    // TODO
+  beforeEach(() => {
+    cy.intercept(
+      { method: 'GET', url: `${API_PREFIX}/projects/*` },
+      {
+        count: 0,
+        results: [],
+      }
+    );
+
+    cy.intercept(
+      { method: 'GET', url: `${API_PREFIX}/activations/*` },
+      {
+        count: 0,
+        results: [],
+      }
+    );
+    cy.intercept(
+      { method: 'GET', url: `${API_PREFIX}/decision-environments/*` },
+      {
+        count: 0,
+        results: [],
+      }
+    );
+    cy.intercept(
+      { method: 'GET', url: `${API_PREFIX}/audit-rules/*` },
+      {
+        count: 0,
+        results: [],
+      }
+    );
+    cy.intercept(
+      { method: 'GET', url: `${API_PREFIX}/audit-rules/` },
+      {
+        count: 0,
+        results: [],
+      }
+    );
+    cy.mount(<EdaDashboard />, {
+      path: RouteObj.EdaDashboard,
+      initialEntries: [RouteObj.EdaDashboard],
+    });
+  });
+  it('Dashboard has the correct title', () => {
+    cy.contains(
+      /^Connect intelligence, analytics and service requests to enable more responsive and resilient automation.$/
+    ).should('be.visible');
+  });
+  it('Dashboard renders all components cards', () => {
+    cy.contains('h3', 'Rulebook Activations').scrollIntoView();
+    cy.hasTitle(/^There are currently no rulebook activations$/).should('be.visible');
+    cy.contains(
+      'div.pf-c-empty-state__body',
+      'Create a rulebook activation by clicking the button below.'
+    );
+    cy.contains('h3', 'Decision Environments').scrollIntoView();
+    cy.hasTitle(/^There are currently no decision environments$/).should('be.visible');
+    cy.contains(
+      'div.pf-c-empty-state__body',
+      'Create a decision environment by clicking the button below.'
+    );
+    cy.contains('h3', 'Rule Audit').scrollIntoView();
+    cy.hasTitle(/^There are currently no rule audit records$/).should('be.visible');
+    cy.contains('h3', 'Projects').scrollIntoView();
+    cy.hasTitle(/^There are currently no projects$/).should('be.visible');
+    cy.contains('div.pf-c-empty-state__body', 'Create a project by clicking the button below.');
   });
 });

--- a/frontend/eda/dashboard/EdaDashboard.tsx
+++ b/frontend/eda/dashboard/EdaDashboard.tsx
@@ -109,8 +109,8 @@ export function EdaDashboard() {
         <RuleAuditChart />
         <EdaRecentProjectsCard view={edaProjectView} />
         <EdaDecisionEnvironmentsCard view={edaDecisionEnvironmentView} />
-        <EdaRuleAuditCard view={edaRuleAuditView} />
         <EdaRulebookActivationsCard view={edaRulebookActivationView} />
+        <EdaRuleAuditCard view={edaRuleAuditView} />
       </PageDashboard>
     </>
   );

--- a/frontend/eda/dashboard/cards/EdaRuleAuditCard.tsx
+++ b/frontend/eda/dashboard/cards/EdaRuleAuditCard.tsx
@@ -21,7 +21,7 @@ export function EdaRuleAuditCard(props: { view: IEdaView<EdaRuleAudit> }) {
   columns = useColumnsWithoutExpandedRow(columns);
   return (
     <PageDashboardCard
-      title={t('Rule audit')}
+      title={t('Rule Audit')}
       subtitle={t('Recently fired rules')}
       height="md"
       linkText={t('Go to Rule Audit')}


### PR DESCRIPTION
Eda Dashboard 

- Switch Audit Role and Activations cards. 
- Update Audit Rules card title

![Screenshot from 2023-06-20 17-14-34](https://github.com/ansible/ansible-ui/assets/12769982/4587d017-cffd-471f-9a2e-3f1b64ac4f66)
