### PR TITLE
[POC]Fix jobs list E2E

### DIFF
--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -114,12 +114,8 @@ describe('jobs', () => {
         const jobId = testJob.id ? testJob.id.toString() : '';
         cy.filterTableByTypeAndText('ID', jobId);
         const jobName = testJob.name ? testJob.name : '';
-        cy.getTableRowByText(jobName, false).within(() => {
-          cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'New');
-          cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Waiting');
-          cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Pending');
-          cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Running');
-        });
+        cy.waitForJobToFinish(testJob.id);
+        cy.reload();
         cy.clickTableRowKebabAction(jobName, /^Delete job$/, false);
         cy.get('#confirm').click();
         cy.clickButton(/^Delete job/);
@@ -140,12 +136,8 @@ describe('jobs', () => {
       const jobId = jobList.id ? jobList.id.toString() : '';
       cy.filterTableByTypeAndText('ID', jobId);
       const jobName = jobList.name ? jobList.name : '';
-      cy.getTableRowByText(jobName, false).within(() => {
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'New');
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Waiting');
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Pending');
-        cy.get('[data-label="Status"]', { timeout: 120 * 1000 }).should('not.contain', 'Running');
-      });
+      cy.waitForJobToFinish(jobList.id);
+      cy.reload();
       cy.selectTableRow(jobName, false);
       cy.clickToolbarKebabAction(/^Delete selected jobs$/);
       cy.get('#confirm').click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -315,6 +315,7 @@ declare global {
         skipSync?: boolean
       ): Chainable<Project>;
 
+      waitForJobToFinish(jobId?: number): Chainable<void>;
       /** Create an execution environment in AWX */
       createAwxExecutionEnvironment(
         executionEnvironment: Partial<Omit<ExecutionEnvironment, 'id'>>


### PR DESCRIPTION
This is a proof of concept

We are currently testing out a new E2E CIP pipeline and we have some failures on the jobs list at this [test](https://github.com/ansible/ansible-ui/blob/main/cypress/e2e/awx/views/jobs.cy.ts#L109) and the one after it.  It seems that the DOM never updates and after conferring with @keithjgrant it seems that websockets are not implemented on that list.  I'm not sure how those tests are passing in our current implementation, but this PR is a solution for the new CI until we get websockets configured on that lsit.