### PR TITLE
Framework component to reorder items (with selections)

### DIFF
--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -10,7 +10,6 @@ import {
 } from '@patternfly/react-table';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import React, { ReactNode, useRef, useState } from 'react';
-import { idKeyFn } from '../../frontend/hub/api';
 
 type ReorderItemsProps<T extends object> = {
   /** Array of columns */
@@ -18,20 +17,23 @@ type ReorderItemsProps<T extends object> = {
     header: string;
     cell: (item: T) => ReactNode | string;
   }[];
-  /** Array of items */
+  /** Array of items that can be reordered */
   items: T[];
-  /** A function that gets a unique key for each item. */
+  /** A function that gets a unique key for each item */
   keyFn: (item: T) => string | number;
+  /** Callback function to process items with the updated order */
   onSave?: (items: string[]) => void;
+  /** Setting to show the table with the `compact` variant and without borders for rows */
   isCompactBorderless?: boolean;
-  isSingleColumnList?: boolean;
+  /** Setting to hide column headers */
+  hideColumnHeaders?: boolean;
 };
 
 /**
  * Component to reorder items in a list by dragging items to a desired position
  */
 export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
-  const { columns, items, isCompactBorderless, isSingleColumnList, keyFn } = props;
+  const { columns, items, isCompactBorderless, hideColumnHeaders, keyFn } = props;
   const [listItems, setListItems] = useState([...items]);
   const [itemStartIndex, setStartItemIndex] = useState<number | null>(null);
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
@@ -141,7 +143,7 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
       variant={isCompactBorderless ? 'compact' : undefined}
       borders={!isCompactBorderless}
     >
