### PR TITLE
Updates to dashboard chart PR

### DIFF
--- a/frontend/awx/dashboard/cards/AwxJobActivityCard.tsx
+++ b/frontend/awx/dashboard/cards/AwxJobActivityCard.tsx
@@ -16,7 +16,7 @@ export function AwxJobActivityCard() {
       linkText={t('Go to Jobs')}
       to={RouteObj.Jobs}
       width="xxl"
-      height="sm"
+      height="md"
       headerControls={
         <Flex spaceItems={{ default: 'spaceItemsNone' }} style={{ gap: 8 }}>
           <FlexItem>

--- a/frontend/awx/dashboard/charts/JobsChart.tsx
+++ b/frontend/awx/dashboard/charts/JobsChart.tsx
@@ -1,4 +1,5 @@
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import { useSettings } from '../../../../framework';
 import { PageDashboardChart } from '../../../../framework/PageDashboard/PageDashboardChart';
@@ -23,6 +24,7 @@ export function JobsChart(props: {
   period?: DashboardJobPeriod;
   jobType?: DashboardJobType;
 }) {
+  const { t } = useTranslation();
   const { period, jobType } = props;
 
   const { data, isLoading } = useSWR<IJobChartData>(
@@ -68,11 +70,12 @@ export function JobsChart(props: {
   return (
     <PageDashboardChart
       groups={[
-        { color: successfulColor, values: successful },
-        { color: failedColor, values: failed },
-        { color: errorColor, values: error },
-        { color: canceledColor, values: canceled },
+        { label: t('Success'), color: successfulColor, values: successful },
+        { label: t('Failed'), color: failedColor, values: failed },
+        { label: t('Error'), color: errorColor, values: error },
+        { label: t('Canceled'), color: canceledColor, values: canceled },
       ]}
+      yLabel={t('Job Count')}
     />
   );
 }

--- a/frontend/eda/dashboard/cards/EdaRuleAuditChartCard.tsx
+++ b/frontend/eda/dashboard/cards/EdaRuleAuditChartCard.tsx
@@ -111,14 +111,14 @@ const RuleAuditChart = () => {
     <PageDashboardCard
       title={t('Rule Runs')}
       width="xxl"
-      height="sm"
+      height="md"
       to={RouteObj.EdaRuleAudit}
       help={t('Rule audit allows auditing of rules which have been triggered by incoming events.')}
     >
       <PageDashboardChart
         groups={[
-          { color: pfSuccess, values: successfulRuns },
-          { color: pfDanger, values: failedRuns },
+          { label: t('Success'), color: pfSuccess, values: successfulRuns },
+          { label: t('Failed'), color: pfDanger, values: failedRuns },
         ]}
       />
     </PageDashboardCard>


### PR DESCRIPTION

- Generate legend data from data groups to keep it in sync for developers easier
- Support both stacked and line charts: defaults to stacked, useLines to use line
- Removed sizing by percentage `width={size.height * 0.1}`. This will not scale well with different sizes.

![Screenshot 2023-08-14 at 2 12 31 PM](https://github.com/ansible/ansible-ui/assets/6277895/5b4a6343-c603-4cb1-9243-00624ae1a4ed)
