### PR TITLE
fix cypress e2e cleanup for projects

### DIFF
--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -21,7 +21,7 @@ describe('projects', () => {
   });
 
   after(() => {
-    cy.deleteAwxOrganization(organization).then(() => {
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false }).then(() => {
       /**
        * Deleting the organization does not delete the underlying projects.
        * So get all projects without an organization and delete them. Multiple test runs


### PR DESCRIPTION
Sometimes a delete of an organization in the project e2e test cleanup fails with
```
{
  "error": "Resource is being used by running jobs.",
  "active_jobs": [
    {
      "id": 2862,
      "type": "project_update"
    }
  ]
}
```

This will ignore that error as the organization will be cleaned up later by the cleanup job if that happens.