### PR TITLE
page table list view layout inconsistencies

### DIFF
--- a/framework/PageTable/PageTableList.tsx
+++ b/framework/PageTable/PageTableList.tsx
@@ -284,6 +284,7 @@ export function useColumnsToDataList<T extends object>(
                   position={DropdownPosition.right}
                   selectedItem={item}
                   iconOnly
+                  collapse="always"
                 />
               </DataListAction>
             )}


### PR DESCRIPTION
This makes actions always collapse in list view so that the right most column of the list view is not irregular across items.

Fixes this:
![Screenshot 2023-09-25 at 4 08 03 PM](https://github.com/ansible/ansible-ui/assets/6277895/4fe76b03-10b9-42bc-adb1-62b9df407e75)
