### PR TITLE
Fix nested job and workflow job template routes

### DIFF
--- a/frontend/awx/useAwxNavigation.tsx
+++ b/frontend/awx/useAwxNavigation.tsx
@@ -265,49 +265,49 @@ export function useAwxNavigation() {
             path: 'resources',
             children: [
               {
+                path: 'job_template',
+                children: [
+                  {
+                    id: AwxRoute.CreateTemplate,
+                    path: 'create',
+                    element: <CreateJobTemplate />,
+                  },
+                  {
+                    id: AwxRoute.EditTemplate,
+                    path: ':id/edit',
+                    element: <EditJobTemplate />,
+                  },
+                  {
+                    id: AwxRoute.TemplateSchedule,
+                    path: ':id/schedules/:schedule_id/*',
+                    element: <SchedulePage />,
+                  },
+                  {
+                    id: AwxRoute.TemplateDetails,
+                    path: ':id/*',
+                    element: <TemplatePage />,
+                  },
+                ],
+              },
+              {
+                path: 'workflow_job_template',
+                children: [
+                  {
+                    id: AwxRoute.WorkflowJobTemplateSchedule,
+                    path: ':id/schedules/:schedule_id/*',
+                    element: <SchedulePage />,
+                  },
+                  {
+                    id: AwxRoute.WorkflowJobTemplateDetails,
+                    path: ':id/*',
+                    element: <WorkflowJobTemplatePage />,
+                  },
+                ],
+              },
+              {
                 label: 'Templates',
                 path: 'templates',
                 children: [
-                  {
-                    path: 'jobs',
-                    children: [
-                      {
-                        id: AwxRoute.CreateTemplate,
-                        path: 'create',
-                        element: <CreateJobTemplate />,
-                      },
-                      {
-                        id: AwxRoute.EditTemplate,
-                        path: ':id/edit',
-                        element: <EditJobTemplate />,
-                      },
-                      {
-                        id: AwxRoute.TemplateSchedule,
-                        path: ':id/schedules/:schedule_id/*',
-                        element: <SchedulePage />,
-                      },
-                      {
-                        id: AwxRoute.TemplateDetails,
-                        path: ':id/*',
-                        element: <TemplatePage />,
-                      },
-                    ],
-                  },
-                  {
-                    path: 'workflows',
-                    children: [
-                      {
-                        id: AwxRoute.WorkflowJobTemplateSchedule,
-                        path: ':id/schedules/:schedule_id/*',
-                        element: <SchedulePage />,
-                      },
-                      {
-                        id: AwxRoute.WorkflowJobTemplateDetails,
-                        path: ':id/*',
-                        element: <WorkflowJobTemplatePage />,
-                      },
-                    ],
-                  },
                   {
                     id: AwxRoute.Templates,
                     path: '',


### PR DESCRIPTION
This PR updates the nested job template and workflow job template route objects in useAwxNavigation to match the RouteObj definitions. 

[RouteObj file
](https://github.com/ansible/ansible-ui/blob/main/frontend/common/Routes.ts#L68)
```
RouteObj: {
    ...
    CreateJobTemplate: `${awxRoutePrefix}/resources/job_template/create`,
}
 ```

Before: `/resources/templates/jobs/create`
After: `/resources/job_template/create`