### PR TITLE
[AAP-12159] Make the project SCM type field disabled in create/edit project pages

### DIFF
--- a/frontend/eda/Resources/projects/EditProject.tsx
+++ b/frontend/eda/Resources/projects/EditProject.tsx
@@ -41,7 +41,8 @@ function ProjectCreateInputs() {
       />
       <PageFormTextInput
         name="type"
-        isReadOnly={true}
+        aria-disabled={true}
+        isDisabled={true}
         label={t('SCM type')}
         placeholder={t('Git')}
         labelHelpTitle={t('SCM type')}
@@ -98,7 +99,8 @@ function ProjectEditInputs() {
       />
       <PageFormTextInput
         name="type"
-        isReadOnly={true}
+        aria-disabled={true}
+        isDisabled={true}
         label={t('SCM type')}
         placeholder={t('Git')}
       />


### PR DESCRIPTION
Make the project SCM type field disabled in create/edit project pages

![Screenshot from 2023-06-30 15-32-21](https://github.com/ansible/ansible-ui/assets/12769982/0e4310c9-bf04-4844-bc8f-b156d651d454)
