### PR TITLE
Approvals reject

### DIFF
--- a/frontend/hub/approvals/Approvals.tsx
+++ b/frontend/hub/approvals/Approvals.tsx
@@ -5,11 +5,14 @@ import { useHubView } from '../useHubView';
 import { CollectionVersionSearch } from './Approval';
 import { useApprovalFilters } from './hooks/useApprovalFilters';
 import { useApprovalsColumns } from './hooks/useApprovalsColumns';
+import { useApprovalActions } from './hooks/useApprovalActions';
 
 export function Approvals() {
   const { t } = useTranslation();
   const toolbarFilters = useApprovalFilters();
   const tableColumns = useApprovalsColumns();
+  const rowActions = useApprovalActions();
+
   const view = useHubView<CollectionVersionSearch>({
     url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
     keyFn: collectionKeyFn,
@@ -25,6 +28,7 @@ export function Approvals() {
       <PageTable<CollectionVersionSearch>
         toolbarFilters={toolbarFilters}
         tableColumns={tableColumns}
+        rowActions={rowActions}
         errorStateTitle={t('Error loading approvals')}
         emptyStateTitle={t('No approvals yet')}
         {...view}

--- a/frontend/hub/approvals/Approvals.tsx
+++ b/frontend/hub/approvals/Approvals.tsx
@@ -6,12 +6,12 @@ import { CollectionVersionSearch } from './Approval';
 import { useApprovalFilters } from './hooks/useApprovalFilters';
 import { useApprovalsColumns } from './hooks/useApprovalsColumns';
 import { useApprovalActions } from './hooks/useApprovalActions';
+import { useApprovalsActions } from './hooks/useApprovalsActions';
 
 export function Approvals() {
   const { t } = useTranslation();
   const toolbarFilters = useApprovalFilters();
   const tableColumns = useApprovalsColumns();
-  const rowActions = useApprovalActions();
 
   const view = useHubView<CollectionVersionSearch>({
     url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
@@ -22,6 +22,9 @@ export function Approvals() {
     defaultFilters: { status: ['pipeline=staging'] },
   });
 
+  const rowActions = useApprovalActions(view.unselectItemsAndRefresh);
+  const toolbarActions = useApprovalsActions(view.unselectItemsAndRefresh);
+
   return (
     <PageLayout>
       <PageHeader title={t('Collection Approvals')} />
@@ -29,6 +32,7 @@ export function Approvals() {
         toolbarFilters={toolbarFilters}
         tableColumns={tableColumns}
         rowActions={rowActions}
+        toolbarActions={toolbarActions}
         errorStateTitle={t('Error loading approvals')}
         emptyStateTitle={t('No approvals yet')}
         {...view}

--- a/frontend/hub/approvals/hooks/rejectCollection.tsx
+++ b/frontend/hub/approvals/hooks/rejectCollection.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { postRequest } from '../../../common/crud/Data';
+import { useGetRequest } from '../../../common/crud/useGetRequest';
+import { collectionKeyFn } from '../../api';
+import { CollectionVersionSearch } from '../Approval';
+
+import { pulpAPI, parsePulpIDFromURL } from '../../api';
+import { useApprovalsColumns } from './useApprovalsColumns';
+import { PulpItemsResponse } from '../../usePulpView';
+
+export function useDeleteCollections(onComplete?: (collections: CollectionVersionSearch[]) => void) {
+  const { t } = useTranslation();
+  const confirmationColumns = useApprovalsColumns();
+  const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
+  
+  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+
+  const getRequest = useGetRequest();
+  
+  return useCallback(
+    (collections: CollectionVersionSearch[]) => {
+      bulkAction({
+        title: t('Reject collections', { count: collections.length }),
+        confirmText: t('Yes, I confirm that I want to reject these {{count}} collections.', {
+          count: collections.length,
+        }),
+        actionButtonText: t('Reject collections', { count: collections.length }),
+        items: collections.sort((l, r) => compareStrings(l.collection_version.pulp_href + l.repository.name, r.collection_version.pulp_href + r.repository.name)),
+        keyFn: collectionKeyFn,
+        isDanger: true,
+        confirmationColumns,
+        actionColumns,
+        onComplete,
+        actionFn: (collection: CollectionVersionSearch) => rejectCollection(collection, getRequest)
+        
+        /*postRequest(
+            pulpAPI`v3/repositories/ansible/ansible/${parsePulpIDFromURL(collection.repository.pulp_href) || ''}/move_collection_version/`, {
+                collection_versions : [`${ collection.collection_version.pulp_href }`]
+            })*/
+      });
+    },
+    [actionColumns, bulkAction, confirmationColumns, onComplete, t]
+  );
+}
+
+
+export function rejectCollection(collection : CollectionVersionSearch, getRequest : ReturnType<typeof useGetRequest>)
+{
+    let rejectedRepo = '';
+
+    async function innerAsync()
+    {
+        const repoRes = await getRequest(pulpAPI`/repositories/ansible/ansible/?name=rejected`) as PulpItemsResponse<Repository>;
+        rejectedRepo = repoRes.results[0].pulp_href;
+    
+        return  postRequest(
+            pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(collection.repository.pulp_href) || ''}/move_collection_version/`, {
+                collection_versions : [`${ collection.collection_version.pulp_href }`],
+                destination_repositories : [ rejectedRepo ],
+    
+            });
+    }
+
+    return innerAsync();
+}
+
+export interface Repository
+{
+    name : string;
+    pulp_href : string;
+}
+
+

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -1,0 +1,32 @@
+import { TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { IPageAction, PageActionSelection, PageActionType } from '../../../../framework';
+import { CollectionVersionSearch } from '../Approval';
+import { rejectCollection } from '../hooks/rejectCollection';
+import { useGetRequest } from '../../../common/crud/useGetRequest';
+
+export function useApprovalActions(callback?: (collections: CollectionVersionSearch[]) => void) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const getRequest = useGetRequest();
+
+  //const deleteCollections = useDeleteCollections(callback);
+
+  return useMemo<IPageAction<CollectionVersionSearch>[]>(
+    () => [
+      { type: PageActionType.Seperator },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Reject'),
+        //onClick: (collection) => deleteCollections([collection]),
+        onClick: (collection) => rejectCollection(collection, getRequest),
+        isDanger: true,
+      },
+    ],
+    [t, navigate]
+  );
+}

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -16,6 +16,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
+        isPinned: true,
         icon: TrashIcon,
         label: t('Reject'),
         onClick: (collection) => rejectCollections([collection]),

--- a/frontend/hub/approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalsActions.tsx
@@ -2,23 +2,21 @@ import { TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../framework';
-import { CollectionVersionSearch } from '../Approval';
 import { useRejectCollections } from './useRejectCollections';
+import { CollectionVersionSearch } from '../Approval';
 
-export function useApprovalActions(callback?: (collections: CollectionVersionSearch[]) => void) {
+export function useApprovalsActions(callback: (collections: CollectionVersionSearch[]) => void) {
   const { t } = useTranslation();
-
   const rejectCollections = useRejectCollections(callback);
 
   return useMemo<IPageAction<CollectionVersionSearch>[]>(
     () => [
-      { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,
-        selection: PageActionSelection.Single,
+        selection: PageActionSelection.Multiple,
         icon: TrashIcon,
-        label: t('Reject'),
-        onClick: (collection) => rejectCollections([collection]),
+        label: t('Reject selected collections'),
+        onClick: rejectCollections,
         isDanger: true,
       },
     ],

--- a/frontend/hub/approvals/hooks/useRejectCollections.tsx
+++ b/frontend/hub/approvals/hooks/useRejectCollections.tsx
@@ -10,7 +10,7 @@ import { pulpAPI, parsePulpIDFromURL } from '../../api';
 import { useApprovalsColumns } from './useApprovalsColumns';
 import { PulpItemsResponse } from '../../usePulpView';
 
-export function useDeleteCollections(
+export function useRejectCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void
 ) {
   const { t } = useTranslation();
@@ -41,14 +41,9 @@ export function useDeleteCollections(
         actionColumns,
         onComplete,
         actionFn: (collection: CollectionVersionSearch) => rejectCollection(collection, getRequest),
-
-        /*postRequest(
-            pulpAPI`v3/repositories/ansible/ansible/${parsePulpIDFromURL(collection.repository.pulp_href) || ''}/move_collection_version/`, {
-                collection_versions : [`${ collection.collection_version.pulp_href }`]
-            })*/
       });
     },
-    [actionColumns, bulkAction, confirmationColumns, onComplete, t]
+    [actionColumns, bulkAction, confirmationColumns, onComplete, t, getRequest]
   );
 }
 


### PR DESCRIPTION
Adds rejection button into the approvals page.

The reject works for single collection or for multiple collections as bulk operation.

The rejection will move collection from the selected repository into rejected repository. Thus if rejecting the same collection from multiple repositories, the collection will appear only once in rejected.

Not implemented yet - error handling and RBAC. We are currently discussing in the team how to do it in framework, because our API returns task, rather then task completition error.

![image](https://github.com/ansible/ansible-ui/assets/23277791/85429d96-b132-4b02-ac71-d52cea63a882)
