### PR TITLE
Fix template form to template details navigation bug

### DIFF
--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -11,7 +11,6 @@ import {
   usePageNavigate,
 } from '../../../../framework';
 import { LoadingPage } from '../../../../framework/components/LoadingPage';
-import { RouteObj } from '../../../common/Routes';
 import { postRequest, requestGet, requestPatch } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
@@ -122,6 +121,7 @@ export function EditJobTemplate() {
 export function CreateJobTemplate() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const pageNavigate = usePageNavigate();
   const postRequest = usePostRequest<JobTemplateCreate, JobTemplate>();
   const defaultValues = useMemo(() => getJobTemplateDefaultValues(t, {} as JobTemplate), [t]);
 
@@ -153,7 +153,7 @@ export function CreateJobTemplate() {
       }
       if (promises.length > 0) await Promise.all(promises);
 
-      navigate(RouteObj.JobTemplateDetails.replace(':id', template.id.toString()));
+      pageNavigate(AwxRoute.JobTemplateDetails, { params: { id: template.id } });
     } catch (err) {
       setError(getAwxError(err));
     }

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.cy.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.cy.tsx
@@ -12,7 +12,11 @@ describe('TemplatePage', () => {
       { fixture: 'jobTemplate.json' }
     );
     cy.fixture('organizations').then((organizations: AwxItemsResponse<Organization[]>) => {
-      cy.intercept('GET', 'api/v2/organizations?role_level=notification_admin_role', organizations);
+      cy.intercept(
+        'GET',
+        'api/v2/organizations/?role_level=notification_admin_role',
+        organizations
+      );
     });
     cy.intercept(
       { method: 'GET', url: '/api/v2/job_templates/1/instance_groups', hostname: 'localhost' },
@@ -29,7 +33,7 @@ describe('TemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -55,7 +59,7 @@ describe('TemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -80,7 +84,7 @@ describe('TemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -112,7 +116,7 @@ describe('TemplatePage', () => {
 
       cy.intercept(
         'GET',
-        '/api/v2/organizations?role_level=notification_admin_role',
+        '/api/v2/organizations/?role_level=notification_admin_role',
         organizations
       ).as('getOrganizations');
     });
@@ -150,7 +154,7 @@ describe('TemplatePage', () => {
 
       cy.intercept(
         'GET',
-        '/api/v2/organizations?role_level=notification_admin_role',
+        '/api/v2/organizations/?role_level=notification_admin_role',
         organizations
       ).as('getOrganizations');
     });

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -36,9 +36,9 @@ export function TemplatePage() {
     error: isNotifAdminError,
     refresh: refreshNotifAdmin,
     isLoading: isNotifAdminLoading,
-  } = useGet<AwxItemsResponse<Organization>>('/api/v2/organizations', {
-    role_level: 'notification_admin_role',
-  });
+  } = useGet<AwxItemsResponse<Organization>>(
+    '/api/v2/organizations/?role_level=notification_admin_role'
+  );
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const itemActions = useTemplateActions({

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.cy.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.cy.tsx
@@ -13,7 +13,11 @@ describe('WorflowJobTemplatePage', () => {
     );
 
     cy.fixture('organizations').then((organizations: AwxItemsResponse<Organization[]>) => {
-      cy.intercept('GET', 'api/v2/organizations?role_level=notification_admin_role', organizations);
+      cy.intercept(
+        'GET',
+        'api/v2/organizations/?role_level=notification_admin_role',
+        organizations
+      );
     });
     cy.intercept(
       {
@@ -34,7 +38,7 @@ describe('WorflowJobTemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -62,7 +66,7 @@ describe('WorflowJobTemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -90,7 +94,7 @@ describe('WorflowJobTemplatePage', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/v2/organizations?role_level=notification_admin_role',
+        url: '/api/v2/organizations/?role_level=notification_admin_role',
         hostname: 'localhost',
       },
       { fixture: 'organizations.json' }
@@ -121,7 +125,7 @@ describe('WorflowJobTemplatePage', () => {
 
       cy.intercept(
         'GET',
-        '/api/v2/organizations?role_level=notification_admin_role',
+        '/api/v2/organizations/?role_level=notification_admin_role',
         organizations
       ).as('getOrganizations');
     });
@@ -155,7 +159,7 @@ describe('WorflowJobTemplatePage', () => {
 
       cy.intercept(
         'GET',
-        '/api/v2/organizations?role_level=notification_admin_role',
+        '/api/v2/organizations/?role_level=notification_admin_role',
         organizations
       ).as('getOrganizations');
     });

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -37,9 +37,9 @@ export function WorkflowJobTemplatePage() {
     error: isNotifAdminError,
     refresh: refreshNotifAdmin,
     isLoading: isNotifAdminLoading,
-  } = useGet<AwxItemsResponse<Organization>>('/api/v2/organizations', {
-    role_level: 'notification_admin_role',
-  });
+  } = useGet<AwxItemsResponse<Organization>>(
+    '/api/v2/organizations/?role_level=notification_admin_role'
+  );
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const itemActions = useTemplateActions({

--- a/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
-import { ITableColumn } from '../../../../../framework';
-import { RouteObj } from '../../../../common/Routes';
+import { ITableColumn, usePageNavigate } from '../../../../../framework';
 import {
   useCreatedColumn,
   useDescriptionColumn,
@@ -12,20 +10,21 @@ import {
 } from '../../../../common/columns';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
+import { AwxRoute } from '../../../AwxRoutes';
 
 export function useTemplateColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
-  const navigate = useNavigate();
   const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
   // TODO: URL should be dependant on template type
   const nameClick = useCallback(
     (template: JobTemplate | WorkflowJobTemplate) => {
       if (template.type === 'job_template') {
-        navigate(RouteObj.JobTemplateDetails.replace(':id', template.id.toString()));
+        pageNavigate(AwxRoute.JobTemplateDetails, { params: { id: template.id } });
         return;
       }
-      navigate(RouteObj.WorkflowJobTemplateDetails.replace(':id', template.id.toString()));
+      pageNavigate(AwxRoute.WorkflowJobTemplateDetails, { params: { id: template.id } });
     },
-    [navigate]
+    [pageNavigate]
   );
   const nameColumn = useNameColumn({
     ...options,


### PR DESCRIPTION
This PR fixes navigation to template details. 

We were missing a trailing '/' when querying organizations by role_level. I hardcoded the role_level query string to fix the 301 error `'/api/v2/organizations/?role_level=notification_admin_role'`


![Screenshot 2023-10-03 at 4 36 09 PM](https://github.com/ansible/ansible-ui/assets/15881645/fc349983-a4d6-45a5-9e57-f29b2c65bbb9)
