### PR TITLE
[AAP-14612] Use Status cell in activation instance details page. Add icon for the Stopped status

### DIFF
--- a/frontend/common/Status.tsx
+++ b/frontend/common/Status.tsx
@@ -8,6 +8,7 @@ import {
   HourglassStartIcon,
   InfoCircleIcon,
   MinusCircleIcon,
+  StopCircleIcon,
 } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { RunningIcon, TextCell } from '../../framework';
@@ -70,10 +71,12 @@ function useLabel(status: string, t: (str: string) => string) {
     running: t('Running'),
     skipped: t('Skipped'),
     starting: t('Starting'),
+    stopped: t('Stopped'),
     success: t('Success'),
     successful: t('Successful'),
     timedOut: t('Timed out'),
     unavailable: t('Unavailable'),
+    unknown: t('Unknown'),
     unreachable: t('Unreachable'),
     waiting: t('Waiting'),
   };
@@ -161,6 +164,8 @@ function getIcon(status: string) {
       return MinusCircleIcon;
     case 'starting':
       return HourglassStartIcon;
+    case 'stopped':
+      return StopCircleIcon;
     default:
       return null;
   }

--- a/frontend/common/Status.tsx
+++ b/frontend/common/Status.tsx
@@ -114,6 +114,8 @@ function getColor(status: string) {
     case 'changed':
     case 'unknown':
       return 'orange';
+    case 'stopped':
+      return undefined;
     case 'deprovisioning':
     case 'disabled':
     case 'provisioning':

--- a/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstanceDetails.tsx
@@ -20,6 +20,7 @@ import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../constants';
 import { EdaActivationInstance } from '../interfaces/EdaActivationInstance';
 import { EdaActivationInstanceLog } from '../interfaces/EdaActivationInstanceLog';
 import { EdaRulebookActivation } from '../interfaces/EdaRulebookActivation';
+import { StatusCell } from '../../common/Status';
 
 export function ActivationInstanceDetails() {
   const { t } = useTranslation();
@@ -59,7 +60,9 @@ export function ActivationInstanceDetails() {
           <PageDetail label={t('Name')}>
             {`${activationInstance?.id || ''} - ${activationInstance?.name || ''}`}
           </PageDetail>
-          <PageDetail label={t('Status')}>{activationInstance?.status || ''}</PageDetail>
+          <PageDetail label={t('Status')}>
+            {<StatusCell status={activationInstance?.status || 'unknown'} />}
+          </PageDetail>
           <PageDetail label={t('Start date')}>
             {activationInstance?.started_at ? formatDateString(activationInstance?.started_at) : ''}
           </PageDetail>


### PR DESCRIPTION
Use Status cell in activation instance details page. Add icon for the Stopped status

![Screenshot from 2023-08-03 14-50-34](https://github.com/ansible/ansible-ui/assets/12769982/1cc4ead8-0a7f-4205-b135-01bb6154f001)
![Screenshot from 2023-08-04 14-49-02](https://github.com/ansible/ansible-ui/assets/12769982/845da32a-17fe-406f-b02f-89a1245d53f0)
![Screenshot from 2023-08-04 14-48-05](https://github.com/ansible/ansible-ui/assets/12769982/ba43f8c4-1772-4ac6-a3e9-a3da38f51ef9)

