### PR TITLE
Fix flaky Cypress test for Jobs List

### DIFF
--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -47,7 +47,10 @@ describe('jobs', () => {
   it('renders jobs list', () => {
     cy.navigateTo(/^Jobs$/);
     cy.hasTitle(/^Jobs$/);
-    cy.contains(jobList.name as string);
+    const jobId = jobList.id ? jobList.id.toString() : '';
+    const jobName = jobList.name ? jobList.name : '';
+    cy.filterTableByTypeAndText('ID', jobId);
+    cy.contains(jobName);
   });
 
   it('relaunches job and navigates to job output', () => {


### PR DESCRIPTION
Based on the test failure rates seen on the cypress dashboard:
https://cloud.cypress.io/projects/77sud6/analytics/top-failures/2201cbf6-6150-5188-342d-01ab64554a3d-d530393e-53ce-77d2-dbbf-7d390fd224ea
`jobs > renders jobs list` is failing about 8% - 12% of the time

Looking at the test, it is looking for the job name in the job list.
There may be enough jobs in the list that the test job is not on the first page, and that will cause the test to randomly fail. Adding a filter for the job ID should bring it to the first page and get the test to consistently pass.