### PR TITLE
Disable Cypress auto-cancel-after-failures

### DIFF
--- a/.github/workflows/on-pull-request-run-tests.yml
+++ b/.github/workflows/on-pull-request-run-tests.yml
@@ -127,7 +127,7 @@ jobs:
           install: false
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.awx.config.ts
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_AUI_AWX_CCT_PROJECT_ID }}
@@ -177,7 +177,7 @@ jobs:
           install: false
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.eda.config.ts
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_AUI_EDA_CCT_PROJECT_ID }}
@@ -227,7 +227,7 @@ jobs:
           install: false
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.hub.config.ts
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_AUI_HUB_CCT_PROJECT_ID }}
@@ -277,7 +277,7 @@ jobs:
           install: false
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.afw.config.ts
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_AUI_AFW_CCT_PROJECT_ID }}
@@ -379,7 +379,7 @@ jobs:
           wait-on: 'https://localhost:4101'
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.awx.config.ts
         env:
           AWX_SERVER: ${{ vars.AWX_SERVER }}
@@ -591,7 +591,7 @@ jobs:
           wait-on: 'https://localhost:4103'
           record: true
           parallel: true
-          auto-cancel-after-failures: 1
+          # auto-cancel-after-failures: 1
           config-file: cypress.eda.config.ts
         env:
           AWX_SERVER: ${{ vars.AWX_SERVER }}


### PR DESCRIPTION
This is causing issues with the ability to triage and retry failed jobs.