### PR TITLE
[AA-1538] Reports list view

### DIFF
--- a/frontend/awx/AwxRoutes.tsx
+++ b/frontend/awx/AwxRoutes.tsx
@@ -174,6 +174,7 @@ export enum AwxRoute {
 
   Analytics = 'awx-analytics',
   Reports = 'awx-reports',
+  AutomationCalculator = 'awx-automation-calculator',
   HostMetrics = 'awx-host-metrics',
   SubscriptionUsage = 'awx-subscription-usage',
 

--- a/frontend/awx/analytics/Reports/ReportsList.tsx
+++ b/frontend/awx/analytics/Reports/ReportsList.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+import { PageHeader, PageLayout } from '../../../../framework';
+import { PageNotImplemented } from '../../../common/PageNotImplemented';
+
+export default function ReportsList() {
+  const { t } = useTranslation();
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Reports')}
+        description={t('View various reports to gain insights into your automations.')}
+        titleHelpTitle={t('Reports')}
+        titleHelp={t('View various reports to gain insights into your automations.')}
+      />
+      <PageNotImplemented />
+    </PageLayout>
+  );
+}

--- a/frontend/awx/useAwxNavigation.tsx
+++ b/frontend/awx/useAwxNavigation.tsx
@@ -44,6 +44,7 @@ import { NotificationPage } from './administration/notifications/NotificationPag
 import { Notifications } from './administration/notifications/Notifications';
 import Reports from './analytics/Reports/Reports';
 import { Test } from './analytics/AnalyticsReportBuilder/Test';
+import ReportsList from './analytics/Reports/ReportsList';
 import SubscriptionUsage from './analytics/subscription-usage/SubscriptionUsage';
 import { AwxDashboard } from './dashboard/AwxDashboard';
 import { CreateCredential, EditCredential } from './resources/credentials/CredentialForm';
@@ -1041,6 +1042,12 @@ export function useAwxNavigation() {
                 id: AwxRoute.Reports,
                 label: t('Reports'),
                 path: 'reports',
+                element: <ReportsList />,
+              },
+              {
+                id: AwxRoute.AutomationCalculator,
+                label: t('Automation Calculator'),
+                path: 'automation-calculator',
                 element: <Reports />,
               },
               {


### PR DESCRIPTION
This PR adds the preliminary skeleton for the analytics reports list view. The 'Reports' tab in the side nav bar has been re-routed to an empty page. The automation calculator report, previously under the 'Reports' tab, is now located under its own nav item called 'Automation Calculator'. 

Work to add the contents for this page is underway in separate jira tickets. 

Jira issue: https://issues.redhat.com/browse/AA-1538 

![Screenshot 2023-09-26 at 3 36 42 PM](https://github.com/ansible/ansible-ui/assets/89094075/a6839b27-a570-4ae1-9fd1-bbd703da653c)