### PR TITLE
Job output websockets

### DIFF
--- a/frontend/awx/common/useAwxWebSocket.tsx
+++ b/frontend/awx/common/useAwxWebSocket.tsx
@@ -80,7 +80,7 @@ export function WebSocketProvider(props: { children?: ReactNode }) {
 }
 
 export function useAwxWebSocketSubscription(
-  events: { [group: string]: string[] },
+  events: { [group: string]: string[] | number[] },
   onMessage: (message: unknown) => void
 ) {
   const [evts] = useState(() => events);

--- a/frontend/awx/views/jobs/JobOutput/HostStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/HostStatusBar.tsx
@@ -13,7 +13,7 @@ import type { HostStatusCounts } from '../../../interfaces/Job';
 const BarWrapper = styled.div`
   background-color: var(--pf-global--Color--light-300);
   display: flex;
-  height: 7px;
+  min-height: 7px;
   margin-top: 16px;
   margin-bottom: 8px;
   width: 100%;

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.css
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.css
@@ -5,10 +5,10 @@
   grid-template-columns: minmax(var(--output-line-column-width), auto) 1fr;
   overflow-x: auto;
   background-color: var(--pf-global--BackgroundColor--100);
+}
 
-  .pf-theme-dark & {
-    background-color: var(--pf-global--BackgroundColor--200);
-  }
+.pf-theme-dark .output-grid {
+  background-color: var(--pf-global--BackgroundColor--200);
 }
 
 .output-grid-row {

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -1,6 +1,4 @@
 import { useMemo, useRef, useState } from 'react';
-import { Banner } from '@patternfly/react-core';
-import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Job } from '../../../interfaces/Job';
 import './JobOutput.css';
@@ -34,7 +32,6 @@ interface IJobOutputEventsProps {
 }
 
 export function JobOutputEvents(props: IJobOutputEventsProps) {
-  const { t } = useTranslation();
   const { job, toolbarFilters, filters } = props;
   // TODO set job status on ws event change
   const isJobRunning = !job.status || runningJobTypes.includes(job.status);
@@ -97,25 +94,6 @@ export function JobOutputEvents(props: IJobOutputEventsProps) {
 
   return (
     <>
-      {/* <PageSection variant="light">
-        <LabelGroup numLabels={999}>
-          <Label variant="outline">Event Count: {jobEventCount}</Label>
-          <Label variant="outline">Row Count: {jobOutputRows.length}</Label>
-          <Label variant="outline">Visible Row Count: {visibleItems.length}</Label>
-          <Label variant="outline">Before Spacing: {beforeRowsHeight}px</Label>
-          <Label variant="outline">After Spacing: {afterRowsHeight}px</Label>
-        </LabelGroup>
-      </PageSection>
-      <Divider /> */}
-      {isJobRunning ? (
-        <Banner variant="warning">
-          <p>
-            {t(
-              'This job is currently running. Live event streaming has not been added yet to the tech preview.'
-            )}
-          </p>
-        </Banner>
-      ) : null}
       <ScrollContainer
         ref={containerRef}
         tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex

--- a/frontend/awx/views/jobs/JobOutput/JobOutputLoadingRow.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputLoadingRow.tsx
@@ -6,7 +6,10 @@ export function JobOutputLoadingRow(props: {
   counter: number;
   queryJobOutputEvent: (counter: number) => void;
 }) {
-  useEffect(() => props.queryJobOutputEvent(props.counter), [props]);
+  useEffect(() => {
+    props.queryJobOutputEvent(props.counter);
+  }, [props]);
+
   return (
     <div className="output-grid-row">
       <div className="expand-column"></div>

--- a/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
@@ -79,10 +79,12 @@ export function useJobOutput(
             const eventCounters = Object.keys(missingEvents.current).filter((counter) => {
               return !jobEvents[Number(counter)];
             });
-            const qsParts = ['order_by=counter', `counter__in=${eventCounters.join(',')}`];
+            if (eventCounters.length > 0) {
+              const qsParts = ['order_by=counter', `counter__in=${eventCounters.join(',')}`];
+              fetchEvents(qsParts);
+            }
             missingEvents.current = {};
             queryTimeout.current = undefined;
-            fetchEvents(qsParts);
           }, 2500);
         }
         return jobEvent;

--- a/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
@@ -1,8 +1,16 @@
 import { useCallback, useRef, useState, useEffect } from 'react';
 import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { useAwxWebSocketSubscription } from '../../../common/useAwxWebSocket';
 import { Job } from '../../../interfaces/Job';
 import { JobEvent } from '../../../interfaces/JobEvent';
 import type { IToolbarFilter } from '../../../../../framework';
+
+type WebSocketMessage = {
+  group_name?: string;
+  type?: string;
+  status?: string;
+  inventory_id?: number;
+};
 
 export function useJobOutput(
   job: Job,
@@ -16,9 +24,9 @@ export function useJobOutput(
 
   const getJobOutputEvent = useCallback((counter: number) => jobEvents[counter + 1], [jobEvents]);
 
+  const isFiltered = Object.keys(filters).length > 0;
   const queryJobOutputEvent = useCallback(
     (counter: number) => {
-      const isFiltered = Object.keys(filters).length > 0;
       const jobEvent = jobEvents[counter + 1];
       if (!jobEvent && !isQuerying.current.querying) {
         isQuerying.current.querying = true;
@@ -57,7 +65,64 @@ export function useJobOutput(
       }
       return jobEvent;
     },
-    [job.id, job.type, jobEvents, pageSize, filters, toolbarFilters]
+    [job.id, job.type, jobEvents, pageSize, filters, toolbarFilters, isFiltered]
+  );
+
+  const batchedEvents = useRef([] as JobEvent[]);
+  const batchTimeout = useRef(undefined as ReturnType<typeof setTimeout> | undefined);
+  const addBatchedEvents = useCallback(() => {
+    if (isFiltered) {
+      console.log('is filtered');
+      return;
+    }
+    console.log('adding', batchedEvents.current);
+    const newCount = jobEventCount + batchedEvents.current.length;
+    setJobEvents((jobEvents) => {
+      batchedEvents.current.forEach((message: JobEvent) => {
+        jobEvents[message.counter] = message;
+      });
+      batchedEvents.current = [];
+      return jobEvents;
+    });
+    setJobEventCount(newCount);
+  }, [isFiltered, jobEventCount]);
+
+  const eventGroup = `${job.type}_events`;
+  const handleWebSocketMessage = useCallback(
+    (message?: WebSocketMessage) => {
+      if (message?.group_name === eventGroup) {
+        const jobEvent = message as JobEvent;
+        // setJobEvents((jobEvents) => {
+        //   jobEvents = { ...jobEvents };
+        //   let i = Object.keys(jobEvents).length + 1;
+        //   if (isFiltered) {
+        //     jobEvents[i] = jobEvent;
+        //     i++;
+        //   } else {
+        //     jobEvents[jobEvent.counter] = jobEvent;
+        //   }
+        //   return jobEvents;
+        // });
+        // setJobEventCount((jobEventCount) => Math.max(jobEventCount, jobEvent.counter));
+        batchedEvents.current.push(jobEvent);
+        clearTimeout(batchTimeout.current);
+        if (batchedEvents.current.length >= 10) {
+          console.log('10 events batched, adding...');
+          addBatchedEvents();
+        } else {
+          batchTimeout.current = setTimeout(addBatchedEvents, 500);
+        }
+      }
+    },
+    [addBatchedEvents, eventGroup]
+  );
+  useAwxWebSocketSubscription(
+    {
+      control: ['limit_reached_1'],
+      jobs: ['summary', 'status_changed'],
+      [eventGroup]: [job.id],
+    },
+    handleWebSocketMessage as (message: unknown) => void
   );
 
   useEffect(() => {


### PR DESCRIPTION
Add live job events to job output screen from websocket messages.

* websocket events are added to the jobEvents object
* missing/skipped event indexes are tracked in a `missingEvents` object
* after a 2.5 second delay, any missing events that the UI attempts to render (still haven't come in via websockets) are fetched via API to fill in the gaps