### PR TITLE
[AAP-13112] Change Project Git Hash field on Activation Details page

### DIFF
--- a/frontend/eda/interfaces/generated/eda-api.ts
+++ b/frontend/eda/interfaces/generated/eda-api.ts
@@ -140,6 +140,8 @@ export interface ActivationRead {
    */
   status: StatusB37Enum;
   project?: ProjectRef | null;
+  /** Git hash of the project that rulebook is part of */
+  git_hash: string;
   /** Serializer for Rulebook reference. */
   rulebook: RulebookRef;
   extra_var?: ExtraVarRef | null;

--- a/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationDetails.tsx
@@ -195,7 +195,7 @@ export function RulebookActivationDetails({ initialTabIndex = 0 }) {
           </PageDetail>
           <PageDetail label={t('Project git hash')}>
             <ClipboardCopy hoverTip="Copy" clickTip="Copied" variant="inline-compact">
-              {rulebookActivation?.project?.git_hash || ''}
+              {rulebookActivation?.git_hash || ''}
             </ClipboardCopy>
           </PageDetail>
           <PageDetail label={t('Number of rules')}>


### PR DESCRIPTION
## Problem

When the activation is created without a project, the git hash doesn't appear in the activation detail view. 

## Solution

There is a [PR](https://github.com/ansible/eda-server/pull/375) up for the eda-server side that creates a new `git_hash` field for Activations, which depends on the rulebook field to populate rather than project field.

Depends on https://github.com/ansible/eda-server/pull/375

Solves: [AAP-13112](https://issues.redhat.com/browse/AAP-13112)
