### PR TITLE
Signed and approved in approval and collection list

### DIFF
--- a/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
@@ -44,9 +44,19 @@ export function useApprovalsColumns(_options?: { disableSort?: boolean; disableL
           }
 
           if (approval.repository?.pulp_labels?.pipeline == 'approved') {
-            return (
-              <TextCell icon={<ThumbsUpIcon />} text={t('Approved')} color={PFColorE.Success} />
-            );
+            if (approval.is_signed) {
+              return (
+                <TextCell
+                  icon={<ThumbsUpIcon />}
+                  text={t('Signed and Approved')}
+                  color={PFColorE.Success}
+                />
+              );
+            } else {
+              return (
+                <TextCell icon={<ThumbsUpIcon />} text={t('Approved')} color={PFColorE.Success} />
+              );
+            }
           }
 
           if (approval.repository?.pulp_labels?.pipeline == 'rejected') {

--- a/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
@@ -3,9 +3,13 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateTimeCell, ITableColumn, PFColorE, TextCell } from '../../../../framework';
 import { CollectionVersionSearch } from '../Approval';
+import { useHubContext } from './../../useHubContext';
 
 export function useApprovalsColumns(_options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
+  const context = useHubContext();
+  const { display_signatures } = context.featureFlags;
+
   const tableColumns = useMemo<ITableColumn<CollectionVersionSearch>[]>(
     () => [
       {
@@ -44,7 +48,7 @@ export function useApprovalsColumns(_options?: { disableSort?: boolean; disableL
           }
 
           if (approval.repository?.pulp_labels?.pipeline == 'approved') {
-            if (approval.is_signed) {
+            if (approval.is_signed && display_signatures) {
               return (
                 <TextCell
                   icon={<ThumbsUpIcon />}

--- a/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
@@ -78,7 +78,7 @@ export function useApprovalsColumns(_options?: { disableSort?: boolean; disableL
         sort: 'pulp_created',
       },
     ],
-    [t]
+    [t, display_signatures]
   );
   return tableColumns;
 }


### PR DESCRIPTION
Approval list now contains sign: "Signed and approved" for approved signed collections and only "Approved" for unsigned approved collections.