### PR TITLE
Hub Dashboard: Manage content modal

### DIFF
--- a/cypress/fixtures/collection_versions_eda.json
+++ b/cypress/fixtures/collection_versions_eda.json
@@ -1,0 +1,421 @@
+{
+  "meta": {
+    "count": 10
+  },
+  "links": {
+    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda",
+    "previous": null,
+    "next": null,
+    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda"
+  },
+  "data": [
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
+        "namespace": "test_ns",
+        "name": "test_collection10",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:48.347423Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
+        "namespace": "test_ns",
+        "name": "test_collection9",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:41.206428Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
+        "namespace": "test_ns",
+        "name": "test_collection8",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:31.379698Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
+        "namespace": "test_ns",
+        "name": "test_collection7",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:24.360393Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
+        "namespace": "test_ns",
+        "name": "test_collection6",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:16.466165Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
+        "namespace": "test_ns",
+        "name": "test_collection2",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:14.104935Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
+        "namespace": "test_ns",
+        "name": "test_collection1",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:06.698846Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
+        "namespace": "test_ns",
+        "name": "test_collection",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-31T20:42:25.998080Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
+        "namespace": "e2e_namespace_shkb",
+        "name": "e2e_collection_1yfo",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-30T15:45:51.298736Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": null,
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
+        "namespace": "e2e_namespace_shkb",
+        "name": "e2e_collection_ficu",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-30T15:45:44.780145Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": null,
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    }
+  ]
+}

--- a/cypress/fixtures/collection_versions_offset0.json
+++ b/cypress/fixtures/collection_versions_offset0.json
@@ -1,0 +1,433 @@
+{
+  "meta": {
+    "count": 16
+  },
+  "links": {
+    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
+    "previous": null,
+    "next": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=10&repository_label=%21hide_from_search",
+    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
+  },
+  "data": [
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/d7678469-4808-4bf3-bf66-8e91f73f3625/",
+        "namespace": "test_ns",
+        "name": "test_collection3",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:34.584019Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "storage"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e5efd402-0022-4ad9-9dbf-82dd1607b910/",
+        "namespace": "test_ns",
+        "name": "test_collection4",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:57.421598Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "cloud"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/0a0e3f4e-4e2f-4f97-8d35-3cf8fdd8fdfd/",
+        "namespace": "test_ns",
+        "name": "test_collection5",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:05.223879Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "cloud"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
+        "namespace": "test_ns",
+        "name": "test_collection6",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:16.466165Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
+        "namespace": "test_ns",
+        "name": "test_collection7",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:24.360393Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
+        "namespace": "test_ns",
+        "name": "test_collection8",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:31.379698Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
+        "namespace": "test_ns",
+        "name": "test_collection9",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:41.206428Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
+        "namespace": "test_ns",
+        "name": "test_collection10",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:27:48.347423Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/2a32d31d-5241-449c-8660-926c98ad0e8e/",
+        "namespace": "test_ns",
+        "name": "test_collection11",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-07T14:28:33.849733Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "storage"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b7132f91-6efb-4057-866b-c38e70acd026/",
+        "namespace": "test_ns",
+        "name": "test_collection12",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-07T14:29:00.141254Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "networking"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    }
+  ]
+}

--- a/cypress/fixtures/collection_versions_offset10.json
+++ b/cypress/fixtures/collection_versions_offset10.json
@@ -1,0 +1,253 @@
+{
+  "meta": {
+    "count": 16
+  },
+  "links": {
+    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
+    "previous": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&repository_label=%21hide_from_search",
+    "next": null,
+    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
+  },
+  "data": [
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/a10be89c-a127-4d84-951b-b9ab872e42d6/",
+        "namespace": "test_ns",
+        "name": "test_collection13",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-07T14:29:08.358735Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "networking"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
+        "namespace": "e2e_namespace_shkb",
+        "name": "e2e_collection_ficu",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-30T15:45:44.780145Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": null,
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
+        "namespace": "e2e_namespace_shkb",
+        "name": "e2e_collection_1yfo",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-30T15:45:51.298736Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": null,
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
+        "namespace": "test_ns",
+        "name": "test_collection",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-08-31T20:42:25.998080Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
+        "namespace": "test_ns",
+        "name": "test_collection1",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:06.698846Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    },
+    {
+      "repository": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_created": "2023-08-24T16:00:10.249391Z",
+        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "pulp_labels": {
+          "pipeline": "approved"
+        },
+        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "name": "published",
+        "description": "Certified content repository",
+        "retain_repo_versions": 1,
+        "remote": null
+      },
+      "collection_version": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
+        "namespace": "test_ns",
+        "name": "test_collection2",
+        "version": "1.0.0",
+        "requires_ansible": ">=2",
+        "pulp_created": "2023-09-06T20:26:14.104935Z",
+        "contents": [],
+        "dependencies": {},
+        "description": "a collection with some deps on other collections",
+        "tags": [
+          {
+            "name": "eda"
+          }
+        ]
+      },
+      "repository_version": "latest",
+      "namespace_metadata": {
+        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "name": "test_ns",
+        "company": "",
+        "description": "",
+        "avatar_url": null
+      },
+      "is_highest": true,
+      "is_deprecated": false,
+      "is_signed": true
+    }
+  ]
+}

