### PR TITLE
Update the Automation Calculator Toolbar PR with typescript typing fixes

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -28,11 +28,9 @@ import {
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base';
 import useResizeObserver from '@react-hook/resize-observer';
 import {
-  Dispatch,
   Fragment,
   MouseEvent,
   ReactNode,
-  SetStateAction,
   UIEvent,
   useCallback,
   useEffect,
@@ -65,7 +63,7 @@ import {
 import { PageTableList } from './PageTableList';
 import { PageTableViewType, PageTableViewTypeE } from './PageToolbar/PageTableViewType';
 import { PageTableToolbar } from './PageToolbar/PageToolbar';
-import { IToolbarFilter } from './PageToolbar/PageToolbarFilter';
+import { FilterState, IToolbarFilter, SetFilterState } from './PageToolbar/PageToolbarFilter';
 import { usePageToolbarSortOptionsFromColumns } from './PageToolbar/PageToolbarSort';
 
 const ScrollDiv = styled.div`
@@ -103,8 +101,8 @@ export type PageTableProps<T extends object> = {
   rowActions?: IPageAction<T>[];
 
   toolbarFilters?: IToolbarFilter[];
-  filters?: Record<string, string[]>;
-  setFilters?: Dispatch<SetStateAction<Record<string, string[]>>>;
+  filters?: FilterState;
+  setFilters?: SetFilterState;
   clearAllFilters?: () => void;
 
   sort?: string;

--- a/framework/PageTable/PageToolbar/PageToolbar.tsx
+++ b/framework/PageTable/PageToolbar/PageToolbar.tsx
@@ -2,15 +2,15 @@ import {
   Flex,
   OnPerPageSelect,
   OnSetPage,
+  ToolbarContent as PFToolbarContent,
   Pagination,
   PaginationVariant,
   Skeleton,
   Toolbar,
-  ToolbarContent as PFToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { Dispatch, Fragment, SetStateAction, useCallback } from 'react';
+import { Fragment, useCallback } from 'react';
 import styled from 'styled-components';
 import { IPageAction, PageActionSelection } from '../../PageActions/PageAction';
 import { PageActions } from '../../PageActions/PageActions';
@@ -18,7 +18,12 @@ import { BulkSelector } from '../../components/BulkSelector';
 import { useBreakpoint } from '../../components/useBreakPoint';
 import { PageTableViewType } from './PageTableViewType';
 import './PageToolbar.css';
-import { IToolbarFilter, PageToolbarFilters } from './PageToolbarFilter';
+import {
+  FilterState,
+  IToolbarFilter,
+  PageToolbarFilters,
+  SetFilterState,
+} from './PageToolbarFilter';
 import { PageTableSortOption, PageToolbarSort } from './PageToolbarSort';
 import { PageToolbarView } from './PageToolbarView';
 
@@ -42,10 +47,10 @@ export type PagetableToolbarProps<T extends object> = {
   toolbarActions?: IPageAction<T>[];
 
   toolbarFilters?: IToolbarFilter[];
-  filters?: Record<string, string[]>;
-  setFilters?: (
-    value: Record<string, string[]>
-  ) => void | Dispatch<SetStateAction<Record<string, string[]>>>;
+  filters?: FilterState;
+
+  setFilters?: SetFilterState;
+
   clearAllFilters?: () => void;
 
   page: number;

--- a/framework/PageTable/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageTable/PageToolbar/PageToolbarFilter.tsx
@@ -29,7 +29,8 @@ export type IToolbarFilter = IToolbarTextFilter | IToolbarSelectFilter | IToolba
  */
 export type FilterState = Record<string, string[]>;
 
-/** Function to set the filters using an update function that takes in the current filters and returns the new filter state. */
+/** Function to set the filters using an update function that takes in the current filters and returns the new filter state.
+ * This follows the pattern of react useState setter functions so that it can be used with the useState hook. */
 export type SetFilterState = (updateFilters: (currentFilters: FilterState) => FilterState) => void;
 
 export type PageToolbarFiltersProps = {

--- a/framework/useView.tsx
+++ b/framework/useView.tsx
@@ -1,4 +1,5 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FilterState, SetFilterState } from './PageTable/PageToolbar/PageToolbarFilter';
 import { useSearchParams } from './components/useSearchParams';
 
 export interface IView {
@@ -10,8 +11,8 @@ export interface IView {
   setSort: (sort: string) => void;
   sortDirection: 'asc' | 'desc';
   setSortDirection: (sortDirection: 'asc' | 'desc') => void;
-  filters: Record<string, string[]>;
-  setFilters: Dispatch<SetStateAction<Record<string, string[]>>>;
+  filters: FilterState;
+  setFilters: SetFilterState;
   clearAllFilters: () => void;
 }
 
@@ -74,7 +75,7 @@ export function useView(view?: Partial<IView> | undefined, disableQueryString?: 
   });
 
   const [filters, setFilters] = useState<Record<string, string[]>>(() => {
-    const filters: Record<string, string[]> = {};
+    const filters: FilterState = {};
     for (const key of searchParams.keys()) {
       switch (key) {
         case 'sort':

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -1,18 +1,18 @@
-import { useMemo, useRef, useState } from 'react';
 import { Banner } from '@patternfly/react-core';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import type { FilterState, IToolbarFilter } from '../../../../../framework';
 import { Job } from '../../../interfaces/Job';
 import './JobOutput.css';
 import { JobOutputLoadingRow } from './JobOutputLoadingRow';
-import { IJobOutputRow, jobEventToRows, tracebackToRows, JobOutputRow } from './JobOutputRow';
+import { IJobOutputRow, JobOutputRow, jobEventToRows, tracebackToRows } from './JobOutputRow';
 import { useJobOutput } from './useJobOutput';
 import {
-  useJobOutputChildrenSummary,
   IJobOutputChildrenSummary,
+  useJobOutputChildrenSummary,
 } from './useJobOutputChildrenSummary';
 import { useVirtualizedList } from './useVirtualized';
-import type { IToolbarFilter } from '../../../../../framework';
 
 export interface ICollapsed {
   [uuid: string]: boolean;
@@ -30,7 +30,7 @@ const ScrollContainer = styled.div`
 interface IJobOutputEventsProps {
   job: Job;
   toolbarFilters: IToolbarFilter[];
-  filters: Record<string, string[]>;
+  filters: FilterState;
 }
 
 export function JobOutputEvents(props: IJobOutputEventsProps) {

--- a/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
@@ -1,19 +1,22 @@
-import { Dispatch, SetStateAction } from 'react';
 import { Toolbar, ToolbarContent } from '@patternfly/react-core';
-import { PageToolbarFilters } from '../../../../../framework/PageTable/PageToolbar/PageToolbarFilter';
 import { IToolbarFilter } from '../../../../../framework';
+import {
+  FilterState,
+  PageToolbarFilters,
+  SetFilterState,
+} from '../../../../../framework/PageTable/PageToolbar/PageToolbarFilter';
 
 interface IJobOutputToolbarProps {
   toolbarFilters: IToolbarFilter[];
-  filters: Record<string, string[]>;
-  setFilters: Dispatch<SetStateAction<Record<string, string[]>>>;
+  filters: FilterState;
+  setFilters: SetFilterState;
 }
 
 export function JobOutputToolbar(props: IJobOutputToolbarProps) {
   const { toolbarFilters, filters, setFilters } = props;
 
   return (
-    <Toolbar clearAllFilters={() => setFilters({})}>
+    <Toolbar clearAllFilters={() => setFilters(() => ({}))}>
       <ToolbarContent>
         <PageToolbarFilters
           toolbarFilters={toolbarFilters}

--- a/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useRef, useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FilterState, IToolbarFilter } from '../../../../../framework';
 import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
 import { Job } from '../../../interfaces/Job';
 import { JobEvent } from '../../../interfaces/JobEvent';
-import type { IToolbarFilter } from '../../../../../framework';
 
 export function useJobOutput(
   job: Job,
   toolbarFilters: IToolbarFilter[],
-  filters: Record<string, string[]>,
+  filters: FilterState,
   pageSize: number
 ) {
   const isQuerying = useRef({ querying: false });
@@ -68,10 +68,7 @@ export function useJobOutput(
   return { jobEventCount, getJobOutputEvent, queryJobOutputEvent };
 }
 
-function getFiltersQueryString(
-  toolbarFilters: IToolbarFilter[],
-  filters: Record<string, string[]>
-) {
+function getFiltersQueryString(toolbarFilters: IToolbarFilter[], filters: FilterState) {
   if (!filters) {
     return '';
   }


### PR DESCRIPTION
Changes the Toolbar `setFilters` from
```
setFilters: Dispatch<SetStateAction<Record<string, string[]>>>
```
to 
```
setFilters: SetFilterState
```
where `SetFilterState`
```
/** Function to set the filters using an update function that takes in the current filters and returns the new filter state.
 * This follows the pattern of react useState setter functions so that it can be used with the useState hook. */
export type SetFilterState = (updateFilters: (currentFilters: FilterState) => FilterState) => void;
```
so that the toolbar filters can be used even when not using a `useState` hook to manage filter state.