### PR TITLE
Hub collection hooks - use right repo in compareStrings

### DIFF
--- a/frontend/hub/collections/hooks/useDeleteCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollections.tsx
@@ -25,7 +25,7 @@ export function useDeleteCollections(
         items: collections.sort((l, r) =>
           compareStrings(
             l.collection_version?.name || '' + l.repository?.name,
-            r.collection_version?.name || '' + l.repository?.name
+            r.collection_version?.name || '' + r.repository?.name
           )
         ),
         keyFn: collectionKeyFn,

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -24,7 +24,7 @@ export function useDeleteCollectionsFromRepository(
         items: collections.sort((l, r) =>
           compareStrings(
             l.collection_version?.name || '' + l.repository?.name,
-            r.collection_version?.name || '' + l.repository?.name
+            r.collection_version?.name || '' + r.repository?.name
           )
         ),
         keyFn: collectionKeyFn,

--- a/frontend/hub/collections/hooks/useDeprecateCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeprecateCollections.tsx
@@ -25,7 +25,7 @@ export function useDeprecateCollections(
         items: collections.sort((l, r) =>
           compareStrings(
             l.collection_version?.name || '' + l.repository?.name,
-            r.collection_version?.name || '' + l.repository?.name
+            r.collection_version?.name || '' + r.repository?.name
           )
         ),
         keyFn: collectionKeyFn,


### PR DESCRIPTION
Noticed while reviewing https://github.com/ansible/ansible-ui/pull/993,
a couple of collection hooks compare left side collection + left side repo with right side collection + **left** side repo.

Fixing.