### PR TITLE
Hub - add hook for settings, feature flags & permissions

### DIFF
--- a/frontend/hub/Hub.tsx
+++ b/frontend/hub/Hub.tsx
@@ -2,11 +2,14 @@ import { Page } from '@patternfly/react-core';
 import { AnsibleMasthead } from '../common/Masthead';
 import { HubRouter } from './HubRouter';
 import { HubSidebar } from './HubSidebar';
+import { HubContextProvider } from './useHubContext';
 
 export function Hub() {
   return (
     <Page header={<AnsibleMasthead />} sidebar={<HubSidebar />}>
-      <HubRouter />
+      <HubContextProvider>
+        <HubRouter />
+      </HubContextProvider>
     </Page>
   );
 }

--- a/frontend/hub/useHubContext.tsx
+++ b/frontend/hub/useHubContext.tsx
@@ -1,0 +1,138 @@
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import { LoadingPage } from '../../framework/components/LoadingPage';
+import { useGet } from '../common/crud/useGet';
+import { hubAPI } from './api';
+
+type HubFeatureFlags = {
+  // execution environments
+  container_signing: boolean;
+  execution_environments: boolean;
+
+  // keycloak login screen
+  external_authentication: boolean;
+
+  // community mode
+  ai_deny_index: boolean;
+  display_repositories: boolean;
+  legacy_roles: boolean;
+
+  // collection signing
+  can_create_signatures: boolean;
+  can_upload_signatures: boolean;
+  collection_auto_sign: boolean;
+  collection_signing: boolean;
+  display_signatures: boolean;
+  require_upload_signatures: boolean;
+  signatures_enabled: boolean;
+
+  // errors
+  _messages: string[];
+};
+
+type HubSettings = {
+  GALAXY_AUTO_SIGN_COLLECTIONS: boolean;
+  GALAXY_COLLECTION_SIGNING_SERVICE: string;
+  GALAXY_CONTAINER_SIGNING_SERVICE: string;
+  GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: boolean;
+  GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD: boolean;
+  GALAXY_MINIMUM_PASSWORD_LENGTH: number | null;
+  GALAXY_REQUIRE_CONTENT_APPROVAL: boolean;
+  GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL: boolean;
+  GALAXY_SIGNATURE_UPLOAD_ENABLED: boolean;
+  GALAXY_TOKEN_EXPIRATION: number | null;
+};
+
+type HubPermissions = {
+  [key: string]: {
+    global_description: string;
+    has_model_permission: boolean;
+    name: string;
+    object_description: string;
+    ui_category: string;
+  };
+};
+
+type HubGroup = {
+  id: number;
+  name: string;
+  object_roles?: string[];
+};
+
+type HubUser = {
+  auth_provider: string[];
+  date_joined: string;
+  email: string;
+  first_name: string;
+  groups: HubGroup[];
+  id: number;
+  is_anonymous: boolean;
+  is_superuser: boolean;
+  last_name: string;
+  model_permissions: HubPermissions;
+  username: string;
+};
+
+export type HubContext = {
+  featureFlags: HubFeatureFlags;
+  hasPermission: (name: string) => boolean;
+  settings: HubSettings;
+  user: HubUser;
+};
+
+const HubContext = createContext<HubContext>(null);
+
+export const useHubContext = (): HubContext => useContext(HubContext);
+
+export const HubContextProvider = ({ children }: { children: ReactNode }) => {
+  const getFeatureFlags = useGet(hubAPI`/_ui/v1/feature-flags/`);
+  const getSettings = useGet(hubAPI`/_ui/v1/settings/`);
+  const getUser = useGet(hubAPI`/_ui/v1/me/`);
+
+  const [context, setContext] = useState<HubContext>(null);
+
+  useEffect(() => {
+    if (getFeatureFlags.isLoading || getSettings.isLoading || getUser.isLoading) {
+      return;
+    }
+
+    setContext({
+      errors: [
+        getFeatureFlags.error,
+        getSettings.error,
+        getUser.error,
+        ...(getFeatureFlags.data?._messages || []),
+      ].filter(Boolean),
+      feature_flags: getFeatureFlags.data,
+      settings: getSettings.data,
+      user: getUser.data,
+    });
+  }, [getFeatureFlags.isLoading, getSettings.isLoading, getUser.isLoading]);
+
+  return context ? (
+    <HubContext.Provider
+      value={{
+        ...context,
+        hasPermission: hasPermission(context),
+      }}
+    >
+      {children}
+    </HubContext.Provider>
+  ) : (
+    <LoadingPage />
+  );
+};
+
+const hasPermission =
+  ({ user }: HubContext) =>
+  (name) => {
+    if (!user?.model_permissions) {
+      return false;
+    }
+
+    if (!user.model_permissions[name]) {
+      console.error(`Unknown permission ${name}`);
+      return !!user.is_superuser;
+    }
+
+    return !!user.model_permissions[name].has_model_permission;
+  };


### PR DESCRIPTION
Ensures all Hub pages have a context with settings, feature flags & permissions available.

(This makes it possible to do permission checking and feature flag checking in the hub portion of code. It doesn't attempt to add anything using it, and it does not attempt to bring this all the way to HubSidebar yet.)

---

Example usage:

```diff
--- a/frontend/hub/namespaces/HubNamespaceDetails.tsx
+++ b/frontend/hub/namespaces/HubNamespaceDetails.tsx
@@ -10,8 +10,11 @@ import { useHubNamespaceActions } from './hooks/useHubNamespaceActions';
 import { useHubNamespacesColumns } from './hooks/useHubNamespacesColumns';
 import { DropdownPosition } from '@patternfly/react-core';
 import { hubAPI } from '../api';
+import { useHubContext } from '../useHubContext';
+import { EmptyStateUnauthorized } from '../../../framework/components/EmptyStateUnauthorized';
 
 export function NamespaceDetails() {
+  const { hasPermission } = useHubContext();
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data } = useGet<HubItemsResponse<HubNamespace>>(
@@ -23,6 +26,11 @@ export function NamespaceDetails() {
   }
 
   const pageActions = useHubNamespaceActions();
+
+  if (!hasPermission('ansible.add_ansiblerepository')) {
+    return <EmptyStateUnauthorized />;
+  }
+
   return (
     <PageLayout>
       <PageHeader
```

Provides `user`, `featureFlags`, `settings`, `hasPermission`, and `errors`.
(leaving a TODO for later - expose errors in a toast if any)
(and possibly TODO more logic around errors and empty states)