### PR TITLE
Hub dashboard UI updates + some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 UI projects for [Ansible](https://www.ansible.com).
 
-- [Getting Started](#getting-started)
-- [Environment Variables](#environment-variables)
-- [NPM Scripts](#npm-scripts)
-- [Documentation](#documentation)
-- [Code of Conduct](#code-of-conduct)
+- [Ansible UI](#ansible-ui)
+  - [Getting Started](#getting-started)
+  - [Environment Variables](#environment-variables)
+  - [NPM Scripts](#npm-scripts)
+  - [Documentation](#documentation)
+  - [Code of Conduct](#code-of-conduct)
 
 ## Getting Started
 
@@ -31,25 +32,27 @@ UI projects for [Ansible](https://www.ansible.com).
 
 ## Environment Variables
 
-|   Environment Variable | Description                                |
-| ---------------------: | ------------------------------------------ |
-|         `AWX_PROTOCOL` | The AWX server protocol (http) or (https). |
-|             `AWX_HOST` | The AWX server address with port.          |
-|   `CYPRESS_AWX_SERVER` | The AWX server URL.                        |
-| `CYPRESS_AWX_USERNAME` | The AWX server username.                   |
-| `CYPRESS_AWX_PASSWORD` | The AWX server password.                   |
-|                        |                                            |
-|         `HUB_PROTOCOL` | The HUB server protocol (http) or (https). |
-|             `HUB_HOST` | The HUB server address with port.          |
-|   `CYPRESS_HUB_SERVER` | The HUB server URL.                        |
-| `CYPRESS_HUB_USERNAME` | The HUB server username.                   |
-| `CYPRESS_HUB_PASSWORD` | The HUB server password.                   |
-|                        |                                            |
-|         `EDA_PROTOCOL` | The EDA server protocol (http) or (https). |
-|             `EDA_HOST` | The EDA server address with port.          |
-|   `CYPRESS_EDA_SERVER` | The EDA server URL.                        |
-| `CYPRESS_EDA_USERNAME` | The EDA server username.                   |
-| `CYPRESS_EDA_PASSWORD` | The EDA server password.                   |
+|            Environment Variable | Description                                             |
+| ------------------------------: | ------------------------------------------------------- |
+|                  `AWX_PROTOCOL` | The AWX server protocol (http) or (https).              |
+|                      `AWX_HOST` | The AWX server address with port.                       |
+|            `CYPRESS_AWX_SERVER` | The AWX server URL.                                     |
+|          `CYPRESS_AWX_USERNAME` | The AWX server username.                                |
+|          `CYPRESS_AWX_PASSWORD` | The AWX server password.                                |
+|                                 |                                                         |
+|                  `HUB_PROTOCOL` | The HUB server protocol (http) or (https).              |
+|                      `HUB_HOST` | The HUB server address with port.                       |
+|            `CYPRESS_HUB_SERVER` | The HUB server URL.                                     |
+|          `CYPRESS_HUB_USERNAME` | The HUB server username.                                |
+|          `CYPRESS_HUB_PASSWORD` | The HUB server password.                                |
+|        `CYPRESS_HUB_API_PREFIX` | The HUB API prefix (eg. `/api/automation-hub/`).        |
+| `CYPRESS_HUB_GALAXYKIT_COMMAND` | The galaxykit command (eg. `galaxykit --ignore-certs`). |
+|                                 |                                                         |
+|                  `EDA_PROTOCOL` | The EDA server protocol (http) or (https).              |
+|                      `EDA_HOST` | The EDA server address with port.                       |
+|            `CYPRESS_EDA_SERVER` | The EDA server URL.                                     |
+|          `CYPRESS_EDA_USERNAME` | The EDA server username.                                |
+|          `CYPRESS_EDA_PASSWORD` | The EDA server password.                                |
 
 ```zsh
 export AWX_PROTOCOL=http

--- a/cypress/e2e/hub/constants.ts
+++ b/cypress/e2e/hub/constants.ts
@@ -1,3 +1,7 @@
-export const HubDashboard = { title: 'Welcome to Automation Hub' };
+export const HubDashboard = {
+  title: 'Welcome to Automation Hub',
+  description:
+    'Find and use content that is supported by Red Hat and our partners to deliver reassurance for the most demanding environments. Get started by exploring the options below.',
+};
 
 export const HubRoutes = { dashboard: '/hub/dashboard' };

--- a/cypress/e2e/hub/hub-dashboard.cy.ts
+++ b/cypress/e2e/hub/hub-dashboard.cy.ts
@@ -30,24 +30,42 @@ describe('hub dashboard', () => {
   it('render the hub dashboard', () => {
     cy.visit(HubRoutes.dashboard);
     cy.get('.pf-c-title').contains(HubDashboard.title);
+    cy.get('section.pf-c-page__main-section')
+      .first()
+      .within(() => {
+        cy.get('.pf-c-title').should('contain', HubDashboard.title);
+        cy.get('span.pf-c-truncate__start').should('contain', HubDashboard.description);
+      });
   });
-  it('Verify that EDA collections are displayed', () => {
+  it('verify that EDA collections are displayed', () => {
     cy.visit(HubRoutes.dashboard);
     cy.contains('div.pf-c-card__header', 'Event-Driven Ansible content')
       .parent()
       .within(() => {
-        cy.get(`article.pf-c-card[id=${collectionNames.eda.collection1}]`).should('be.visible');
+        cy.get(`article.pf-c-card[id=${collectionNames.eda.collection1}]`).should('exist');
       });
+  });
+  it('clicking on "Go to collections" opens collections UI filtered by EDA collections', () => {
+    cy.visit(HubRoutes.dashboard);
+    cy.contains('div.pf-c-card__header', 'Event-Driven Ansible content')
+      .parent()
+      .within(() => {
+        cy.contains('a', 'Go to collections').click();
+      });
+    cy.url().should('contain', 'tags=eda');
+    cy.get('div.pf-c-toolbar__group').contains('Tags').should('be.visible');
+    cy.get('div.pf-c-toolbar__group').contains('eda').should('be.visible');
+    cy.getTableRowByText(collectionNames.eda.collection1).should('be.visible');
   });
   it('clicking on Cog icon opens the Manage view modal', () => {
     cy.visit(HubRoutes.dashboard);
-    cy.clickPageAction(/^Manage view/);
+    cy.clickButton('Manage view');
     cy.get('.pf-c-modal-box__title-text').should('contain', 'Manage Dashboard');
     cy.get('[aria-label="Close"]').click();
   });
   it('within the Manage Dashboard modal, unchecking a resource should hide the resource', () => {
     cy.visit(HubRoutes.dashboard);
-    cy.clickPageAction(/^Manage view/);
+    cy.clickButton('Manage view');
     cy.contains('tr', 'Cloud collections').find('input').uncheck();
     cy.contains('tr', 'Networking collections').find('input').uncheck();
     cy.contains('tr', 'Database collections').find('input').uncheck();
@@ -55,7 +73,7 @@ describe('hub dashboard', () => {
     cy.contains('tr', 'Storage collections').find('input').uncheck();
     cy.clickModalButton('Apply');
     cy.get('div.pf-c-card__header').should('not.contain', 'Storage collections');
-    cy.clickPageAction(/^Manage view/);
+    cy.clickButton(/^Manage view/);
     cy.contains('tr', 'Storage collections').find('input').check();
     cy.clickModalButton('Apply');
     cy.contains('div.pf-c-card__header', 'Storage collections').should('be.visible');

--- a/frontend/hub/dashboard/CollectionCard.tsx
+++ b/frontend/hub/dashboard/CollectionCard.tsx
@@ -101,7 +101,10 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
           title: (
             <TextCell
               text={item.collection_version.name}
-              to={RouteObj.CollectionDetails.replace(':id', item.collection_version.name)}
+              to={
+                RouteObj.CollectionDetails +
+                `?name=${item.collection_version.name}&namespace=${item.collection_version.namespace}&repository=${item.repository.name}`
+              }
             />
           ),
           iconAboveTitle: true,

--- a/frontend/hub/dashboard/CollectionCategories.cy.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.cy.tsx
@@ -8,7 +8,14 @@ describe('CollectionCategories.cy.tsx', () => {
     cy.fixture('application_collection_versions').then(
       (collectionVersionsResponse: HubItemsResponse<CollectionVersionSearch>) => {
         const collections = collectionVersionsResponse.data;
-        cy.mount(<CollectionCategoryCarousel collections={collections} category="application" />);
+        cy.mount(
+          <CollectionCategoryCarousel
+            collections={collections}
+            category="application"
+            searchKey="tags"
+            searchValue="application"
+          />
+        );
         cy.get('.pf-c-card__header').should('contain', 'Application collections');
         // Based on the viewport size in the cypress config, the carousel will display 3 of the 4 cards
         cy.get('div[id="page-carousel-cards-application-collections-0"]').within(() => {
@@ -22,7 +29,14 @@ describe('CollectionCategories.cy.tsx', () => {
     cy.fixture('application_collection_versions').then(
       (collectionVersionsResponse: HubItemsResponse<CollectionVersionSearch>) => {
         const collections = collectionVersionsResponse.data;
-        cy.mount(<CollectionCategoryCarousel collections={collections} category="application" />);
+        cy.mount(
+          <CollectionCategoryCarousel
+            collections={collections}
+            category="application"
+            searchKey="tags"
+            searchValue="application"
+          />
+        );
         // The 4th collection card should not be visible at first
         cy.contains(
           'div[id="slide-container-application-collections"] div.pf-c-card__title',

--- a/frontend/hub/dashboard/CollectionCategories.cy.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.cy.tsx
@@ -61,7 +61,12 @@ describe('CollectionCategories.cy.tsx', () => {
         const collections = collectionVersionsResponse.data;
         cy.mount(
           <HubContextProvider>
-            <CollectionCategoryCarousel collections={collections} category="eda" />
+            <CollectionCategoryCarousel
+              collections={collections}
+              category="eda"
+              searchKey="tags"
+              searchValue="eda"
+            />
           </HubContextProvider>
         );
         cy.get('.pf-c-card__footer button').contains('Manage content').should('be.visible');
@@ -71,6 +76,7 @@ describe('CollectionCategories.cy.tsx', () => {
 
   it('Manage Content button should not be shown for non-admin user', () => {
     cy.fixture('hub_admin').then((user: HubUser) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       cy.intercept('**/_ui/v1/me/', { ...user, is_superuser: false });
     });
     cy.intercept('**/_ui/v1/settings/', { fixture: 'hub_settings.json' });
@@ -80,7 +86,12 @@ describe('CollectionCategories.cy.tsx', () => {
         const collections = collectionVersionsResponse.data;
         cy.mount(
           <HubContextProvider>
-            <CollectionCategoryCarousel collections={collections} category="eda" />
+            <CollectionCategoryCarousel
+              collections={collections}
+              category="eda"
+              searchKey="tags"
+              searchValue="eda"
+            />
           </HubContextProvider>
         );
         cy.contains('Manage content', 'button').should('not.exist');

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -12,6 +12,7 @@ import { postHubRequest } from '../api/request';
 import { hubAPI } from '../api/utils';
 import { errorToAlertProps, usePageAlertToaster } from '../../../framework';
 import { useHubContext } from '../useHubContext';
+import { RouteObj } from '../../common/Routes';
 
 type FooterAction = {
   icon?: ReactNode;
@@ -25,8 +26,10 @@ type FooterAction = {
 export function CollectionCategoryCarousel(props: {
   category: string;
   collections: CollectionVersionSearch[];
+  searchKey: string;
+  searchValue: string;
 }) {
-  const { category, collections } = props;
+  const { category, collections, searchKey, searchValue } = props;
   const { t } = useTranslation();
   const categoryName = useCategoryName(category, t);
   const selectCollections = useSelectCollectionsDialog(collections);
@@ -79,6 +82,7 @@ export function CollectionCategoryCarousel(props: {
       linkText={t('Go to Collections')}
       width="xxl"
       footerActionButton={footerActionButton}
+      to={RouteObj.Collections + `?${searchKey}=${searchValue}`}
     >
       {collections.map((collection: CollectionVersionSearch) => (
         <CollectionCard

--- a/frontend/hub/dashboard/CollectionCategories.tsx
+++ b/frontend/hub/dashboard/CollectionCategories.tsx
@@ -79,10 +79,10 @@ export function CollectionCategoryCarousel(props: {
   return (
     <PageDashboardCarousel
       title={categoryName}
-      linkText={t('Go to Collections')}
+      linkText={t('Go to collections')}
+      to={RouteObj.Collections + `?${searchKey}=${searchValue}`}
       width="xxl"
       footerActionButton={footerActionButton}
-      to={RouteObj.Collections + `?${searchKey}=${searchValue}`}
     >
       {collections.map((collection: CollectionVersionSearch) => (
         <CollectionCard

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -61,7 +61,7 @@ export function HubDashboard() {
               </Button>
             }
             title={t('There is currently no content selected to be shown on the dashboard.')}
-            description={t('There is currently no content selected to be shown on the dashboard.')}
+            description={t('Please manage this view by using the button below.')}
             variant="full"
           ></EmptyStateNoData>
         </Bullseye>

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { ButtonVariant, DropdownPosition } from '@patternfly/react-core';
+import { Bullseye, Button, ButtonVariant, DropdownPosition } from '@patternfly/react-core';
 import { CogIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { CategorizedCollections } from './CollectionCategory';
 import { useCategorizeCollections } from './hooks/useCategorizeCollections';
 import { CollectionCategoryCarousel } from './CollectionCategories';
+import { EmptyStateNoData } from '../../../framework/components/EmptyStateNoData';
 
 export function HubDashboard() {
   const { t } = useTranslation();
@@ -51,6 +52,20 @@ export function HubDashboard() {
           />
         }
       />
+      {managedCategories.length === 0 && (
+        <Bullseye>
+          <EmptyStateNoData
+            button={
+              <Button icon={<CogIcon />} onClick={openManageDashboard}>
+                {t('Manage view')}
+              </Button>
+            }
+            title={t('There is currently no content selected to be shown on the dashboard.')}
+            description={t('There is currently no content selected to be shown on the dashboard.')}
+            variant="full"
+          ></EmptyStateNoData>
+        </Bullseye>
+      )}
       <PageDashboard>
         {managedCategories.map((category) =>
           categorizedCollections[category.id] ? (

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -58,6 +58,8 @@ export function HubDashboard() {
               key={category.id}
               category={category.id}
               collections={categorizedCollections[category.id]}
+              searchKey={category.searchKey}
+              searchValue={category.searchValue}
             />
           ) : null
         )}

--- a/frontend/hub/dashboard/Dashboard.tsx
+++ b/frontend/hub/dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ export function HubDashboard() {
             actions={[
               {
                 icon: CogIcon,
-                label: 'Manage view',
+                label: t('Manage view'),
                 type: PageActionType.Button,
                 variant: ButtonVariant.link,
                 isPinned: true,


### PR DESCRIPTION
1. Empty state for when all categories are unselected from the Manage View modal
2. Build Environment button removed
3. Manage View button brought to the top level
4. "Go to collection" button on each carousel should navigate to the collections UI filtered by that category
5. The collection name link in the collection card should navigate to the collection details page

<img width="1378" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/74d8c40f-8b7f-4a95-85f0-31428278c23a">

<img width="1065" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/5adc616d-ac42-499c-a428-dcd1c1bcf893">