--- a/cypress/fixtures/hub_admin.json
+++ b/cypress/fixtures/hub_admin.json
@@ -1,0 +1,294 @@
+{
+  "id": 1,
+  "username": "admin",
+  "first_name": "",
+  "last_name": "",
+  "email": "admin@example.com",
+  "groups": [],
+  "date_joined": "2023-08-24T16:00:23.634857Z",
+  "is_superuser": true,
+  "auth_provider": ["django"],
+  "model_permissions": {
+    "galaxy.add_namespace": {
+      "name": "Add namespace",
+      "object_description": null,
+      "global_description": "Create a new namespace.",
+      "ui_category": "Collection Namespaces",
+      "has_model_permission": true
+    },
+    "galaxy.change_namespace": {
+      "name": "Change namespace",
+      "object_description": "Edit this namespace.",
+      "global_description": "Edit any existing namespace.",
+      "ui_category": "Collection Namespaces",
+      "has_model_permission": true
+    },
+    "galaxy.delete_namespace": {
+      "name": "Delete namespace",
+      "object_description": "Delete this namespace.",
+      "global_description": "Delete any existing namespace.",
+      "ui_category": "Collection Namespaces",
+      "has_model_permission": true
+    },
+    "galaxy.upload_to_namespace": {
+      "name": "Upload to namespace",
+      "object_description": "Upload collections to this namespace.",
+      "global_description": "Upload collections to any existing namespace.",
+      "ui_category": "Collection Namespaces",
+      "has_model_permission": true
+    },
+    "ansible.delete_collection": {
+      "name": "Delete collection",
+      "object_description": "Delete this collection.",
+      "global_description": "Delete any existing collection.",
+      "ui_category": "Collections",
+      "has_model_permission": true
+    },
+    "ansible.modify_ansible_repo_content": {
+      "name": "Modify Ansible repo content",
+      "object_description": "Modify content of this Ansible repository.",
+      "global_description": "Upload collections to any existing namespace.",
+      "ui_category": "Collections",
+      "has_model_permission": true
+    },
+    "ansible.sign_ansiblerepository": {
+      "name": "Sign collections",
+      "object_description": "Sign collections in this repository.",
+      "global_description": "Sign collections in any repository.",
+      "ui_category": "Collections",
+      "has_model_permission": true
+    },
+    "galaxy.add_user": {
+      "name": "Add user",
+      "object_description": null,
+      "global_description": "Add new users to the system.",
+      "ui_category": "Users",
+      "has_model_permission": true
+    },
+    "galaxy.change_user": {
+      "name": "Change user",
+      "object_description": "Edit this user.",
+      "global_description": "Edit any existing user in the system.",
+      "ui_category": "Users",
+      "has_model_permission": true
+    },
+    "galaxy.delete_user": {
+      "name": "Delete user",
+      "object_description": "Delete this user.",
+      "global_description": "Delete any existing user in the system.",
+      "ui_category": "Users",
+      "has_model_permission": true
+    },
+    "galaxy.view_user": {
+      "name": "View user",
+      "object_description": "View this user.",
+      "global_description": "View any user in the system.",
+      "ui_category": "Users",
+      "has_model_permission": true
+    },
+    "galaxy.add_group": {
+      "name": "Add group",
+      "object_description": null,
+      "global_description": "Create new groups in the system.",
+      "ui_category": "Groups",
+      "has_model_permission": true
+    },
+    "galaxy.change_group": {
+      "name": "Change group",
+      "object_description": "Edit this group",
+      "global_description": "Edit any existing group in the system.",
+      "ui_category": "Groups",
+      "has_model_permission": true
+    },
+    "galaxy.delete_group": {
+      "name": "Delete group",
+      "object_description": "Delete this group.",
+      "global_description": "Delete any group in the system.",
+      "ui_category": "Groups",
+      "has_model_permission": true
+    },
+    "galaxy.view_group": {
+      "name": "View group",
+      "object_description": "View this group.",
+      "global_description": "View any existing group in the system.",
+      "ui_category": "Groups",
+      "has_model_permission": true
+    },
+    "ansible.view_collectionremote": {
+      "name": "View collection remote",
+      "object_description": "View this collection remote.",
+      "global_description": "View any collection remote existing in the system.",
+      "ui_category": "Collection Remotes",
+      "has_model_permission": true
+    },
+    "ansible.add_collectionremote": {
+      "name": "Add collection remote",
+      "object_description": "Add this collection remote.",
+      "global_description": "Add any collection remote existing in the system.",
+      "ui_category": "Collection Remotes",
+      "has_model_permission": true
+    },
+    "ansible.change_collectionremote": {
+      "name": "Change collection remote",
+      "object_description": "Edit this collection remote.",
+      "global_description": "Edit any collection remote existing in the system.",
+      "ui_category": "Collection Remotes",
+      "has_model_permission": true
+    },
+    "ansible.delete_collectionremote": {
+      "name": "Delete collection remote",
+      "object_description": "Delete this collection remote.",
+      "global_description": "Delete any collection remote existing in the system.",
+      "ui_category": "Collection Remotes",
+      "has_model_permission": true
+    },
+    "ansible.manage_roles_collectionremote": {
+      "name": "Manage remote roles",
+      "object_description": "Configure who has permissions on this remote.",
+      "global_description": "Configure who has permissions on any remote.",
+      "ui_category": "Collection Remotes",
+      "has_model_permission": true
+    },
+    "ansible.view_ansiblerepository": {
+      "name": "View Ansible repository",
+      "object_description": "View this Ansible repository.",
+      "global_description": "View any Ansible repository existing in the system.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "ansible.add_ansiblerepository": {
+      "name": "Add Ansible repository",
+      "object_description": "Add this Ansible repository.",
+      "global_description": "Add any Ansible repository existing in the system.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "ansible.change_ansiblerepository": {
+      "name": "Change Ansible repository",
+      "object_description": "Change this Ansible repository.",
+      "global_description": "Change any Ansible repository existing in the system.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "ansible.delete_ansiblerepository": {
+      "name": "Delete Ansible repository",
+      "object_description": "Delete this Ansible repository.",
+      "global_description": "Delete any Ansible repository existing in the system.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "ansible.manage_roles_ansiblerepository": {
+      "name": "Manage repository roles",
+      "object_description": "Configure who has permissions on this repository.",
+      "global_description": "Configure who has permissions on any repository.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "ansible.repair_ansiblerepository": {
+      "name": "Repair Ansible repository",
+      "object_description": "Repair artifacts associated with this Ansible repository.",
+      "global_description": "Repair artifacts associated with any Ansible repository existing in the system.",
+      "ui_category": "Ansible Repository",
+      "has_model_permission": true
+    },
+    "container.change_containernamespace": {
+      "name": "Change container namespace permissions",
+      "object_description": "Edit permissions on this container namespace.",
+      "global_description": "Edit permissions on any existing container namespace.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.namespace_change_containerdistribution": {
+      "name": "Change containers",
+      "object_description": "Edit all objects in this container namespace.",
+      "global_description": "Edit all objects in any container namespace in the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.namespace_modify_content_containerpushrepository": {
+      "name": "Change image tags",
+      "object_description": "Edit an image's tag in this container namespace",
+      "global_description": "Edit an image's tag in any container namespace the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.add_containernamespace": {
+      "name": "Create new containers",
+      "object_description": null,
+      "global_description": "Add new containers to the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.delete_containerrepository": {
+      "name": "Delete container repository",
+      "object_description": "Delete this container repository.",
+      "global_description": "Delete any existing container repository in the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.namespace_push_containerdistribution": {
+      "name": "Push to existing containers",
+      "object_description": "Push to this namespace.",
+      "global_description": "Push to any existing namespace in the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.namespace_add_containerdistribution": {
+      "name": "Push new containers",
+      "object_description": "Push a new container to this namespace.",
+      "global_description": "Push a new containers to any namespace in the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "container.manage_roles_containernamespace": {
+      "name": "Manage container namespace roles",
+      "object_description": "Manage container namespace roles.",
+      "global_description": "Manage container namespace roles existing in the system.",
+      "ui_category": "Execution Environments",
+      "has_model_permission": true
+    },
+    "galaxy.add_containerregistryremote": {
+      "name": "Add remote registry",
+      "object_description": null,
+      "global_description": "Add remote registry to the system.",
+      "ui_category": "Container Registry Remotes",
+      "has_model_permission": true
+    },
+    "galaxy.change_containerregistryremote": {
+      "name": "Change remote registry",
+      "object_description": "Edit this remote registry.",
+      "global_description": "Change any remote registry existing in the system.",
+      "ui_category": "Container Registry Remotes",
+      "has_model_permission": true
+    },
+    "galaxy.delete_containerregistryremote": {
+      "name": "Delete remote registry",
+      "object_description": "Delete this remote registry.",
+      "global_description": "Delete any remote registry existing in the system.",
+      "ui_category": "Container Registry Remotes",
+      "has_model_permission": true
+    },
+    "core.change_task": {
+      "name": "Change task",
+      "object_description": "Edit this task.",
+      "global_description": "Edit any task existing in the system.",
+      "ui_category": "Task Management",
+      "has_model_permission": true
+    },
+    "core.delete_task": {
+      "name": "Delete task",
+      "object_description": "Delete this task.",
+      "global_description": "Delete any task existing in the system.",
+      "ui_category": "Task Management",
+      "has_model_permission": true
+    },
+    "core.view_task": {
+      "name": "View all tasks",
+      "object_description": "View this task.",
+      "global_description": "View any task existing in the system.",
+      "ui_category": "Task Management",
+      "has_model_permission": true
+    }
+  },
+  "is_anonymous": false
+}

--- a/cypress/fixtures/hub_feature_flags.json
+++ b/cypress/fixtures/hub_feature_flags.json
@@ -1,0 +1,15 @@
+{
+  "legacy_roles": false,
+  "display_repositories": true,
+  "execution_environments": true,
+  "ai_deny_index": false,
+  "collection_signing": true,
+  "require_upload_signatures": false,
+  "signatures_enabled": true,
+  "can_upload_signatures": false,
+  "can_create_signatures": true,
+  "collection_auto_sign": true,
+  "display_signatures": true,
+  "container_signing": true,
+  "_messages": []
+}

--- a/cypress/fixtures/hub_settings.json
+++ b/cypress/fixtures/hub_settings.json
@@ -1,0 +1,30 @@
+{
+  "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS": false,
+  "GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD": false,
+  "GALAXY_FEATURE_FLAGS": {
+    "legacy_roles": false,
+    "display_repositories": true,
+    "execution_environments": true,
+    "ai_deny_index": false,
+    "collection_signing": true,
+    "require_upload_signatures": false,
+    "signatures_enabled": true,
+    "can_upload_signatures": false,
+    "can_create_signatures": true,
+    "collection_auto_sign": true,
+    "display_signatures": true,
+    "container_signing": true,
+    "_messages": []
+  },
+  "GALAXY_TOKEN_EXPIRATION": null,
+  "GALAXY_REQUIRE_CONTENT_APPROVAL": false,
+  "GALAXY_COLLECTION_SIGNING_SERVICE": "ansible-default",
+  "GALAXY_AUTO_SIGN_COLLECTIONS": true,
+  "GALAXY_SIGNATURE_UPLOAD_ENABLED": false,
+  "GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL": false,
+  "GALAXY_MINIMUM_PASSWORD_LENGTH": null,
+  "GALAXY_AUTH_LDAP_ENABLED": null,
+  "GALAXY_CONTAINER_SIGNING_SERVICE": "container-default",
+  "GALAXY_LDAP_MIRROR_ONLY_EXISTING_GROUPS": false,
+  "GALAXY_LDAP_DISABLE_REFERRALS": null
+}

--- a/framework/PageDashboard/PageDashboardCard.tsx
+++ b/framework/PageDashboard/PageDashboardCard.tsx
@@ -1,4 +1,14 @@
-import { Card, CardHeader, Flex, FlexItem, Stack, Text, Title } from '@patternfly/react-core';
+import {
+  Button,
+  Card,
+  CardFooter,
+  CardHeader,
+  Flex,
+  FlexItem,
+  Stack,
+  Text,
+  Title,
+} from '@patternfly/react-core';
 import { CSSProperties, ReactNode, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { Help } from '../components/Help';
@@ -17,6 +27,11 @@ export function PageDashboardCard(props: {
   linkText?: string;
   to?: string;
   children?: ReactNode;
+  footerActionButton?: {
+    icon?: ReactNode;
+    title: string;
+    onClick: () => unknown;
+  };
 
   /**
    * Cards are in a grid layout with 12 columns.
@@ -194,6 +209,29 @@ export function PageDashboardCard(props: {
         </CardHeader>
       )}
       {props.children}
+      {props.footerActionButton && (
+        <CardFooter>
+          <Stack style={{ width: '100%' }}>
+            <Flex
+              fullWidth={{ default: 'fullWidth' }}
+              spaceItems={{ default: 'spaceItemsNone' }}
+              alignItems={{ default: 'alignItemsFlexStart' }}
+              justifyContent={{ default: 'justifyContentFlexEnd' }}
+              style={{ columnGap: 24, rowGap: 8 }}
+            >
+              <FlexItem>
+                <Button
+                  variant="link"
+                  icon={props.footerActionButton.icon ? props.footerActionButton.icon : null}
+                  onClick={props.footerActionButton.onClick}
+                >
+                  {props.footerActionButton.title}
+                </Button>
+              </FlexItem>
+            </Flex>
+          </Stack>
+        </CardFooter>
+      )}
     </Card>
   );
 }

--- a/framework/PageDashboard/PageDashboardCard.tsx
+++ b/framework/PageDashboard/PageDashboardCard.tsx
@@ -30,7 +30,7 @@ export function PageDashboardCard(props: {
   footerActionButton?: {
     icon?: ReactNode;
     title: string;
-    onClick: () => unknown;
+    onClick: () => void;
   };
 
   /**
@@ -223,7 +223,9 @@ export function PageDashboardCard(props: {
                 <Button
                   variant="link"
                   icon={props.footerActionButton.icon ? props.footerActionButton.icon : null}
-                  onClick={props.footerActionButton.onClick}
+                  onClick={() => {
+                    void props.footerActionButton?.onClick();
+                  }}
                 >
                   {props.footerActionButton.title}
                 </Button>

--- a/framework/PageDashboard/PageDashboardCarousel.tsx
+++ b/framework/PageDashboard/PageDashboardCarousel.tsx
@@ -9,6 +9,11 @@ export function PageDashboardCarousel(props: {
   to?: string;
   width?: PageDashboardCardWidth;
   children: ReactNode;
+  footerActionButton?: {
+    icon?: ReactNode;
+    title: string;
+    onClick: () => unknown;
+  };
 }) {
   return (
     <PageDashboardCard
@@ -16,6 +21,7 @@ export function PageDashboardCarousel(props: {
       linkText={props.linkText}
       to={props.to}
       width={props.width}
+      footerActionButton={props.footerActionButton}
     >
       <CardBody>
         <PageCarousel carouselId={props.title.replace(/\s+/g, '-').toLowerCase()}>

--- a/framework/PageDashboard/PageDashboardCarousel.tsx
+++ b/framework/PageDashboard/PageDashboardCarousel.tsx
@@ -12,7 +12,7 @@ export function PageDashboardCarousel(props: {
   footerActionButton?: {
     icon?: ReactNode;
     title: string;
-    onClick: () => unknown;
+    onClick: () => void;
   };
 }) {
   return (

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -30,6 +30,7 @@ export type MultiSelectDialogProps<T extends object> = {
   cancelText?: string;
   emptyStateTitle?: string;
   errorStateTitle?: string;
+  defaultSort?: string;
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
@@ -42,6 +43,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     confirmText,
     cancelText,
     onSelect,
+    defaultSort,
   } = props;
   const [_, setDialog] = usePageDialog();
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
@@ -125,6 +127,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
             disableListView
             compact
             disableBodyPadding
+            sort={defaultSort}
           />
         </div>
       </Collapse>

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -32,6 +32,7 @@ export type MultiSelectDialogProps<T extends object> = {
   errorStateTitle?: string;
   defaultSort?: string;
   maxSelections?: number;
+  allowZeroSelections?: boolean;
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
@@ -46,6 +47,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     onSelect,
     defaultSort,
     maxSelections,
+    allowZeroSelections,
   } = props;
   const [_, setDialog] = usePageDialog();
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
@@ -68,7 +70,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
             onClose();
             onSelect(view.selectedItems);
           }}
-          isAriaDisabled={view.selectedItems.length === 0}
+          isAriaDisabled={view.selectedItems.length === 0 && !allowZeroSelections}
         >
           {confirmText ?? translations.confirmText}
         </Button>,

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -1,15 +1,27 @@
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import {
+  Button,
+  Label,
+  LabelGroup,
+  Modal,
+  ModalBoxBody,
+  ModalVariant,
+  Skeleton,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 import { useCallback } from 'react';
 import { PageTable } from '../PageTable/PageTable';
-import { ITableColumn } from '../PageTable/PageTableColumn';
+import { ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
 import { ISelected } from '../PageTable/useTableItems';
 import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { IView } from '../useView';
 import { usePageDialog } from './PageDialog';
+import { Collapse } from '../components/Collapse';
 
 export type MultiSelectDialogProps<T extends object> = {
   title: string;
+  description?: string;
   view: IView & ISelected<T> & { itemCount?: number; pageItems: T[] | undefined };
   tableColumns: ITableColumn<T>[];
   toolbarFilters: IToolbarFilter[];
@@ -21,7 +33,16 @@ export type MultiSelectDialogProps<T extends object> = {
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
-  const { title, view, tableColumns, toolbarFilters, confirmText, cancelText, onSelect } = props;
+  const {
+    title,
+    description,
+    view,
+    tableColumns,
+    toolbarFilters,
+    confirmText,
+    cancelText,
+    onSelect,
+  } = props;
   const [_, setDialog] = usePageDialog();
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
   const [translations] = useFrameworkTranslations();
@@ -29,6 +50,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     <Modal
       title={title}
       aria-label={title}
+      description={description}
       isOpen
       onClose={onClose}
       variant={ModalVariant.medium}
@@ -52,27 +74,60 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
       ]}
       hasNoBodyWrapper
     >
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          maxHeight: 500,
-          overflow: 'hidden',
-        }}
-      >
-        <PageTable<T>
-          tableColumns={tableColumns}
-          toolbarFilters={toolbarFilters}
-          {...view}
-          emptyStateTitle={props.emptyStateTitle ?? translations.noItemsFound}
-          errorStateTitle={props.errorStateTitle ?? translations.errorText}
-          showSelect
-          disableCardView
-          disableListView
-          compact
-          disableBodyPadding
-        />
-      </div>
+      <ModalBoxBody style={{ overflow: 'hidden' }}>
+        <Split hasGutter>
+          <SplitItem style={{ fontWeight: 'bold' }}>{translations.selectedText}</SplitItem>
+          {view.selectedItems.length > 0 ? (
+            <LabelGroup>
+              {view.selectedItems.map((item, i) => {
+                if (tableColumns && tableColumns.length > 0) {
+                  return (
+                    <Label key={i} onClick={() => view.unselectItem(item)}>
+                      <TableColumnCell
+                        item={item}
+                        column={
+                          tableColumns.find(
+                            (column) => column.card === 'name' || column.list === 'name'
+                          ) ?? tableColumns[0]
+                        }
+                      />
+                    </Label>
+                  );
+                }
+                return <></>;
+              })}
+            </LabelGroup>
+          ) : (
+            <SplitItem style={{ fontStyle: 'italic' }}>{translations.noneSelectedText}</SplitItem>
+          )}
+        </Split>
+      </ModalBoxBody>
+      <Collapse open={view.itemCount === undefined}>
+        <Skeleton height="80px" />
+      </Collapse>
+      <Collapse open={view.itemCount !== undefined}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            maxHeight: 500,
+            overflow: 'hidden',
+          }}
+        >
+          <PageTable<T>
+            tableColumns={tableColumns}
+            toolbarFilters={toolbarFilters}
+            {...view}
+            emptyStateTitle={props.emptyStateTitle ?? translations.noItemsFound}
+            errorStateTitle={props.errorStateTitle ?? translations.errorText}
+            showSelect
+            disableCardView
+            disableListView
+            compact
+            disableBodyPadding
+          />
+        </div>
+      </Collapse>
     </Modal>
   );
 }

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -31,6 +31,7 @@ export type MultiSelectDialogProps<T extends object> = {
   emptyStateTitle?: string;
   errorStateTitle?: string;
   defaultSort?: string;
+  maxSelections?: number;
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
@@ -44,6 +45,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     cancelText,
     onSelect,
     defaultSort,
+    maxSelections,
   } = props;
   const [_, setDialog] = usePageDialog();
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
@@ -128,6 +130,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
             compact
             disableBodyPadding
             sort={defaultSort}
+            maxSelections={maxSelections}
           />
         </div>
       </Collapse>

--- a/framework/PageDialogs/useSelectDialog.tsx
+++ b/framework/PageDialogs/useSelectDialog.tsx
@@ -35,10 +35,9 @@ interface ISelectDialogOptions<T extends object, TMultiple> {
 /**
  * @deprecated use SelectSingleDialog
  */
-export function useSelectDialog<
-  T extends { id: number | string; name: string | undefined },
-  TMultiple = false,
->(options: ISelectDialogOptions<T, TMultiple>) {
+export function useSelectDialog<T extends object, TMultiple = false>(
+  options: ISelectDialogOptions<T, TMultiple>
+) {
   const { view, tableColumns, toolbarFilters, confirm, cancel, selected, isMultiple } = options;
   const [title, setTitle] = useState('');
   type ISetter = TMultiple extends true ? (item: T[]) => void : (item: T) => void;
@@ -97,10 +96,9 @@ export type SelectDialogProps<T extends object, TMultiple> = {
   keyFn: (item: T) => string | number;
 } & ISelectDialogOptions<T, TMultiple>;
 
-export function SelectDialog<
-  T extends { id: number | string; name: string | undefined },
-  TMultiple = false,
->(props: SelectDialogProps<T, TMultiple>) {
+export function SelectDialog<T extends object, TMultiple = false>(
+  props: SelectDialogProps<T, TMultiple>
+) {
   const {
     title,
     open,

--- a/framework/PageDialogs/useSelectDialog.tsx
+++ b/framework/PageDialogs/useSelectDialog.tsx
@@ -35,9 +35,10 @@ interface ISelectDialogOptions<T extends object, TMultiple> {
 /**
  * @deprecated use SelectSingleDialog
  */
-export function useSelectDialog<T extends object, TMultiple = false>(
-  options: ISelectDialogOptions<T, TMultiple>
-) {
+export function useSelectDialog<
+  T extends { id: number | string; name: string | undefined },
+  TMultiple = false,
+>(options: ISelectDialogOptions<T, TMultiple>) {
   const { view, tableColumns, toolbarFilters, confirm, cancel, selected, isMultiple } = options;
   const [title, setTitle] = useState('');
   type ISetter = TMultiple extends true ? (item: T[]) => void : (item: T) => void;
@@ -96,9 +97,10 @@ export type SelectDialogProps<T extends object, TMultiple> = {
   keyFn: (item: T) => string | number;
 } & ISelectDialogOptions<T, TMultiple>;
 
-export function SelectDialog<T extends object, TMultiple = false>(
-  props: SelectDialogProps<T, TMultiple>
-) {
+export function SelectDialog<
+  T extends { id: number | string; name: string | undefined },
+  TMultiple = false,
+>(props: SelectDialogProps<T, TMultiple>) {
   const {
     title,
     open,

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -182,6 +182,8 @@ export type PageTableProps<T extends object> = {
 
   disableLastRowBorder?: boolean;
 
+  maxSelections?: number;
+
   /**
    * This will render content between PageToolbar and table hader. Set scrollOutsideTable to true, if you want proper scrolling in table.
    */
@@ -406,6 +408,7 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
     clearAllFilters,
     onSelect,
     unselectAll,
+    maxSelections,
   } = props;
 
   const tableColumns = useVisibleTableColumns(props.tableColumns);
@@ -565,6 +568,8 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
                   expandedRow={expandedRow}
                   isLastRow={rowIndex === pageItems.length - 1}
                   disableLastRowBorder={props.disableLastRowBorder}
+                  maxSelections={maxSelections}
+                  selectedItems={props.selectedItems}
                 />
               ))}
         </Tbody>
@@ -728,6 +733,8 @@ function TableRow<T extends object>(props: {
   expandedRow?: (item: T) => ReactNode;
   isLastRow?: boolean;
   disableLastRowBorder?: boolean;
+  maxSelections?: number;
+  selectedItems?: T[];
 }) {
   const {
     columns,
@@ -743,10 +750,23 @@ function TableRow<T extends object>(props: {
     onSelect,
     expandedRow,
     disableLastRowBorder,
+    maxSelections,
+    selectedItems,
   } = props;
   const [expanded, setExpanded] = useState(false);
   const settings = useSettings();
   const expandedContent = expandedRow?.(item);
+  const disableRow = useCallback(
+    (item: T) => {
+      if (selectedItems?.length === maxSelections) {
+        // disable checkboxes for remaining rows
+        return !selectedItems?.includes(item);
+      }
+      return false;
+    },
+    [maxSelections, selectedItems]
+  );
+
   return (
     <>
       <Tr
@@ -783,6 +803,7 @@ function TableRow<T extends object>(props: {
                       }
                     },
                     isSelected: isItemSelected,
+                    isDisabled: maxSelections && selectedItems ? disableRow(item) : false,
                   }
                 : undefined
             }
@@ -804,6 +825,7 @@ function TableRow<T extends object>(props: {
               },
               isSelected: isItemSelected ?? false,
               variant: isSelectMultiple ? 'checkbox' : 'radio',
+              disable: maxSelections && selectedItems ? disableRow(item) : false,
             }}
             isStickyColumn
             stickyMinWidth="0px"

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -182,6 +182,9 @@ export type PageTableProps<T extends object> = {
 
   disableLastRowBorder?: boolean;
 
+  /** Optional: Max selections permitted in a table. If this number of selections has been made,
+   * the checkboxes on the rest of the rows are disabled until an item is unselected.
+   */
   maxSelections?: number;
 
   /**

--- a/framework/PageToolbar/PageToolbar.tsx
+++ b/framework/PageToolbar/PageToolbar.tsx
@@ -78,6 +78,9 @@ export type PageToolbarProps<T extends object> = {
   disablePagination?: boolean;
   bottomBorder?: boolean;
   sortOptions?: PageTableSortOption[];
+  /** Optional: Max selections permitted in a table. The bulk selector within the toolbar is disabled based on this value.
+   */
+  maxSelections?: number;
 };
 
 export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {

--- a/framework/useFrameworkTranslations.tsx
+++ b/framework/useFrameworkTranslations.tsx
@@ -21,6 +21,7 @@ export interface IFrameworkTranslations {
   noResultsMatchCriteria: string;
   noSelection: string;
   noSelections: string;
+  noneSelectedText: string;
   ofText: string;
   pendingText: string;
   pleaseFixValidationErrors: string;
@@ -58,6 +59,7 @@ const defaultTranslations: IFrameworkTranslations = {
   noResultsMatchCriteria: 'No results match this filter criteria. Clear all filters and try again.',
   noSelection: 'No selection',
   noSelections: 'No selections',
+  noneSelectedText: 'None - Please make a selection below.',
   ofText: 'of',
   pendingText: 'Pending',
   pleaseFixValidationErrors: 'Please fix validation errors.',

--- a/frontend/hub/collections/hooks/useSelectCollections.cy.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.cy.tsx
@@ -1,0 +1,147 @@
+import { CollectionVersionSearch } from '../../approvals/Approval';
+import { HubItemsResponse } from '../../useHubView';
+import { CollectionMultiSelectDialog } from './useSelectCollections';
+
+/**
+ * TODO: The category and corresponding fixture needs to be changed to "featured".
+ * Since we don't have the API to retrieve "featured" collections yet,
+ * this is set to "eda" temporarily to be able to view and test the UI.
+ */
+describe('CollectionMultiSelectDialog', () => {
+  beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '**/plugin/ansible/search/collection-versions**&offset=0&*',
+        hostname: 'localhost',
+      },
+      {
+        fixture: 'collection_versions_offset0.json',
+      }
+    );
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '**/plugin/ansible/search/collection-versions/**&offset=10&*',
+        hostname: 'localhost',
+      },
+      {
+        fixture: 'collection_versions_offset10.json',
+      }
+    );
+  });
+  it('renders dialog to select collections', () => {
+    /**
+     * TODO: The category and corresponding fixture needs to be changed to "featured".
+     * Since we don't have the API to retrieve "featured" collections yet,
+     * this is set to "eda" temporarily to be able to view and test the UI.
+     */
+    cy.fixture('collection_versions_eda').then(
+      (edaCollections: HubItemsResponse<CollectionVersionSearch>) => {
+        cy.mount(
+          <CollectionMultiSelectDialog
+            // eslint-disable-next-line i18next/no-literal-string
+            title="Select featured collections content"
+            // eslint-disable-next-line i18next/no-literal-string
+            description="Please select content below to be shown on the dashboard. Note: The max amount of selections is 12."
+            onSelect={async function (collections?: CollectionVersionSearch[]) {
+              return new Cypress.Promise((resolve, _) => {
+                // Verify number of selections
+                expect(collections?.length).to.equal(10);
+                resolve(collections);
+              });
+            }}
+            defaultSelection={edaCollections.data}
+            maxSelections={12}
+            allowZeroSelections
+          />
+        );
+        cy.contains('Select featured collections content').should('be.visible');
+        cy.contains(
+          'Please select content below to be shown on the dashboard. Note: The max amount of selections is 12.'
+        ).should('be.visible');
+        cy.clickModalButton('Select');
+      }
+    );
+  });
+  it('should display selected items and allow expanding and collapsing labels', () => {
+    cy.fixture('collection_versions_eda').then(
+      (edaCollections: HubItemsResponse<CollectionVersionSearch>) => {
+        cy.mount(
+          <CollectionMultiSelectDialog
+            // eslint-disable-next-line i18next/no-literal-string
+            title="Select featured collections content"
+            // eslint-disable-next-line i18next/no-literal-string
+            description="Please select content below to be shown on the dashboard. Note: The max amount of selections is 12."
+            onSelect={async function (collections?: CollectionVersionSearch[]) {
+              return new Cypress.Promise((resolve, _) => {
+                resolve(collections);
+              });
+            }}
+            defaultSelection={edaCollections.data}
+            maxSelections={12}
+            allowZeroSelections
+          />
+        );
+        cy.contains('Selected')
+          .next('div.pf-c-label-group')
+          .within(() => {
+            cy.get('li.pf-c-label-group__list-item').should('have.length', 4);
+            cy.get('li.pf-c-label-group__list-item').should('contain', 'test_collection10');
+            cy.get('li.pf-c-label-group__list-item').should('contain', 'test_collection9');
+            cy.get('li.pf-c-label-group__list-item').should('contain', 'test_collection8');
+            cy.get('li.pf-c-label-group__list-item').should('contain', '7 more');
+            cy.get('button').contains('7 more').click();
+            cy.get('li.pf-c-label-group__list-item').should('have.length', 11);
+            cy.get('button').contains('Show Less').click();
+            cy.get('li.pf-c-label-group__list-item').should('have.length', 4);
+          });
+      }
+    );
+  });
+  it('should enable selecting up to a maximum of 12 collections', () => {
+    cy.fixture('collection_versions_eda').then(
+      (edaCollections: HubItemsResponse<CollectionVersionSearch>) => {
+        cy.mount(
+          <CollectionMultiSelectDialog
+            // eslint-disable-next-line i18next/no-literal-string
+            title="Select featured collections content"
+            // eslint-disable-next-line i18next/no-literal-string
+            description="Please select content below to be shown on the dashboard. Note: The max amount of selections is 12."
+            onSelect={async function (collections?: CollectionVersionSearch[]) {
+              return new Cypress.Promise((resolve, _) => {
+                resolve(collections);
+              });
+            }}
+            defaultSelection={edaCollections.data}
+            maxSelections={12}
+            allowZeroSelections
+          />
+        );
+        /** Since 10 collections are already selected and bulk selecting on this page
+         * will push the selected items over the limit of 12, bulk selection is disabled
+         */
+        cy.get('div.pf-m-bulk-select').should('contain', '10 selected');
+        cy.get('div.pf-m-bulk-select').within(() => {
+          cy.get('div.pf-c-dropdown__toggle').should('have.class', 'pf-m-disabled');
+        });
+
+        // Select 12 collections
+        cy.selectTableRow('test_collection3');
+        cy.selectTableRow('test_collection4');
+        // Max 12 selections
+        cy.get('div.pf-m-bulk-select').should('contain', '12 selected');
+        // Remaining checkboxes are disabled after max selections
+        cy.getTableRowByText('test_collection5').within(() => {
+          cy.get('input[type=checkbox]').should('have.attr', 'disabled');
+        });
+        // Unselect an existing selection to re-enable the checkboxes
+        cy.selectTableRow('test_collection4');
+        cy.get('div.pf-m-bulk-select').should('contain', '11 selected');
+        cy.getTableRowByText('test_collection5').within(() => {
+          cy.get('input[type=checkbox]').should('not.have.attr', 'disabled');
+        });
+      }
+    );
+  });
+});

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -4,7 +4,6 @@ import { useCollectionFilters } from './useCollectionFilters';
 import {
   ColumnTableOption,
   ITableColumn,
-  LabelsCell,
   MultiSelectDialog,
   TextCell,
   usePageDialog,

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -18,6 +18,7 @@ export function CollectionMultiSelectDialog(props: {
   onSelect: (collections: CollectionVersionSearch[]) => Promise<unknown>;
   defaultSelection: CollectionVersionSearch[];
   maxSelections?: number;
+  allowZeroSelections?: boolean;
 }) {
   const { t } = useTranslation();
   const toolbarFilters = useCollectionFilters();
@@ -69,6 +70,7 @@ export function CollectionMultiSelectDialog(props: {
       defaultSort="name"
       confirmText={t('Select')}
       maxSelections={props.maxSelections}
+      allowZeroSelections={props.allowZeroSelections}
     />
   );
 }
@@ -80,7 +82,10 @@ export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSe
       title: string,
       description: string,
       onSelect: (collections: CollectionVersionSearch[]) => Promise<unknown>,
-      maxSelections?: number
+      options?: {
+        maxSelections?: number;
+        allowZeroSelections?: boolean;
+      }
     ) => {
       setDialog(
         <CollectionMultiSelectDialog
@@ -88,7 +93,8 @@ export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSe
           description={description}
           onSelect={onSelect}
           defaultSelection={defaultSelection}
-          maxSelections={maxSelections}
+          maxSelections={options?.maxSelections}
+          allowZeroSelections={options?.allowZeroSelections}
         />
       );
     },

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -4,6 +4,7 @@ import { useCollectionFilters } from './useCollectionFilters';
 import {
   ColumnTableOption,
   ITableColumn,
+  LabelsCell,
   MultiSelectDialog,
   TextCell,
   usePageDialog,
@@ -11,6 +12,15 @@ import {
 import { CollectionVersionSearch } from '../Collection';
 import { collectionKeyFn, hubAPI } from '../../api/utils';
 import { useHubView } from '../../useHubView';
+import { Label, Truncate } from '@patternfly/react-core';
+
+// TODO: If deployment mode is INSIGHTS, CERTIFIED_REPO should be set to 'published'. This needs to be updated
+// in the future when we are able to identify INSIGHTS mode
+const CERTIFIED_REPO = 'rh-certified';
+
+function CertifiedIcon() {
+  return <i className="fas fa-certificate"></i>;
+}
 
 export function CollectionMultiSelectDialog(props: {
   title: string;
@@ -45,6 +55,19 @@ export function CollectionMultiSelectDialog(props: {
         value: (collection) => collection.collection_version.version,
         table: ColumnTableOption.Hidden,
         sort: 'version',
+      },
+      {
+        header: t('Repository'),
+        cell: (collection: CollectionVersionSearch) =>
+          collection.repository.name === CERTIFIED_REPO ? (
+            <Label color="blue" icon={<CertifiedIcon />} variant="outline">
+              <Truncate content={t('Certified')} style={{ minWidth: 0 }} />
+            </Label>
+          ) : (
+            <Label color="blue" variant="outline">
+              <Truncate content={collection.repository.name} style={{ minWidth: 0 }} />
+            </Label>
+          ),
       },
     ],
     [t]

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -26,6 +26,8 @@ export function CollectionMultiSelectDialog(props: {
         value: (collection) => collection.collection_version.name,
         cell: (collection) => <TextCell text={collection.collection_version.name} />,
         sort: 'name',
+        card: 'name',
+        list: 'name',
         defaultSort: true,
       },
       {
@@ -61,6 +63,8 @@ export function CollectionMultiSelectDialog(props: {
       toolbarFilters={toolbarFilters}
       tableColumns={tableColumns}
       view={view}
+      defaultSort="name"
+      confirmText={t('Select')}
     />
   );
 }

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCollectionFilters } from './useCollectionFilters';
+import {
+  ColumnTableOption,
+  ITableColumn,
+  MultiSelectDialog,
+  TextCell,
+  usePageDialog,
+} from '../../../../framework';
+import { CollectionVersionSearch } from '../Collection';
+import { collectionKeyFn, hubAPI } from '../../api/utils';
+import { useHubView } from '../../useHubView';
+
+export function CollectionMultiSelectDialog(props: {
+  title: string;
+  description: string;
+  onSelect: (collections: CollectionVersionSearch[]) => void;
+}) {
+  const { t } = useTranslation();
+  const toolbarFilters = useCollectionFilters();
+  const tableColumns = useMemo<ITableColumn<CollectionVersionSearch>[]>(
+    () => [
+      {
+        header: t('Name'),
+        value: (collection) => collection.collection_version.name,
+        cell: (collection) => <TextCell text={collection.collection_version.name} />,
+        sort: 'name',
+        defaultSort: true,
+      },
+      {
+        header: t('Description'),
+        type: 'description',
+        value: (collection) => collection.collection_version.description,
+        table: ColumnTableOption.Expanded,
+      },
+      {
+        header: t('Version'),
+        type: 'text',
+        value: (collection) => collection.collection_version.version,
+        table: ColumnTableOption.Hidden,
+        sort: 'version',
+      },
+    ],
+    [t]
+  );
+  const view = useHubView<CollectionVersionSearch>({
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions`,
+    keyFn: collectionKeyFn,
+    sortKey: 'order_by',
+    queryParams: {
+      is_deprecated: 'false',
+      repository_label: '!hide_from_search',
+      is_highest: 'true',
+    },
+    toolbarFilters,
+  });
+  return (
+    <MultiSelectDialog
+      {...props}
+      toolbarFilters={toolbarFilters}
+      tableColumns={tableColumns}
+      view={view}
+    />
+  );
+}
+
+export function useSelectCollectionsDialog() {
+  const [_, setDialog] = usePageDialog();
+  const openSelectCollectionsDialog = useCallback(
+    (
+      title: string,
+      description: string,
+      onSelect: (collections: CollectionVersionSearch[]) => void
+    ) => {
+      setDialog(
+        <CollectionMultiSelectDialog title={title} description={description} onSelect={onSelect} />
+      );
+    },
+    [setDialog]
+  );
+  return openSelectCollectionsDialog;
+}

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -15,7 +15,9 @@ import { useHubView } from '../../useHubView';
 export function CollectionMultiSelectDialog(props: {
   title: string;
   description: string;
-  onSelect: (collections: CollectionVersionSearch[]) => void;
+  onSelect: (collections: CollectionVersionSearch[]) => Promise<unknown>;
+  defaultSelection: CollectionVersionSearch[];
+  maxSelections?: number;
 }) {
   const { t } = useTranslation();
   const toolbarFilters = useCollectionFilters();
@@ -56,6 +58,7 @@ export function CollectionMultiSelectDialog(props: {
       is_highest: 'true',
     },
     toolbarFilters,
+    defaultSelection: props.defaultSelection,
   });
   return (
     <MultiSelectDialog
@@ -65,23 +68,31 @@ export function CollectionMultiSelectDialog(props: {
       view={view}
       defaultSort="name"
       confirmText={t('Select')}
+      maxSelections={props.maxSelections}
     />
   );
 }
 
-export function useSelectCollectionsDialog() {
+export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSearch[]) {
   const [_, setDialog] = usePageDialog();
   const openSelectCollectionsDialog = useCallback(
     (
       title: string,
       description: string,
-      onSelect: (collections: CollectionVersionSearch[]) => void
+      onSelect: (collections: CollectionVersionSearch[]) => Promise<unknown>,
+      maxSelections?: number
     ) => {
       setDialog(
-        <CollectionMultiSelectDialog title={title} description={description} onSelect={onSelect} />
+        <CollectionMultiSelectDialog
+          title={title}
+          description={description}
+          onSelect={onSelect}
+          defaultSelection={defaultSelection}
+          maxSelections={maxSelections}
+        />
       );
     },
-    [setDialog]
+    [defaultSelection, setDialog]
   );
   return openSelectCollectionsDialog;
 }

--- a/frontend/hub/common/Logo.tsx
+++ b/frontend/hub/common/Logo.tsx
@@ -30,15 +30,15 @@ export function Logo(props: LogoProps) {
 
   useEffect(() => {
     if (flexGrow) {
-      setStyle({ ...style, flexGrow: 1 });
+      setStyle((prevStyle) => ({ ...prevStyle, flexGrow: 1 }));
     }
 
     if (unlockWidth) {
-      setStyle({ ...style, minWidth: logoSize });
+      setStyle((prevStyle) => ({ ...prevStyle, minWidth: logoSize }));
     } else {
-      setStyle({ ...style, width: logoSize });
+      setStyle((prevStyle) => ({ ...prevStyle, width: logoSize }));
     }
-  }, [flexGrow, logoSize, style, unlockWidth]);
+  }, [flexGrow, logoSize, unlockWidth]);
 
   return (
     <div className={className} style={style}>

--- a/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
+++ b/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
@@ -1,0 +1,54 @@
+import { collectionKeyFn } from '../../api/utils';
+import { CollectionVersionSearch } from '../../collections/Collection';
+
+/**
+ * Utility function to get arrays of collections to be removed from selection and added to selections
+ * based on original and updated selection of collections
+ * @param original original list of items
+ * @param current updated list of items
+ * @returns object containing 2 lists: ids to be added and ids to be removed
+ */
+export function getAddedAndRemovedCollections(
+  original: CollectionVersionSearch[],
+  current: CollectionVersionSearch[]
+) {
+  original = original || [];
+  current = current || [];
+  const added: CollectionVersionSearch[] = [];
+  const removed: CollectionVersionSearch[] = [];
+  original.forEach((orig) => {
+    if (
+      !current.find(
+        (cur) =>
+          collectionKeyFn({
+            collection_version: { pulp_href: cur.collection_version.pulp_href },
+            repository: { name: cur.repository.name },
+          }) ===
+          collectionKeyFn({
+            collection_version: { pulp_href: orig.collection_version.pulp_href },
+            repository: { name: orig.repository.name },
+          })
+      )
+    ) {
+      removed.push(orig);
+    }
+  });
+  current.forEach((cur) => {
+    if (
+      !original.find(
+        (orig) =>
+          collectionKeyFn({
+            collection_version: { pulp_href: orig.collection_version.pulp_href },
+            repository: { name: orig.repository.name },
+          }) ===
+          collectionKeyFn({
+            collection_version: { pulp_href: cur.collection_version.pulp_href },
+            repository: { name: cur.repository.name },
+          })
+      )
+    ) {
+      added.push(cur);
+    }
+  });
+  return { added, removed };
+}

--- a/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
+++ b/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
@@ -2,11 +2,11 @@ import { collectionKeyFn } from '../../api/utils';
 import { CollectionVersionSearch } from '../../collections/Collection';
 
 /**
- * Utility function to get arrays of collections (pulp_hrefs) to be removed from selection and added to selections
- * based on original and updated selection of collections
- * @param original original list of items
- * @param current updated list of items
- * @returns object containing 2 lists: pulp_hrefs of collections to be added and collections to be removed
+ * Utility function to get arrays of collections (pulp_hrefs) to be removed and added based on original and
+ * updated selection of collections (in a select dialog for example)
+ * @param original original list of collections
+ * @param current updated list of collections
+ * @returns object containing 2 lists: pulp_hrefs of collections to be added and pulp_hrefs of collections to be removed
  */
 export function getAddedAndRemovedCollections(
   original: CollectionVersionSearch[],

--- a/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
+++ b/frontend/hub/common/utils/getAddedAndRemovedCollections.ts
@@ -2,11 +2,11 @@ import { collectionKeyFn } from '../../api/utils';
 import { CollectionVersionSearch } from '../../collections/Collection';
 
 /**
- * Utility function to get arrays of collections to be removed from selection and added to selections
+ * Utility function to get arrays of collections (pulp_hrefs) to be removed from selection and added to selections
  * based on original and updated selection of collections
  * @param original original list of items
  * @param current updated list of items
- * @returns object containing 2 lists: ids to be added and ids to be removed
+ * @returns object containing 2 lists: pulp_hrefs of collections to be added and collections to be removed
  */
 export function getAddedAndRemovedCollections(
   original: CollectionVersionSearch[],

--- a/frontend/hub/common/utils/parsePulpIDFromURL.ts
+++ b/frontend/hub/common/utils/parsePulpIDFromURL.ts
@@ -1,0 +1,11 @@
+const UUIDRegEx = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/i;
+
+export function parsePulpIDFromURL(url: string): string | null {
+  for (const section of url.split('/')) {
+    if (section.match(UUIDRegEx)) {
+      return section;
+    }
+  }
+
+  return null;
+}

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -6,6 +6,7 @@ import { CollectionVersionSearch } from '../collections/CollectionVersionSearch'
 import { ReactNode, useMemo } from 'react';
 import { CogIcon } from '@patternfly/react-icons';
 import { useSelectCollectionsDialog } from '../collections/hooks/useSelectCollections';
+import { collectionKeyFn } from '../api/utils';
 
 type FooterAction = {
   icon?: ReactNode;
@@ -31,7 +32,6 @@ export function CollectionCategoryCarousel(props: {
         icon: <CogIcon />,
         title: t('Manage content'),
         onClick: () => {
-          console.log('Clicked Manage content');
           selectCollections(
             t('Select featured collections content'),
             t(
@@ -39,6 +39,7 @@ export function CollectionCategoryCarousel(props: {
             ),
             (collections: CollectionVersionSearch[]) => {
               console.log('Collections', collections);
+              // Create post requests to Marks API to mark featured collections
             }
           );
         },
@@ -62,3 +63,33 @@ export function CollectionCategoryCarousel(props: {
     </PageDashboardCarousel>
   );
 }
+
+// async function saveFeaturedCollections(
+//   currentFeaturedCollections: CollectionVersionSearch[],
+//   originalFeaturedCollections: CollectionVersionSearch[]
+// ) {
+//   // TODO: move getAddedAndRemoved to common folder outside awx folder
+//   const { added, removed } = getAddedAndRemoved(
+//     originalFeaturedCollections ?? ([] as CollectionVersionSearch[]),
+//     currentFeaturedCollections ?? ([] as CollectionVersionSearch[])
+//   );
+
+//   if (added.length === 0 && removed.length === 0) {
+//     return;
+//   }
+
+//   const promisesToUnmarkFeaturedCollections = removed.map((collection: CollectionVersionSearch) =>
+//     postRequest(`/api/v2/inventories/${inventory.id.toString()}/instance_groups/`, {
+//       id: instanceGroup.id,
+//       disassociate: true,
+//     })
+//   );
+//   const promisesToMarkFeaturedCollections = added.map((collection: CollectionVersionSearch) =>
+//     postRequest(`/api/v2/inventories/${inventory.id.toString()}/instance_groups/`, {
+//       id: instanceGroup.id,
+//     })
+//   );
+
+//   const results = await Promise.all([...disassociationPromises, ...associationPromises]);
+//   return results;
+// }

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -3,6 +3,15 @@ import { PageDashboardCarousel } from '../../../framework/PageDashboard/PageDash
 import { useCategoryName } from './hooks/useCategoryName';
 import { CollectionCard } from './CollectionCard';
 import { CollectionVersionSearch } from '../collections/CollectionVersionSearch';
+import { ReactNode, useMemo } from 'react';
+import { CogIcon } from '@patternfly/react-icons';
+import { useSelectCollectionsDialog } from '../collections/hooks/useSelectCollections';
+
+type FooterAction = {
+  icon?: ReactNode;
+  title: string;
+  onClick: () => unknown;
+};
 
 /**
  * Carousel view representing a category of collections
@@ -14,9 +23,36 @@ export function CollectionCategoryCarousel(props: {
   const { category, collections } = props;
   const { t } = useTranslation();
   const categoryName = useCategoryName(category, t);
+  const selectCollections = useSelectCollectionsDialog();
+
+  const footerActionButton = useMemo<FooterAction | undefined>(() => {
+    if (props.category === 'eda') {
+      return {
+        icon: <CogIcon />,
+        title: t('Manage content'),
+        onClick: () => {
+          console.log('Clicked Manage content');
+          selectCollections(
+            t('Select featured collections content'),
+            t(
+              'Please select content below to be shown on the dashboard. Note: The max amount of selections is 12.'
+            ),
+            (collections: CollectionVersionSearch[]) => {
+              console.log('Collections', collections);
+            }
+          );
+        },
+      };
+    }
+  }, [props.category, selectCollections, t]);
 
   return (
-    <PageDashboardCarousel title={categoryName} linkText={t('Go to Collections')} width="xxl">
+    <PageDashboardCarousel
+      title={categoryName}
+      linkText={t('Go to Collections')}
+      width="xxl"
+      footerActionButton={footerActionButton}
+    >
       {collections.map((collection: CollectionVersionSearch) => (
         <CollectionCard
           key={collection.collection_version.name}

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -11,7 +11,6 @@ import { parsePulpIDFromURL } from '../common/utils/parsePulpIDFromURL';
 import { postHubRequest } from '../api/request';
 import { hubAPI } from '../api/utils';
 import { errorToAlertProps, usePageAlertToaster } from '../../../framework';
-// import { collectionKeyFn } from '../api/utils';
 
 type FooterAction = {
   icon?: ReactNode;
@@ -33,6 +32,11 @@ export function CollectionCategoryCarousel(props: {
   const alertToaster = usePageAlertToaster();
 
   const footerActionButton = useMemo<FooterAction | undefined>(() => {
+    /**
+     * TODO: This needs to be changed to category "featured" but since we don't have the API
+     * to retrieve "Featured" collections yet, this is set to "eda" temporarily to be able to
+     * view the UI
+     */
     if (props.category === 'eda') {
       return {
         icon: <CogIcon />,
@@ -50,7 +54,7 @@ export function CollectionCategoryCarousel(props: {
                 alertToaster.addAlert(errorToAlertProps(error));
               }
             },
-            3 // Select max 12 collections
+            12 // Select max 12 collections
           );
         },
       };

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -31,7 +31,7 @@ export function CollectionCategoryCarousel(props: {
   const categoryName = useCategoryName(category, t);
   const selectCollections = useSelectCollectionsDialog(collections);
   const alertToaster = usePageAlertToaster();
-  const { user } = useHubContext();
+  const context = useHubContext();
 
   const footerActionButton = useMemo<FooterAction | undefined>(() => {
     /**
@@ -39,7 +39,7 @@ export function CollectionCategoryCarousel(props: {
      * Since we don't have the API to retrieve "featured" collections yet,
      * this is set to "eda" temporarily to be able to view the UI.
      */
-    if (user.is_superuser && props.category === 'eda') {
+    if (context?.user?.is_superuser && props.category === 'eda') {
       return {
         icon: <CogIcon />,
         title: t('Manage content'),
@@ -64,7 +64,14 @@ export function CollectionCategoryCarousel(props: {
         },
       };
     }
-  }, [alertToaster, collections, props.category, selectCollections, t, user.is_superuser]);
+  }, [
+    alertToaster,
+    collections,
+    context?.user?.is_superuser,
+    props.category,
+    selectCollections,
+    t,
+  ]);
 
   return (
     <PageDashboardCarousel

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable i18next/no-literal-string */
 import { ButtonVariant, DropdownPosition } from '@patternfly/react-core';
-import { CogIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { CogIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   PageActionSelection,
@@ -38,18 +38,11 @@ export function HubDashboard() {
           <PageActions
             actions={[
               {
-                label: 'Build Environment',
-                icon: PlusCircleIcon,
-                type: PageActionType.Button,
-                variant: ButtonVariant.primary,
-                selection: PageActionSelection.None,
-                isPinned: true,
-                onClick: () => alert('TODO'),
-              },
-              {
                 icon: CogIcon,
                 label: 'Manage view',
                 type: PageActionType.Button,
+                variant: ButtonVariant.link,
+                isPinned: true,
                 selection: PageActionSelection.None,
                 onClick: openManageDashboard,
               },

--- a/frontend/hub/useHubContext.tsx
+++ b/frontend/hub/useHubContext.tsx
@@ -58,7 +58,7 @@ type HubGroup = {
   object_roles?: string[];
 };
 
-type HubUser = {
+export type HubUser = {
   auth_provider: string[];
   date_joined: string;
   email: string;

--- a/frontend/hub/useHubView.tsx
+++ b/frontend/hub/useHubView.tsx
@@ -41,6 +41,7 @@ export function useHubView<T extends object>({
   defaultFilters,
   defaultSort: initialDefaultSort,
   defaultSortDirection: initialDefaultSortDirection,
+  defaultSelection,
 }: {
   url: string;
   keyFn: (item: T) => string | number;
@@ -52,6 +53,7 @@ export function useHubView<T extends object>({
   defaultFilters?: Record<string, string[]>;
   defaultSort?: string | undefined;
   defaultSortDirection?: 'asc' | 'desc' | undefined;
+  defaultSelection?: T[];
 }): IHubView<T> {
   let defaultSort: string | undefined = initialDefaultSort;
   let defaultSortDirection: 'asc' | 'desc' | undefined = initialDefaultSortDirection;
@@ -137,7 +139,7 @@ export function useHubView<T extends object>({
     }
   }
 
-  const selection = useSelected(data?.data ?? [], keyFn);
+  const selection = useSelected(data?.data ?? [], keyFn, defaultSelection);
 
   if (data?.meta.count !== undefined) {
     itemCountRef.current.itemCount = data?.meta.count;


### PR DESCRIPTION
This PR adds functionality to manage content in the "featured collections" section of the dashboard. 

Since the API for featured collections is not available yet, as a temporary measure the "Manage Content" button will show up in the section "Event-driven Ansible content" ("eda" tagged collections)

### Framework enhancements:
1. New props in the `MultiSelectDialog` component to support the design for Manage Content:
    1. description
    2. defaultSort
    3. maxSelections
    4. allowZeroSelections
2. A "Selected" section in the `MultiSelectDialog` header with labels to indicate selected items.
3.  Updates to `PageTable`, `PageToolbar` and `BulkSelector` components to accept `maxSelections` as an optional prop to limit the number of selections. If the max selections is reached, the remaining checkboxes are disabled. In case of bulk selector, if a bulk selection operation will cause max selections to be exceeded, it is disabled.

### Testing

- Use steps here to create "eda" tagged collections for the Hub dashboard: https://docs.google.com/document/d/1gtbrnPoprm3TmUnZ4XxF6Pzr-XDdNC_pJlphLyTK2gs/edit?usp=sharing
- Use steps from the [Readme](https://github.com/ansible/ansible-ui#environment-variables) to set environment variables and start up the Hub dashboard.

<img width="1252" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/d7d5f944-96f2-419c-aafb-1d4e86083344">
