### PR TITLE
Refactor PageFormSelectOption to streamline in preparation for PF5

### DIFF
--- a/framework/PageForm/Inputs/PageFormSelectOption.tsx
+++ b/framework/PageForm/Inputs/PageFormSelectOption.tsx
@@ -171,7 +171,7 @@ export function PageFormSelectOption<
               placeholderText={placeholderText}
               variant="single"
               aria-describedby={id ? `${id}-form-group` : undefined}
-              selections={selected}
+              selections={selected?.label}
               onSelect={onSelectHandler}
               isOpen={open}
               onToggle={onToggle}

--- a/framework/PageForm/Inputs/PageFormSelectOption.tsx
+++ b/framework/PageForm/Inputs/PageFormSelectOption.tsx
@@ -1,58 +1,198 @@
+import { FormGroup, Select, SelectOption, SelectOptionObject } from '@patternfly/react-core';
+import { ChangeEvent, ReactNode, useCallback, useState } from 'react';
 import {
   Controller,
   FieldPath,
   FieldPathValue,
   FieldValues,
-  useFormContext,
   Validate,
+  useFormContext,
 } from 'react-hook-form';
+import { Help } from '../../components/Help';
+import { useFrameworkTranslations } from '../../useFrameworkTranslations';
 import { capitalizeFirstLetter } from '../../utils/strings';
-import { FormGroupSelectOption, FormGroupSelectOptionProps } from './FormGroupSelectOption';
+import { IFormGroupSelectOption } from './FormGroupSelectOption';
 
 export type PageFormSelectOptionProps<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TSelection = unknown
 > = {
+  /**
+   * The id attribute specifies a unique id for an HTML element. The value of the id attribute must be unique within the HTML document.
+   *
+   * It is also used by JavaScript to access and manipulate the element with the specific id.
+   */
+  id?: string;
+
+  /**
+   * The name attribute specifies the name of an <input> element.
+   *
+   * The name attribute is used to reference elements in a JavaScript, or to reference form data after a form is submitted.
+   */
   name: TFieldName;
+
+  /**
+   * The <label> tag defines a label for several elements.
+   *
+   * Proper use of labels with the elements will benefit:
+   * - Screen reader users (will read out loud the label, when the user is focused on the element)
+   * - Users who have difficulty clicking on very small regions (such as checkboxes) - because when a user clicks the text within the <label> element, it toggles the input (this increases the hit area).
+   */
+  label?: string;
+
+  // TODO - convert this to `help: ReactNode` and use the `HelperText` component
+  labelHelpTitle?: string;
+  labelHelp?: ReactNode;
+
+  // Additional label information displayed after the label.
+  additionalControls?: ReactNode;
+
+  /**
+   * The placeholder attribute specifies a short hint that describes the expected value of an input field (e.g. a sample value or a short description of the expected format).
+   *
+   * The short hint is displayed in the input field before the user enters a value.
+   *
+   * Note: The placeholder attribute works with the following input types: text, search, url, tel, email, and password.
+   */
+  placeholderText?: string;
+
+  options: IFormGroupSelectOption<TSelection>[];
+
+  footer?: ReactNode;
+
+  helperText?: string;
+
+  /**
+   * When present, it specifies that the <input> element should be disabled.
+   *
+   * A disabled input element is unusable and un-clickable.
+   *
+   * The disabled attribute can be set to keep a user from using the <input> element until some other condition has been met (like selecting a checkbox, etc.). Then, a JavaScript could remove the disabled value, and make the <input> element usable.
+   */
+  isDisabled?: boolean;
+
+  /**
+   * When present, it specifies that an input field is read-only.
+   *
+   * A read-only input field cannot be modified (however, a user can tab to it, highlight it, and copy the text from it).
+   *
+   * The readonly attribute can be set to keep a user from changing the value until some other conditions have been met (like selecting a checkbox, etc.). Then, a JavaScript can remove the readonly value, and make the input field editable.
+   */
+  isReadOnly?: boolean;
+
+  /**
+   * When present, it specifies that an input field must be filled out before submitting the form.
+   *
+   * Note: The required attribute works with the following input types: text, search, url, tel, email, password, date pickers, number, checkbox, radio, and file.
+   */
+  isRequired?: boolean;
+
   validate?:
     | Validate<FieldPathValue<TFieldValues, TFieldName>, TFieldValues>
     | Record<string, Validate<FieldPathValue<TFieldValues, TFieldName>, TFieldValues>>;
-} & Omit<FormGroupSelectOptionProps<TSelection>, 'onSelect' | 'value'>;
+};
 
