### PR TITLE
[AAP-15392] Update label and help text for the Token field in the credential form to indicate it can also be a password

### DIFF
--- a/frontend/eda/Resources/credentials/EditCredential.tsx
+++ b/frontend/eda/Resources/credentials/EditCredential.tsx
@@ -82,12 +82,12 @@ function CredentialInputs() {
       />
       <PageFormTextInput<EdaCredentialCreate>
         name="secret"
-        label={t('Token')}
+        label={t('Token/Password')}
         type="password"
-        placeholder={t('Enter credential token')}
+        placeholder={t('Enter credential token or password')}
         isRequired
-        labelHelp={t('Tokens allow you to authenticate to your destination.')}
-        labelHelpTitle={t('Token')}
+        labelHelp={t('Tokens/passwords allow you to authenticate to your destination.')}
+        labelHelpTitle={t('Token/Password')}
       />
     </>
   );


### PR DESCRIPTION
Update label and help text for the Token field in the credential form to indicate it can also be a password
![Screenshot from 2023-09-27 15-11-17](https://github.com/ansible/ansible-ui/assets/12769982/597b3ee4-e3e9-408e-88ea-48769cbf3a06)
