### PR TITLE
Job output follow mode & scroll buttons

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobOutput.cy.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.cy.tsx
@@ -27,13 +27,13 @@ describe('JobOutput.cy.tsx', () => {
   });
 
   it('renders job output', () => {
-    cy.mount(<JobOutput job={job as unknown as Job} />);
+    cy.mount(<JobOutput job={job as unknown as Job} reloadJob={() => null} />);
     cy.get('h1').should('have.text', 'Demo Job Template');
     cy.get('.output-grid').find('.output-grid-row').should('have.length', 13);
   });
 
   it('collapses play output', () => {
-    cy.mount(<JobOutput job={job as unknown as Job} />);
+    cy.mount(<JobOutput job={job as unknown as Job} reloadJob={() => null} />);
     cy.get('.output-grid').find('.output-grid-row').should('have.length', 13);
     cy.get('.output-grid').find('button > svg').first().click();
     cy.get('.output-grid').find('.output-grid-row').should('have.length', 5);

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -1,5 +1,5 @@
+import { useState, useEffect, useMemo } from 'react';
 import { PageSection, Skeleton } from '@patternfly/react-core';
-import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { IFilterState, ToolbarFilterType, type IToolbarFilter } from '../../../../../framework';
@@ -17,11 +17,30 @@ const Section = styled(PageSection)`
   height: calc(100vh - 204px);
 `;
 
-export function JobOutput(props: { job: Job }) {
-  const { job } = props;
+export function JobOutput(props: { job: Job; reloadJob: () => void }) {
+  const { job, reloadJob } = props;
   const toolbarFilters = useOutputFilters();
   const [filterState, setFilterState] = useState<IFilterState>({});
-  const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(isJobRunning(job.status));
+  const isRunning = isJobRunning(job.status);
+  const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(isRunning);
+
+  useEffect(() => {
+    if (!isRunning && isFollowModeEnabled) {
+      setIsFollowModeEnabled(false);
+    }
+  }, [isRunning, isFollowModeEnabled]);
+  // useEffect(() => {
+  //   if (!isRunning && isFollowModeEnabled) {
+  //     console.log('useEffect not isRunning', job);
+  //     setTimeout(() => {
+  //       console.log('A turning off follow mode');
+  //       setTimeout(() => {
+  //         console.log('B turning off follow mode');
+  //         setIsFollowModeEnabled(false);
+  //       }, 500);
+  //     }, 500);
+  //   }
+  // }, [isRunning]);
 
   if (!job) {
     return <Skeleton />;
@@ -40,6 +59,7 @@ export function JobOutput(props: { job: Job }) {
       />
       <JobOutputEvents
         job={job}
+        reloadJob={reloadJob}
         toolbarFilters={toolbarFilters}
         filterState={filterState}
         isFollowModeEnabled={isFollowModeEnabled}

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -24,23 +24,11 @@ export function JobOutput(props: { job: Job; reloadJob: () => void }) {
   const isRunning = isJobRunning(job.status);
   const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(isRunning);
 
-  useEffect(() => {
-    if (!isRunning && isFollowModeEnabled) {
-      setIsFollowModeEnabled(false);
-    }
-  }, [isRunning, isFollowModeEnabled]);
   // useEffect(() => {
   //   if (!isRunning && isFollowModeEnabled) {
-  //     console.log('useEffect not isRunning', job);
-  //     setTimeout(() => {
-  //       console.log('A turning off follow mode');
-  //       setTimeout(() => {
-  //         console.log('B turning off follow mode');
-  //         setIsFollowModeEnabled(false);
-  //       }, 500);
-  //     }, 500);
+  //     setIsFollowModeEnabled(false);
   //   }
-  // }, [isRunning]);
+  // }, [isRunning, isFollowModeEnabled]);
 
   if (!job) {
     return <Skeleton />;

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { PageSection, Skeleton } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -23,12 +23,6 @@ export function JobOutput(props: { job: Job; reloadJob: () => void }) {
   const [filterState, setFilterState] = useState<IFilterState>({});
   const isRunning = isJobRunning(job.status);
   const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(isRunning);
-
-  // useEffect(() => {
-  //   if (!isRunning && isFollowModeEnabled) {
-  //     setIsFollowModeEnabled(false);
-  //   }
-  // }, [isRunning, isFollowModeEnabled]);
 
   if (!job) {
     return <Skeleton />;

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -63,6 +63,7 @@ export function JobOutput(props: { job: Job; reloadJob: () => void }) {
         toolbarFilters={toolbarFilters}
         filterState={filterState}
         isFollowModeEnabled={isFollowModeEnabled}
+        setIsFollowModeEnabled={setIsFollowModeEnabled}
       />
     </Section>
   );

--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -9,6 +9,7 @@ import './JobOutput.css';
 import { JobOutputEvents } from './JobOutputEvents';
 import { JobOutputToolbar } from './JobOutputToolbar';
 import { JobStatusBar } from './JobStatusBar';
+import { isJobRunning } from './util';
 
 const Section = styled(PageSection)`
   display: flex;
@@ -20,6 +21,7 @@ export function JobOutput(props: { job: Job }) {
   const { job } = props;
   const toolbarFilters = useOutputFilters();
   const [filterState, setFilterState] = useState<IFilterState>({});
+  const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(isJobRunning(job.status));
 
   if (!job) {
     return <Skeleton />;
@@ -32,8 +34,16 @@ export function JobOutput(props: { job: Job }) {
         toolbarFilters={toolbarFilters}
         filterState={filterState}
         setFilterState={setFilterState}
+        jobStatus={job.status}
+        isFollowModeEnabled={isFollowModeEnabled}
+        setIsFollowModeEnabled={setIsFollowModeEnabled}
       />
-      <JobOutputEvents job={job} toolbarFilters={toolbarFilters} filterState={filterState} />
+      <JobOutputEvents
+        job={job}
+        toolbarFilters={toolbarFilters}
+        filterState={filterState}
+        isFollowModeEnabled={isFollowModeEnabled}
+      />
     </Section>
   );
 }

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -11,12 +11,11 @@ import {
   useJobOutputChildrenSummary,
 } from './useJobOutputChildrenSummary';
 import { useVirtualizedList } from './useVirtualized';
+import { isJobRunning } from './util';
 
 export interface ICollapsed {
   [uuid: string]: boolean;
 }
-
-const runningJobTypes: string[] = ['new', 'pending', 'waiting', 'running'];
 
 const ScrollContainer = styled.div`
   overflow: auto;
@@ -29,17 +28,17 @@ interface IJobOutputEventsProps {
   job: Job;
   toolbarFilters: IToolbarFilter[];
   filterState: IFilterState;
+  isFollowModeEnabled: boolean;
 }
 
 export function JobOutputEvents(props: IJobOutputEventsProps) {
-  const { job, toolbarFilters, filterState } = props;
+  const { job, toolbarFilters, filterState, isFollowModeEnabled } = props;
   // TODO set job status on ws event change
-  const isJobRunning = !job.status || runningJobTypes.includes(job.status);
   const isFiltered = Object.keys(filterState).length > 0;
 
   const { childrenSummary, isFlatMode } = useJobOutputChildrenSummary(
     job,
-    isJobRunning || isFiltered
+    isJobRunning(job.status) || isFiltered
   );
   const { jobEventCount, getJobOutputEvent, queryJobOutputEvent } = useJobOutput(
     job,
@@ -85,7 +84,8 @@ export function JobOutputEvents(props: IJobOutputEventsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { beforeRowsHeight, visibleItems, setRowHeight, afterRowsHeight } = useVirtualizedList(
     containerRef,
-    nonCollapsedRows
+    nonCollapsedRows,
+    isFollowModeEnabled
   );
 
   const canCollapseEvents = childrenSummary?.event_processing_finished && childrenSummary.is_tree;

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -57,7 +57,6 @@ export function JobOutputEvents(props: IJobOutputEventsProps) {
     filterState,
     50
   );
-  // const [isScrolledToEnd, setIsScrolledToEnd] = useState(isFollowModeEnabled);
 
   const jobOutputRows = useMemo(() => {
     const jobOutputRows: (IJobOutputRow | number)[] = [];

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -107,7 +107,8 @@ export function JobOutputEvents(props: IJobOutputEventsProps) {
     containerRef,
     isFollowModeEnabled,
     setIsFollowModeEnabled,
-    jobOutputRows.length
+    jobOutputRows.length,
+    isJobRunning(job.status)
   );
 
   return (

--- a/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
@@ -1,19 +1,41 @@
-import { Toolbar, ToolbarContent } from '@patternfly/react-core';
 import { Dispatch, SetStateAction } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
+import { Toolbar, ToolbarContent, Button } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 import {
   IFilterState,
   PageToolbarFilters,
 } from '../../../../../framework/PageToolbar/PageToolbarFilter';
+import { IToolbarFilter } from '../../../../../framework';
+import { JobStatus, isJobRunning } from './util';
 
 interface IJobOutputToolbarProps {
   toolbarFilters: IToolbarFilter[];
   filterState: IFilterState;
   setFilterState: Dispatch<SetStateAction<IFilterState>>;
+  jobStatus?: JobStatus;
+  isFollowModeEnabled: boolean;
+  setIsFollowModeEnabled: (value: boolean) => void;
 }
 
 export function JobOutputToolbar(props: IJobOutputToolbarProps) {
-  const { toolbarFilters, filterState, setFilterState } = props;
+  const {
+    toolbarFilters,
+    filterState,
+    setFilterState,
+    jobStatus,
+    isFollowModeEnabled,
+    setIsFollowModeEnabled,
+  } = props;
+  const { t } = useTranslation();
+
+  const handleFollowToggle = () => {
+    if (isFollowModeEnabled) {
+      setIsFollowModeEnabled(false);
+    } else {
+      setIsFollowModeEnabled(true);
+      // scrollToEnd();
+    }
+  };
 
   return (
     <Toolbar clearAllFilters={() => setFilterState({})}>
@@ -23,6 +45,14 @@ export function JobOutputToolbar(props: IJobOutputToolbarProps) {
           filterState={filterState}
           setFilterState={setFilterState}
         />
+        {isJobRunning(jobStatus) || true ? (
+          <Button
+            variant={isFollowModeEnabled ? 'secondary' : 'primary'}
+            onClick={handleFollowToggle}
+          >
+            {isFollowModeEnabled ? t('Unfollow') : t('Follow')}
+          </Button>
+        ) : null}
       </ToolbarContent>
     </Toolbar>
   );

--- a/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
@@ -33,7 +33,6 @@ export function JobOutputToolbar(props: IJobOutputToolbarProps) {
       setIsFollowModeEnabled(false);
     } else {
       setIsFollowModeEnabled(true);
-      // scrollToEnd();
     }
   };
 

--- a/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputToolbar.tsx
@@ -45,7 +45,7 @@ export function JobOutputToolbar(props: IJobOutputToolbarProps) {
           filterState={filterState}
           setFilterState={setFilterState}
         />
-        {isJobRunning(jobStatus) || true ? (
+        {isJobRunning(jobStatus) ? (
           <Button
             variant={isFollowModeEnabled ? 'secondary' : 'primary'}
             onClick={handleFollowToggle}

--- a/frontend/awx/views/jobs/JobOutput/PageControls.tsx
+++ b/frontend/awx/views/jobs/JobOutput/PageControls.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@patternfly/react-core';
+import {
+  AngleDoubleUpIcon,
+  AngleDoubleDownIcon,
+  AngleUpIcon,
+  AngleDownIcon,
+  AngleRightIcon,
+} from '@patternfly/react-icons';
+import styled from 'styled-components';
+
+const ControllsWrapper = styled.div`
+  display: flex;
+  height: 35px;
+  border: 1px solid #d7d7d7;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const ScrollWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+const ExpandCollapseWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  & > Button {
+    padding-left: 8px;
+  }
+`;
+
+interface IPageControlsProps {
+  onScrollFirst: () => void;
+  onScrollLast: () => void;
+  onScrollNext: () => void;
+  onScrollPrevious: () => void;
+  toggleExpandCollapseAll: () => void;
+  isAllCollapsed: boolean;
+  isFlatMode: boolean;
+  isTemplateJob: boolean;
+}
+
+export function PageControls(props: IPageControlsProps) {
+  const {
+    onScrollFirst,
+    onScrollLast,
+    onScrollNext,
+    onScrollPrevious,
+    toggleExpandCollapseAll,
+    isAllCollapsed,
+    isFlatMode,
+    isTemplateJob,
+  } = props;
+  const { t } = useTranslation();
+
+  return (
+    <ControllsWrapper>
+      <ExpandCollapseWrapper>
+        {!isFlatMode && isTemplateJob && (
+          <Button
+            aria-label={isAllCollapsed ? t`Expand job events` : t`Collapse all job events`}
+            variant="plain"
+            type="button"
+            onClick={toggleExpandCollapseAll}
+          >
+            {isAllCollapsed ? <AngleRightIcon /> : <AngleDownIcon />}
+          </Button>
+        )}
+      </ExpandCollapseWrapper>
+      <ScrollWrapper>
+        <Button
+          ouiaId="job-output-scroll-previous-button"
+          aria-label={t`Scroll previous`}
+          onClick={onScrollPrevious}
+          variant="plain"
+        >
+          <AngleUpIcon />
+        </Button>
+        <Button
+          ouiaId="job-output-scroll-next-button"
+          aria-label={t`Scroll next`}
+          onClick={onScrollNext}
+          variant="plain"
+        >
+          <AngleDownIcon />
+        </Button>
+        <Button
+          ouiaId="job-output-scroll-first-button"
+          aria-label={t`Scroll first`}
+          onClick={onScrollFirst}
+          variant="plain"
+        >
+          <AngleDoubleUpIcon />
+        </Button>
+        <Button
+          ouiaId="job-output-scroll-last-button"
+          aria-label={t`Scroll last`}
+          onClick={onScrollLast}
+          variant="plain"
+        >
+          <AngleDoubleDownIcon />
+        </Button>
+      </ScrollWrapper>
+    </ControllsWrapper>
+  );
+}

--- a/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutput.tsx
@@ -11,6 +11,7 @@ type WebSocketMessage = {
   type?: string;
   status?: string;
   inventory_id?: number;
+  unified_job_id?: number;
 };
 
 const WS_EVENTS_BATCH_SIZE = 15;
@@ -18,6 +19,7 @@ const runningJobTypes: string[] = ['new', 'pending', 'waiting', 'running'];
 
 export function useJobOutput(
   job: Job,
+  reloadJob: () => void,
   toolbarFilters: IToolbarFilter[],
   filterState: IFilterState,
   pageSize: number
@@ -136,8 +138,11 @@ export function useJobOutput(
           batchTimeout.current = setTimeout(addBatchedEvents, 500);
         }
       }
+      if (message?.group_name === 'jobs' && message?.unified_job_id === job.id && message?.status) {
+        reloadJob();
+      }
     },
-    [addBatchedEvents, eventGroup]
+    [addBatchedEvents, eventGroup, reloadJob, job.id]
   );
   useAwxWebSocketSubscription(
     {

--- a/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
@@ -38,31 +38,17 @@ export function useScrollControls(
       return;
     }
     const interval = setInterval(() => {
-      console.log(numTicksAtBottom);
       if (!containerRef.current) {
-        console.log('no ref');
         return;
       }
       if (numTicksAtBottom >= 3) {
-        console.log('turning follow mode off');
         setIsFollowModeEnabled(false);
         return;
       }
 
       if (isAtBottom(containerRef.current)) {
-        console.log('incementing');
         setNumTicksAtBottom((prev) => prev + 1);
       } else {
-        console.log('not at bottom');
-        const { clientHeight, scrollHeight, scrollTop } = containerRef.current;
-        const scrollTopMax = scrollHeight - clientHeight;
-        console.log({
-          clientHeight,
-          scrollHeight,
-          scrollTop,
-          scrollTopMax,
-          isAtBottom: scrollTop >= scrollTopMax,
-        });
         setNumTicksAtBottom(0);
       }
     }, 200);

--- a/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
@@ -1,0 +1,78 @@
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+export function useScrollControls(
+  containerRef: RefObject<HTMLElement>,
+  isFollowModeEnabled: boolean,
+  setIsFollowModeEnabled: (value: boolean) => void,
+  numRows: number
+) {
+  const [isScrolledToEnd, setIsScrolledToEnd] = useState(isFollowModeEnabled);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    console.log({ isFollowModeEnabled, numRows, isScrolledToEnd });
+    if (isFollowModeEnabled || isScrolledToEnd) {
+      // outputEndRef.current?.scrollIntoView();
+      containerRef.current.scrollTo({ top: containerRef.current.scrollHeight });
+      setIsScrolledToEnd(true);
+    }
+    if (!isFollowModeEnabled) {
+      setIsScrolledToEnd(false);
+    }
+  }, [isFollowModeEnabled, isScrolledToEnd, numRows, containerRef]);
+
+  const onScroll = useCallback(() => {
+    if (!containerRef.current) return;
+    console.log('X onScroll');
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    el.addEventListener('scroll', onScroll);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+    };
+  }, [containerRef, onScroll]);
+
+  const scrollToTop = () => {
+    containerRef.current?.scrollTo({ top: 0 });
+    setIsScrolledToEnd(false);
+  };
+
+  const scrollToBottom = () => {
+    if (!containerRef.current) {
+      return;
+    }
+    // outputEndRef.current?.scrollIntoView();
+    containerRef.current.scrollTo({ top: containerRef.current.scrollHeight });
+    setIsFollowModeEnabled(true);
+    // setIsScrolledToEnd(true);
+  };
+
+  const scrollPageDown = () => {
+    if (!containerRef.current) {
+      return;
+    }
+    const { height } = containerRef.current.getBoundingClientRect();
+    containerRef.current?.scrollBy({ top: height - 48 });
+  };
+
+  const scrollPageUp = () => {
+    if (!containerRef.current) {
+      return;
+    }
+    const { height } = containerRef.current.getBoundingClientRect();
+    containerRef.current?.scrollBy({ top: (height - 48) * -1 });
+  };
+
+  return {
+    scrollToTop,
+    scrollToBottom,
+    scrollPageDown,
+    scrollPageUp,
+  };
+}

--- a/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
@@ -38,17 +38,31 @@ export function useScrollControls(
       return;
     }
     const interval = setInterval(() => {
+      console.log(numTicksAtBottom);
       if (!containerRef.current) {
+        console.log('no ref');
         return;
       }
       if (numTicksAtBottom >= 3) {
+        console.log('turning follow mode off');
         setIsFollowModeEnabled(false);
         return;
       }
 
       if (isAtBottom(containerRef.current)) {
+        console.log('incementing');
         setNumTicksAtBottom((prev) => prev + 1);
       } else {
+        console.log('not at bottom');
+        const { clientHeight, scrollHeight, scrollTop } = containerRef.current;
+        const scrollTopMax = scrollHeight - clientHeight;
+        console.log({
+          clientHeight,
+          scrollHeight,
+          scrollTop,
+          scrollTopMax,
+          isAtBottom: scrollTop >= scrollTopMax,
+        });
         setNumTicksAtBottom(0);
       }
     }, 200);

--- a/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useScrollControls.tsx
@@ -52,9 +52,13 @@ export function useScrollControls(
         setNumTicksAtBottom(0);
       }
     }, 200);
+    const failSafe = setTimeout(() => {
+      setIsFollowModeEnabled(false);
+    }, 1200);
 
     return () => {
       clearInterval(interval);
+      clearTimeout(failSafe);
     };
   }, [isFollowModeEnabled, isJobRunning, containerRef, numTicksAtBottom, setIsFollowModeEnabled]);
 

--- a/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
@@ -10,8 +10,15 @@ export function useVirtualizedList<T>(
 
   const [scrollTop, setScrollTop] = useState(0);
   const onScroll = useCallback(() => {
-    console.log('onScroll');
     if (!containerRef.current) return;
+    const { clientHeight, scrollHeight, scrollTop } = containerRef.current;
+    console.log('onScroll', {
+      clientHeight,
+      scrollHeight,
+      scrollTop,
+      isAtBottom: scrollTop + clientHeight >= scrollHeight,
+      event: containerRef.current,
+    });
     setScrollTop(containerRef.current.scrollTop);
     setContainerHeight(containerRef.current.clientHeight);
   }, [containerRef]);
@@ -22,7 +29,7 @@ export function useVirtualizedList<T>(
 
   const [containerHeight, setContainerHeight] = useState(0);
   const onResize = useCallback(() => {
-    console.log('onResize');
+    // console.log('onResize');
     if (!containerRef.current) return;
     setContainerHeight(containerRef.current.clientHeight);
   }, [containerRef]);
@@ -32,7 +39,7 @@ export function useVirtualizedList<T>(
   const [minRowHeight, setMinRowHeight] = useState(24);
   const setRowHeight = useCallback(
     (index: number, height: number) => {
-      console.log('setRowHeights');
+      // console.log('setRowHeights');
       setRowHeights((heights) => {
         const existingHeight = heights[index];
         if (existingHeight === height) return heights;
@@ -42,19 +49,19 @@ export function useVirtualizedList<T>(
         return newHeights;
       });
       if (isFollowModeEnabled && containerRef.current) {
-        console.log('B');
-        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+        // console.log('B');
+        // containerRef.current.scrollTop = containerRef.current.scrollHeight;
       }
     },
     [minRowHeight, containerRef, isFollowModeEnabled]
   );
 
-  useEffect(() => {
-    if (isFollowModeEnabled && containerRef.current) {
-      console.log('A');
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [isFollowModeEnabled, containerRef]);
+  // useEffect(() => {
+  //   if (isFollowModeEnabled && containerRef.current) {
+  //     console.log('A');
+  //     containerRef.current.scrollTop = containerRef.current.scrollHeight;
+  //   }
+  // }, [isFollowModeEnabled, containerRef]);
 
   const totalRowCount = items.length;
 

--- a/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
@@ -7,7 +7,6 @@ export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, item
   const [containerHeight, setContainerHeight] = useState(0);
 
   const onScroll = useCallback(() => {
-    // console.log('onScroll');
     if (!containerRef.current) return;
     setScrollTop(containerRef.current.scrollTop);
     setContainerHeight(containerRef.current.clientHeight);
@@ -24,7 +23,6 @@ export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, item
   }, [containerRef, onScroll]);
 
   const onResize = useCallback(() => {
-    // console.log('onResize');
     if (!containerRef.current) return;
     setContainerHeight(containerRef.current.clientHeight);
   }, [containerRef]);

--- a/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
@@ -1,33 +1,28 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import { RefObject, useCallback, useEffect, useState } from 'react';
 
-export function useVirtualizedList<T>(
-  containerRef: RefObject<HTMLElement>,
-  items: T[],
-  isFollowModeEnabled: boolean
-) {
+export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, items: T[]) {
   const scrollBuffer = 400;
-
   const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
   const onScroll = useCallback(() => {
+    // console.log('onScroll');
     if (!containerRef.current) return;
-    const { clientHeight, scrollHeight, scrollTop } = containerRef.current;
-    console.log('onScroll', {
-      clientHeight,
-      scrollHeight,
-      scrollTop,
-      isAtBottom: scrollTop + clientHeight >= scrollHeight,
-      event: containerRef.current,
-    });
     setScrollTop(containerRef.current.scrollTop);
     setContainerHeight(containerRef.current.clientHeight);
   }, [containerRef]);
+
   useEffect(() => {
     if (!containerRef.current) return;
-    containerRef.current.onscroll = onScroll;
+    const el = containerRef.current;
+    el.addEventListener('scroll', onScroll);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+    };
   }, [containerRef, onScroll]);
 
-  const [containerHeight, setContainerHeight] = useState(0);
   const onResize = useCallback(() => {
     // console.log('onResize');
     if (!containerRef.current) return;
@@ -39,7 +34,6 @@ export function useVirtualizedList<T>(
   const [minRowHeight, setMinRowHeight] = useState(24);
   const setRowHeight = useCallback(
     (index: number, height: number) => {
-      // console.log('setRowHeights');
       setRowHeights((heights) => {
         const existingHeight = heights[index];
         if (existingHeight === height) return heights;
@@ -48,20 +42,9 @@ export function useVirtualizedList<T>(
         newHeights[index] = height;
         return newHeights;
       });
-      if (isFollowModeEnabled && containerRef.current) {
-        // console.log('B');
-        // containerRef.current.scrollTop = containerRef.current.scrollHeight;
-      }
     },
-    [minRowHeight, containerRef, isFollowModeEnabled]
+    [minRowHeight]
   );
-
-  // useEffect(() => {
-  //   if (isFollowModeEnabled && containerRef.current) {
-  //     console.log('A');
-  //     containerRef.current.scrollTop = containerRef.current.scrollHeight;
-  //   }
-  // }, [isFollowModeEnabled, containerRef]);
 
   const totalRowCount = items.length;
 

--- a/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useVirtualized.tsx
@@ -1,11 +1,16 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import { RefObject, useCallback, useEffect, useState } from 'react';
 
-export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, items: T[]) {
+export function useVirtualizedList<T>(
+  containerRef: RefObject<HTMLElement>,
+  items: T[],
+  isFollowModeEnabled: boolean
+) {
   const scrollBuffer = 400;
 
   const [scrollTop, setScrollTop] = useState(0);
   const onScroll = useCallback(() => {
+    console.log('onScroll');
     if (!containerRef.current) return;
     setScrollTop(containerRef.current.scrollTop);
     setContainerHeight(containerRef.current.clientHeight);
@@ -17,6 +22,7 @@ export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, item
 
   const [containerHeight, setContainerHeight] = useState(0);
   const onResize = useCallback(() => {
+    console.log('onResize');
     if (!containerRef.current) return;
     setContainerHeight(containerRef.current.clientHeight);
   }, [containerRef]);
@@ -26,6 +32,7 @@ export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, item
   const [minRowHeight, setMinRowHeight] = useState(24);
   const setRowHeight = useCallback(
     (index: number, height: number) => {
+      console.log('setRowHeights');
       setRowHeights((heights) => {
         const existingHeight = heights[index];
         if (existingHeight === height) return heights;
@@ -34,9 +41,20 @@ export function useVirtualizedList<T>(containerRef: RefObject<HTMLElement>, item
         newHeights[index] = height;
         return newHeights;
       });
+      if (isFollowModeEnabled && containerRef.current) {
+        console.log('B');
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
     },
-    [minRowHeight]
+    [minRowHeight, containerRef, isFollowModeEnabled]
   );
+
+  useEffect(() => {
+    if (isFollowModeEnabled && containerRef.current) {
+      console.log('A');
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [isFollowModeEnabled, containerRef]);
 
   const totalRowCount = items.length;
 

--- a/frontend/awx/views/jobs/JobOutput/util.ts
+++ b/frontend/awx/views/jobs/JobOutput/util.ts
@@ -1,0 +1,15 @@
+export type JobStatus =
+  | 'new'
+  | 'pending'
+  | 'waiting'
+  | 'running'
+  | 'successful'
+  | 'failed'
+  | 'error'
+  | 'canceled';
+
+const runningJobTypes: string[] = ['new', 'pending', 'waiting', 'running'];
+
+export function isJobRunning(jobStatus?: JobStatus) {
+  return !jobStatus || runningJobTypes.includes(jobStatus);
+}

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -51,7 +51,7 @@ function useGetJob(id?: string, type?: string) {
   const { data: job, refresh: refreshJob } = useGet<Job>(
     id ? `/api/v2/${path}/${id}/` : '',
     undefined,
-    0
+    { refreshInterval: 0 }
   );
   return { job, refreshJob };
 }

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -13,7 +13,7 @@ import { WorkflowOutput } from './WorkflowOutput';
 export function JobPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string; job_type: string }>();
-  const job = useGetJob(params.id, params.job_type);
+  const { job, refreshJob } = useGetJob(params.id, params.job_type);
   // TODO handle 404/no job
   return (
     <PageLayout>
@@ -24,7 +24,11 @@ export function JobPage() {
       <RoutedTabs isLoading={!job} baseUrl={RouteObj.JobPage}>
         <PageBackTab label={t('Back to Jobs')} url={RouteObj.Jobs} persistentFilterKey="jobs" />
         <RoutedTab label={t('Output')} url={RouteObj.JobOutput}>
-          {job?.type === 'workflow_job' ? <WorkflowOutput job={job} /> : <JobOutput job={job!} />}
+          {job?.type === 'workflow_job' ? (
+            <WorkflowOutput job={job} />
+          ) : (
+            <JobOutput job={job!} reloadJob={refreshJob} />
+          )}
         </RoutedTab>
         <RoutedTab label={t('Details')} url={RouteObj.JobDetails}>
           <JobDetails job={job!} />
@@ -44,6 +48,10 @@ function useGetJob(id?: string, type?: string) {
     workflow: 'workflow_jobs',
   };
   const path = type ? apiPaths[type] : 'jobs';
-  const { data: job } = useGet<Job>(id ? `/api/v2/${path}/${id}/` : '');
-  return job;
+  const { data: job, refresh: refreshJob } = useGet<Job>(
+    id ? `/api/v2/${path}/${id}/` : '',
+    undefined,
+    0
+  );
+  return { job, refreshJob };
 }


### PR DESCRIPTION
Adds follow mode & pagination buttons to the job output page

* Clicking Unfollow exits follow mode
* Clicking page up or scroll to top buttons exits follow mode
* Scrolling manually does *not* exit follow mode -- I decided I cannot rely on `onScroll` events to exit follow mode, because follow mode itself fires off so many of them and I could not reliably distinguish between those and user-driven scroll events
* Clicking the scroll to bottom button enables follow mode. This enables the UI to scroll to bottom repeatedly so it stays at the bottom while the last events load and render.
* If the job is not running and follow mode is enabled, it will wait until the output has been locked to the bottom consistently for 600ms (checking every 200ms) -- allowing for the final events to render & resize properly -- then it will automatically disable follow mode.