### PR TITLE
[AAP-12147] Add clipboard copy to the git hash field in the rulebook activation details page

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -1,4 +1,10 @@
-import { DropdownPosition, PageSection, Skeleton, Stack } from '@patternfly/react-core';
+import {
+  ClipboardCopy,
+  DropdownPosition,
+  PageSection,
+  Skeleton,
+  Stack,
+} from '@patternfly/react-core';
 import { CubesIcon, RedoIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -191,7 +197,9 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
               <StatusCell status={rulebookActivation?.status || ''} />
             </PageDetail>
             <PageDetail label={t('Project git hash')}>
-              {rulebookActivation?.project?.git_hash || ''}
+              <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+                {rulebookActivation?.project?.git_hash || ''}
+              </ClipboardCopy>
             </PageDetail>
             <PageDetail label={t('Number of rules')}>
               {rulebookActivation?.rules_count || 0}


### PR DESCRIPTION
Add clipboard copy to the git hash field in the rulebook activation details page.
![Screenshot from 2023-06-30 16-44-22](https://github.com/ansible/ansible-ui/assets/12769982/40fdbc98-79eb-450e-aff1-86da470752f7)
