### PR TITLE
Turn login autocomplete on in dev

### DIFF
--- a/framework/PageForm/Inputs/PageFormTextInput.tsx
+++ b/framework/PageForm/Inputs/PageFormTextInput.tsx
@@ -162,6 +162,15 @@ export type PageFormTextInputProps<
    * When present, it specifies that an <input> element should automatically get focus when the page loads.
    */
   autoFocus?: boolean;
+
+  /**
+   * The autocomplete attribute specifies whether or not an input field should have autocomplete enabled.
+   *
+   * Autocomplete allows the browser to predict the value. When a user starts to type in a field, the browser should display options to fill in the field, based on earlier typed values.
+   *
+   * Note: The autocomplete attribute works with the following input types: text, search, url, tel, email, password, datepickers, range, and color.
+   */
+  autoComplete?: string;
 };
 
 /**
@@ -197,6 +206,7 @@ export function PageFormTextInput<
     selectOpen,
     selectValue,
     autoFocus,
+    autoComplete,
   } = props;
 
   const id = useID(props);
@@ -251,7 +261,7 @@ export function PageFormTextInput<
                 readOnlyVariant={isReadOnly ? 'default' : undefined}
                 isDisabled={isDisabled}
                 autoFocus={autoFocus}
-                autoComplete="off"
+                autoComplete={autoComplete || 'off'}
                 data-cy={id}
               />
               {type === 'password' && (

--- a/frontend/common/LoginModal.tsx
+++ b/frontend/common/LoginModal.tsx
@@ -231,6 +231,7 @@ function LoginForm(props: LoginFormProps) {
           name="username"
           label={t('Username')}
           placeholder={t('Enter username')}
+          autoComplete={process.env.NODE_ENV === 'development' ? 'on' : 'off'}
           isRequired
           autoFocus
         />
@@ -239,6 +240,7 @@ function LoginForm(props: LoginFormProps) {
           label={t('Password')}
           placeholder={t('Enter password')}
           type="password"
+          autoComplete={process.env.NODE_ENV === 'development' ? 'on' : 'off'}
           isRequired
         />
       </PageForm>


### PR DESCRIPTION
We'll keep autocomplete off by default for prod but for dev we'll turn it back on.  Here was the original PR: https://github.com/ansible/ansible-ui/pull/878