### PR TITLE
Rename ItemsResponse to AwxItemsResponse

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -2,8 +2,8 @@
 /// <reference types="cypress" />
 
 import { randomString } from '../../../../framework/utils/random-string';
+import { AwxItemsResponse } from '../../../../frontend/awx/common/AwxItemsResponse';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { ItemsResponse } from '../../../../frontend/common/crud/Data';
 
 describe('organizations', () => {
   let organization: Organization;
@@ -20,7 +20,7 @@ describe('organizations', () => {
     cy.deleteAwxOrganization(organization);
     // Sometimes if tests are stopped in the middle, we get left over organizations
     // Cleanup E2E organizations older than 20 minutes
-    cy.requestGet<ItemsResponse<Organization>>(
+    cy.requestGet<AwxItemsResponse<Organization>>(
       `/api/v2/organizations/?page_size=100&created__lt=${new Date(
         Date.now() - 20 * 60 * 1000
       ).toISOString()}&name__startswith=E2E`

--- a/cypress/e2e/awx/cleanup/awx-cleanup.cy.ts
+++ b/cypress/e2e/awx/cleanup/awx-cleanup.cy.ts
@@ -1,3 +1,4 @@
+import { AwxItemsResponse } from '../../../../frontend/awx/common/AwxItemsResponse';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Job } from '../../../../frontend/awx/interfaces/Job';
 import { JobTemplate } from '../../../../frontend/awx/interfaces/JobTemplate';
@@ -5,13 +6,12 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { User } from '../../../../frontend/awx/interfaces/User';
 import { getJobsAPIUrl } from '../../../../frontend/awx/views/jobs/jobUtils';
-import { ItemsResponse } from '../../../../frontend/common/crud/Data';
 
 const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
 
 describe('AWX Cleanup', () => {
   it('cleanup projects', () => {
-    cy.awxRequestGet<ItemsResponse<Project>>(
+    cy.awxRequestGet<AwxItemsResponse<Project>>(
       `/api/v2/projects?name__startswith=E2E&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {
@@ -21,7 +21,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup inventories', () => {
-    cy.awxRequestGet<ItemsResponse<Inventory>>(
+    cy.awxRequestGet<AwxItemsResponse<Inventory>>(
       `/api/v2/inventories?name__startswith=E2E&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {
@@ -31,7 +31,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup organizations', () => {
-    cy.awxRequestGet<ItemsResponse<Organization>>(
+    cy.awxRequestGet<AwxItemsResponse<Organization>>(
       `/api/v2/organizations?name__startswith=E2E&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {
@@ -41,7 +41,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup users', () => {
-    cy.awxRequestGet<ItemsResponse<User>>(
+    cy.awxRequestGet<AwxItemsResponse<User>>(
       `/api/v2/users?username__startswith=e2e&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {
@@ -51,7 +51,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup templates', () => {
-    cy.awxRequestGet<ItemsResponse<JobTemplate>>(
+    cy.awxRequestGet<AwxItemsResponse<JobTemplate>>(
       `/api/v2/unified_job_templates/?name__startswith=E2E&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {
@@ -61,7 +61,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup jobs', () => {
-    cy.awxRequestGet<ItemsResponse<Job>>(
+    cy.awxRequestGet<AwxItemsResponse<Job>>(
       `/api/v2/unified_jobs/?name__startswith=E2E&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {

--- a/cypress/e2e/awx/general-ui/dashboard-checks.cy.ts
+++ b/cypress/e2e/awx/general-ui/dashboard-checks.cy.ts
@@ -1,4 +1,4 @@
-import { ItemsResponse } from '../../../../frontend/common/crud/Data';
+import { AwxItemsResponse } from '../../../../frontend/awx/common/AwxItemsResponse';
 import { Job } from '../../../../frontend/awx/interfaces/Job';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 
@@ -84,7 +84,7 @@ describe('Dashboard: General UI tests - resources count and empty state check', 
     cy.checkAnchorLinks('Go to Jobs');
     cy.wait('@getJobs')
       .its('response.body.results')
-      .then((results: ItemsResponse<Job>) => {
+      .then((results: AwxItemsResponse<Job>) => {
         if (results.count === 0) {
           cy.log('empty state check');
           cy.hasTitle(/^There are currently no jobs$/).should('be.visible');
@@ -113,7 +113,7 @@ describe('Dashboard: General UI tests - resources count and empty state check', 
     cy.checkAnchorLinks('Go to Projects');
     cy.wait('@getProjects')
       .its('response.body.results')
-      .then((results: ItemsResponse<Project>) => {
+      .then((results: AwxItemsResponse<Project>) => {
         if (results.count === 0) {
           cy.log('empty state check');
           cy.hasTitle(/^There are currently no projects$/).should('be.visible');

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -2,9 +2,9 @@
 /// <reference types="cypress" />
 
 import { randomString } from '../../../../framework/utils/random-string';
+import { AwxItemsResponse } from '../../../../frontend/awx/common/AwxItemsResponse';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
-import { ItemsResponse } from '../../../../frontend/common/crud/Data';
 
 describe('projects', () => {
   let organization: Organization;
@@ -29,7 +29,7 @@ describe('projects', () => {
        * This also cleans up projects that were syncing and could not be deleted by other runs,
        * making a self cleaning E2E system for the live server.
        */
-      cy.requestGet<ItemsResponse<Project>>(
+      cy.requestGet<AwxItemsResponse<Project>>(
         `/api/v2/projects/?page_size=100&organization=null`
       ).then((itemsResponse) => {
         for (const project of itemsResponse.results) {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1,6 +1,7 @@
 import '@cypress/code-coverage/support';
 import { SetRequired } from 'type-fest';
 import { randomString } from '../../framework/utils/random-string';
+import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
 import { AwxHost } from '../../frontend/awx/interfaces/AwxHost';
 import { AwxToken } from '../../frontend/awx/interfaces/AwxToken';
 import { Credential } from '../../frontend/awx/interfaces/Credential';
@@ -14,7 +15,6 @@ import { Project } from '../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../frontend/awx/interfaces/Schedule';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { User } from '../../frontend/awx/interfaces/User';
-import { ItemsResponse } from '../../frontend/common/crud/Data';
 import './auth';
 import './commands';
 import './rest-commands';
@@ -674,7 +674,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('getAwxJobTemplateByName', (awxJobTemplateName: string) => {
-  cy.awxRequestGet<ItemsResponse<JobTemplate>>(
+  cy.awxRequestGet<AwxItemsResponse<JobTemplate>>(
     `/api/v2/job_templates/?name=${awxJobTemplateName}`
   ).then((result) => {
     cy.log('RESULT RESULT', result);

--- a/frontend/awx/access/organizations/components/PageFormOrganizationSelect.tsx
+++ b/frontend/awx/access/organizations/components/PageFormOrganizationSelect.tsx
@@ -3,7 +3,8 @@ import { FieldPath, FieldPathValue, FieldValues, Path, useFormContext } from 're
 import { useTranslation } from 'react-i18next';
 import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
 import { PageFormTextInput } from '../../../../../framework/PageForm/Inputs/PageFormTextInput';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { requestGet } from '../../../../common/crud/Data';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { Organization } from '../../../interfaces/Organization';
 import { useSelectOrganization, useSelectOrganization2 } from '../hooks/useSelectOrganization';
 
@@ -25,7 +26,7 @@ export function PageFormOrganizationSelect<
       validate={async (organizationName: string) => {
         if (!props.isRequired && !organizationName) return;
         try {
-          const itemsResponse = await requestGet<ItemsResponse<Organization>>(
+          const itemsResponse = await requestGet<AwxItemsResponse<Organization>>(
             `/api/v2/organizations/?name=${organizationName}`
           );
           if (itemsResponse.results.length === 0) return t('Organization not found.');
@@ -51,7 +52,7 @@ export function PageFormSelectOrganization<
   const { t } = useTranslation();
   const openSelectDialog = useSelectOrganization2();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<Organization>>(
+    const response = await requestGet<AwxItemsResponse<Organization>>(
       `/api/v2/organizations/?page_size=200`
     );
     return Promise.resolve({

--- a/frontend/awx/access/organizations/utils/getOrganizationByName.ts
+++ b/frontend/awx/access/organizations/utils/getOrganizationByName.ts
@@ -1,8 +1,9 @@
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { requestGet } from '../../../../common/crud/Data';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { Organization } from '../../../interfaces/Organization';
 
 export async function getOrganizationByName(organizationName: string) {
-  const itemsResponse = await requestGet<ItemsResponse<Organization>>(
+  const itemsResponse = await requestGet<AwxItemsResponse<Organization>>(
     `/api/v2/organizations/?name=${organizationName}`
   );
   if (itemsResponse.results.length >= 1) {

--- a/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
+++ b/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
@@ -1,11 +1,12 @@
+import { Tooltip } from '@patternfly/react-core';
 import { ReactElement } from 'react';
 import { FieldPath, FieldValues, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { PageFormTextInput } from '../../../../../framework/PageForm/Inputs/PageFormTextInput';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { requestGet } from '../../../../common/crud/Data';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
 import { useSelectExecutionEnvironments } from '../hooks/useSelectExecutionEnvironments';
-import { Tooltip } from '@patternfly/react-core';
 
 export function PageFormExecutionEnvironmentSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -43,7 +44,7 @@ export function PageFormExecutionEnvironmentSelect<
             return undefined;
           }
           try {
-            const itemsResponse = await requestGet<ItemsResponse<ExecutionEnvironment>>(
+            const itemsResponse = await requestGet<AwxItemsResponse<ExecutionEnvironment>>(
               `/api/v2/execution_environments/?name=${executionEnvironmentName}`
             );
             if (itemsResponse.results.length === 0) return t('Execution environment not found.');

--- a/frontend/awx/common/AwxItemsResponse.tsx
+++ b/frontend/awx/common/AwxItemsResponse.tsx
@@ -1,0 +1,9 @@
+/**
+ * Interface for AWX API responses that return a list of items.
+ */
+export interface AwxItemsResponse<T> {
+  count: number;
+  next?: string | null;
+  previous?: string | null;
+  results: T[];
+}

--- a/frontend/awx/dashboard/AwxDashboard.tsx
+++ b/frontend/awx/dashboard/AwxDashboard.tsx
@@ -6,8 +6,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import { PageHeader, PageLayout, usePageDialog } from '../../../framework';
 import { PageDashboard } from '../../../framework/PageDashboard/PageDashboard';
-import { ItemsResponse } from '../../common/crud/Data';
 import { useGet } from '../../common/crud/useGet';
+import { AwxItemsResponse } from '../common/AwxItemsResponse';
 import { useAwxConfig } from '../common/useAwxConfig';
 import { ExecutionEnvironment } from '../interfaces/ExecutionEnvironment';
 import { Job } from '../interfaces/Job';
@@ -198,7 +198,7 @@ function useAwxItemsResponse<T>(options: {
   query?: Record<string, string | number | boolean>;
 }) {
   const { url, query } = options;
-  const response = useGet<ItemsResponse<T>>(url, query);
+  const response = useGet<AwxItemsResponse<T>>(url, query);
   return {
     ...response.data,
     loading: !response.data && !response.error,

--- a/frontend/awx/resources/credentials/CredentialForm.tsx
+++ b/frontend/awx/resources/credentials/CredentialForm.tsx
@@ -1,25 +1,26 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-  compareStrings,
   PageFormSelectOption,
   PageHeader,
   PageLayout,
+  compareStrings,
 } from '../../../../framework';
 import { PageFormTextArea } from '../../../../framework/PageForm/Inputs/PageFormTextArea';
 import { PageFormTextInput } from '../../../../framework/PageForm/Inputs/PageFormTextInput';
 import { PageForm, PageFormSubmitHandler } from '../../../../framework/PageForm/PageForm';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
-import { ItemsResponse, requestPatch } from '../../../common/crud/Data';
+import { RouteObj } from '../../../Routes';
+import { requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { useActiveUser } from '../../../common/useActiveUser';
-import { RouteObj } from '../../../Routes';
 import { PageFormOrganizationSelect } from '../../access/organizations/components/PageFormOrganizationSelect';
 import { getOrganizationByName } from '../../access/organizations/utils/getOrganizationByName';
 import { Credential } from '../../interfaces/Credential';
 import { CredentialType } from '../../interfaces/CredentialType';
 import { getAwxError } from '../../useAwxView';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 
 interface CredentialForm extends Credential {
   user?: number;
@@ -135,7 +136,7 @@ export function EditCredential() {
 
 function CredentialInputs() {
   const { t } = useTranslation();
-  const itemsResponse = useGet<ItemsResponse<CredentialType>>(
+  const itemsResponse = useGet<AwxItemsResponse<CredentialType>>(
     '/api/v2/credential_types/?page=1&page_size=200'
   );
   return (

--- a/frontend/awx/resources/credentials/components/PageFormCredentialSelect.tsx
+++ b/frontend/awx/resources/credentials/components/PageFormCredentialSelect.tsx
@@ -1,11 +1,12 @@
 import { ReactElement } from 'react';
 import { FieldPath, FieldValues, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { PageFormTextInput } from '../../../../../framework';
 import { PageFormMultiInput } from '../../../../../framework/PageForm/Inputs/PageFormMultiInput';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { requestGet } from '../../../../common/crud/Data';
 import { Credential } from '../../../interfaces/Credential';
 import { useMultiSelectCredential, useSingleSelectCredential } from '../hooks/useSelectCredential';
-import { PageFormTextInput } from '../../../../../framework';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function PageFormCredentialSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -42,7 +43,7 @@ export function PageFormCredentialSelect<
           return;
         }
         try {
-          const itemsResponse = await requestGet<ItemsResponse<Credential>>(
+          const itemsResponse = await requestGet<AwxItemsResponse<Credential>>(
             `/api/v2/credentials/?name=${credentials[0].name}`
           );
           if (itemsResponse.results.length === 0) return t('Credential not found.');
@@ -74,7 +75,7 @@ export function PageFormCredentialSelect<
           return;
         }
         try {
-          const itemsResponse = await requestGet<ItemsResponse<Credential>>(
+          const itemsResponse = await requestGet<AwxItemsResponse<Credential>>(
             `/api/v2/credentials/?name=${credentialName}`
           );
           if (itemsResponse.results.length === 0) return t('Credential not found.');

--- a/frontend/awx/resources/credentials/hooks/useCredentialsColumns.tsx
+++ b/frontend/awx/resources/credentials/hooks/useCredentialsColumns.tsx
@@ -10,10 +10,10 @@ import {
   useModifiedColumn,
   useNameColumn,
 } from '../../../../common/columns';
-import { Credential } from '../../../interfaces/Credential';
 import { useGet } from '../../../../common/crud/useGet';
-import { ItemsResponse } from '../../../../common/crud/Data';
+import { Credential } from '../../../interfaces/Credential';
 import { CredentialType } from '../../../interfaces/CredentialType';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function useCredentialsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -28,7 +28,7 @@ export function useCredentialsColumns(options?: { disableSort?: boolean; disable
   const descriptionColumn = useDescriptionColumn();
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);
-  const itemsResponse = useGet<ItemsResponse<CredentialType>>(
+  const itemsResponse = useGet<AwxItemsResponse<CredentialType>>(
     '/api/v2/credential_types/?page=1&page_size=200'
   );
   const credentialTypesMap: { [id: number]: string } = useMemo(() => {

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -6,7 +6,7 @@ import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGro
 import { PageFormTextInput } from '../../../../framework/PageForm/Inputs/PageFormTextInput';
 import { PageForm, PageFormSubmitHandler } from '../../../../framework/PageForm/PageForm';
 import { RouteObj } from '../../../Routes';
-import { ItemsResponse, postRequest, requestPatch } from '../../../common/crud/Data';
+import { postRequest, requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { PageFormSelectOrganization } from '../../access/organizations/components/PageFormOrganizationSelect';
@@ -18,6 +18,7 @@ import { InstanceGroup } from '../../interfaces/InstanceGroup';
 import { Inventory } from '../../interfaces/Inventory';
 import { Label } from '../../interfaces/Label';
 import { getAwxError } from '../../useAwxView';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 
 interface InventoryFields extends FieldValues {
   inventory: Inventory;
@@ -89,7 +90,7 @@ export function EditInventory() {
   const params = useParams<{ id?: string }>();
   const id = Number(params.id);
   const { data: inventory } = useGet<Inventory>(`/api/v2/inventories/${id.toString()}/`);
-  const { data: igResponse } = useGet<ItemsResponse<InstanceGroup>>(
+  const { data: igResponse } = useGet<AwxItemsResponse<InstanceGroup>>(
     `/api/v2/inventories/${id.toString()}/instance_groups/`
   );
   // Fetch instance groups associated with the inventory

--- a/frontend/awx/resources/inventories/components/PageFormInventorySelect.tsx
+++ b/frontend/awx/resources/inventories/components/PageFormInventorySelect.tsx
@@ -1,10 +1,11 @@
 import { ReactElement, useCallback } from 'react';
 import { FieldPath, FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { requestGet } from '../../../../common/crud/Data';
 import { Inventory } from '../../../interfaces/Inventory';
 import { useSelectInventory } from '../hooks/useSelectInventory';
-import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function PageFormInventorySelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -18,7 +19,7 @@ export function PageFormInventorySelect<
   const { t } = useTranslation();
   const openSelectDialog = useSelectInventory();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<Inventory>>(
+    const response = await requestGet<AwxItemsResponse<Inventory>>(
       `/api/v2/inventories/?page_size=200`
     );
     return Promise.resolve({

--- a/frontend/awx/resources/inventories/components/PageFormInventorySourceSelect.tsx
+++ b/frontend/awx/resources/inventories/components/PageFormInventorySourceSelect.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { FieldPath, FieldPathValue, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { requestGet } from '../../../../common/crud/Data';
 import { InventorySource } from '../../../interfaces/InventorySource';
 import { useSelectInventorySource } from '../hooks/useSelectInventorySource';
-import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function PageFormInventorySourceSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -13,7 +14,7 @@ export function PageFormInventorySourceSelect<
   const { t } = useTranslation();
   const openSelectDialog = useSelectInventorySource();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<InventorySource>>(
+    const response = await requestGet<AwxItemsResponse<InventorySource>>(
       `/api/v2/inventories/${props.inventoryId.toString()}/inventory_sources/?page_size=200`
     );
     return Promise.resolve({

--- a/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
+++ b/frontend/awx/resources/projects/components/PageFormProjectSelect.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { FieldPath, FieldPathValue, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { requestGet } from '../../../../common/crud/Data';
 import { Project } from '../../../interfaces/Project';
 import { useSelectProject } from '../hooks/useSelectProject';
-import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function PageFormProjectSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -14,7 +15,7 @@ export function PageFormProjectSelect<
 
   const openSelectDialog = useSelectProject();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<Project>>('/api/v2/projects/?page_size=200');
+    const response = await requestGet<AwxItemsResponse<Project>>('/api/v2/projects/?page_size=200');
     return Promise.resolve({
       total: response.count,
       values: response.results as FieldPathValue<TFieldValues, Path<TFieldValues>>[],

--- a/frontend/awx/resources/projects/hooks/useGetCredentialTypeIDs.tsx
+++ b/frontend/awx/resources/projects/hooks/useGetCredentialTypeIDs.tsx
@@ -1,19 +1,19 @@
 import { useMemo } from 'react';
-import { ItemsResponse } from '../../../../common/crud/Data';
 import { useGet } from '../../../../common/crud/useGet';
 import { CredentialType } from '../../../interfaces/CredentialType';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 /**
  * Returns an object that maps credential types (scm, Insights, cryptography) to their IDs
  */
 export function useGetCredentialTypeIDs() {
-  const scmCredentialTypeResponse = useGet<ItemsResponse<CredentialType>>(
+  const scmCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
     '/api/v2/credential_types/?kind=scm'
   );
-  const insightsCredentialTypeResponse = useGet<ItemsResponse<CredentialType>>(
+  const insightsCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
     '/api/v2/credential_types/?name=Insights'
   );
-  const cryptoCredentialTypeResponse = useGet<ItemsResponse<CredentialType>>(
+  const cryptoCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
     '/api/v2/credential_types/?kind=cryptography'
   );
   const credentialTypeIDs: { [key: string]: number } = useMemo(() => {

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -5,7 +5,7 @@ import { useSWRConfig } from 'swr';
 import { PageForm, PageFormSubmitHandler, PageHeader, PageLayout } from '../../../../framework';
 import { LoadingPage } from '../../../../framework/components/LoadingPage';
 import { RouteObj } from '../../../Routes';
-import {  postRequest, requestGet, requestPatch } from '../../../common/crud/Data';
+import { postRequest, requestGet, requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { AwxError } from '../../common/AwxError';

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -3,22 +3,23 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
 import { PageForm, PageFormSubmitHandler, PageHeader, PageLayout } from '../../../../framework';
-import { ItemsResponse, postRequest, requestGet, requestPatch } from '../../../common/crud/Data';
+import { LoadingPage } from '../../../../framework/components/LoadingPage';
+import { RouteObj } from '../../../Routes';
+import {  postRequest, requestGet, requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
+import { AwxError } from '../../common/AwxError';
 import { getAddedAndRemoved } from '../../common/util/getAddedAndRemoved';
-import { RouteObj } from '../../../Routes';
 import { Credential } from '../../interfaces/Credential';
 import { InstanceGroup } from '../../interfaces/InstanceGroup';
 import { JobTemplate } from '../../interfaces/JobTemplate';
 import { JobTemplateForm } from '../../interfaces/JobTemplateForm';
 import { Label } from '../../interfaces/Label';
+import { Organization } from '../../interfaces/Organization';
 import { getAwxError } from '../../useAwxView';
 import { getJobTemplateDefaultValues } from './JobTemplateFormHelpers';
 import JobTemplateInputs from './JobTemplateInputs';
-import { AwxError } from '../../common/AwxError';
-import { LoadingPage } from '../../../../framework/components/LoadingPage';
-import { Organization } from '../../interfaces/Organization';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 
 const stringifyTags: (tags: { value: string }[]) => string = (tags) => {
   const stringifiedTags = tags.filter((tag) => {
@@ -42,7 +43,7 @@ export function EditJobTemplate() {
     error: instanceGroupsError,
     isLoading: isInstanceGroupsLoading,
     refresh: instanceGroupRefresh,
-  } = useGet<ItemsResponse<InstanceGroup>>(
+  } = useGet<AwxItemsResponse<InstanceGroup>>(
     `/api/v2/job_templates/${id.toString()}/instance_groups/`
   );
 
@@ -238,7 +239,7 @@ async function submitLabels(template: JobTemplate, labels: Label[]) {
   if (!template.summary_fields?.organization?.id) {
     // eslint-disable-next-line no-useless-catch
     try {
-      const data = await requestGet<ItemsResponse<Organization>>('/api/v2/organizations/');
+      const data = await requestGet<AwxItemsResponse<Organization>>('/api/v2/organizations/');
       orgId = data.results[0].id;
     } catch (err) {
       throw err;
@@ -261,7 +262,7 @@ async function submitLabels(template: JobTemplate, labels: Label[]) {
   return results;
 }
 async function submitInstanceGroups(templateId: number, newInstanceGroups: InstanceGroup[]) {
-  const originalInstanceGroups = await requestGet<ItemsResponse<InstanceGroup>>(
+  const originalInstanceGroups = await requestGet<AwxItemsResponse<InstanceGroup>>(
     `/api/v2/job_templates/${templateId.toString()}/instance_groups/`
   );
   if (!isEqual(newInstanceGroups, originalInstanceGroups.results)) {

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -9,6 +9,7 @@ import { postRequest, requestGet, requestPatch } from '../../../common/crud/Data
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { AwxError } from '../../common/AwxError';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { getAddedAndRemoved } from '../../common/util/getAddedAndRemoved';
 import { Credential } from '../../interfaces/Credential';
 import { InstanceGroup } from '../../interfaces/InstanceGroup';
@@ -19,7 +20,6 @@ import { Organization } from '../../interfaces/Organization';
 import { getAwxError } from '../../useAwxView';
 import { getJobTemplateDefaultValues } from './JobTemplateFormHelpers';
 import JobTemplateInputs from './JobTemplateInputs';
-import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 
 const stringifyTags: (tags: { value: string }[]) => string = (tags) => {
   const stringifiedTags = tags.filter((tag) => {

--- a/frontend/awx/resources/templates/components/PageFormJobTemplateSelect.tsx
+++ b/frontend/awx/resources/templates/components/PageFormJobTemplateSelect.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { FieldPath, FieldPathValue, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { requestGet } from '../../../../common/crud/Data';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { useSelectJobTemplate } from '../hooks/useSelectJobTemplate';
-import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 export function PageFormJobTemplateSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -19,7 +20,7 @@ export function PageFormJobTemplateSelect<
 
   const openSelectDialog = useSelectJobTemplate();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<JobTemplate>>(
+    const response = await requestGet<AwxItemsResponse<JobTemplate>>(
       `/api/v2/job_templates/?page_size=200`
     );
 

--- a/frontend/awx/resources/templates/components/PageFormWorkflowJobTemplateSelect.tsx
+++ b/frontend/awx/resources/templates/components/PageFormWorkflowJobTemplateSelect.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { FieldPath, FieldPathValue, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
+import { requestGet } from '../../../../common/crud/Data';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { useSelectWorkflowJobTemplate } from '../hooks/useSelectWorkflowJobTemplate';
-import { PageFormAsyncSelect } from '../../../../../framework/PageForm/Inputs/PageFormAsyncSelect';
 
 export function PageFormWorkflowJobTemplateSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -19,7 +20,7 @@ export function PageFormWorkflowJobTemplateSelect<
 
   const openSelectDialog = useSelectWorkflowJobTemplate();
   const query = useCallback(async () => {
-    const response = await requestGet<ItemsResponse<WorkflowJobTemplate>>(
+    const response = await requestGet<AwxItemsResponse<WorkflowJobTemplate>>(
       `/api/v2/workflow_job_templates/?page_size=200`
     );
 

--- a/frontend/awx/resources/templates/components/WebhookSubForm.tsx
+++ b/frontend/awx/resources/templates/components/WebhookSubForm.tsx
@@ -1,15 +1,16 @@
 import { Button, FormSection } from '@patternfly/react-core';
-import { PageFormSelectOption, PageFormTextInput } from '../../../../../framework';
-import { JobTemplateForm } from '../../../interfaces/JobTemplateForm';
-import { useTranslation } from 'react-i18next';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import { PageFormCredentialSelect } from '../../credentials/components/PageFormCredentialSelect';
-import { CredentialType } from '../../../interfaces/CredentialType';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
-import { useGet } from '../../../../common/crud/useGet';
-import { useParams, useLocation } from 'react-router-dom';
-import { useFormContext } from 'react-hook-form';
 import { useCallback, useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useParams } from 'react-router-dom';
+import { PageFormSelectOption, PageFormTextInput } from '../../../../../framework';
+import { requestGet } from '../../../../common/crud/Data';
+import { useGet } from '../../../../common/crud/useGet';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { CredentialType } from '../../../interfaces/CredentialType';
+import { JobTemplateForm } from '../../../interfaces/JobTemplateForm';
+import { PageFormCredentialSelect } from '../../credentials/components/PageFormCredentialSelect';
 
 export function WebhookSubForm() {
   const { t } = useTranslation();
@@ -21,7 +22,7 @@ export function WebhookSubForm() {
 
   const { pathname } = useLocation();
 
-  const { data: webhookCredentialType } = useGet<ItemsResponse<CredentialType>>(
+  const { data: webhookCredentialType } = useGet<AwxItemsResponse<CredentialType>>(
     `/api/v2/credential_types/`,
     {
       namespace: `${webhookService as string}_token`,
@@ -36,7 +37,7 @@ export function WebhookSubForm() {
     }
   }, [isWebhookEnabled, setValue, params]);
 
-  useGet<ItemsResponse<CredentialType>>(
+  useGet<AwxItemsResponse<CredentialType>>(
     `/api/v2/credential_types/?namespace=${webhookService as string}_token`
   );
 

--- a/frontend/awx/useAwxView.tsx
+++ b/frontend/awx/useAwxView.tsx
@@ -3,13 +3,14 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { ISelected, ITableColumn, IToolbarFilter, useSelected } from '../../framework';
 import { IView, useView } from '../../framework/useView';
-import { ItemsResponse, getItemKey, swrOptions, useFetcher } from '../common/crud/Data';
+import { getItemKey, swrOptions, useFetcher } from '../common/crud/Data';
+import { AwxItemsResponse } from './common/AwxItemsResponse';
 
 export type IAwxView<T extends { id: number }> = IView &
   ISelected<T> & {
     itemCount: number | undefined;
     pageItems: T[] | undefined;
-    refresh: () => Promise<ItemsResponse<T> | undefined>;
+    refresh: () => Promise<AwxItemsResponse<T> | undefined>;
     selectItemsAndRefresh: (items: T[]) => void;
     unselectItemsAndRefresh: (items: T[]) => void;
     refreshing: boolean;
@@ -104,7 +105,7 @@ export function useAwxView<T extends { id: number }>(options: {
 
   url += queryString;
   const fetcher = useFetcher();
-  const response = useSWR<ItemsResponse<T>>(url, fetcher, swrOptions);
+  const response = useSWR<AwxItemsResponse<T>>(url, fetcher, swrOptions);
   const { data, mutate } = response;
   const [refreshing, setRefreshing] = useState(false);
   const refresh = useCallback(() => {
@@ -114,7 +115,7 @@ export function useAwxView<T extends { id: number }>(options: {
     });
   }, [mutate]);
 
-  useSWR<ItemsResponse<T>>(data?.next, fetcher, swrOptions);
+  useSWR<AwxItemsResponse<T>>(data?.next, fetcher, swrOptions);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let error: Error | undefined = response.error;

--- a/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useRef, useState, useEffect } from 'react';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { IToolbarFilter } from '../../../../../framework';
+import { requestGet } from '../../../../common/crud/Data';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { useAwxWebSocketSubscription } from '../../../common/useAwxWebSocket';
 import { Job } from '../../../interfaces/Job';
 import { JobEvent } from '../../../interfaces/JobEvent';
-import type { IToolbarFilter } from '../../../../../framework';
 
 type WebSocketMessage = {
   group_name?: string;
@@ -37,7 +38,7 @@ export function useJobOutput(
       const eventsSlug = job.type === 'job' ? 'job_events' : 'events';
       isQuerying.current.querying = true;
 
-      requestGet<ItemsResponse<JobEvent>>(
+      requestGet<AwxItemsResponse<JobEvent>>(
         `/api/v2/${job.type}s/${job.id.toString()}/${eventsSlug}/?${qsParts.join('&')}`
       )
         .then((itemsResponse) => {

--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { usePageAlertToaster } from '../../../../../framework';
-import { ItemsResponse, requestGet } from '../../../../common/crud/Data';
+import { requestGet } from '../../../../common/crud/Data';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import {
   AdHocCommandRelaunch,
   InventorySourceUpdate,
@@ -31,11 +32,15 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
       let relaunchConfig;
       switch (job.type) {
         case 'ad_hoc_command': {
-          relaunchConfig = await requestGet<ItemsResponse<AdHocCommandRelaunch>>(relaunchEndpoint);
+          relaunchConfig = await requestGet<AwxItemsResponse<AdHocCommandRelaunch>>(
+            relaunchEndpoint
+          );
           break;
         }
         case 'workflow_job': {
-          relaunchConfig = await requestGet<ItemsResponse<WorkflowJobRelaunch>>(relaunchEndpoint);
+          relaunchConfig = await requestGet<AwxItemsResponse<WorkflowJobRelaunch>>(
+            relaunchEndpoint
+          );
           break;
         }
         case 'job': {

--- a/frontend/awx/views/jobs/jobUtils.cy.tsx
+++ b/frontend/awx/views/jobs/jobUtils.cy.tsx
@@ -1,4 +1,4 @@
-import { ItemsResponse } from '../../../common/crud/Data';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { getJobsAPIUrl, getRelaunchEndpoint } from './jobUtils';
 
@@ -9,7 +9,7 @@ describe('jobUtils', () => {
   });
 
   it('Returns correct relaunch endpoint based on job type', () => {
-    cy.fixture('jobs.json').then((response: ItemsResponse<UnifiedJob>) => {
+    cy.fixture('jobs.json').then((response: AwxItemsResponse<UnifiedJob>) => {
       const endpoint = getRelaunchEndpoint(response.results[0]);
       expect(endpoint).to.equal('/api/v2/workflow_jobs/491/relaunch/');
     });

--- a/frontend/common/crud/Data.tsx
+++ b/frontend/common/crud/Data.tsx
@@ -113,13 +113,6 @@ export function useFetcher() {
   return requestGet;
 }
 
-export interface ItemsResponse<T> {
-  count: number;
-  next?: string | null;
-  previous?: string | null;
-  results: T[];
-}
-
 export function getItemKey(item: { id: number | string }) {
   return item.id.toString();
 }

--- a/frontend/common/crud/useGetAllPagesAWX.tsx
+++ b/frontend/common/crud/useGetAllPagesAWX.tsx
@@ -1,12 +1,12 @@
-import useSWRInfinite from 'swr/infinite';
 import { useCallback, useMemo } from 'react';
-import { ItemsResponse } from './Data';
+import useSWRInfinite from 'swr/infinite';
+import { AwxItemsResponse } from '../../awx/common/AwxItemsResponse';
 import { useGetRequest } from './useGetRequest';
 
 export function useGetAllPagesAWX<T extends object>(url: string) {
-  const getRequest = useGetRequest<ItemsResponse<T>>();
+  const getRequest = useGetRequest<AwxItemsResponse<T>>();
   const getKey = useCallback(
-    (pageIndex: number, previousPageData: ItemsResponse<T>) => {
+    (pageIndex: number, previousPageData: AwxItemsResponse<T>) => {
       if (previousPageData && !previousPageData.next) return null;
 
       return `${url}?page=${pageIndex + 1}&page_size=200`;
@@ -14,7 +14,7 @@ export function useGetAllPagesAWX<T extends object>(url: string) {
     [url]
   );
 
-  const { data, error, isLoading, mutate } = useSWRInfinite<ItemsResponse<T>, Error>(
+  const { data, error, isLoading, mutate } = useSWRInfinite<AwxItemsResponse<T>, Error>(
     getKey,
     getRequest,
     {
@@ -23,7 +23,7 @@ export function useGetAllPagesAWX<T extends object>(url: string) {
   );
 
   const items = useMemo(() => {
-    return data?.reduce((items: T[], page: ItemsResponse<T>) => {
+    return data?.reduce((items: T[], page: AwxItemsResponse<T>) => {
       if (Array.isArray(page.results)) {
         return [...items, ...page.results];
       }

--- a/frontend/common/useActiveUser.tsx
+++ b/frontend/common/useActiveUser.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { AwxItemsResponse } from '../awx/common/AwxItemsResponse';
 import { User } from '../awx/interfaces/User';
-import { ItemsResponse } from './crud/Data';
 import { useGet } from './crud/useGet';
 
 const ActiveUserContext = createContext<User | null | undefined>(undefined);
@@ -15,7 +15,7 @@ export function useActiveUser() {
 
 export function ActiveUserProvider(props: { children?: ReactNode }) {
   const [activeUser, setActiveUser] = useState<User | null | undefined>(undefined);
-  const userResponse = useGet<ItemsResponse<User>>('/api/v2/me/');
+  const userResponse = useGet<AwxItemsResponse<User>>('/api/v2/me/');
   useEffect(() => {
     if (
       userResponse.data &&

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -10,16 +10,16 @@ import {
   PageTabs,
   Scrollable,
 } from '../../../framework';
+import { PageDetailCodeEditor } from '../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../framework/utils/formatDateString';
 import { RouteObj } from '../../Routes';
-import { ItemsResponse } from '../../common/crud/Data';
+import { AwxItemsResponse } from '../../awx/common/AwxItemsResponse';
 import { useGet } from '../../common/crud/useGet';
 import { PageDetailsSection } from '../common/PageDetailsSection';
 import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
 import { EdaActivationInstanceLog } from '../interfaces/EdaActivationInstanceLog';
 import { EdaRulebookActivation } from '../interfaces/EdaRulebookActivation';
-import { PageDetailCodeEditor } from '../../../framework/PageDetails/PageDetailCodeEditor';
 
 export function ActivationInstanceDetails() {
   const { t } = useTranslation();
@@ -30,13 +30,13 @@ export function ActivationInstanceDetails() {
     SWR_REFRESH_INTERVAL
   );
 
-  const { data: activationInstanceLogInfo } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
+  const { data: activationInstanceLogInfo } = useGet<AwxItemsResponse<EdaActivationInstanceLog>>(
     `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=1`,
     undefined,
     SWR_REFRESH_INTERVAL
   );
 
-  const { data: activationInstanceLog } = useGet<ItemsResponse<EdaActivationInstanceLog>>(
+  const { data: activationInstanceLog } = useGet<AwxItemsResponse<EdaActivationInstanceLog>>(
     `${API_PREFIX}/activation-instances/${params.id ?? ''}/logs/?page_size=${
       activationInstanceLogInfo?.count || 10
     }`,

--- a/frontend/eda/useEventDrivenView.tsx
+++ b/frontend/eda/useEventDrivenView.tsx
@@ -3,14 +3,15 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { ISelected, ITableColumn, IToolbarFilter, useSelected } from '../../framework';
 import { IView, useView } from '../../framework/useView';
-import { ItemsResponse, getItemKey, swrOptions, useFetcher } from '../common/crud/Data';
+import { AwxItemsResponse } from '../awx/common/AwxItemsResponse';
+import { getItemKey, swrOptions, useFetcher } from '../common/crud/Data';
 import { SWR_REFRESH_INTERVAL } from './constants';
 
 export type IEdaView<T extends { id: number | string }> = IView &
   ISelected<T> & {
     itemCount: number | undefined;
     pageItems: T[] | undefined;
-    refresh: () => Promise<ItemsResponse<T> | undefined>;
+    refresh: () => Promise<AwxItemsResponse<T> | undefined>;
     selectItemsAndRefresh: (items: T[]) => void;
     unselectItemsAndRefresh: (items: T[]) => void;
     refreshing: boolean;
@@ -94,7 +95,7 @@ export function useEdaView<T extends { id: number | string }>(options: {
 
   url += queryString;
   const fetcher = useFetcher();
-  const response = useSWR<ItemsResponse<T>>(url, fetcher, {
+  const response = useSWR<AwxItemsResponse<T>>(url, fetcher, {
     ...swrOptions,
     refreshInterval: SWR_REFRESH_INTERVAL,
   });
@@ -107,7 +108,7 @@ export function useEdaView<T extends { id: number | string }>(options: {
     });
   }, [mutate]);
 
-  useSWR<ItemsResponse<T>>(data?.next, fetcher, swrOptions);
+  useSWR<AwxItemsResponse<T>>(data?.next, fetcher, swrOptions);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let error: Error | undefined = response.error;


### PR DESCRIPTION
This makes it clearer that this interface represents the response from AWX API
Also matches the naming pattern HubItemResponse and PulpItemsResponse.