-      {isSingleColumnList ? null : (
+      {hideColumnHeaders ? null : (
         <Thead>
           <Tr>
             <Th />

--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -22,7 +22,7 @@ type ReorderItemsProps<T extends object> = {
   /** A function that gets a unique key for each item */
   keyFn: (item: T) => string | number;
   /** Callback function to process items with the updated order */
-  onSave?: (items: string[]) => void;
+  onSave: (items: T[]) => void;
   /** Setting to show the table with the `compact` variant and without borders for rows */
   isCompactBorderless?: boolean;
   /** Setting to hide column headers */
@@ -33,7 +33,7 @@ type ReorderItemsProps<T extends object> = {
  * Component to reorder items in a list by dragging items to a desired position
  */
 export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
-  const { columns, items, isCompactBorderless, hideColumnHeaders, keyFn } = props;
+  const { columns, items, isCompactBorderless, hideColumnHeaders, keyFn, onSave } = props;
   const [listItems, setListItems] = useState([...items]);
   const [itemStartIndex, setStartItemIndex] = useState<number | null>(null);
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
@@ -90,6 +90,7 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
       if (newDraggedItemIndex !== itemStartIndex && draggedItemId) {
         const tempItemOrder = moveItem([...listItems], draggedItemId, newDraggedItemIndex);
         setListItems(tempItemOrder);
+        onSave(tempItemOrder);
       }
     }
     return null;

--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -1,0 +1,186 @@
+import {
+  TableComposable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TbodyProps,
+  TrProps,
+} from '@patternfly/react-table';
+import { v4 } from 'uuid';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+import React, { ReactNode, useRef, useState } from 'react';
+
+type ReorderItemsProps<T extends { uuid?: string }> = {
+  /** Array of columns */
+  columns: {
+    header: string;
+    cell: (item: T) => ReactNode | string;
+  }[];
+  /** Array of items */
+  items: T[];
+  // /** A function that gets a unique key for each item. */
+  // keyFn: (item: T) => string | number;
+  onSave?: (items: string[]) => void;
+  isCompactBorderless?: boolean;
+  isSingleColumnList?: boolean;
+};
+
+/**
+ * Component to reorder items in a list by dragging items to a desired position
+ */
+export function ReorderItems<T extends { uuid?: string }>(props: ReorderItemsProps<T>) {
+  const { columns, items, isCompactBorderless, isSingleColumnList } = props;
+  const [listItems, setListItems] = useState([...items]);
+  const [itemStartIndex, setStartItemIndex] = useState<number | null>(null);
+  const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const addUUIDToRows = (allData: T[]) => {
+    return allData.map((item) => ({ ...item, uuid: v4() }));
+  };
+
+  React.useEffect(() => {
+    setListItems(addUUIDToRows(listItems));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const bodyRef = useRef<HTMLTableSectionElement>(null);
+
+  const isValidDrop = (evt: React.DragEvent<HTMLTableSectionElement | HTMLTableRowElement>) => {
+    if (bodyRef.current) {
+      const ulRect = bodyRef.current.getBoundingClientRect();
+      return (
+        evt.clientX > ulRect.x &&
+        evt.clientX < ulRect.x + ulRect.width &&
+        evt.clientY > ulRect.y &&
+        evt.clientY < ulRect.y + ulRect.height
+      );
+    }
+    return false;
+  };
+
+  const onDrop: TrProps['onDrop'] = (evt) => {
+    if (!isValidDrop(evt)) {
+      onDragCancel();
+    }
+  };
+
+  const onDragCancel = () => {
+    if (bodyRef.current) {
+      Array.from(bodyRef.current.children).forEach((el) => {
+        el.classList.remove(styles.modifiers.ghostRow);
+        el.setAttribute('aria-pressed', 'false');
+      });
+    }
+    setDraggedItemId(null);
+    setStartItemIndex(null);
+    setIsDragging(false);
+  };
+
+  const onDragOver: TbodyProps['onDragOver'] = (evt) => {
+    evt.preventDefault();
+
+    const curListItem = (evt.target as HTMLTableSectionElement).closest('tr');
+    if (
+      !curListItem ||
+      !(bodyRef.current && bodyRef.current.contains(curListItem)) ||
+      curListItem.id === draggedItemId
+    ) {
+      return null;
+    } else {
+      const dragId = curListItem.id;
+      const newDraggedItemIndex = Array.from(bodyRef.current.children).findIndex(
+        (item) => item.id === dragId
+      );
+      if (newDraggedItemIndex !== itemStartIndex && draggedItemId) {
+        const tempItemOrder = moveItem([...listItems], draggedItemId, newDraggedItemIndex);
+        setListItems(tempItemOrder);
+      }
+    }
+    return null;
+  };
+
+  const moveItem = (arr: T[], itemId: string, toIndex: number) => {
+    const fromIndex = arr.findIndex((item) => item.uuid === itemId);
+
+    if (fromIndex === toIndex) {
+      return arr;
+    }
+    const temp = arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, temp[0]);
+
+    return arr;
+  };
+
+  const onDragLeave: TbodyProps['onDragLeave'] = (evt) => {
+    if (!isValidDrop(evt)) {
+      setStartItemIndex(null);
+    }
+  };
+
+  const onDragEnd: TrProps['onDragEnd'] = (evt) => {
+    const target = evt.target as HTMLTableRowElement;
+    target.classList.remove(styles.modifiers.ghostRow);
+    target.setAttribute('aria-pressed', 'false');
+    setDraggedItemId(null);
+    setStartItemIndex(null);
+    setIsDragging(false);
+  };
+
+  const onDragStart: TrProps['onDragStart'] = (evt) => {
+    if (bodyRef.current) {
+      evt.dataTransfer.effectAllowed = 'move';
+      const newDraggedItemId = evt.currentTarget.id;
+
+      const originalStartIndex = Array.from(bodyRef.current.children).findIndex(
+        (item) => item.id === evt.currentTarget.id
+      );
+      evt.currentTarget.setAttribute('aria-pressed', 'true');
+      setDraggedItemId(newDraggedItemId);
+      setStartItemIndex(originalStartIndex);
+    }
+  };
+
+  return (
+    <TableComposable
+      // aria-label="Draggable table"
+      className={isDragging ? styles.modifiers.dragOver : ''}
+      variant={isCompactBorderless ? 'compact' : undefined}
+      borders={!isCompactBorderless}
+    >
+      {isSingleColumnList ? null : (
+        <Thead>
+          <Tr>
+            <Th />
+            {columns.map((column, columnIndex) => (
+              <Th key={columnIndex}>{column.header}</Th>
+            ))}
+          </Tr>
+        </Thead>
+      )}
+      <Tbody ref={bodyRef} onDragOver={onDragOver} onDragLeave={onDragLeave}>
+        {listItems.map((listItem) => (
+          <Tr
+            key={listItem.uuid}
+            id={listItem.uuid}
+            draggable
+            onDrop={onDrop}
+            onDragEnd={onDragEnd}
+            onDragStart={onDragStart}
+          >
+            <Td
+              draggableRow={{
+                id: `draggable-row-${listItem.uuid as string}`,
+              }}
+            />
+            {columns.map((column, columnIndex) => (
+              <Td key={`${listItem.uuid as string}_${columnIndex}`}>{column.cell(listItem)}</Td>
+            ))}
+          </Tr>
+        ))}
+      </Tbody>
+    </TableComposable>
+  );
+}

--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-table';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import React, { ReactNode, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type ReorderItemsProps<T extends object> = {
   /** Array of columns */
@@ -38,6 +39,7 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
   const [itemStartIndex, setStartItemIndex] = useState<number | null>(null);
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const { t } = useTranslation();
 
   const bodyRef = useRef<HTMLTableSectionElement>(null);
 
@@ -139,7 +141,7 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
 
   return (
     <TableComposable
-      // aria-label="Draggable table"
+      aria-label={t(`Table with draggable rows`)}
       className={isDragging ? styles.modifiers.dragOver : ''}
       variant={isCompactBorderless ? 'compact' : undefined}
       borders={!isCompactBorderless}

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   PageActionType,
   PageActions,
   PageDashboard,
+  PageDashboardCard,
   PageHeader,
   PageLayout,
 } from '../../../framework';
@@ -18,6 +19,7 @@ import { useExecutionEnvironments } from '../execution-environments/hooks/useExe
 import { useHubNamespaces } from '../namespaces/hooks/useHubNamespaces';
 import { HubGettingStartedCard } from './HubGettingStarted';
 import { PageDashboardCarousel } from '../../../framework/PageDashboard/PageDashboardCarousel';
+import { ReorderItems } from '../../../framework/components/ReorderItems';
 
 export function HubDashboard() {
   const { t } = useTranslation();
@@ -32,6 +34,49 @@ export function HubDashboard() {
   const hasCollection = (collections?.length ?? 0) > 0;
   const hasExecutionEnvironment = (environments?.length ?? 0) > 0;
   const hasNamespace = (namespaces?.length ?? 0) > 0;
+
+  type Item = { [key: string]: string };
+  const columns = [
+    {
+      header: 'IDs',
+      cell: (item: Item) => item.id,
+    },
+    {
+      header: 'Repositories',
+      cell: (item: Item) => item.repository,
+    },
+    {
+      header: 'Branches',
+      cell: (item: Item) => item.branch,
+    },
+  ];
+  const items: Item[] = [
+    {
+      id: 'row1',
+      repository: 'one',
+      branch: 'two',
+    },
+    {
+      id: 'row2',
+      repository: 'one -2',
+      branch: 'two',
+    },
+    {
+      id: 'row3',
+      repository: 'one - 3',
+      branch: 'two - 3',
+    },
+    {
+      id: 'row4',
+      repository: 'one - 4',
+      branch: 'two - 4',
+    },
+    {
+      id: 'row5',
+      repository: 'one - 5',
+      branch: 'two - 5',
+    },
+  ];
 
   return (
     <PageLayout>
@@ -128,6 +173,11 @@ export function HubDashboard() {
             <CardBody>Card 3</CardBody>
           </Card>
         </PageDashboardCarousel>
+        <PageDashboardCard title="Reorder" width="xxl">
+          <CardBody>
+            <ReorderItems columns={columns} items={items} />
+          </CardBody>
+        </PageDashboardCard>
       </PageDashboard>
     </PageLayout>
   );

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -7,9 +7,9 @@ import {
   PageActionType,
   PageActions,
   PageDashboard,
-  PageDashboardCard,
   PageHeader,
   PageLayout,
+  usePageDialog,
 } from '../../../framework';
 import { PageDashboardCountBar } from '../../../framework/PageDashboard/PageDashboardCountBar';
 import { LoadingPage } from '../../../framework/components/LoadingPage';
@@ -19,13 +19,14 @@ import { useExecutionEnvironments } from '../execution-environments/hooks/useExe
 import { useHubNamespaces } from '../namespaces/hooks/useHubNamespaces';
 import { HubGettingStartedCard } from './HubGettingStarted';
 import { PageDashboardCarousel } from '../../../framework/PageDashboard/PageDashboardCarousel';
-import { ReorderItems } from '../../../framework/components/ReorderItems';
+import { ManageView } from './ManageView';
 
 export function HubDashboard() {
   const { t } = useTranslation();
   const namespaces = useHubNamespaces();
   const collections = useCollections();
   const environments = useExecutionEnvironments();
+  const [_, setDialog] = usePageDialog();
 
   if (!namespaces) {
     return <LoadingPage />;
@@ -34,52 +35,6 @@ export function HubDashboard() {
   const hasCollection = (collections?.length ?? 0) > 0;
   const hasExecutionEnvironment = (environments?.length ?? 0) > 0;
   const hasNamespace = (namespaces?.length ?? 0) > 0;
-
-  type Item = { [key: string]: string };
-  const columns = [
-    {
-      header: 'IDs',
-      cell: (item: Item) => item.id,
-    },
-    {
-      header: 'Repositories',
-      cell: (item: Item) => item.repository,
-    },
-    {
-      header: 'Branches',
-      cell: (item: Item) => item.branch,
-    },
-  ];
-  const items: Item[] = [
-    {
-      id: 'row1',
-      repository: 'one',
-      branch: 'two',
-    },
-    {
-      id: 'row2',
-      repository: 'one -2',
-      branch: 'two',
-    },
-    {
-      id: 'row3',
-      repository: 'one - 3',
-      branch: 'two - 3',
-    },
-    {
-      id: 'row4',
-      repository: 'one - 4',
-      branch: 'two - 4',
-    },
-    {
-      id: 'row5',
-      repository: 'one - 5',
-      branch: 'two - 5',
-    },
-  ];
-  const getItemKey = (item: Item) => {
-    return item.id.toString();
-  };
 
   return (
     <PageLayout>
@@ -102,7 +57,9 @@ export function HubDashboard() {
                 label: 'Manage View',
                 type: PageActionType.Button,
                 selection: PageActionSelection.None,
-                onClick: () => alert('TODO'),
+                onClick: () => {
+                  setDialog(<ManageView />);
+                },
               },
             ]}
             position={DropdownPosition.right}
@@ -176,11 +133,6 @@ export function HubDashboard() {
             <CardBody>Card 3</CardBody>
           </Card>
         </PageDashboardCarousel>
-        <PageDashboardCard title="Reorder" width="xxl">
-          <CardBody>
-            <ReorderItems columns={columns} items={items} keyFn={getItemKey} />
-          </CardBody>
-        </PageDashboardCard>
       </PageDashboard>
     </PageLayout>
   );

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -77,6 +77,9 @@ export function HubDashboard() {
       branch: 'two - 5',
     },
   ];
+  const getItemKey = (item: Item) => {
+    return item.id.toString();
+  };
 
   return (
     <PageLayout>
@@ -175,7 +178,7 @@ export function HubDashboard() {
         </PageDashboardCarousel>
         <PageDashboardCard title="Reorder" width="xxl">
           <CardBody>
-            <ReorderItems columns={columns} items={items} />
+            <ReorderItems columns={columns} items={items} keyFn={getItemKey} />
           </CardBody>
         </PageDashboardCard>
       </PageDashboard>

--- a/frontend/hub/dashboard/ManageView.tsx
+++ b/frontend/hub/dashboard/ManageView.tsx
@@ -13,7 +13,7 @@ export function ManageView() {
   const { t } = useTranslation();
   const [_, setDialog] = usePageDialog();
   /** TODO: Since this is mock data for demonstration purposes, we will need to update the columns
-   * and collectionCategories when the API for fetching collection-categories becomes available.
+   * collectionCategories, and defaultSelection when the API for fetching collection-categories becomes available.
    */
   type Category = { id: string; name: string };
   const columns = [
@@ -44,6 +44,7 @@ export function ManageView() {
       name: t('System collections'),
     },
   ];
+  const defaultSelection = collectionCategories.slice(0, 2);
   const [updatedOrder, setUpdatedOrder] = useState<Category[]>(collectionCategories);
   const [selectedCategories, setSelectedCategories] = useState<Category[]>([]);
 
@@ -64,8 +65,6 @@ export function ManageView() {
     console.log('🚀 ~ file: ManageView.tsx: selectedCategories: ', selectedCategories);
     onClose();
   };
-
-  // const ref = useRef();
 
   return (
     <Modal
@@ -90,17 +89,17 @@ export function ManageView() {
     >
       <ContainerDiv>
         <ReorderItems
-          // ref={ref}
           columns={columns}
           items={collectionCategories}
           keyFn={getItemKey}
-          onSave={(reorderedItems, selectedItems) => {
+          onChange={(reorderedItems, selectedItems) => {
             setUpdatedOrder(reorderedItems);
             setSelectedCategories(selectedItems);
           }}
           isCompactBorderless
           hideColumnHeaders
           isSelectableWithCheckbox
+          defaultSelection={defaultSelection}
         />
       </ContainerDiv>
     </Modal>

--- a/frontend/hub/dashboard/ManageView.tsx
+++ b/frontend/hub/dashboard/ManageView.tsx
@@ -1,0 +1,99 @@
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { usePageDialog } from '../../../framework';
+import { useCallback, useState } from 'react';
+import { ReorderItems } from '../../../framework/components/ReorderItems';
+import styled from 'styled-components';
+
+const ContainerDiv = styled.div`
+  margin-top: 16px;
+`;
+
+export function ManageView() {
+  const { t } = useTranslation();
+  const [_, setDialog] = usePageDialog();
+  /** TODO: Since this is mock data for demonstration purposes, we will need to update the columns
+   * and collectionCategories when the API for fetching collection-categories becomes available.
+   */
+  type Category = { id: string; name: string };
+  const columns = [
+    {
+      header: t('Categories of collections'),
+      cell: (item: Category) => item.name,
+    },
+  ];
+  const collectionCategories: Category[] = [
+    {
+      id: 'owner',
+      name: t('My collections'),
+    },
+    {
+      id: 'featured',
+      name: t('Featured collections'),
+    },
+    {
+      id: 'eda',
+      name: t('Event-Driven Ansible content'),
+    },
+    {
+      id: 'storage',
+      name: t('Storage collections'),
+    },
+    {
+      id: 'system',
+      name: t('System collections'),
+    },
+  ];
+  const [updatedOrder, setUpdatedOrder] = useState<Category[]>(collectionCategories);
+
+  const onClose = useCallback(() => {
+    setDialog(undefined);
+  }, [setDialog]);
+
+  const getItemKey = (item: Category) => {
+    return item.id.toString();
+  };
+
+  const onApplyChanges = () => {
+    // TODO: Update order in which panels show up in the dashboard UI using updatedOrder
+    // TODO: Update order in browser's local storage
+    // eslint-disable-next-line no-console
+    console.log('updatedOrder: ', updatedOrder);
+  };
+
+  return (
+    <Modal
+      title={t('Manage View')}
+      description={t(
+        'Hide or show the panels you want to see on the overview page by selecting or unselecting, respectively. The panels are ordered from top to bottom on the list. Use the draggable icon :: to re-order your view.'
+      )}
+      variant={ModalVariant.medium}
+      isOpen
+      onClose={() => onClose()}
+      actions={[
+        <Button
+          variant="primary"
+          key="save"
+          onClick={() => {
+            onApplyChanges();
+          }}
+        >{t`Apply`}</Button>,
+        <Button key="cancel" variant="link" onClick={() => onClose()}>{t`Cancel`}</Button>,
+      ]}
+      hasNoBodyWrapper
+    >
+      <ContainerDiv>
+        <ReorderItems
+          columns={columns}
+          items={collectionCategories}
+          keyFn={getItemKey}
+          onSave={(reorderedItems) => {
+            setUpdatedOrder(reorderedItems);
+          }}
+          isCompactBorderless
+          hideColumnHeaders
+        />
+      </ContainerDiv>
+    </Modal>
+  );
+}

--- a/frontend/hub/dashboard/ManageView.tsx
+++ b/frontend/hub/dashboard/ManageView.tsx
@@ -45,6 +45,7 @@ export function ManageView() {
     },
   ];
   const [updatedOrder, setUpdatedOrder] = useState<Category[]>(collectionCategories);
+  const [selectedCategories, setSelectedCategories] = useState<Category[]>([]);
 
   const onClose = useCallback(() => {
     setDialog(undefined);
@@ -58,8 +59,13 @@ export function ManageView() {
     // TODO: Update order in which panels show up in the dashboard UI using updatedOrder
     // TODO: Update order in browser's local storage
     // eslint-disable-next-line no-console
-    console.log('updatedOrder: ', updatedOrder);
+    console.log('🚀 ~ file: ManageView.tsx: updatedOrder: ', updatedOrder);
+    // eslint-disable-next-line no-console
+    console.log('🚀 ~ file: ManageView.tsx: selectedCategories: ', selectedCategories);
+    onClose();
   };
+
+  // const ref = useRef();
 
   return (
     <Modal
@@ -84,14 +90,17 @@ export function ManageView() {
     >
       <ContainerDiv>
         <ReorderItems
+          // ref={ref}
           columns={columns}
           items={collectionCategories}
           keyFn={getItemKey}
-          onSave={(reorderedItems) => {
+          onSave={(reorderedItems, selectedItems) => {
             setUpdatedOrder(reorderedItems);
+            setSelectedCategories(selectedItems);
           }}
           isCompactBorderless
           hideColumnHeaders
+          isSelectableWithCheckbox
         />
       </ContainerDiv>
     </Modal>


### PR DESCRIPTION
Framework component to reorder items in a table by dragging rows to the desired position. It also supports selection of items from the list.

This component is being used in the Manage View functionality on the hub dashboard (currently using mock data since we don't have the API endpoint for it yet).

For now, this can be tested by viewing the console log after applying changes in the Manage View modal:

<img width="797" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/7c6cbd97-d9dc-438f-ab09-d7c7d60237fe">

It can also be utilized in the future for editing the order of template survey questions:

<img width="1001" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/74871d88-4b57-4388-ba51-8620872f4b36">

