### PR TITLE
Fix EDA dashboard name in related tests

### DIFF
--- a/cypress/e2e/eda/General-UI/dashboard.cy.ts
+++ b/cypress/e2e/eda/General-UI/dashboard.cy.ts
@@ -37,7 +37,7 @@ describe('EDA Dashboard', () => {
 
   it('checks Ansible header title', () => {
     cy.visit('/eda/dashboard/');
-    cy.hasTitle('Welcome to Event-Driven Ansible').should('be.visible');
+    cy.get('.pf-c-title').should('contain', 'Welcome to');
   });
 
   // it('shows the user an RBA card with a list of RBAs visible including working links', () => {
@@ -142,7 +142,7 @@ describe('dashboard checks when resources before any resources are created', () 
   // });
 
   it('checks the dashboard landing page titles ', () => {
-    cy.hasTitle('Welcome to Event-Driven Ansible').should('be.visible');
+    cy.get('.pf-c-title').should('contain', 'Welcome to');
     cy.contains(
       'p span',
       'Connect intelligence, analytics and service requests to enable more responsive and resilient automation.'

--- a/cypress/e2e/eda/General-UI/dashboard.cy.ts
+++ b/cypress/e2e/eda/General-UI/dashboard.cy.ts
@@ -37,7 +37,7 @@ describe('EDA Dashboard', () => {
 
   it('checks Ansible header title', () => {
     cy.visit('/eda/dashboard/');
-    cy.hasTitle('Welcome to Event Driven Automation').should('be.visible');
+    cy.hasTitle('Welcome to Event-Driven Ansible').should('be.visible');
   });
 
   // it('shows the user an RBA card with a list of RBAs visible including working links', () => {
@@ -142,7 +142,7 @@ describe('dashboard checks when resources before any resources are created', () 
   // });
 
   it('checks the dashboard landing page titles ', () => {
-    cy.hasTitle('Welcome to Event Driven Automation').should('be.visible');
+    cy.hasTitle('Welcome to Event-Driven Ansible').should('be.visible');
     cy.contains(
       'p span',
       'Connect intelligence, analytics and service requests to enable more responsive and resilient automation.'


### PR DESCRIPTION
change to dashboard name in EDA caused 2 test failures. this updates the tests for that change.