### PR TITLE
Milan async toolbar filters

### DIFF
--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -10,19 +10,23 @@ export interface PageAsyncSingleSelectQueryResult<ValueT> {
   options: PageSelectOption<ValueT>[];
 }
 
+export type pageAsyncSingleSelectOptionsFunction<ValueT> = (
+  page: number,
+  signal: AbortSignal
+) => Promise<PageAsyncSingleSelectQueryResult<ValueT>>;
+
+export type pageQueryErrorTextType =  string | ((error: Error) => string)
+
 export interface PageAsyncSingleSelectProps<ValueT>
   extends Omit<PageSingleSelectProps<ValueT>, 'options'> {
   /** The function to query for options. */
-  queryOptions: (
-    page: number,
-    signal: AbortSignal
-  ) => Promise<PageAsyncSingleSelectQueryResult<ValueT>>;
+  queryOptions: pageAsyncSingleSelectOptionsFunction<ValueT>;
 
   /** The placeholder to show while querying. */
   queryPlaceholder?: string;
 
   /** The placeholder to show if the query fails. */
-  queryErrorText?: string | ((error: Error) => string);
+  queryErrorText?: pageQueryErrorTextType;
 }
 
 /**

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -49,7 +49,7 @@ export interface PageAsyncSingleSelectProps<ValueT>
  */
 export function PageAsyncSingleSelect<
   /** The type of the value of the select and of the options values. */
