### PR TITLE
disable https in dev

### DIFF
--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -169,7 +169,7 @@ module.exports = function (env, argv) {
       ],
     },
     devServer: {
-      https: true,
+      // https: true, // Enable for using oAuth in dev environment
       historyApiFallback: true,
       compress: true,
       hot: true,


### PR DESCRIPTION
this is only really needed for oath testing in dev, so we can leave it commented out