### PR TITLE
[AAP-15875] Upgrade monaco-yaml to v5.1.0

### DIFF
--- a/framework/PageForm/Inputs/DataEditor.tsx
+++ b/framework/PageForm/Inputs/DataEditor.tsx
@@ -1,6 +1,6 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import * as monaco from 'monaco-editor';
-import { setDiagnosticsOptions as setYamlDiagnosticOptions } from 'monaco-yaml';
+import { configureMonacoYaml } from 'monaco-yaml';
 import { useEffect, useRef } from 'react';
 import { FieldPath, FieldValues, UseFormClearErrors, UseFormSetError } from 'react-hook-form';
 import { useSettings } from '../../Settings';
@@ -31,7 +31,7 @@ export function DataEditor<
   const settings = useSettings();
 
   useEffect(() => {
-    setYamlDiagnosticOptions({
+    configureMonacoYaml(monaco, {
       validate: true,
       format: true,
       schemas: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "mini-css-extract-plugin": "2.7.6",
         "monaco-editor": "0.41.0",
         "monaco-editor-webpack-plugin": "7.1.0",
-        "monaco-yaml": "4.0.4",
+        "monaco-yaml": "5.1.0",
         "node-util": "0.0.6",
         "os-browserify": "0.3.0",
         "p-limit": "4.0.0",
@@ -11828,6 +11828,18 @@
         "webpack": "^4.5.0 || 5.x"
       }
     },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.2.3.tgz",
+      "integrity": "sha512-QyV5R7s+rJ87bX1sRioMJZULWiTnMp0Vm+RLILgMEL0SqWuBsQBSW0EZunr4xMZhv6Qun3UZNCN4JrCCLURcgQ==",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
     "node_modules/monaco-marker-data-provider": {
       "version": "1.1.1",
       "license": "MIT",
@@ -11838,6 +11850,14 @@
         "monaco-editor": ">=0.30.0"
       }
     },
+    "node_modules/monaco-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.0.tgz",
+      "integrity": "sha512-aWK7SN9hAqNYi0WosPoMjenMeXJjwCxDibOqWffyQ/qXdzB/86xshGQobRferfmNz7BSNQ8GB0MD0oby9/5fTQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
     "node_modules/monaco-worker-manager": {
       "version": "2.0.1",
       "license": "MIT",
@@ -11846,15 +11866,15 @@
       }
     },
     "node_modules/monaco-yaml": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "workspaces": [
-        "examples/*"
-      ],
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.1.0.tgz",
+      "integrity": "sha512-DU+cgXSJdOFKQ4I4oLg0V+mHKq1dJX+7hbIE4fJsgegUf1zEHW3PNlGj6qabUU2HZIPJ5NmXEf005GU9YDzTYQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.0",
         "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.2.0",
         "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
         "path-browserify": "^1.0.0",
         "prettier": "^2.0.0",
@@ -11867,7 +11887,7 @@
         "url": "https://github.com/sponsors/remcohaszing"
       },
       "peerDependencies": {
-        "monaco-editor": ">=0.30"
+        "monaco-editor": ">=0.36"
       }
     },
     "node_modules/monaco-yaml/node_modules/prettier": {
@@ -16374,6 +16394,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.1.0",
+        "vscode-languageserver-types": "3.17.3"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "mini-css-extract-plugin": "2.7.6",
     "monaco-editor": "0.41.0",
     "monaco-editor-webpack-plugin": "7.1.0",
-    "monaco-yaml": "4.0.4",
+    "monaco-yaml": "5.1.0",
     "node-util": "0.0.6",
     "os-browserify": "0.3.0",
     "p-limit": "4.0.0",


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-15875

Upgrading to monaco-yaml major version 5 introduced a breaking change. 
You must pass the monaco editor to monaco-yaml, and `setDiagnosticsOptions` was renamed to `configureMonacoYaml`.

https://github.com/remcohaszing/monaco-yaml/releases