-  ValueT
+  ValueT,
 >(props: PageAsyncSingleSelectProps<ValueT>) {
   const { t } = useTranslation();
 

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -10,23 +10,23 @@ export interface PageAsyncSingleSelectQueryResult<ValueT> {
   options: PageSelectOption<ValueT>[];
 }
 
-export type pageAsyncSingleSelectOptionsFunction<ValueT> = (
+export type PageAsyncSingleSelectOptionsFn<ValueT> = (
   page: number,
   signal: AbortSignal
 ) => Promise<PageAsyncSingleSelectQueryResult<ValueT>>;
 
-export type pageQueryErrorTextType = string | ((error: Error) => string);
+export type PageAsyncQueryErrorTextType = string | ((error: Error) => string);
 
 export interface PageAsyncSingleSelectProps<ValueT>
   extends Omit<PageSingleSelectProps<ValueT>, 'options'> {
   /** The function to query for options. */
-  queryOptions: pageAsyncSingleSelectOptionsFunction<ValueT>;
+  queryOptions: PageAsyncSingleSelectOptionsFn<ValueT>;
 
   /** The placeholder to show while querying. */
   queryPlaceholder?: string;
 
   /** The placeholder to show if the query fails. */
-  queryErrorText?: pageQueryErrorTextType;
+  queryErrorText?: PageAsyncQueryErrorTextType;
 }
 
 /**
@@ -49,7 +49,7 @@ export interface PageAsyncSingleSelectProps<ValueT>
  */
 export function PageAsyncSingleSelect<
   /** The type of the value of the select and of the options values. */
-  ValueT,
+  ValueT
 >(props: PageAsyncSingleSelectProps<ValueT>) {
   const { t } = useTranslation();
 

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -15,7 +15,7 @@ export type pageAsyncSingleSelectOptionsFunction<ValueT> = (
   signal: AbortSignal
 ) => Promise<PageAsyncSingleSelectQueryResult<ValueT>>;
 
-export type pageQueryErrorTextType =  string | ((error: Error) => string)
+export type pageQueryErrorTextType = string | ((error: Error) => string);
 
 export interface PageAsyncSingleSelectProps<ValueT>
   extends Omit<PageSingleSelectProps<ValueT>, 'options'> {

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -24,6 +24,7 @@ import {
 import { IToolbarTextFilter, ToolbarTextFilter } from './PageToolbarFilters/ToolbarTextFilter';
 
 import { IToolbarAsyncSingleSelectFilter } from './PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
+import { PageAsyncSingleSelect } from '../PageInputs/PageAsyncSingleSelect';
 
 /** Represents the types of filters that can be used in the toolbar */
 export enum ToolbarFilterType {
@@ -281,6 +282,19 @@ function ToolbarFilterComponent(props: {
           setFilterValues={setFilterValues}
           options={filter.options}
           isRequired={filter.isRequired}
+        />
+      );
+
+    case ToolbarFilterType.AsyncSingleSelect:
+      return (
+        <PageAsyncSingleSelect<string>
+          id={props.id ?? filter.key}
+          value={filterValues && filterValues?.length > 0 ? filterValues[0] : ''}
+          onSelect={(item) => {
+            setFilterValues(() => [item]);
+          }}
+          placeholder={filter.placeholder || ''}
+          {...filter}
         />
       );
 

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -23,6 +23,8 @@ import {
 } from './PageToolbarFilters/ToolbarSingleSelectFilter';
 import { IToolbarTextFilter, ToolbarTextFilter } from './PageToolbarFilters/ToolbarTextFilter';
 
+import { IToolbarAsyncSingleSelectFilter } from './PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
+
 /** Represents the types of filters that can be used in the toolbar */
 export enum ToolbarFilterType {
   Text,
@@ -37,7 +39,8 @@ export type IToolbarFilter =
   | IToolbarTextFilter
   | IToolbarDateRangeFilter
   | IToolbarSingleSelectFilter
-  | IToolbarMultiSelectFilter;
+  | IToolbarMultiSelectFilter
+  | IToolbarAsyncSingleSelectFilter;
 
 /** Represents the state of the toolbar filters. i.e. What is currently selected for filters. */
 export type IFilterState = Record<string, string[] | undefined>;
@@ -306,4 +309,5 @@ function ToolbarFilterComponent(props: {
         />
       );
   }
+  return <></>;
 }

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -6,9 +6,11 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { PageAsyncSingleSelect } from '../PageInputs/PageAsyncSingleSelect';
 import { PageSingleSelect } from '../PageInputs/PageSingleSelect';
 import { useBreakpoint } from '../components/useBreakPoint';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { IToolbarAsyncSingleSelectFilter } from './PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
 import {
   IToolbarDateRangeFilter,
   ToolbarDateRangeFilter,
@@ -22,9 +24,6 @@ import {
   ToolbarSingleSelectFilter,
 } from './PageToolbarFilters/ToolbarSingleSelectFilter';
 import { IToolbarTextFilter, ToolbarTextFilter } from './PageToolbarFilters/ToolbarTextFilter';
-
-import { IToolbarAsyncSingleSelectFilter } from './PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
-import { PageAsyncSingleSelect } from '../PageInputs/PageAsyncSingleSelect';
 
 /** Represents the types of filters that can be used in the toolbar */
 export enum ToolbarFilterType {
@@ -290,11 +289,12 @@ function ToolbarFilterComponent(props: {
         <PageAsyncSingleSelect<string>
           id={props.id ?? filter.key}
           value={filterValues && filterValues?.length > 0 ? filterValues[0] : ''}
-          onSelect={(item) => {
-            setFilterValues(() => [item]);
-          }}
+          onSelect={(item) => setFilterValues(() => [item])}
           placeholder={filter.placeholder || ''}
-          {...filter}
+          queryOptions={filter.queryOptions}
+          queryErrorText={filter.queryErrorText}
+          queryPlaceholder={filter.queryPlaceholder}
+          isRequired={filter.isRequired}
         />
       );
 
@@ -323,5 +323,4 @@ function ToolbarFilterComponent(props: {
         />
       );
   }
-  return <></>;
 }

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -29,6 +29,7 @@ export enum ToolbarFilterType {
   SingleSelect,
   MultiSelect,
   DateRange,
+  AsyncSingleSelect,
 }
 
 /** An IToolbarFilter represents a filter that can be used in the toolbar */

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -5,7 +5,7 @@ import {
   pageQueryErrorTextType,
 } from './../../PageInputs/PageAsyncSingleSelect';
 
-export interface IToolbarSingleSelectFilter extends ToolbarFilterCommon {
+export interface IToolbarAsyncSingleSelectFilter extends ToolbarFilterCommon {
   type: ToolbarFilterType.AsyncSingleSelect;
   isRequired?: boolean;
   placeholder: string;

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -1,21 +1,24 @@
 import { ToolbarFilterType } from '../PageToolbarFilter';
 import { ToolbarFilterCommon } from './ToolbarFilterCommon';
-import { pageAsyncSingleSelectOptionsFunction, pageQueryErrorTextType } from './../../PageInputs/PageAsyncSingleSelect';
+import {
+  pageAsyncSingleSelectOptionsFunction,
+  pageQueryErrorTextType,
+} from './../../PageInputs/PageAsyncSingleSelect';
 
-export interface IToolbarSingleSelectFilter<ValueT> extends ToolbarFilterCommon {
+export interface IToolbarSingleSelectFilter extends ToolbarFilterCommon {
   type: ToolbarFilterType.AsyncSingleSelect;
   isRequired?: boolean;
   placeholder: string;
 
-    /** The function to query for options. */
-    queryOptions: pageAsyncSingleSelectOptionsFunction<ValueT>;
+  /** The function to query for options. */
+  queryOptions: pageAsyncSingleSelectOptionsFunction<string>;
 
-    /** The placeholder to show while querying. */
-    queryPlaceholder?: string;
-  
-    /** The placeholder to show if the query fails. */
-    queryErrorText?: pageQueryErrorTextType;
+  /** The placeholder to show while querying. */
+  queryPlaceholder?: string;
 
-    // useHook for modal here
-    openBrowse?: (onSelect: (value: ValueT) => void, defaultSelection?: ValueT) => void;
+  /** The placeholder to show if the query fails. */
+  queryErrorText?: pageQueryErrorTextType;
+
+  // useHook for modal here
+  openBrowse?: (onSelect: (value: string) => void, defaultSelection?: string) => void;
 }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -8,7 +8,6 @@ import {
 export interface IToolbarAsyncSingleSelectFilter extends ToolbarFilterCommon {
   type: ToolbarFilterType.AsyncSingleSelect;
   isRequired?: boolean;
-  placeholder: string;
 
   /** The function to query for options. */
   queryOptions: pageAsyncSingleSelectOptionsFunction<string>;

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -1,0 +1,21 @@
+import { ToolbarFilterType } from '../PageToolbarFilter';
+import { ToolbarFilterCommon } from './ToolbarFilterCommon';
+import { pageAsyncSingleSelectOptionsFunction, pageQueryErrorTextType } from './../../PageInputs/PageAsyncSingleSelect';
+
+export interface IToolbarSingleSelectFilter<ValueT> extends ToolbarFilterCommon {
+  type: ToolbarFilterType.AsyncSingleSelect;
+  isRequired?: boolean;
+  placeholder: string;
+
+    /** The function to query for options. */
+    queryOptions: pageAsyncSingleSelectOptionsFunction<ValueT>;
+
+    /** The placeholder to show while querying. */
+    queryPlaceholder?: string;
+  
+    /** The placeholder to show if the query fails. */
+    queryErrorText?: pageQueryErrorTextType;
+
+    // useHook for modal here
+    openBrowse?: (onSelect: (value: ValueT) => void, defaultSelection?: ValueT) => void;
+}

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -1,23 +1,30 @@
 import { ToolbarFilterType } from '../PageToolbarFilter';
-import { ToolbarFilterCommon } from './ToolbarFilterCommon';
 import {
-  pageAsyncSingleSelectOptionsFunction,
-  pageQueryErrorTextType,
+  PageAsyncQueryErrorTextType,
+  PageAsyncSingleSelectOptionsFn,
 } from './../../PageInputs/PageAsyncSingleSelect';
+import { ToolbarFilterCommon } from './ToolbarFilterCommon';
 
 export interface IToolbarAsyncSingleSelectFilter extends ToolbarFilterCommon {
   type: ToolbarFilterType.AsyncSingleSelect;
-  isRequired?: boolean;
 
   /** The function to query for options. */
-  queryOptions: pageAsyncSingleSelectOptionsFunction<string>;
+  queryOptions: PageAsyncSingleSelectOptionsFn<string>;
 
   /** The placeholder to show while querying. */
   queryPlaceholder?: string;
 
   /** The placeholder to show if the query fails. */
-  queryErrorText?: pageQueryErrorTextType;
+  queryErrorText?: PageAsyncQueryErrorTextType;
 
   // useHook for modal here
   openBrowse?: (onSelect: (value: string) => void, defaultSelection?: string) => void;
+
+  /**
+   * Whether the select required an option to be selected.
+   *
+   * If true, the select will autoselect the first option,
+   * else the select will contain a clear button.
+   */
+  isRequired?: boolean;
 }

--- a/frontend/hub/approvals/hooks/useApprovalFilters.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalFilters.tsx
@@ -16,12 +16,12 @@ export function useApprovalFilters() {
       const pageSize = 10;
 
       async function load() {
-        const data = await repoRequest(pulpAPI`/v3/repositories/ansible/ansible/`, {
-          offset: pageSize * page,
+        const data = await repoRequest(pulpAPI`/repositories/ansible/ansible/`, {
+          offset: pageSize * (page - 1),
           limit: pageSize,
         });
         return {
-          total: pageSize,
+          total: pageSize * 10,
           options: data.results.map((r) => {
             return { label: r.name, value: r.name };
           }),
@@ -53,7 +53,7 @@ export function useApprovalFilters() {
         key: 'repository',
         label: t('Repository'),
         type: ToolbarFilterType.AsyncSingleSelect,
-        query: 'repository',
+        query: 'repository_name',
         queryOptions: repoQueryOptions,
       },
       {

--- a/frontend/hub/approvals/hooks/useApprovalFilters.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalFilters.tsx
@@ -1,17 +1,16 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IToolbarFilter, ToolbarFilterType } from '../../../../framework';
 import { useGetRequest } from '../../../common/crud/useGetRequest';
-import { pageAsyncSingleSelectOptionsFunction } from './../../../../framework/PageInputs/PageAsyncSingleSelect';
-import { PulpItemsResponse } from './../../usePulpView';
+import { PageAsyncSingleSelectOptionsFn } from './../../../../framework/PageInputs/PageAsyncSingleSelect';
 import { pulpAPI } from './../../api';
-import { useCallback } from 'react';
+import { PulpItemsResponse } from './../../usePulpView';
 
 export function useApprovalFilters() {
   const { t } = useTranslation();
   const repoRequest = useGetRequest<PulpItemsResponse<Repository>>();
 
-  const repoQueryOptions: pageAsyncSingleSelectOptionsFunction<string> = useCallback(
+  const repoQueryOptions: PageAsyncSingleSelectOptionsFn<string> = useCallback(
     (page) => {
       const pageSize = 10;
 
@@ -21,7 +20,7 @@ export function useApprovalFilters() {
           limit: pageSize,
         });
         return {
-          total: pageSize * 10,
+          total: data.count,
           options: data.results.map((r) => {
             return { label: r.name, value: r.name };
           }),


### PR DESCRIPTION
Async dropdown with lazy loading of items has been already implemented into framework.

This PR uses it also in filters. Example was created in Approvals list, where you can now filter also by repository.

![image](https://github.com/ansible/ansible-ui/assets/23277791/6df6bf5c-1413-4553-95fa-3e2d55d56bc7)
