### PR TITLE
Legend enhancements

### DIFF
--- a/framework/PageDashboard/PageChartLegend.tsx
+++ b/framework/PageDashboard/PageChartLegend.tsx
@@ -6,19 +6,21 @@ export function PageChartLegend(props: {
   id: string;
   legend: { label: string; count?: number; color: string; link?: string }[];
   horizontal?: boolean;
+  showLegendCount?: boolean;
+  allowZero?: boolean;
 }) {
   if (props.horizontal) {
     return (
       <PageChartLegendHorizontalStyle>
         {props.legend.map((item, index) => {
-          if (item.count === 0) return <Fragment key={index} />;
+          if (item.count === 0 && props.allowZero != true) return <Fragment key={index} />;
           return (
             <PageChartLegendHorizontalItemStyle key={index}>
               <PageChartLegendColor
                 id={`${props.id}-${item.label.toLowerCase().replace(/ /g, '-')}-count`}
                 color={item.color}
               />
-              <PageChartLegendCount count={item.count} />
+              {props.showLegendCount == false ? null : <PageChartLegendCount count={item.count} />}
               <PageChartLegendLabel label={item.label} link={item.link} />
             </PageChartLegendHorizontalItemStyle>
           );
@@ -29,14 +31,16 @@ export function PageChartLegend(props: {
   return (
     <PageChartLegendVerticalStyle>
       {props.legend.map((item, index) => {
-        if (item.count === 0) return <Fragment key={index} />;
+        if (item.count === 0 && props.allowZero != true) return <Fragment key={index} />;
         return (
           <Fragment key={index}>
             <PageChartLegendColor color={item.color} />
-            <PageChartLegendCount
-              id={`${props.id}-${item.label.toLowerCase().replace(/ /g, '-')}-count`}
-              count={item.count}
-            />
+            {props.showLegendCount == false ? null : (
+              <PageChartLegendCount
+                id={`${props.id}-${item.label.toLowerCase().replace(/ /g, '-')}-count`}
+                count={item.count}
+              />
+            )}
             <PageChartLegendLabel label={item.label} link={item.link} />
           </Fragment>
         );

--- a/framework/PageDashboard/PageDashboardChart.tsx
+++ b/framework/PageDashboard/PageDashboardChart.tsx
@@ -49,6 +49,8 @@ export function PageDashboardChart(props: {
     left?: number;
     right: number;
   };
+  /** show item count in legend */
+  showLegendCount?: boolean;
 
   height?: number;
 }) {
@@ -210,7 +212,13 @@ export function PageDashboardChart(props: {
         {xLabel && (
           <XAxisLabel label={xLabel} paddingLeft={padding.left} paddingRight={padding.right} />
         )}
-        <PageChartLegend id={props.id ?? 'chart'} legend={legend} horizontal />
+        <PageChartLegend
+          id={props.id ?? 'chart'}
+          legend={legend}
+          horizontal
+          showLegendCount={props.showLegendCount}
+          allowZero={props.allowZero}
+        />
       </div>
     </div>
   );

--- a/frontend/awx/analytics/subscription-usage/SubscriptionUsageChart.tsx
+++ b/frontend/awx/analytics/subscription-usage/SubscriptionUsageChart.tsx
@@ -104,6 +104,7 @@ export function SubscriptionUsageChart(props: { period: IFilterState }) {
       allowZero
       onlyIntegerTicks
       padding={{ right: 15 }}
+      showLegendCount={false}
     />
   );
 }


### PR DESCRIPTION
This PR enhances the `PageChartLegend` component to allow for more flexibility and accommodate a wider range of use cases. 

- Added prop `allowZero`: if true, will show all legend items at all times, even if item count is zero
- Added prop `showLegendCount`: if false, will remove the count in each legend item

Before:
![Screenshot 2023-09-18 at 2 44 21 PM](https://github.com/ansible/ansible-ui/assets/89094075/464b5e3a-3760-4f32-94a9-f98c6d523636)

After: 
![Screenshot 2023-09-18 at 2 43 44 PM](https://github.com/ansible/ansible-ui/assets/89094075/dc5663e8-5990-4396-bb34-50957c82af15)