### PR TITLE
webpack.config: disable istanbul in development

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -41,7 +41,6 @@ module.exports = function (env, argv) {
           test: /\.(ts|tsx|js|jsx)$/,
           exclude: /node_modules/,
           use: [
-            isDevelopment && 'coverage-istanbul-loader',
             {
               loader: 'babel-loader',
               options: {


### PR DESCRIPTION
This is still enabled in cypress.config for tests,

but in dev mode, istanbul instrumentation breaks chrome console debugging, disabling.