-/**  Select wrapper for use with react-hook-form */
 export function PageFormSelectOption<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TSelection = unknown
 >(props: PageFormSelectOptionProps<TFieldValues, TFieldName, TSelection>) {
-  const { label, isRequired, validate } = props;
+  const {
+    name,
+    label,
+    labelHelpTitle,
+    labelHelp,
+    additionalControls,
+    placeholderText,
+    options,
+    footer,
+    helperText,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    validate,
+  } = props;
+
+  const id = props.id ?? name.split('.').join('-');
+
   const {
     control,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isValidating },
   } = useFormContext<TFieldValues>();
+
+  const [open, setOpen] = useState(false);
+  const onToggle = useCallback(() => setOpen((open) => !open), []);
+
+  const [translations] = useFrameworkTranslations();
 
   return (
     <Controller<TFieldValues, TFieldName>
-      name={props.name}
+      name={name}
       control={control}
       shouldUnregister
       render={({ field: { onChange, value }, fieldState: { error } }) => {
         if (value === '') {
-          if (props.options.length === 1 && isRequired) {
-            onChange(props.options[0].value);
+          if (options.length === 1 && isRequired) {
+            onChange(options[0].value);
           }
         }
+        const onSelectHandler = (
+          _event: React.MouseEvent<Element, MouseEvent> | ChangeEvent<Element>,
+          label: string | SelectOptionObject
+        ) => {
+          onChange(options.find((option) => option.label === label.toString())?.value);
+          setOpen(false);
+        };
+
+        const helperTextInvalid = error?.message
+          ? validate && isValidating
+            ? translations.validating
+            : error?.message
+          : undefined;
+
+        const selected = options.find((option) => option.value === value);
 
         return (
-          <FormGroupSelectOption
-            {...props}
-            id={props.id ?? props.name}
-            value={value as TSelection}
-            onSelect={(_, value) => onChange(value)}
-            helperTextInvalid={error?.message}
-            isReadOnly={props.isReadOnly || isSubmitting}
-          />
+          <FormGroup
+            id={`${id ?? ''}-form-group`}
+            fieldId={id}
+            label={label}
+            helperText={helperText}
+            helperTextInvalid={helperTextInvalid}
+            validated={helperTextInvalid ? 'error' : undefined}
+            isRequired={isRequired}
+            labelIcon={labelHelp ? <Help title={labelHelpTitle} help={labelHelp} /> : undefined}
+            labelInfo={additionalControls}
+          >
+            <Select
+              id={id}
+              label={undefined}
+              placeholderText={placeholderText}
+              variant="single"
+              aria-describedby={id ? `${id}-form-group` : undefined}
+              selections={selected}
+              onSelect={onSelectHandler}
+              isOpen={open}
+              onToggle={onToggle}
+              maxHeight={280}
+              validated={helperTextInvalid ? 'error' : undefined}
+              isDisabled={isDisabled || isReadOnly || isSubmitting}
+              hasPlaceholderStyle
+              footer={footer}
+            >
+              {options.map((option) => (
+                <SelectOption
+                  key={option.label}
+                  value={option.label}
+                  label={option.label}
+                  description={option.description}
+                >
+                  {option.label}
+                </SelectOption>
+              ))}
+            </Select>
+          </FormGroup>
         );
       }}
       rules={{
@@ -63,7 +203,7 @@ export function PageFormSelectOption<
                 message: `${capitalizeFirstLetter(label.toLocaleLowerCase())} is required.`,
               }
             : undefined,
-        validate: validate,
+        validate,
       }}
     />
   );

--- a/framework/PageForm/Inputs/PageFormTextInput.tsx
+++ b/framework/PageForm/Inputs/PageFormTextInput.tsx
@@ -1,6 +1,6 @@
 import { Button, FormGroup, InputGroup, TextInput } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon, SearchIcon } from '@patternfly/react-icons';
-import { ReactElement, ReactNode, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import {
   Controller,
   FieldPath,
@@ -82,7 +82,7 @@ export type PageFormTextInputProps<
    *
    * An input group groups multiple related controls or inputs together so they appear as one control.
    */
-  button?: ReactElement;
+  button?: ReactNode;
 
   helperText?: string;
 


### PR DESCRIPTION
PF5 changes prop names and breaks the ansible code.
This removed dependency on the PF props and uses explicit props.
This will make the migration to PF5 easier.