### PR TITLE
Add requirements file to add, edit and details page for remotes

### DIFF
--- a/frontend/hub/remotes/RemoteDetails.tsx
+++ b/frontend/hub/remotes/RemoteDetails.tsx
@@ -2,6 +2,7 @@ import { Label, LabelGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PageDetail, PageDetails, PageHeader, PageLayout, useGetPageUrl } from '../../../framework';
+import { PageDetailCodeEditor } from '../../../framework/PageDetails/PageDetailCodeEditor';
 import { LoadingPage } from '../../../framework/components/LoadingPage';
 import { AwxError } from '../../awx/common/AwxError';
 import { useGet } from '../../common/crud/useGet';
@@ -62,6 +63,9 @@ export function RemoteDetails() {
   if (loadingOrErrorRemotes) return loadingOrErrorRemotes;
   if (loadingOrErrorRepositories) return loadingOrErrorRepositories;
 
+  const emptyRequirementFieldValue = '---';
+  const requirementsFileValue = remote?.requirements_file ?? emptyRequirementFieldValue;
+
   return (
     <>
       <PageLayout>
@@ -107,6 +111,13 @@ export function RemoteDetails() {
               t('---')
             )}
           </PageDetail>
+        </PageDetails>
+        <PageDetails numberOfColumns="single">
+          <PageDetailCodeEditor
+            label={t('YAML requirements')}
+            value={requirementsFileValue}
+            showCopyToClipboard={requirementsFileValue !== emptyRequirementFieldValue}
+          />
         </PageDetails>
       </PageLayout>
     </>

--- a/frontend/hub/remotes/Remotes.tsx
+++ b/frontend/hub/remotes/Remotes.tsx
@@ -18,7 +18,7 @@ export interface IRemotes {
   pulp_href: string;
   pulp_created: string;
   rate_limit: number | null;
-  requirements_file: string | null;
+  requirements_file?: string;
   tls_validation: boolean;
   url: string;
   signed_only: boolean;

--- a/frontend/hub/remotes/hooks/useRemoteActions.tsx
+++ b/frontend/hub/remotes/hooks/useRemoteActions.tsx
@@ -22,7 +22,7 @@ export function useRemoteActions(view: IPulpView<IRemotes>) {
       {
         icon: EditIcon,
         isPinned: true,
-        label: t('Edit remote 2'),
+        label: t('Edit remote'),
         onClick: (remotes) => pageNavigate(HubRoute.EditRemote, { params: { id: remotes.name } }),
         selection: PageActionSelection.Single,
         type: PageActionType.Button,


### PR DESCRIPTION
Add YAML requirements file to add, edit and details page for remotes.


<img width="1471" alt="image" src="https://github.com/ansible/ansible-ui/assets/9053044/533519a6-5be3-472b-8a7e-fbb4999f18ca">


<img width="1202" alt="image" src="https://github.com/ansible/ansible-ui/assets/9053044/9fbba552-5ef5-4f68-8449-b1100d35ca54">

See: https://issues.redhat.com/browse/AAH-2496
Also: https://issues.redhat.com/browse/AAH-2493
