### PR TITLE
adds / to project and orgs get url

### DIFF
--- a/frontend/awx/access/organizations/OrganizationPage/OrganizationPage.tsx
+++ b/frontend/awx/access/organizations/OrganizationPage/OrganizationPage.tsx
@@ -31,7 +31,7 @@ export function OrganizationPage() {
     data: organization,
     error,
     refresh,
-  } = useGet<Organization>(`/api/v2/organizations/${params.id ?? ''}`);
+  } = useGet<Organization>(`/api/v2/organizations/${params.id ?? ''}/`);
   const history = useNavigate();
 
   const deleteOrganizations = useDeleteOrganizations((deleted: Organization[]) => {

--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
@@ -17,7 +17,7 @@ import { ProjectDetails } from './ProjectDetails';
 export function ProjectPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { error, data: project, refresh } = useGet<Project>(`/api/v2/projects/${params.id ?? ''}`);
+  const { error, data: project, refresh } = useGet<Project>(`/api/v2/projects/${params.id ?? ''}/`);
   const navigate = useNavigate();
   const itemActions = useProjectActions(() => navigate(RouteObj.Projects));
 


### PR DESCRIPTION
Calls were getting redirected with 301 errors when fetching the Projects and Organizations details page.
During troubleshooting, James found that there is a `/` missing at the end of useGet custom hook URL