### PR TITLE
Collection cards for Hub dashboard carousel view

### DIFF
--- a/framework/PageCarousel/PageCarousel.tsx
+++ b/framework/PageCarousel/PageCarousel.tsx
@@ -4,7 +4,7 @@ import useResizeObserver from '@react-hook/resize-observer';
 import { ReactNode, useLayoutEffect, useRef, useState, Children, useMemo, useEffect } from 'react';
 import styled from 'styled-components';
 
-const CardSpan = (1662 - 59) / 4;
+export const CardSpan = (1662 - 59) / 4;
 
 const SlideContainer = styled.div`
   display: flex;
@@ -23,20 +23,24 @@ const SlideContainer = styled.div`
  * A carousel component that displays children (eg. page cards) within it and switches
  * between pages of cards using smooth animation.
  */
-export function PageCarousel(props: { children: ReactNode; carouselId: string }) {
+export function PageCarousel(props: {
+  children: ReactNode;
+  carouselId: string;
+  cardWidth?: number;
+}) {
   const slideContainerRef = useRef<HTMLDivElement>(null);
   const [pageIndex, setPageIndex] = useState(0);
-
+  const cardSpan = props.cardWidth ?? CardSpan;
   const [visibleCardsPerPage, setVisibleCardsPerPage] = useState(1);
 
   useLayoutEffect(() => {
     setVisibleCardsPerPage(
-      Math.max(1, Math.floor((slideContainerRef.current?.clientWidth ?? 0) / CardSpan))
+      Math.max(1, Math.floor((slideContainerRef.current?.clientWidth ?? 0) / cardSpan))
     );
-  }, []);
+  }, [cardSpan]);
 
   useResizeObserver(slideContainerRef, (entry) => {
-    setVisibleCardsPerPage(Math.max(1, Math.floor((entry.contentRect.width ?? 0) / CardSpan)));
+    setVisibleCardsPerPage(Math.max(1, Math.floor((entry.contentRect.width ?? 0) / cardSpan)));
   });
 
   const pagesOfCards = useMemo(() => {

--- a/framework/PageCarousel/PageCarousel.tsx
+++ b/framework/PageCarousel/PageCarousel.tsx
@@ -29,8 +29,15 @@ const SlideContainer = styled.div`
   }
 `;
 
-const CarouselContext = createContext<{ width: number; visibleCards: number }>({});
+const CarouselContext = createContext<{ width: number; visibleCards: number }>({
+  width: 0,
+  visibleCards: 0,
+});
 
+/** This hook provides real time context of the carousel's width and the number
+ * of visible cards. The information may be needed for adjusting the widths of cards
+ * that show up inside the carousel.
+ */
 export function useCarouselContext() {
   return useContext(CarouselContext);
 }

--- a/framework/PageDashboard/PageDashboardCarousel.tsx
+++ b/framework/PageDashboard/PageDashboardCarousel.tsx
@@ -9,7 +9,6 @@ export function PageDashboardCarousel(props: {
   to?: string;
   width?: PageDashboardCardWidth;
   children: ReactNode;
-  childCardWidth?: number;
 }) {
   return (
     <PageDashboardCard
@@ -19,10 +18,7 @@ export function PageDashboardCarousel(props: {
       width={props.width}
     >
       <CardBody>
-        <PageCarousel
-          carouselId={props.title.replace(/\s+/g, '-').toLowerCase()}
-          cardWidth={props.childCardWidth}
-        >
+        <PageCarousel carouselId={props.title.replace(/\s+/g, '-').toLowerCase()}>
           {props.children}
         </PageCarousel>
       </CardBody>

--- a/framework/PageDashboard/PageDashboardCarousel.tsx
+++ b/framework/PageDashboard/PageDashboardCarousel.tsx
@@ -9,6 +9,7 @@ export function PageDashboardCarousel(props: {
   to?: string;
   width?: PageDashboardCardWidth;
   children: ReactNode;
+  childCardWidth?: number;
 }) {
   return (
     <PageDashboardCard
@@ -18,7 +19,10 @@ export function PageDashboardCarousel(props: {
       width={props.width}
     >
       <CardBody>
-        <PageCarousel carouselId={props.title.replace(/\s+/g, '-').toLowerCase()}>
+        <PageCarousel
+          carouselId={props.title.replace(/\s+/g, '-').toLowerCase()}
+          cardWidth={props.childCardWidth}
+        >
           {props.children}
         </PageCarousel>
       </CardBody>

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -38,7 +38,12 @@ export interface IPageTableCard {
   title: ReactNode;
   subtitle?: ReactNode;
   cardBody: ReactNode;
-  labels?: { label: string; color?: LabelColor }[]; // TODO - disable/enable auto generated filters
+  labels?: {
+    label: string;
+    color?: LabelColor;
+    icon?: ReactNode;
+    variant?: 'outline' | 'filled' | undefined;
+  }[]; // TODO - disable/enable auto generated filters
   badge?: string;
   badgeColor?: LabelColor;
   badgeTooltip?: string;
@@ -213,7 +218,12 @@ export function PageTableCard<T extends object>(props: {
               {card.labels && (
                 <LabelGroup numLabels={999}>
                   {card.labels.map((item) => (
-                    <Label key={item.label} color={item.color}>
+                    <Label
+                      key={item.label}
+                      color={item.color}
+                      icon={item.icon}
+                      variant={item.variant}
+                    >
                       <Truncate content={item.label} style={{ minWidth: 0 }} />
                     </Label>
                   ))}

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -77,14 +77,14 @@ const CardFooterLabelsDiv = styled.div`
   flex-grow: 1;
 `;
 
-const PageDetailDiv = styled.div`
+export const PageDetailDiv = styled.div`
   display: flex;
   gap: 16px;
   margin-top: 8px;
   flex-wrap: wrap;
 `;
 
-const ColumnsDiv = styled.div`
+export const ColumnsDiv = styled.div`
   display: flex;
   gap: 6px;
   align-items: baseline;

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -32,6 +32,9 @@ import {
   TableColumnCell,
 } from './PageTableColumn';
 
+export const Small = styled.small`
+  opacity: 0.7;
+`;
 export interface IPageTableCard {
   id: string | number;
   icon?: ReactNode;
@@ -338,7 +341,7 @@ export function useColumnsToTableCardFn<T extends object>(
                     {countColumns.map((column, i) => (
                       <ColumnsDiv key={i}>
                         <TableColumnCell column={column} item={item} />
-                        <small style={{ opacity: 0.7 }}>{column.header}</small>
+                        <Small>{column.header}</Small>
                       </ColumnsDiv>
                     ))}
                   </PageDetailDiv>

--- a/framework/components/useManagedItems.tsx
+++ b/framework/components/useManagedItems.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageDialog } from '../PageDialogs/PageDialog';
 import { useSelected } from '../PageTable/useTableItems';
@@ -61,9 +61,12 @@ export interface ManageItemsProps<ItemT extends object> {
  * - Display type
  */
 export function useManageItems<ItemT extends object>(options: ManageItemsProps<ItemT>) {
-  const { saveFn, loadFn, isSelected, setSelected } = options;
   const [_, setDialog] = usePageDialog();
   const [keyFn] = useState(() => options.keyFn);
+  const [isSelected] = useState(() => options.isSelected);
+  const [setSelected] = useState(() => options.setSelected);
+  const [saveFn] = useState(() => options.saveFn);
+  const [loadFn] = useState(() => options.loadFn);
 
   const [items, setItems] = useState<ItemT[]>(() => {
     try {
@@ -125,11 +128,17 @@ export function useManageItems<ItemT extends object>(options: ManageItemsProps<I
       />
     );
 
-  const visibleItems = items.filter((item) => (isSelected ? isSelected(item) : true));
+  const visibleItems = useMemo(
+    () => items.filter((item) => (isSelected ? isSelected(item) : true)),
+    [isSelected, items]
+  );
 
   const selectItem = useCallback(() => {
     return setSelected
-      ? (item: ItemT) => setSelected(item, true)
+      ? (item: ItemT) => {
+          setSelected(item, true);
+          setItems((items) => [...items]);
+        }
       : () => {
           alert('No setSelected callback provided');
         };
@@ -137,7 +146,10 @@ export function useManageItems<ItemT extends object>(options: ManageItemsProps<I
 
   const unselectItem = useCallback(() => {
     return setSelected
-      ? (item: ItemT) => setSelected(item, false)
+      ? (item: ItemT) => {
+          setSelected(item, false);
+          setItems((items) => [...items]);
+        }
       : () => {
           alert('No setSelected callback provided');
         };

--- a/frontend/hub/collections/CollectionVersionSearch.tsx
+++ b/frontend/hub/collections/CollectionVersionSearch.tsx
@@ -1,0 +1,50 @@
+export interface ContentSummaryType {
+  name: string;
+  content_type: string;
+  description: string;
+}
+
+export interface CollectionVersionSearch {
+  collection_version: {
+    contents: ContentSummaryType[];
+    dependencies: {
+      [collection: string]: string;
+    };
+    description: string;
+    name: string;
+    namespace: string;
+    pulp_created: string;
+    pulp_href: string;
+    require_ansible: string;
+    tags: {
+      name: string;
+    }[];
+    version: string;
+  };
+  is_deprecated: boolean;
+  is_highest: boolean;
+  is_signed: boolean;
+  // TODO: ansible namespace metadata doesn't work yet
+  // assuming fields from pulp_ansible/NamespaceSummarySerializer
+  namespace_metadata?: {
+    pulp_href: string;
+    name: string;
+    company: string;
+    description: string;
+    avatar_url: string;
+  };
+  repository: {
+    description: string;
+    latest_version_href: string;
+    name: string;
+    pulp_created: string;
+    pulp_href: string;
+    pulp_labels: {
+      pipeline?: string;
+    };
+    remote?: string;
+    retain_repo_versions: number;
+    versions_href: string;
+  };
+  repository_version: string;
+}

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -1,0 +1,86 @@
+import { AnsibleTowerIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import {
+  ColumnsDiv,
+  PageDetailDiv,
+  PageTableCard,
+} from '../../../framework/PageTable/PageTableCard';
+import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
+import { PageDetail, TextCell } from '../../../framework';
+import { useTranslation } from 'react-i18next';
+import { CardBody } from '@patternfly/react-core';
+
+export function CollectionCard(props: { collection: CollectionVersionSearch }) {
+  const { t } = useTranslation();
+  const { collection } = props;
+
+  return (
+    <PageTableCard
+      item={collection}
+      itemToCardFn={(item: CollectionVersionSearch) => ({
+        id: item.collection_version.name,
+        icon: <AnsibleTowerIcon />, // TODO: Update logo to use avatar_url if it exists
+        title: <TextCell text={item.collection_version.name} />,
+        subtitle: (
+          <TextCell
+            text={t('Provided by {{provider}}', {
+              provider: item.collection_version.namespace,
+            })}
+          />
+        ),
+        cardBody: (
+          <CardBody>
+            <TextCell text={item.collection_version.version} />
+            <TextCell text={item.collection_version.description} />
+            <PageDetail>
+              <PageDetailDiv>
+                <ColumnsDiv>
+                  <>
+                    {
+                      item.collection_version.contents.filter((c) => c.content_type === 'module')
+                        .length
+                    }
+                  </>
+                  <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
+                </ColumnsDiv>
+                <ColumnsDiv>
+                  <>
+                    {
+                      item.collection_version.contents.filter((c) => c.content_type === 'role')
+                        .length
+                    }
+                  </>
+                  <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
+                </ColumnsDiv>
+                <ColumnsDiv>
+                  <>
+                    {
+                      item.collection_version.contents.filter(
+                        (c) => c.content_type !== 'module' && c.content_type !== 'role'
+                      ).length
+                    }
+                  </>
+                  <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
+                </ColumnsDiv>
+                <ColumnsDiv>
+                  <>{Object.keys(item.collection_version.dependencies).length}</>
+                  <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
+                </ColumnsDiv>
+              </PageDetailDiv>
+            </PageDetail>
+          </CardBody>
+        ),
+        labels: item.is_signed
+          ? [
+              {
+                label: t('Signed'),
+                color: 'green',
+                icon: <CheckCircleIcon />,
+                variant: 'outline',
+              },
+            ]
+          : undefined,
+      })}
+      showSelect
+    ></PageTableCard>
+  );
+}

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -8,79 +8,86 @@ import { CollectionVersionSearch } from '../collections/CollectionVersionSearch'
 import { PageDetail, TextCell } from '../../../framework';
 import { useTranslation } from 'react-i18next';
 import { CardBody } from '@patternfly/react-core';
+import { forwardRef } from 'react';
 
-export function CollectionCard(props: { collection: CollectionVersionSearch }) {
-  const { t } = useTranslation();
-  const { collection } = props;
+export const CollectionCard = forwardRef<HTMLDivElement, { collection: CollectionVersionSearch }>(
+  (props, ref) => {
+    const { t } = useTranslation();
+    const { collection } = props;
 
-  return (
-    <PageTableCard
-      item={collection}
-      itemToCardFn={(item: CollectionVersionSearch) => ({
-        id: item.collection_version.name,
-        icon: <AnsibleTowerIcon />, // TODO: Update logo to use avatar_url if it exists
-        title: <TextCell text={item.collection_version.name} />,
-        subtitle: (
-          <TextCell
-            text={t('Provided by {{provider}}', {
-              provider: item.collection_version.namespace,
-            })}
-          />
-        ),
-        cardBody: (
-          <CardBody>
-            <TextCell text={item.collection_version.version} />
-            <TextCell text={item.collection_version.description} />
-            <PageDetail>
-              <PageDetailDiv>
-                <ColumnsDiv>
-                  <>
-                    {
-                      item.collection_version.contents.filter((c) => c.content_type === 'module')
-                        .length
-                    }
-                  </>
-                  <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
-                </ColumnsDiv>
-                <ColumnsDiv>
-                  <>
-                    {
-                      item.collection_version.contents.filter((c) => c.content_type === 'role')
-                        .length
-                    }
-                  </>
-                  <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
-                </ColumnsDiv>
-                <ColumnsDiv>
-                  <>
-                    {
-                      item.collection_version.contents.filter(
-                        (c) => c.content_type !== 'module' && c.content_type !== 'role'
-                      ).length
-                    }
-                  </>
-                  <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
-                </ColumnsDiv>
-                <ColumnsDiv>
-                  <>{Object.keys(item.collection_version.dependencies).length}</>
-                  <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
-                </ColumnsDiv>
-              </PageDetailDiv>
-            </PageDetail>
-          </CardBody>
-        ),
-        labels: item.is_signed
-          ? [
-              {
-                label: t('Signed'),
-                color: 'green',
-                icon: <CheckCircleIcon />,
-                variant: 'outline',
-              },
-            ]
-          : undefined,
-      })}
-      showSelect
-    ></PageTableCard>
-  );
-}
+    return (
+      <div ref={ref}>
+        <PageTableCard
+          item={collection}
+          itemToCardFn={(item: CollectionVersionSearch) => ({
+            id: item.collection_version.name,
+            icon: <AnsibleTowerIcon />, // TODO: Update logo to use avatar_url if it exists
+            title: <TextCell text={item.collection_version.name} />,
+            subtitle: (
+              <TextCell
+                text={t('Provided by {{provider}}', {
+                  provider: item.collection_version.namespace,
+                })}
+              />
+            ),
+            cardBody: (
+              <CardBody>
+                <TextCell text={item.collection_version.version} />
+                <TextCell text={item.collection_version.description} />
+                <PageDetail>
+                  <PageDetailDiv>
+                    <ColumnsDiv>
+                      <>
+                        {
+                          item.collection_version.contents.filter(
+                            (c) => c.content_type === 'module'
+                          ).length
+                        }
+                      </>
+                      <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
+                    </ColumnsDiv>
+                    <ColumnsDiv>
+                      <>
+                        {
+                          item.collection_version.contents.filter((c) => c.content_type === 'role')
+                            .length
+                        }
+                      </>
+                      <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
+                    </ColumnsDiv>
+                    <ColumnsDiv>
+                      <>
+                        {
+                          item.collection_version.contents.filter(
+                            (c) => c.content_type !== 'module' && c.content_type !== 'role'
+                          ).length
+                        }
+                      </>
+                      <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
+                    </ColumnsDiv>
+                    <ColumnsDiv>
+                      <>{Object.keys(item.collection_version.dependencies).length}</>
+                      <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
+                    </ColumnsDiv>
+                  </PageDetailDiv>
+                </PageDetail>
+              </CardBody>
+            ),
+            labels: item.is_signed
+              ? [
+                  {
+                    label: t('Signed'),
+                    color: 'green',
+                    icon: <CheckCircleIcon />,
+                    variant: 'outline',
+                  },
+                ]
+              : undefined,
+          })}
+          showSelect
+        ></PageTableCard>
+      </div>
+    );
+  }
+);
+CollectionCard.displayName = 'CollectionCard';

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -3,6 +3,7 @@ import {
   ColumnsDiv,
   PageDetailDiv,
   PageTableCard,
+  Small,
 } from '../../../framework/PageTable/PageTableCard';
 import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
 import { PageDetail, TextCell } from '../../../framework';
@@ -55,7 +56,7 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
                           .length
                       }
                     </>
-                    <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
+                    <Small>{t('Modules')}</Small>
                   </ColumnsDiv>
                   <ColumnsDiv>
                     <>
@@ -64,7 +65,7 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
                           .length
                       }
                     </>
-                    <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
+                    <Small>{t('Roles')}</Small>
                   </ColumnsDiv>
                   <ColumnsDiv>
                     <>
@@ -74,11 +75,11 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
                         ).length
                       }
                     </>
-                    <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
+                    <Small>{t('Plugins')}</Small>
                   </ColumnsDiv>
                   <ColumnsDiv>
                     <>{Object.keys(item.collection_version.dependencies).length}</>
-                    <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
+                    <Small>{t('Dependencies')}</Small>
                   </ColumnsDiv>
                 </PageDetailDiv>
               </PageDetail>

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -8,86 +8,94 @@ import { CollectionVersionSearch } from '../collections/CollectionVersionSearch'
 import { PageDetail, TextCell } from '../../../framework';
 import { useTranslation } from 'react-i18next';
 import { CardBody } from '@patternfly/react-core';
-import { forwardRef } from 'react';
+import { useCarouselContext } from '../../../framework/PageCarousel/PageCarousel';
+import { CSSProperties } from 'styled-components';
+import { useMemo } from 'react';
 
-export const CollectionCard = forwardRef<HTMLDivElement, { collection: CollectionVersionSearch }>(
-  (props, ref) => {
-    const { t } = useTranslation();
-    const { collection } = props;
+export function CollectionCard(props: { collection: CollectionVersionSearch }) {
+  const { t } = useTranslation();
+  const { collection } = props;
+  const { width: parentCarouselWidth, visibleCards } = useCarouselContext();
 
-    return (
-      <div ref={ref}>
-        <PageTableCard
-          item={collection}
-          itemToCardFn={(item: CollectionVersionSearch) => ({
-            id: item.collection_version.name,
-            icon: <AnsibleTowerIcon />, // TODO: Update logo to use avatar_url if it exists
-            title: <TextCell text={item.collection_version.name} />,
-            subtitle: (
-              <TextCell
-                text={t('Provided by {{provider}}', {
-                  provider: item.collection_version.namespace,
-                })}
-              />
-            ),
-            cardBody: (
-              <CardBody>
-                <TextCell text={item.collection_version.version} />
-                <TextCell text={item.collection_version.description} />
-                <PageDetail>
-                  <PageDetailDiv>
-                    <ColumnsDiv>
-                      <>
-                        {
-                          item.collection_version.contents.filter(
-                            (c) => c.content_type === 'module'
-                          ).length
-                        }
-                      </>
-                      <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
-                    </ColumnsDiv>
-                    <ColumnsDiv>
-                      <>
-                        {
-                          item.collection_version.contents.filter((c) => c.content_type === 'role')
-                            .length
-                        }
-                      </>
-                      <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
-                    </ColumnsDiv>
-                    <ColumnsDiv>
-                      <>
-                        {
-                          item.collection_version.contents.filter(
-                            (c) => c.content_type !== 'module' && c.content_type !== 'role'
-                          ).length
-                        }
-                      </>
-                      <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
-                    </ColumnsDiv>
-                    <ColumnsDiv>
-                      <>{Object.keys(item.collection_version.dependencies).length}</>
-                      <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
-                    </ColumnsDiv>
-                  </PageDetailDiv>
-                </PageDetail>
-              </CardBody>
-            ),
-            labels: item.is_signed
-              ? [
-                  {
-                    label: t('Signed'),
-                    color: 'green',
-                    icon: <CheckCircleIcon />,
-                    variant: 'outline',
-                  },
-                ]
-              : undefined,
-          })}
-          showSelect
-        ></PageTableCard>
-      </div>
-    );
-  }
-);
-CollectionCard.displayName = 'CollectionCard';
+  const divMaxWidth: CSSProperties = useMemo(() => {
+    if (visibleCards === 4) {
+      return { maxWidth: 380 };
+    }
+    if (parentCarouselWidth) {
+      return { maxWidth: Math.floor((parentCarouselWidth - 60) / visibleCards) }; // 60 represents the combined gap between cards
+    }
+    return {};
+  }, [parentCarouselWidth, visibleCards]);
+
+  return (
+    <div className="size-container" style={divMaxWidth}>
+      <PageTableCard
+        item={collection}
+        itemToCardFn={(item: CollectionVersionSearch) => ({
+          id: item.collection_version.name,
+          icon: <AnsibleTowerIcon />, // TODO: Update logo to use avatar_url if it exists
+          title: <TextCell text={item.collection_version.name} />,
+          subtitle: (
+            <TextCell
+              text={t('Provided by {{provider}}', {
+                provider: item.collection_version.namespace,
+              })}
+            />
+          ),
+          cardBody: (
+            <CardBody>
+              <TextCell text={item.collection_version.version} />
+              <TextCell text={item.collection_version.description} />
+              <PageDetail>
+                <PageDetailDiv>
+                  <ColumnsDiv>
+                    <>
+                      {
+                        item.collection_version.contents.filter((c) => c.content_type === 'module')
+                          .length
+                      }
+                    </>
+                    <small style={{ opacity: 0.7 }}>{t('Modules')}</small>
+                  </ColumnsDiv>
+                  <ColumnsDiv>
+                    <>
+                      {
+                        item.collection_version.contents.filter((c) => c.content_type === 'role')
+                          .length
+                      }
+                    </>
+                    <small style={{ opacity: 0.7 }}>{t('Roles')}</small>
+                  </ColumnsDiv>
+                  <ColumnsDiv>
+                    <>
+                      {
+                        item.collection_version.contents.filter(
+                          (c) => c.content_type !== 'module' && c.content_type !== 'role'
+                        ).length
+                      }
+                    </>
+                    <small style={{ opacity: 0.7 }}>{t('Plugins')}</small>
+                  </ColumnsDiv>
+                  <ColumnsDiv>
+                    <>{Object.keys(item.collection_version.dependencies).length}</>
+                    <small style={{ opacity: 0.7 }}>{t('Dependencies')}</small>
+                  </ColumnsDiv>
+                </PageDetailDiv>
+              </PageDetail>
+            </CardBody>
+          ),
+          labels: item.is_signed
+            ? [
+                {
+                  label: t('Signed'),
+                  color: 'green',
+                  icon: <CheckCircleIcon />,
+                  variant: 'outline',
+                },
+              ]
+            : undefined,
+        })}
+      ></PageTableCard>
+    </div>
+  );
+}

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next';
+import { PageDashboardCarousel } from '../../../framework/PageDashboard/PageDashboardCarousel';
+import { CategorizedCollections, CollectionCategory } from './CollectionCategory';
+import { useCategoryName } from './hooks/useCategoryName';
+import { CollectionCard } from './CollectionCard';
+import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { CardSpan } from '../../../framework/PageCarousel/PageCarousel';
+
+/**
+ * Carousel view representing a category of collections
+ */
+export function CollectionCategoryCarousel(props: {
+  collectionCategories: CollectionCategory[];
+  category: string;
+  collections: CollectionVersionSearch[];
+}) {
+  const { collectionCategories, category, collections } = props;
+  const { t } = useTranslation();
+  const categoryName = useCategoryName(category, t);
+  const collectionCategory = useMemo(() => {
+    return collectionCategories.find((collectionCategory) => collectionCategory.id === category);
+  }, [category, collectionCategories]);
+  const [collectionCardWidth, setCollectionCardWidth] = useState<number>(CardSpan);
+  const collectionCardRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (collectionCardRef.current) {
+      const divWidth = window.getComputedStyle((collectionCardRef as HTMLDivElement).current).width;
+      console.log('🚀 ~ file: CollectionCategories.tsx:29 ~ useLayoutEffect ~ divWidth:', divWidth);
+    }
+
+    setCollectionCardWidth(Math.floor(collectionCardRef.current?.clientWidth ?? 0));
+  }, []);
+
+  return collectionCategory?.showInDashboard ? (
+    <PageDashboardCarousel
+      title={categoryName}
+      linkText={t('Go to Collections')}
+      width="xxl"
+      childCardWidth={collectionCardWidth}
+    >
+      {collections.map((collection: CollectionVersionSearch) => (
+        <CollectionCard
+          ref={collectionCardRef}
+          key={collection.collection_version.name}
+          collection={collection}
+        ></CollectionCard>
+      ))}
+    </PageDashboardCarousel>
+  ) : null;
+}
+
+/**
+ * Component to display multiple categories of collections
+ * with each category of collections represented in a carousel
+ */
+export function CollectionCategories(props: {
+  collectionCategories: CollectionCategory[];
+  categorizedCollections: CategorizedCollections;
+}) {
+  const { collectionCategories, categorizedCollections } = props;
+  return (
+    <>
+      {Object.keys(categorizedCollections).map((category) => (
+        <CollectionCategoryCarousel
+          key={category}
+          collectionCategories={collectionCategories}
+          category={category}
+          collections={categorizedCollections[category]}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -4,24 +4,19 @@ import { CategorizedCollections, CollectionCategory } from './CollectionCategory
 import { useCategoryName } from './hooks/useCategoryName';
 import { CollectionCard } from './CollectionCard';
 import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
-import { useMemo } from 'react';
 
 /**
  * Carousel view representing a category of collections
  */
 export function CollectionCategoryCarousel(props: {
-  collectionCategories: CollectionCategory[];
   category: string;
   collections: CollectionVersionSearch[];
 }) {
-  const { collectionCategories, category, collections } = props;
+  const { category, collections } = props;
   const { t } = useTranslation();
   const categoryName = useCategoryName(category, t);
-  const collectionCategory = useMemo(() => {
-    return collectionCategories.find((collectionCategory) => collectionCategory.id === category);
-  }, [category, collectionCategories]);
 
-  return collectionCategory?.showInDashboard ? (
+  return (
     <PageDashboardCarousel title={categoryName} linkText={t('Go to Collections')} width="xxl">
       {collections.map((collection: CollectionVersionSearch) => (
         <CollectionCard
@@ -30,7 +25,7 @@ export function CollectionCategoryCarousel(props: {
         ></CollectionCard>
       ))}
     </PageDashboardCarousel>
-  ) : null;
+  );
 }
 
 /**
@@ -38,20 +33,21 @@ export function CollectionCategoryCarousel(props: {
  * with each category of collections represented in a carousel
  */
 export function CollectionCategories(props: {
-  collectionCategories: CollectionCategory[];
+  categories: CollectionCategory[];
   categorizedCollections: CategorizedCollections;
 }) {
-  const { collectionCategories, categorizedCollections } = props;
+  const { categories, categorizedCollections } = props;
   return (
     <>
-      {Object.keys(categorizedCollections).map((category) => (
-        <CollectionCategoryCarousel
-          key={category}
-          collectionCategories={collectionCategories}
-          category={category}
-          collections={categorizedCollections[category]}
-        />
-      ))}
+      {categories.map((category) =>
+        categorizedCollections[category.id] ? (
+          <CollectionCategoryCarousel
+            key={category.id}
+            category={category.id}
+            collections={categorizedCollections[category.id]}
+          />
+        ) : null
+      )}
     </>
   );
 }

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -4,8 +4,7 @@ import { CategorizedCollections, CollectionCategory } from './CollectionCategory
 import { useCategoryName } from './hooks/useCategoryName';
 import { CollectionCard } from './CollectionCard';
 import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { CardSpan } from '../../../framework/PageCarousel/PageCarousel';
+import { useMemo } from 'react';
 
 /**
  * Carousel view representing a category of collections
@@ -21,28 +20,11 @@ export function CollectionCategoryCarousel(props: {
   const collectionCategory = useMemo(() => {
     return collectionCategories.find((collectionCategory) => collectionCategory.id === category);
   }, [category, collectionCategories]);
-  const [collectionCardWidth, setCollectionCardWidth] = useState<number>(CardSpan);
-  const collectionCardRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    if (collectionCardRef.current) {
-      const divWidth = window.getComputedStyle((collectionCardRef as HTMLDivElement).current).width;
-      console.log('🚀 ~ file: CollectionCategories.tsx:29 ~ useLayoutEffect ~ divWidth:', divWidth);
-    }
-
-    setCollectionCardWidth(Math.floor(collectionCardRef.current?.clientWidth ?? 0));
-  }, []);
 
   return collectionCategory?.showInDashboard ? (
-    <PageDashboardCarousel
-      title={categoryName}
-      linkText={t('Go to Collections')}
-      width="xxl"
-      childCardWidth={collectionCardWidth}
-    >
+    <PageDashboardCarousel title={categoryName} linkText={t('Go to Collections')} width="xxl">
       {collections.map((collection: CollectionVersionSearch) => (
         <CollectionCard
-          ref={collectionCardRef}
           key={collection.collection_version.name}
           collection={collection}
         ></CollectionCard>

--- a/frontend/hub/dashboard/CollectionCategory.tsx
+++ b/frontend/hub/dashboard/CollectionCategory.tsx
@@ -5,12 +5,7 @@ export interface CollectionCategory {
   name: string;
   searchKey: string;
   searchValue: string;
-<<<<<<< HEAD
-  showInDashoard?: boolean;
   selected?: boolean;
-=======
-  showInDashboard?: boolean;
->>>>>>> d2a0a914 (temp)
 }
 
 export interface CategorizedCollections {

--- a/frontend/hub/dashboard/CollectionCategory.tsx
+++ b/frontend/hub/dashboard/CollectionCategory.tsx
@@ -1,0 +1,15 @@
+import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
+
+export interface CollectionCategory {
+  id: string;
+  name: string;
+  searchKey: string;
+  searchValue: string;
+  showInDashoard?: boolean;
+  selected?: boolean;
+}
+
+export interface CategorizedCollections {
+  // Maps category ID to collections from Search API
+  [key: string]: CollectionVersionSearch[];
+}

--- a/frontend/hub/dashboard/CollectionCategory.tsx
+++ b/frontend/hub/dashboard/CollectionCategory.tsx
@@ -5,8 +5,12 @@ export interface CollectionCategory {
   name: string;
   searchKey: string;
   searchValue: string;
+<<<<<<< HEAD
   showInDashoard?: boolean;
   selected?: boolean;
+=======
+  showInDashboard?: boolean;
+>>>>>>> d2a0a914 (temp)
 }
 
 export interface CategorizedCollections {

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -10,7 +10,6 @@ import {
   PageHeader,
   PageLayout,
 } from '../../../framework';
-import { PageDashboardCarousel } from '../../../framework/PageDashboard/PageDashboardCarousel';
 import { PageDashboardCountBar } from '../../../framework/PageDashboard/PageDashboardCountBar';
 import { LoadingPage } from '../../../framework/components/LoadingPage';
 import { RouteObj } from '../../Routes';
@@ -20,8 +19,9 @@ import { useHubNamespaces } from '../namespaces/hooks/useHubNamespaces';
 import { HubGettingStartedCard } from './HubGettingStarted';
 import { useManageHubDashboard } from './useManageHubDashboard';
 import { useState } from 'react';
-import { CategorizedCollections, CollectionCategory } from './CollectionCategory';
+import { CategorizedCollections } from './CollectionCategory';
 import { useCategorizeCollections } from './hooks/useCategorizeCollections';
+import { CollectionCategories } from './CollectionCategories';
 
 export function HubDashboard() {
   const { t } = useTranslation();
@@ -30,12 +30,12 @@ export function HubDashboard() {
   const environments = useExecutionEnvironments();
 
   const { openManageDashboard, managedCategories } = useManageHubDashboard();
+
   /** Data for collection category carousels */
-  const [collectionCategories, setCollectionCategories] = useState<CollectionCategory[]>([]);
   const [categorizedCollections, setCategorizedCollections] = useState<CategorizedCollections>({});
 
   /** Retrieve and set categories of collections and map categories to collections */
-  useCategorizeCollections(setCollectionCategories, setCategorizedCollections);
+  useCategorizeCollections(managedCategories, setCategorizedCollections);
 
   if (!namespaces) {
     return <LoadingPage />;
@@ -90,20 +90,12 @@ export function HubDashboard() {
             },
           ]}
         />
-        {managedCategories.map((category) => (
-          <PageDashboardCarousel
-            key={category.id}
-            title={category.name}
-            linkText="Go to Collections"
-            width="xxl"
-          >
-            {new Array(12).fill(0).map((_, i) => (
-              <Card isRounded isFlat key={i}>
-                <CardBody>Card {i + 1}</CardBody>
-              </Card>
-            ))}
-          </PageDashboardCarousel>
-        ))}
+        {managedCategories.length ? (
+          <CollectionCategories
+            categories={managedCategories}
+            categorizedCollections={categorizedCollections}
+          />
+        ) : null}
       </PageDashboard>
     </PageLayout>
   );

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable i18next/no-literal-string */
-import {
-  ButtonVariant,
-  Card,
-  CardBody,
-  DescriptionList,
-  DropdownPosition,
-} from '@patternfly/react-core';
-import { AnsibleTowerIcon, CogIcon } from '@patternfly/react-icons';
+import { ButtonVariant, Card, CardBody, DropdownPosition } from '@patternfly/react-core';
+import { CogIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   PageActionSelection,

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -19,6 +19,9 @@ import { useExecutionEnvironments } from '../execution-environments/hooks/useExe
 import { useHubNamespaces } from '../namespaces/hooks/useHubNamespaces';
 import { HubGettingStartedCard } from './HubGettingStarted';
 import { useManageHubDashboard } from './useManageHubDashboard';
+import { useState } from 'react';
+import { CategorizedCollections, CollectionCategory } from './CollectionCategory';
+import { useCategorizeCollections } from './hooks/useCategorizeCollections';
 
 export function HubDashboard() {
   const { t } = useTranslation();
@@ -27,6 +30,12 @@ export function HubDashboard() {
   const environments = useExecutionEnvironments();
 
   const { openManageDashboard, managedCategories } = useManageHubDashboard();
+  /** Data for collection category carousels */
+  const [collectionCategories, setCollectionCategories] = useState<CollectionCategory[]>([]);
+  const [categorizedCollections, setCategorizedCollections] = useState<CategorizedCollections>({});
+
+  /** Retrieve and set categories of collections and map categories to collections */
+  useCategorizeCollections(setCollectionCategories, setCategorizedCollections);
 
   if (!namespaces) {
     return <LoadingPage />;

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { ButtonVariant, Card, CardBody, DropdownPosition } from '@patternfly/react-core';
+import { ButtonVariant, DropdownPosition } from '@patternfly/react-core';
 import { CogIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable i18next/no-literal-string */
-import { ButtonVariant, Card, CardBody, DropdownPosition } from '@patternfly/react-core';
-import { CogIcon } from '@patternfly/react-icons';
+import {
+  ButtonVariant,
+  Card,
+  CardBody,
+  DescriptionList,
+  DropdownPosition,
+} from '@patternfly/react-core';
+import { AnsibleTowerIcon, CogIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   PageActionSelection,

--- a/frontend/hub/dashboard/hooks/useCategorizeCollections.tsx
+++ b/frontend/hub/dashboard/hooks/useCategorizeCollections.tsx
@@ -1,0 +1,44 @@
+import { HubItemsResponse } from '../../useHubView';
+import { hubAPI } from '../../api';
+import { CollectionVersionSearch } from '../../collections/CollectionVersionSearch';
+import { CategorizedCollections, CollectionCategory } from '../CollectionCategory';
+import { requestGet } from '../../../common/crud/Data';
+import { SetStateAction, useCallback, useEffect } from 'react';
+import { useCollectionCategories } from './useCollectionCategories';
+import { errorToAlertProps, usePageAlertToaster } from '../../../../framework';
+
+export function useCategorizeCollections(
+  setCollectionCategories: (value: SetStateAction<CollectionCategory[]>) => void,
+  setCategorizedCollections: (value: SetStateAction<CategorizedCollections>) => void
+) {
+  const collectionCategories = useCollectionCategories();
+  const alertToaster = usePageAlertToaster();
+
+  const fetchCollectionsForEachCategory = useCallback(async () => {
+    const collectionsInCategories: CategorizedCollections = {};
+    const searchAPIPromises = collectionCategories.map((collectionCategory: CollectionCategory) =>
+      requestGet<HubItemsResponse<CollectionVersionSearch>>(
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?${collectionCategory.searchKey}=${collectionCategory.searchValue}`
+      )
+    );
+    const results = await Promise.allSettled(searchAPIPromises);
+    if (results) {
+      results.forEach((result, index) => {
+        const categoryAssociatedWithResult = collectionCategories[index];
+        categoryAssociatedWithResult.showInDashoard = result.status === 'fulfilled' ? true : false;
+        collectionsInCategories[categoryAssociatedWithResult.id] =
+          result.status === 'fulfilled' ? result.value.data : [];
+      });
+      setCollectionCategories(collectionCategories);
+      setCategorizedCollections(collectionsInCategories);
+    }
+  }, [collectionCategories, setCategorizedCollections, setCollectionCategories]);
+
+  useEffect(() => {
+    if (collectionCategories) {
+      setCollectionCategories(collectionCategories);
+    }
+    fetchCollectionsForEachCategory().catch((err) => alertToaster.addAlert(errorToAlertProps(err)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionCategories]);
+}

--- a/frontend/hub/dashboard/hooks/useCategorizeCollections.tsx
+++ b/frontend/hub/dashboard/hooks/useCategorizeCollections.tsx
@@ -25,7 +25,8 @@ export function useCategorizeCollections(
     if (results) {
       results.forEach((result, index) => {
         const categoryAssociatedWithResult = collectionCategories[index];
-        categoryAssociatedWithResult.showInDashoard = result.status === 'fulfilled' ? true : false;
+        categoryAssociatedWithResult.showInDashboard =
+          result.status === 'fulfilled' && result.value.data.length ? true : false;
         collectionsInCategories[categoryAssociatedWithResult.id] =
           result.status === 'fulfilled' ? result.value.data : [];
       });

--- a/frontend/hub/dashboard/hooks/useCategoryName.tsx
+++ b/frontend/hub/dashboard/hooks/useCategoryName.tsx
@@ -1,20 +1,25 @@
+import { useMemo } from 'react';
+
 export function useCategoryName(category: string, t: (str: string) => string) {
-  const categories: { [key: string]: string } = {
-    application: t('Application collections'),
-    cloud: t('Cloud collections'),
-    database: t('Database collections'),
-    infrastructure: t('Infrastructure collections'),
-    linux: t('Linux collections'),
-    monitoring: t('Monitoring collections'),
-    networking: t('Networking collections'),
-    security: t('Security collections'),
-    storage: t('Storage collections'),
-    tools: t('Tools collections'),
-    windows: t('Windows collections'),
-    eda: t('Event-Driven Ansible content'),
-    featured: t('Featured collections'),
-    owner: t('My collections'),
-  };
+  const categories: { [key: string]: string } = useMemo(
+    () => ({
+      application: t('Application collections'),
+      cloud: t('Cloud collections'),
+      database: t('Database collections'),
+      infrastructure: t('Infrastructure collections'),
+      linux: t('Linux collections'),
+      monitoring: t('Monitoring collections'),
+      networking: t('Networking collections'),
+      security: t('Security collections'),
+      storage: t('Storage collections'),
+      tools: t('Tools collections'),
+      windows: t('Windows collections'),
+      eda: t('Event-Driven Ansible content'),
+      featured: t('Featured collections'),
+      owner: t('My collections'),
+    }),
+    [t]
+  );
 
   return categories[category] || category;
 }

--- a/frontend/hub/dashboard/hooks/useCategoryName.tsx
+++ b/frontend/hub/dashboard/hooks/useCategoryName.tsx
@@ -1,0 +1,20 @@
+export function useCategoryName(category: string, t: (str: string) => string) {
+  const categories: { [key: string]: string } = {
+    application: t('Application collections'),
+    cloud: t('Cloud collections'),
+    database: t('Database collections'),
+    infrastructure: t('Infrastructure collections'),
+    linux: t('Linux collections'),
+    monitoring: t('Monitoring collections'),
+    networking: t('Networking collections'),
+    security: t('Security collections'),
+    storage: t('Storage collections'),
+    tools: t('Tools collections'),
+    windows: t('Windows collections'),
+    eda: t('Event-Driven Ansible content'),
+    featured: t('Featured collections'),
+    owner: t('My collections'),
+  };
+
+  return categories[category] || category;
+}

--- a/frontend/hub/dashboard/hooks/useCollectionCategories.tsx
+++ b/frontend/hub/dashboard/hooks/useCollectionCategories.tsx
@@ -1,0 +1,57 @@
+// import { useGet } from '../../../common/crud/useGet';
+// import { HubItemsResponse } from '../../useHubView';
+// import { hubAPI } from '../../api';
+import { CollectionCategory } from '../CollectionCategory';
+import { useMemo } from 'react';
+
+/**
+ * Hook to retrieve the collection categories for the Hub Dashboard UI
+ */
+export function useCollectionCategories() {
+  // NOTE: The following is mock data used for developing this feature while the API endpoint is under development
+  const t = useMemo(
+    () => ({
+      meta: {
+        count: 2,
+      },
+      data: [
+        {
+          id: 'networking',
+          name: 'Networking collections',
+          searchKey: 'tags',
+          searchValue: 'networking',
+        },
+        {
+          id: 'storage',
+          name: 'Storage collections',
+          searchKey: 'tags',
+          searchValue: 'storage',
+        },
+        {
+          id: 'system',
+          name: 'System collections',
+          searchKey: 'tags',
+          searchValue: 'linux',
+        },
+        {
+          id: 'eda',
+          name: 'Event-Driven Ansible content',
+          searchKey: 'tags',
+          searchValue: 'eda',
+        },
+      ] as CollectionCategory[],
+      links: {
+        next: null,
+      },
+    }),
+    []
+  );
+
+  return t.data;
+
+  // TODO: The mock data above needs to be replaced with the actual API requests when the API becomes available
+  // const t = useGet<HubItemsResponse<CollectionCategory>>(
+  //   hubAPI`/v3/plugin/ansible/collection-categories/`
+  // );
+  // return t.data?.data;
+}

--- a/frontend/hub/dashboard/hooks/useCollectionCategories.tsx
+++ b/frontend/hub/dashboard/hooks/useCollectionCategories.tsx
@@ -9,10 +9,10 @@ import { useMemo } from 'react';
  */
 export function useCollectionCategories() {
   // NOTE: The following is mock data used for developing this feature while the API endpoint is under development
-  const t = useMemo(
-    () => ({
+  const categories = useMemo(() => {
+    const mockApiResponse = {
       meta: {
-        count: 2,
+        count: 3,
       },
       data: [
         {
@@ -28,12 +28,6 @@ export function useCollectionCategories() {
           searchValue: 'storage',
         },
         {
-          id: 'system',
-          name: 'System collections',
-          searchKey: 'tags',
-          searchValue: 'linux',
-        },
-        {
           id: 'eda',
           name: 'Event-Driven Ansible content',
           searchKey: 'tags',
@@ -43,11 +37,15 @@ export function useCollectionCategories() {
       links: {
         next: null,
       },
-    }),
-    []
-  );
+    };
+    const collectionCategories = mockApiResponse.data.map((category) => ({
+      selected: true,
+      ...category,
+    }));
+    return collectionCategories;
+  }, []);
 
-  return t.data;
+  return categories;
 
   // TODO: The mock data above needs to be replaced with the actual API requests when the API becomes available
   // const t = useGet<HubItemsResponse<CollectionCategory>>(

--- a/frontend/hub/dashboard/useManageHubDashboard.tsx
+++ b/frontend/hub/dashboard/useManageHubDashboard.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useManageItems } from '../../../framework/components/useManagedItems';
-
-type Category = { id: string; name: string; selected: boolean };
+import { CollectionCategory } from './CollectionCategory';
+import { useCollectionCategories } from './hooks/useCollectionCategories';
 
 export function useManageHubDashboard() {
   const { t } = useTranslation();
@@ -10,40 +10,40 @@ export function useManageHubDashboard() {
     () => [
       {
         header: t('Categories of collections'),
-        cell: (item: Category) => item.name,
+        cell: (item: CollectionCategory) => item.name,
       },
     ],
     [t]
   );
-  const categories: Category[] = useMemo(
-    () => [
-      { id: 'owner', name: t('My collections'), selected: true },
-      { id: 'featured', name: t('Featured collections'), selected: true },
-      { id: 'eda', name: t('Event-Driven Ansible content'), selected: true },
-      { id: 'storage', name: t('Storage collections'), selected: true },
-      { id: 'system', name: t('System collections'), selected: true },
-    ],
-    [t]
+  const collectionCategories: CollectionCategory[] = useCollectionCategories();
+
+  const { openModal: openManageDashboard, items: managedCategories } =
+    useManageItems<CollectionCategory>({
+      id: 'hub-dashboard',
+      title: 'Manage Dashboard',
+      description: t(
+        'Hide or show the panels you want to see on the overview page by selecting or unselecting, respectively. The panels are ordered from top to bottom on the list. Use the draggable icon :: to re-order your view.'
+      ),
+      items: collectionCategories,
+      keyFn: (category) => category.id,
+      columns,
+      hideColumnHeaders: true,
+      isSelected: (category) => category.selected ?? true,
+      setSelected: (category, selected) => {
+        category.selected = selected;
+      },
+    });
+
+  const visibleCategories = useMemo(
+    () => managedCategories.filter((category) => category.selected),
+    [managedCategories]
   );
 
-  const { openModal: openManageDashboard, items: managedCategories } = useManageItems<Category>({
-    id: 'hub-dashboard',
-    title: 'Manage Dashboard',
-    description: t(
-      'Hide or show the panels you want to see on the overview page by selecting or unselecting, respectively. The panels are ordered from top to bottom on the list. Use the draggable icon :: to re-order your view.'
-    ),
-    items: categories,
-    keyFn: (categories) => categories.id,
-    columns,
-    hideColumnHeaders: true,
-    isSelected: (category) => category.selected,
-    setSelected: (category, selected) => {
-      category.selected = selected;
-    },
-  });
-
-  return {
-    openManageDashboard,
-    managedCategories: managedCategories.filter((category) => category.selected),
-  };
+  return useMemo(
+    () => ({
+      openManageDashboard,
+      managedCategories: visibleCategories,
+    }),
+    [openManageDashboard, visibleCategories]
+  );
 }


### PR DESCRIPTION
This PR supports displaying collection cards within a collection category in Hub's Dashboard UI.

#### API endpoints:
1. `/collection-categories` - this API is needed to fetch the supported categories of content for the dashboard UI and to determine which search keys and values we need to used to fetch the collections for those categories. This API is not available yet so it has been mocked `frontend/hub/dashboard/hooks/useCollectionCategories.tsx`.
2. `/automation-hub/v3/plugin/ansible/search/collection-versions/` - This API endpoint can currently only supports filtering by `tags` and not by `marks` and `permissions` so we cannot display "Featured Collections" and "My Collections" just yet.

#### Testing:
- I've tested this by using the following steps to create mock collections in the local Hub backend: https://docs.google.com/document/d/1gtbrnPoprm3TmUnZ4XxF6Pzr-XDdNC_pJlphLyTK2gs/edit?usp=sharing

<img width="1455" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/fd25be9b-149b-480e-a6a6-88a6b4e65a84">