### PR TITLE
Hub - fix requests failing on cors

### DIFF
--- a/frontend/hub/api.tsx
+++ b/frontend/hub/api.tsx
@@ -44,6 +44,18 @@ export function parsePulpIDFromURL(url: string): string | null {
   return null;
 }
 
+// pulp next links currently include full url - with the wrong server
+// "http://localhost:5001/api/page/next?what#ever" -> "/api/page/next?what#ever"
+// also has to handle hub links (starting with /api/) and undefined
+export function serverlessURL(url?: string) {
+  if (!url || url.startsWith('/')) {
+    return url;
+  }
+
+  const u = new URL(url);
+  return `${u.pathname}${u.search}${u.hash}`;
+}
+
 export function pulpIdKeyFn(item: { pulp_id: string }) {
   return item.pulp_id;
 }

--- a/frontend/hub/api.tsx
+++ b/frontend/hub/api.tsx
@@ -52,8 +52,8 @@ export function serverlessURL(url?: string) {
     return url;
   }
 
-  const u = new URL(url);
-  return `${u.pathname}${u.search}${u.hash}`;
+  const { pathname, search, hash } = new URL(url);
+  return `${pathname}${search}${hash}`;
 }
 
 export function pulpIdKeyFn(item: { pulp_id: string }) {

--- a/frontend/hub/useHubView.tsx
+++ b/frontend/hub/useHubView.tsx
@@ -9,7 +9,7 @@ import {
   useSelected,
   useView,
 } from '../../framework';
-import { QueryParams, getQueryString } from './api';
+import { QueryParams, getQueryString, serverlessURL } from './api';
 import { useFetcher } from '../common/crud/Data';
 
 export interface HubItemsResponse<T extends object> {
@@ -96,7 +96,8 @@ export function useHubView<T extends object>({
   const { data, mutate } = response;
   const refresh = useCallback(() => mutate(), [mutate]);
 
-  useSWR<HubItemsResponse<T>>(data?.links?.next, fetcher, {
+  const nextPage = serverlessURL(data?.links?.next);
+  useSWR<HubItemsResponse<T>>(nextPage, fetcher, {
     dedupingInterval: 0,
   });
 

--- a/frontend/hub/usePulpView.tsx
+++ b/frontend/hub/usePulpView.tsx
@@ -9,7 +9,7 @@ import {
   useSelected,
   useView,
 } from '../../framework';
-import { QueryParams, getQueryString } from './api';
+import { QueryParams, getQueryString, serverlessURL } from './api';
 import { useFetcher } from '../common/crud/Data';
 
 interface PulpItemsResponse<T extends object> {
@@ -91,7 +91,8 @@ export function usePulpView<T extends object>({
   const { data, mutate } = response;
   const refresh = useCallback(() => mutate(), [mutate]);
 
-  useSWR<PulpItemsResponse<T>>(data?.next, fetcher, {
+  const nextPage = serverlessURL(data?.next);
+  useSWR<PulpItemsResponse<T>>(nextPage, fetcher, {
     dedupingInterval: 0,
   });
 


### PR DESCRIPTION
Pulp API returns the links including a hostname & port.. but doesn't know about all the proxies along the way, leading to some requests failing CORS because we're trying to query localhost:5001 instead of localhost:3002.

Fix by only using the path and sticking to the same server host/port.