### PR TITLE
webpack.config: don't watch vim swapfiles

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -163,6 +163,10 @@ module.exports = function (env, argv) {
       },
     },
     devtool: isProduction ? 'source-map' : 'eval-source-map',
+    watchOptions: {
+      // ignore editor files when watching
+      ignored: ['**/.*.sw[po]'],
+    },
   };
   return config;
 };


### PR DESCRIPTION
Webpack: don't try to rebuild when vim updates swapfiles.