### PR TITLE
[Analytics]: Fix error handling

### DIFF
--- a/frontend/awx/analytics/Reports/Reports.tsx
+++ b/frontend/awx/analytics/Reports/Reports.tsx
@@ -34,17 +34,8 @@ export default function Reports() {
       setSpecificError('');
     } else {
       // @ts-expect-error: Cannot override type coming from useSWR
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      error?.response
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        .clone()
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        .json()
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        .then((r: { error?: { keyword?: string } }) =>
-          setSpecificError(r?.error?.keyword || 'unknown')
-        )
-        .catch(() => setSpecificError('unknown'));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+      setSpecificError(error?.body?.error?.keyword || 'unknown');
     }
   }, [error]);
 


### PR DESCRIPTION
How to easily reproduce:
- write a typo in a request call

Before:
<img width="1720" alt="Screenshot 2023-09-18 at 11 52 47" src="https://github.com/ansible/ansible-ui/assets/9210860/7476b216-dbc8-4662-b313-6ab7895a15a3">

After:
<img width="1419" alt="Screenshot 2023-09-18 at 11 51 58" src="https://github.com/ansible/ansible-ui/assets/9210860/fb6ce2e9-e437-4a2e-b5be-e0becd1cbf77">
