### PR TITLE
Fix 403 error for non-admins in the job template form

### DIFF
--- a/frontend/awx/access/users/UserForm.tsx
+++ b/frontend/awx/access/users/UserForm.tsx
@@ -41,8 +41,8 @@ export function CreateUser() {
       } catch {
         throw new Error(t('Organization not found.'));
       }
-      user.is_superuser = userType === t('System administrator');
-      user.is_system_auditor = userType === t('System auditor');
+      user.is_superuser = userType === 'System administrator';
+      user.is_system_auditor = userType === 'System auditor';
       if (confirmPassword !== user.password) {
         setFieldError('confirmPassword', { message: t('Password does not match.') });
         return false;

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -57,7 +57,7 @@ export function EditJobTemplate() {
     values: JobTemplateForm,
     setError: (message: string) => void
   ) => {
-    const { credentials, labels, instance_groups, ...rest } = values;
+    const { credentials, labels, instance_groups, webhook_key, webhook_url, ...rest } = values;
     const formValues = {
       ...rest,
       project: values.project.id,
@@ -125,7 +125,7 @@ export function CreateJobTemplate() {
   const defaultValues = useMemo(() => getJobTemplateDefaultValues(t, {} as JobTemplate), [t]);
 
   const onSubmit: PageFormSubmitHandler<JobTemplateForm> = async (values, setError) => {
-    const { credentials, labels, instance_groups, ...rest } = values;
+    const { credentials, labels, instance_groups, webhook_key, webhook_url, ...rest } = values;
     const formValues = {
       ...rest,
       project: values.project.id,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-16698

The API returns a 403 when we send `webhook_key` and `webhook_url` to the API as non-admins. This PR removes those two properties from the PATCH request. 

I also removed translation tags from business logic inside the User form.

Reproduce:
1. Create a "Normal" user: _normal_user_
2. Give the user an "Admin" role to a job template: _demo_template_
3. Sign in as _normal_user_
4. Attempt to edit  _demo_template_
5. See error "You do not have permission to perform this action"

![Screenshot 2023-10-02 at 1 37 21 PM](https://github.com/ansible/ansible-ui/assets/15881645/69c4301e-6a91-4cda-b615-724295e5287c)


