### PR TITLE
add debug launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "https://localhost:3002",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "Attach to Chrome",
+      "request": "attach",
+      "type": "chrome",
+      "port": 9222,
+      "urlFilter": "https://localhost:3002/*",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
Adds launch and attach for the debugger.

- Launch opens an anonymous window
  - which means it does not have all your configured servers
    - we will have to look at a plan for solving that
  - should be good when running the UI in a standalone mode
- Attach attaches to an existing tab in Chrome
  - Needs to have chrome launched with remote debugging enabled
    - which is a pain on OSX
   