### PR TITLE
Updates to Hub dashboard collection card (version, label)

### DIFF
--- a/frontend/hub/dashboard/CollectionCard.cy.tsx
+++ b/frontend/hub/dashboard/CollectionCard.cy.tsx
@@ -9,6 +9,10 @@ describe('CollectionCard.cy.tsx', () => {
         const collection = collectionVersions.data[0];
         cy.mount(<CollectionCard collection={collection} />);
         cy.get('div.pf-c-card__title').should('contain', collection.collection_version.name);
+        cy.get('div.pf-c-card__body').should(
+          'contain',
+          `v${collection.collection_version.version}`
+        );
         cy.contains('dt', 'Roles').parent().siblings('dd').should('contain', 1);
         cy.get('.pf-c-label__content').should('contain', 'Signed');
       }

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -21,7 +21,7 @@ export const ColumnsDiv = styled.div`
 const CERTIFIED_REPO = 'rh-certified';
 
 function CertifiedIcon() {
-  return <i class="fas fa-certificate"></i>;
+  return <i className="fas fa-certificate"></i>;
 }
 
 export function CollectionCard(props: { collection: CollectionVersionSearch }) {

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -1,12 +1,12 @@
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { PageDetailDiv, PageTableCard, Small } from '../../../framework/PageTable/PageTableCard';
 import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
-import { PageDetail, TextCell } from '../../../framework';
+import { LabelColor, PageDetail, TextCell } from '../../../framework';
 import { useTranslation } from 'react-i18next';
 import { CardBody, Truncate } from '@patternfly/react-core';
 import { useCarouselContext } from '../../../framework/PageCarousel/PageCarousel';
 import styled, { CSSProperties } from 'styled-components';
-import { useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import { RouteObj } from '../../Routes';
 import { Logo } from '../common/Logo';
 
@@ -19,6 +19,15 @@ export const ColumnsDiv = styled.div`
 // TODO: If deployment mode is INSIGHTS, CERTIFIED_REPO should be set to 'published'. This needs to be updated
 // in the future when we are able to identify INSIGHTS mode
 const CERTIFIED_REPO = 'rh-certified';
+
+type Labels =
+  | {
+      label: string;
+      color?: LabelColor;
+      icon?: ReactNode;
+      variant?: 'outline' | 'filled' | undefined;
+    }[]
+  | undefined;
 
 function CertifiedIcon() {
   return <i className="fas fa-certificate"></i>;
@@ -38,6 +47,38 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
     }
     return {};
   }, [parentCarouselWidth, visibleCards]);
+
+  const getLabels = useCallback(
+    (item: CollectionVersionSearch) => {
+      const cardLabels: Labels =
+        item.repository.name === CERTIFIED_REPO
+          ? [
+              {
+                label: t('Certified'),
+                color: 'blue',
+                icon: <CertifiedIcon />,
+                variant: 'outline',
+              },
+            ]
+          : [
+              {
+                label: item.repository.name,
+                color: 'blue',
+                variant: 'outline',
+              },
+            ];
+      if (item.is_signed) {
+        cardLabels?.push({
+          label: t('Signed'),
+          color: 'green',
+          icon: <CheckCircleIcon />,
+          variant: 'outline',
+        });
+      }
+      return cardLabels;
+    },
+    [t]
+  );
 
   return (
     <div className="size-container" style={divMaxWidth}>
@@ -126,34 +167,7 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
               </PageDetail>
             </CardBody>
           ),
-          labels: [
-            ...(item.repository.name === CERTIFIED_REPO
-              ? [
-                  {
-                    label: t('Certified'),
-                    color: 'blue',
-                    icon: <CertifiedIcon />,
-                    variant: 'outline',
-                  },
-                ]
-              : [
-                  {
-                    label: item.repository.name,
-                    color: 'blue',
-                    variant: 'outline',
-                  },
-                ]),
-            ...(item.is_signed
-              ? [
-                  {
-                    label: t('Signed'),
-                    color: 'green',
-                    icon: <CheckCircleIcon />,
-                    variant: 'outline',
-                  },
-                ]
-              : []),
-          ],
+          labels: getLabels(item),
         })}
       ></PageTableCard>
     </div>

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -16,6 +16,14 @@ export const ColumnsDiv = styled.div`
   align-items: baseline;
 `;
 
+// TODO: If deployment mode is INSIGHTS, CERTIFIED_REPO should be set to 'published'. This needs to be updated
+// in the future when we are able to identify INSIGHTS mode
+const CERTIFIED_REPO = 'rh-certified';
+
+function CertifiedIcon() {
+  return <i class="fas fa-certificate"></i>;
+}
+
 export function CollectionCard(props: { collection: CollectionVersionSearch }) {
   const { t } = useTranslation();
   const { collection } = props;
@@ -65,7 +73,7 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
           ),
           cardBody: (
             <CardBody>
-              <TextCell text={item.collection_version.version} />
+              <TextCell text={`v${item.collection_version.version}`} />
               {item.collection_version.description && (
                 <Truncate
                   content={item.collection_version.description}
@@ -118,16 +126,34 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
               </PageDetail>
             </CardBody>
           ),
-          labels: item.is_signed
-            ? [
-                {
-                  label: t('Signed'),
-                  color: 'green',
-                  icon: <CheckCircleIcon />,
-                  variant: 'outline',
-                },
-              ]
-            : undefined,
+          labels: [
+            ...(item.repository.name === CERTIFIED_REPO
+              ? [
+                  {
+                    label: t('Certified'),
+                    color: 'blue',
+                    icon: <CertifiedIcon />,
+                    variant: 'outline',
+                  },
+                ]
+              : [
+                  {
+                    label: item.repository.name,
+                    color: 'blue',
+                    variant: 'outline',
+                  },
+                ]),
+            ...(item.is_signed
+              ? [
+                  {
+                    label: t('Signed'),
+                    color: 'green',
+                    icon: <CheckCircleIcon />,
+                    variant: 'outline',
+                  },
+                ]
+              : []),
+          ],
         })}
       ></PageTableCard>
     </div>


### PR DESCRIPTION
This PR includes minor updates to the collection cards based on recommendation from the UXD team.
- the repository name/certified label is displayed on collection cards
- the version number on each card is prefixed with the letter v

![Screenshot 2023-08-23 at 10 34 59 AM](https://github.com/ansible/ansible-ui/assets/43621546/53ba3747-6da3-443e-8fcb-72f94e46b014)
