### PR TITLE
Update page form select components for JT, WFJT, and Projects

### DIFF
--- a/framework/PageForm/Inputs/PageFormAsyncSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormAsyncSelect.tsx
@@ -28,6 +28,7 @@ export interface PageFormAsyncSelectProps<
 > {
   id?: string;
   name: TFieldName;
+  variant?: 'single' | 'typeahead' | 'typeaheadMulti';
   label: string;
   labelHelp?: string | ReactNode;
   labelHelpTitle?: string;
@@ -115,6 +116,7 @@ export function PageFormAsyncSelect<
           >
             <AsyncSelect<SelectionType>
               id={id}
+              variant={props.variant}
               query={queryHandler}
               valueToString={valueToString}
               valueToDescription={valueToDescription}
@@ -154,6 +156,7 @@ export interface AsyncSelectProps<SelectionType> {
   onSelect: (value: SelectionType | undefined) => void;
   query: (pageSize: number) => Promise<{ total: number; values: SelectionType[] }>;
   placeholder: string;
+  variant?: 'single' | 'typeahead' | 'typeaheadMulti';
   loadingPlaceholder: string;
   labeledBy?: string;
   isReadOnly?: boolean;
@@ -180,6 +183,7 @@ export function AsyncSelect<SelectionType>(props: AsyncSelectProps<SelectionType
     placeholder,
     query,
     validated,
+    variant,
   } = props;
 
   const [open, setOpen] = useState(false);
@@ -256,7 +260,7 @@ export function AsyncSelect<SelectionType>(props: AsyncSelectProps<SelectionType
       <Select
         toggleId={id}
         aria-labelledby={labeledBy}
-        variant={SelectVariant.single}
+        variant={variant ? SelectVariant[`${variant}`] : SelectVariant.single}
         hasPlaceholderStyle
         placeholderText={
           loadingError

--- a/frontend/awx/access/roles/AddRolesForm.tsx
+++ b/frontend/awx/access/roles/AddRolesForm.tsx
@@ -13,7 +13,7 @@ import { PageFormInventorySelect } from '../../resources/inventories/components/
 import { PageFormProjectSelect } from '../../resources/projects/components/PageFormProjectSelect';
 import { PageFormJobTemplateSelect } from '../../resources/templates/components/PageFormJobTemplateSelect';
 import { PageFormWorkflowJobTemplateSelect } from '../../resources/templates/components/PageFormWorkflowJobTemplateSelect';
-import { PageFormOrganizationSelect } from '../organizations/components/PageFormOrganizationSelect';
+import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
 import { IRoles, useRolesMetadata } from './useRoleMetadata';
 
 interface UserRole {
@@ -143,7 +143,7 @@ function UserJobTemplateRole() {
   const rolesMetadata = useRolesMetadata();
   return (
     <PageFormHidden watch="role" hidden={(type: string) => type !== 'job_template'}>
-      <PageFormJobTemplateSelect name="jobTemplateName" jobTemplatePath="resource" />
+      <PageFormJobTemplateSelect name="resource" />
       <Permissions roles={rolesMetadata.job_template} />
     </PageFormHidden>
   );
@@ -153,10 +153,7 @@ function UserWorkflowJobTemplateRole() {
   const rolesMetadata = useRolesMetadata();
   return (
     <PageFormHidden watch="role" hidden={(type: string) => type !== 'workflow_job_template'}>
-      <PageFormWorkflowJobTemplateSelect
-        name="workflowJobTemplateName"
-        workflowJobTemplatePath="resource"
-      />
+      <PageFormWorkflowJobTemplateSelect name="resource" />
       <Permissions roles={rolesMetadata.workflow_job_template} />
     </PageFormHidden>
   );
@@ -176,7 +173,7 @@ function UserProjectRole() {
   const rolesMetadata = useRolesMetadata();
   return (
     <PageFormHidden watch="role" hidden={(type: string) => type !== 'project'}>
-      <PageFormProjectSelect name="projectName" projectPath="resource" />
+      <PageFormProjectSelect name="resource" />
       <Permissions roles={rolesMetadata.project} />
     </PageFormHidden>
   );
@@ -186,7 +183,7 @@ function UserOrganizationRole() {
   const rolesMetadata = useRolesMetadata();
   return (
     <PageFormHidden watch="role" hidden={(type: string) => type !== 'organization'}>
-      <PageFormOrganizationSelect name="organizationName" organizationPath="resource" isRequired />
+      <PageFormSelectOrganization name="resource" isRequired />
       <Permissions roles={rolesMetadata.organization} />
     </PageFormHidden>
   );

--- a/frontend/awx/interfaces/JobTemplateForm.ts
+++ b/frontend/awx/interfaces/JobTemplateForm.ts
@@ -20,7 +20,7 @@ export interface JobTemplateSummaryFields
     | 'organization'
   > {
   inventory?: { name?: string; id?: number } | null;
-  project?: { id?: number; name?: string; organization?: number };
+  project: { id?: number; name?: string; organization?: number } | null;
   execution_environment?: { id?: number; name?: string };
 }
 
@@ -54,5 +54,5 @@ export interface JobTemplateForm
   isProvisioningCallbackEnabled: boolean;
   arrayedSkipTags: { value: string; label: string }[];
   arrayedJobTags: { value: string; label: string }[];
-  project: number | null;
+  project: number | undefined;
 }

--- a/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
+++ b/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
@@ -1,65 +1,43 @@
-import { useEffect } from 'react';
-import { FieldPath, FieldValues, useFormContext, useWatch } from 'react-hook-form';
+import { useCallback } from 'react';
+import { FieldPath, FieldPathValue, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { PageFormTextInput } from '../../../../../framework/PageForm/Inputs/PageFormTextInput';
 import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
 import { Project } from '../../../interfaces/Project';
 import { useSelectProject } from '../hooks/useSelectProject';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
 
 export function PageFormProjectSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
->(props: { name: TFieldName; projectPath?: string; project?: string }) {
-  const { projectPath, project, name, ...rest } = props;
-
+>(props: { name: TFieldName; isRequired?: boolean; project?: string; projectPath?: string }) {
   const { t } = useTranslation();
-  const {
-    useSelectDialog: selectProject,
-    view: { pageItems },
-  } = useSelectProject(true);
-  const { setValue } = useFormContext();
-  const id = useWatch({ name: 'project' }) as number;
 
-  useEffect(() => {
-    let selectedProject;
-    if (!id && pageItems?.length !== 1) return;
-    if (pageItems?.length === 1) {
-      selectedProject = pageItems[0];
-    }
-    if (id) {
-      selectedProject = pageItems?.find((item) => item.id === id);
-    }
+  const openSelectDialog = useSelectProject();
+  const query = useCallback(async () => {
+    const response = await requestGet<ItemsResponse<Project>>('/api/v2/projects/?page_size=200');
+    return Promise.resolve({
+      total: response.count,
+      values: response.results as FieldPathValue<TFieldValues, Path<TFieldValues>>[],
+    });
+  }, []);
 
-    setValue(name as string, selectedProject?.name);
-    setValue(projectPath as string, selectedProject);
-    setValue(project as string, selectedProject?.id);
-  }, [projectPath, project, id, pageItems, name, setValue]);
   return (
-    <PageFormTextInput<TFieldValues, TFieldName, Project>
-      {...rest}
-      name={name}
+    <PageFormAsyncSelect<TFieldValues, TFieldName>
+      name={props.name}
       label={t('Project')}
-      placeholder={t('Add project')}
-      selectTitle={t('Select a project')}
-      labelHelpTitle={t('Project')}
-      labelHelp={t('Select the project containing the playbook you want this job to execute.')}
-      selectValue={(project: Project) => project.name}
-      selectOpen={selectProject}
-      validate={async (projectName: string) => {
-        try {
-          const itemsResponse = await requestGet<ItemsResponse<Project>>(
-            `/api/v2/projects/?name=${projectName}`
-          );
-          if (itemsResponse.results.length === 0) return t('Job project not found.');
-          if (projectPath) setValue(projectPath, itemsResponse.results[0]);
-          if (project) setValue(project, itemsResponse.results[0].id);
-        } catch (err) {
-          if (err instanceof Error) return err.message;
-          else return 'Unknown error';
+      query={query}
+      valueToString={(value) => {
+        if (value && typeof value === 'string') {
+          return value;
         }
-        return undefined;
+        return (value as Project)?.name ?? '';
       }}
-      isRequired
+      placeholder={t('Select project')}
+      loadingPlaceholder={t('Loading projects...')}
+      loadingErrorText={t('Error loading projects')}
+      isRequired={props.isRequired}
+      limit={200}
+      openSelectDialog={openSelectDialog}
     />
   );
 }

--- a/frontend/awx/resources/projects/hooks/useSelectProject.tsx
+++ b/frontend/awx/resources/projects/hooks/useSelectProject.tsx
@@ -1,39 +1,39 @@
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelectDialog } from '../../../../../framework';
+import { usePageDialog } from '../../../../../framework';
 import { Project } from '../../../interfaces/Project';
 import { useAwxView } from '../../../useAwxView';
 import { useProjectsColumns } from './useProjectsColumns';
 import { useProjectsFilters } from './useProjectsFilters';
+import { SelectSingleDialog } from '../../../../../framework/PageDialogs/SelectSingleDialog';
+import { useCallback } from 'react';
 
-export function useSelectProject(isLookup: boolean) {
-  const { t } = useTranslation();
+function SelectProject(props: { title: string; onSelect: (project: Project) => void }) {
   const toolbarFilters = useProjectsFilters();
   const tableColumns = useProjectsColumns({ disableLinks: true });
-  const columns = useMemo(
-    () =>
-      isLookup
-        ? tableColumns.filter((item) =>
-            ['Name', 'Status', 'Type', 'Organization'].includes(item.header)
-          )
-        : tableColumns,
-    [isLookup, tableColumns]
-  );
   const view = useAwxView<Project>({
     url: '/api/v2/projects/',
     toolbarFilters,
-    tableColumns: columns,
+    tableColumns,
     disableQueryString: true,
   });
-  return {
-    useSelectDialog: useSelectDialog<Project>({
-      toolbarFilters,
-      tableColumns: columns,
-      view,
-      confirm: t('Confirm'),
-      cancel: t('Cancel'),
-      selected: t('Selected'),
-    }),
-    view,
-  };
+  return (
+    <SelectSingleDialog<Project>
+      {...props}
+      toolbarFilters={toolbarFilters}
+      tableColumns={tableColumns}
+      view={view}
+    />
+  );
+}
+
+export function useSelectProject() {
+  const [_, setDialog] = usePageDialog();
+  const { t } = useTranslation();
+  const openSelectInventory = useCallback(
+    (onSelect: (project: Project) => void) => {
+      setDialog(<SelectProject title={t('Select project')} onSelect={onSelect} />);
+    },
+    [setDialog, t]
+  );
+  return openSelectInventory;
 }

--- a/frontend/awx/resources/templates/JobTemplateForm.cy.tsx
+++ b/frontend/awx/resources/templates/JobTemplateForm.cy.tsx
@@ -112,8 +112,18 @@ describe('Create job template ', () => {
     cy.get('button[aria-describedby="job_type-form-group"]').click();
     cy.clickButton(/^Check$/);
     cy.typeInputByLabel(/^Inventory$/, 'Demo Inventory');
-    cy.typeInputByLabel(/^Project$/, 'Demo Project').as('ProjectInput');
-    cy.get('@ProjectInput').blur();
+    cy.contains('.pf-c-form__label-text', /^Project$/)
+      .parent()
+      .parent()
+      .parent()
+      .within(() => {
+        cy.get('button[aria-label="Options menu"]').as('projectField');
+        cy.get('@projectField').click();
+        cy.get('.pf-c-select__menu').within(() => {
+          cy.contains('button', 'Demo Project').click();
+        });
+      });
+
     cy.get('button[aria-describedby="playbook-form-group"]').click();
     cy.clickButton(/^hello_world.yml$/);
     cy.clickButton('Create job template');

--- a/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
+++ b/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
@@ -45,11 +45,13 @@ export function getJobTemplateDefaultValues(
           name: template?.summary_fields?.inventory?.name,
           id: template?.summary_fields?.inventory?.id,
         } || null,
-      project: {
-        name: template?.summary_fields?.project?.name || '',
-        id: template?.summary_fields?.project?.id,
-        organization: template?.summary_fields?.project?.organization,
-      },
+      project: !template?.summary_fields?.project
+        ? null
+        : {
+            name: template?.summary_fields?.project?.name,
+            id: template?.summary_fields?.project?.id,
+            organization: template?.summary_fields?.project?.organization,
+          },
       execution_environment: {
         name: template?.summary_fields?.execution_environment?.name || '',
         id: template?.summary_fields?.execution_environment?.id,
@@ -72,7 +74,7 @@ export function getJobTemplateDefaultValues(
     name: template?.name || '',
     playbook: template?.playbook || '',
     prevent_instance_group_fallback: template?.prevent_instance_group_fallback || false,
-    project: template?.project || null,
+    project: template?.project || undefined,
     scm_branch: template?.scm_branch,
     arrayedSkipTags: template?.arrayedSkipTags ?? [{ value: '', label: '' }],
     skip_tags: '',

--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -25,7 +25,6 @@ function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
   const { t } = useTranslation();
   const { setValue } = useFormContext<JobTemplateForm>();
   const [playbookOptions, setPlaybookOptions] = useState<string[]>();
-  const project = useWatch<JobTemplateForm>({ name: 'project' });
   const projectPath = useWatch({
     name: 'summary_fields.project',
   }) as Project;
@@ -46,15 +45,15 @@ function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
 
   useEffect(() => {
     async function handleFetchPlaybooks() {
-      if (project) {
+      if (projectPath) {
         const playbooks = await requestGet<string[]>(
-          `/api/v2/projects/${project.toString()}/playbooks/`
+          `/api/v2/projects/${projectPath.id.toString()}/playbooks/`
         );
         return setPlaybookOptions(playbooks);
       }
     }
     handleFetchPlaybooks().catch(() => 'there was an error');
-  }, [project, setValue]);
+  }, [projectPath, setValue]);
 
   return (
     <>
@@ -95,9 +94,9 @@ function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
         isRequired={!isInventoryPrompted}
       />
       <PageFormProjectSelect<JobTemplateForm>
-        name="summary_fields.project.name"
+        name="summary_fields.project"
         project="project"
-        projectPath="summary_fields.project"
+        isRequired
       />
 
       <PageFormSelectOption<JobTemplateForm>

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -70,6 +70,7 @@ export function EditJobTemplate() {
       arrayedSkipTags,
       summary_fields: { credentials, labels },
     } = values;
+    values.project = values.summary_fields.project?.id;
     let jobTags = '';
     let skipTags = '';
     if (arrayedJobTags?.length) {
@@ -145,7 +146,7 @@ export function CreateJobTemplate() {
       arrayedSkipTags,
       summary_fields: { credentials = [], labels, webhook_credential },
     } = values;
-
+    values.project = values?.summary_fields?.project?.id;
     let jobTags = '';
     let skipTags = '';
     if (values?.arrayedJobTags?.length) {

--- a/frontend/awx/resources/templates/Templates.tsx
+++ b/frontend/awx/resources/templates/Templates.tsx
@@ -1,12 +1,10 @@
 import { ButtonVariant } from '@patternfly/react-core';
 import { EditIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
   IPageAction,
-  ITableColumn,
-  IToolbarFilter,
   PageActionSelection,
   PageActionType,
   PageHeader,
@@ -15,31 +13,20 @@ import {
 } from '../../../../framework';
 import { RouteObj } from '../../../Routes';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
-import {
-  useCreatedColumn,
-  useDescriptionColumn,
-  useModifiedColumn,
-  useNameColumn,
-  useTypeColumn,
-} from '../../../common/columns';
-import {
-  useCreatedByToolbarFilter,
-  useDescriptionToolbarFilter,
-  useModifiedByToolbarFilter,
-  useNameToolbarFilter,
-} from '../../common/awx-toolbar-filters';
 import { JobTemplate } from '../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../interfaces/WorkflowJobTemplate';
 import { useAwxView } from '../../useAwxView';
 import { useDeleteTemplates } from './hooks/useDeleteTemplates';
 import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
 import { useAwxConfig } from '../../common/useAwxConfig';
+import { useTemplateFilters } from './hooks/useTemplateFilters';
+import { useTemplateColumns } from './hooks/useTemplateColumns';
 
 export function Templates() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const toolbarFilters = useTemplateFilters();
-  const tableColumns = useTemplatesColumns();
+  const tableColumns = useTemplateColumns();
   const view = useAwxView<JobTemplate | WorkflowJobTemplate>({
     url: '/api/v2/unified_job_templates/',
     toolbarFilters,
@@ -138,59 +125,4 @@ export function Templates() {
       />
     </PageLayout>
   );
-}
-
-export function useTemplateFilters() {
-  const nameToolbarFilter = useNameToolbarFilter();
-  const descriptionToolbarFilter = useDescriptionToolbarFilter();
-  const createdByToolbarFilter = useCreatedByToolbarFilter();
-  const modifiedByToolbarFilter = useModifiedByToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [
-      nameToolbarFilter,
-      descriptionToolbarFilter,
-      createdByToolbarFilter,
-      modifiedByToolbarFilter,
-    ],
-    [nameToolbarFilter, descriptionToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
-  );
-  return toolbarFilters;
-}
-
-export function useTemplatesColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
-  const navigate = useNavigate();
-  const { t } = useTranslation();
-  // TODO: URL should be dependant on template type
-  const nameClick = useCallback(
-    (template: JobTemplate | WorkflowJobTemplate) => {
-      if (template.type === 'job_template') {
-        navigate(RouteObj.JobTemplateDetails.replace(':id', template.id.toString()));
-        return;
-      }
-      navigate(RouteObj.WorkflowJobTemplateDetails.replace(':id', template.id.toString()));
-    },
-    [navigate]
-  );
-  const nameColumn = useNameColumn({
-    ...options,
-    onClick: nameClick,
-  });
-  const makeReadable: (template: JobTemplate | WorkflowJobTemplate) => string = (template) => {
-    if (template.type === 'workflow_job_template') {
-      return t('Workflow job template');
-    }
-    return t('Job template');
-  };
-  const createdColumn = useCreatedColumn(options);
-  const descriptionColumn = useDescriptionColumn();
-  const modifiedColumn = useModifiedColumn(options);
-  const typeOfTemplate = useTypeColumn<JobTemplate | WorkflowJobTemplate>({
-    ...options,
-    makeReadable,
-  });
-  const tableColumns = useMemo<ITableColumn<JobTemplate | WorkflowJobTemplate>[]>(
-    () => [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn],
-    [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn]
-  );
-  return tableColumns;
 }

--- a/frontend/awx/resources/templates/hooks/useDeleteTemplates.tsx
+++ b/frontend/awx/resources/templates/hooks/useDeleteTemplates.tsx
@@ -5,13 +5,13 @@ import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
-import { useTemplatesColumns } from '../Templates';
+import { useTemplateColumns } from './useTemplateColumns';
 
 export function useDeleteTemplates(
   onComplete: (templates: (JobTemplate | WorkflowJobTemplate)[]) => void
 ) {
   const { t } = useTranslation();
-  const confirmationColumns = useTemplatesColumns({ disableLinks: true, disableSort: true });
+  const confirmationColumns = useTemplateColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
   const bulkAction = useBulkConfirmation<JobTemplate | WorkflowJobTemplate>();

--- a/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
@@ -1,25 +1,39 @@
 import { useTranslation } from 'react-i18next';
-import { useSelectDialog } from '../../../../../framework';
-import { JobTemplate } from '../../../interfaces/JobTemplate';
+import { SelectSingleDialog } from '../../../../../framework/PageDialogs/SelectSingleDialog';
 import { useAwxView } from '../../../useAwxView';
-import { useTemplateFilters, useTemplatesColumns } from '../Templates';
+import { useTemplateColumns } from './useTemplateColumns';
+import { useTemplateFilters } from './useTemplateFilters';
+import { usePageDialog } from '../../../../../framework';
+import { useCallback } from 'react';
+import { JobTemplate } from '../../../interfaces/JobTemplate';
 
-export function useSelectJobTemplate() {
-  const { t } = useTranslation();
+function SelectJobTemplate(props: { title: string; onSelect: (template: JobTemplate) => void }) {
   const toolbarFilters = useTemplateFilters();
-  const tableColumns = useTemplatesColumns({ disableLinks: true });
+  const tableColumns = useTemplateColumns({ disableLinks: true });
   const view = useAwxView<JobTemplate>({
     url: '/api/v2/job_templates/',
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
-  return useSelectDialog<JobTemplate>({
-    toolbarFilters,
-    tableColumns,
-    view,
-    confirm: t('Confirm'),
-    cancel: t('Cancel'),
-    selected: t('Selected'),
-  });
+  return (
+    <SelectSingleDialog<JobTemplate>
+      {...props}
+      toolbarFilters={toolbarFilters}
+      tableColumns={tableColumns}
+      view={view}
+    />
+  );
+}
+
+export function useSelectJobTemplate() {
+  const [_, setDialog] = usePageDialog();
+  const { t } = useTranslation();
+  const openSelectInventory = useCallback(
+    (onSelect: (template: JobTemplate) => void) => {
+      setDialog(<SelectJobTemplate title={t('Select job template')} onSelect={onSelect} />);
+    },
+    [setDialog, t]
+  );
+  return openSelectInventory;
 }

--- a/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
@@ -1,25 +1,42 @@
 import { useTranslation } from 'react-i18next';
-import { useSelectDialog } from '../../../../../framework';
+import { usePageDialog } from '../../../../../framework';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { useAwxView } from '../../../useAwxView';
-import { useTemplateFilters, useTemplatesColumns } from '../Templates';
+import { useTemplateColumns } from './useTemplateColumns';
+import { useTemplateFilters } from './useTemplateFilters';
+import { SelectSingleDialog } from '../../../../../framework/PageDialogs/SelectSingleDialog';
+import { useCallback } from 'react';
 
-export function useSelectWorkflowJobTemplate() {
-  const { t } = useTranslation();
+function SelectWorkflowJobTemplate(props: {
+  title: string;
+  onSelect: (template: WorkflowJobTemplate) => void;
+}) {
   const toolbarFilters = useTemplateFilters();
-  const tableColumns = useTemplatesColumns({ disableLinks: true });
+  const tableColumns = useTemplateColumns({ disableLinks: true });
   const view = useAwxView<WorkflowJobTemplate>({
-    url: '/api/v2/workflow_job_templates/',
+    url: '/api/v2/job_templates/',
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
-  return useSelectDialog<WorkflowJobTemplate>({
-    toolbarFilters,
-    tableColumns,
-    view,
-    confirm: t('Confirm'),
-    cancel: t('Cancel'),
-    selected: t('Selected'),
-  });
+  return (
+    <SelectSingleDialog<WorkflowJobTemplate>
+      {...props}
+      toolbarFilters={toolbarFilters}
+      tableColumns={tableColumns}
+      view={view}
+    />
+  );
+}
+
+export function useSelectWorkflowJobTemplate() {
+  const [_, setDialog] = usePageDialog();
+  const { t } = useTranslation();
+  const openSelectInventory = useCallback(
+    (onSelect: (template: WorkflowJobTemplate) => void) => {
+      setDialog(<SelectWorkflowJobTemplate title={t('Select job template')} onSelect={onSelect} />);
+    },
+    [setDialog, t]
+  );
+  return openSelectInventory;
 }

--- a/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from 'react-router-dom';
+import { RouteObj } from '../../../../Routes';
+import { useTranslation } from 'react-i18next';
+import { useCallback, useMemo } from 'react';
+import { JobTemplate } from '../../../interfaces/JobTemplate';
+import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
+import {
+  useCreatedColumn,
+  useDescriptionColumn,
+  useModifiedColumn,
+  useNameColumn,
+  useTypeColumn,
+} from '../../../../common/columns';
+import { ITableColumn } from '../../../../../framework';
+
+export function useTemplateColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  // TODO: URL should be dependant on template type
+  const nameClick = useCallback(
+    (template: JobTemplate | WorkflowJobTemplate) => {
+      if (template.type === 'job_template') {
+        navigate(RouteObj.JobTemplateDetails.replace(':id', template.id.toString()));
+        return;
+      }
+      navigate(RouteObj.WorkflowJobTemplateDetails.replace(':id', template.id.toString()));
+    },
+    [navigate]
+  );
+  const nameColumn = useNameColumn({
+    ...options,
+    onClick: nameClick,
+  });
+  const makeReadable: (template: JobTemplate | WorkflowJobTemplate) => string = (template) => {
+    if (template.type === 'workflow_job_template') {
+      return t('Workflow job template');
+    }
+    return t('Job template');
+  };
+  const createdColumn = useCreatedColumn(options);
+  const descriptionColumn = useDescriptionColumn();
+  const modifiedColumn = useModifiedColumn(options);
+  const typeOfTemplate = useTypeColumn<JobTemplate | WorkflowJobTemplate>({
+    ...options,
+    makeReadable,
+  });
+  const tableColumns = useMemo<ITableColumn<JobTemplate | WorkflowJobTemplate>[]>(
+    () => [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn],
+    [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn]
+  );
+  return tableColumns;
+}

--- a/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { IToolbarFilter } from '../../../../../framework';
+import {
+  useCreatedByToolbarFilter,
+  useModifiedByToolbarFilter,
+  useNameToolbarFilter,
+  useDescriptionToolbarFilter,
+} from '../../../common/awx-toolbar-filters';
+
+export function useTemplateFilters() {
+  const nameToolbarFilter = useNameToolbarFilter();
+  const descriptionToolbarFilter = useDescriptionToolbarFilter();
+  const createdByToolbarFilter = useCreatedByToolbarFilter();
+  const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      nameToolbarFilter,
+      descriptionToolbarFilter,
+      createdByToolbarFilter,
+      modifiedByToolbarFilter,
+    ],
+    [nameToolbarFilter, descriptionToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
+  );
+  return toolbarFilters;
+}


### PR DESCRIPTION
We have adopted a slightly different, yet new, convention for form lookups.  This work updates the lookup components for Job Templates, WorkflowJobTemplates, and for Projects, as each of those lookups will be in the schedule form that is up for PR [here](https://github.com/ansible/ansible-ui/pull/635)