### PR TITLE
Reflect updated order in selected items

### DIFF
--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -118,6 +118,13 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
       if (newDraggedItemIndex !== itemStartIndex && draggedItemId) {
         const tempItemOrder = moveItem([...listItems], draggedItemId, newDraggedItemIndex);
         setListItems(tempItemOrder);
+
+        setSelectedItems((prevSelected) => {
+          prevSelected.sort(function (a, b) {
+            return tempItemOrder.indexOf(a) - tempItemOrder.indexOf(b);
+          });
+          return [...prevSelected];
+        });
       }
     }
     return null;

--- a/framework/components/ReorderItems.tsx
+++ b/framework/components/ReorderItems.tsx
@@ -174,7 +174,11 @@ export function ReorderItems<T extends object>(props: ReorderItemsProps<T>) {
   const onSelectItem = (isSelected: boolean, listItem: T) => {
     setSelectedItems((prevSelected) => {
       const otherSelectedItems = prevSelected.filter((item) => item !== listItem);
-      return isSelected ? [...otherSelectedItems, listItem] : otherSelectedItems;
+      const selectedItems = isSelected ? [...otherSelectedItems, listItem] : otherSelectedItems;
+      selectedItems.sort(function (a, b) {
+        return listItems.indexOf(a) - listItems.indexOf(b);
+      });
+      return [...selectedItems];
     });
   };
 


### PR DESCRIPTION
The selected items from the `ReorderItems` component do not reflect the last updated order. This PR fixes that.

This can be tested with the Manage View modal that shows up in the Hub dashboard. The console log reflects the values of `updatedOrder` and `selectedCategories`. `selectedCategories` should match the order of items in `updatedOrder`. 