### PR TITLE
Fix accessibility warning related to ProgressStep

### DIFF
--- a/framework/PageDashboard/PageDashboardGettingStarted.tsx
+++ b/framework/PageDashboard/PageDashboardGettingStarted.tsx
@@ -29,6 +29,8 @@ export function PageDashboardGettingStarted(props: {
             {steps.map((step, index) => (
               <ProgressStep
                 key={index}
+                titleId={`${step.title}-${index}`}
+                id={`${step.title}-${index}`}
                 variant={step.isComplete ? 'success' : 'info'}
                 description={step.description}
               >


### PR DESCRIPTION
Fix accessibility warning related to ProgressStep

```
ProgressStep: The titleId and id properties are required to make this component accessible, and one or both of these properties are missing.
```

https://www.patternfly.org/v4/components/progress-stepper
