### PR TITLE
Cypress upgrade to v13.3.0

### DIFF
--- a/.github/workflows/on-pull-request-run-tests.yml
+++ b/.github/workflows/on-pull-request-run-tests.yml
@@ -44,15 +44,15 @@ jobs:
       - uses: marceloprado/has-changed-path@v1.0.1
         id: changed-awx
         with:
-          paths: frontend/awx frontend/common cypress/e2e/awx framework cypress/support
+          paths: frontend/awx frontend/common cypress/e2e/awx framework cypress/support package.json
       - uses: marceloprado/has-changed-path@v1.0.1
         id: changed-hub
         with:
-          paths: frontend/hub frontend/common cypress/e2e/hub framework cypress/support
+          paths: frontend/hub frontend/common cypress/e2e/hub framework cypress/support package.json
       - uses: marceloprado/has-changed-path@v1.0.1
         id: changed-eda
         with:
-          paths: frontend/eda frontend/common cypress/e2e/eda framework cypress/support
+          paths: frontend/eda frontend/common cypress/e2e/eda framework cypress/support package.json
       - uses: marceloprado/has-changed-path@v1.0.1
         id: changed-afw
         with:
@@ -60,7 +60,7 @@ jobs:
       - uses: marceloprado/has-changed-path@v1.0.1
         id: changed-common
         with:
-          paths: frontend/common framework cypress/support
+          paths: frontend/common framework cypress/support package.json
 
   checks:
     name: ESLint - Prettier - TSC

--- a/framework/components/useSearchParams.tsx
+++ b/framework/components/useSearchParams.tsx
@@ -7,7 +7,9 @@ export function useSearchParams(): [URLSearchParams, (setSearchParams: URLSearch
   const searchParams = useMemo<URLSearchParams>(() => {
     /** Cypress component tests add a specPath param that must be ignored */
     let search = location.location?.search;
-    if (search && search.includes('?specPath')) {
+    if (search && search.includes('?specPath=')) {
+      search = search.substring(0, search.indexOf('?specPath='));
+    } else if (search && search.includes('&specPath=')) {
       search = search.substring(0, search.indexOf('&specPath='));
     }
     return new URLSearchParams(search ?? '/');

--- a/framework/components/useSearchParams.tsx
+++ b/framework/components/useSearchParams.tsx
@@ -4,10 +4,15 @@ import { useWindowLocation } from './useWindowLocation';
 export function useSearchParams(): [URLSearchParams, (setSearchParams: URLSearchParams) => void] {
   const location = useWindowLocation();
   const pathname = location.location?.pathname || '/';
-  const searchParams = useMemo<URLSearchParams>(
-    () => new URLSearchParams(location.location?.search ?? '/'),
-    [location.location?.search]
-  );
+  const searchParams = useMemo<URLSearchParams>(() => {
+    /** Cypress component tests add a specPath param that must be ignored */
+    let search = location.location?.search;
+    if (search && search.includes('?specPath')) {
+      search = search.substring(0, search.indexOf('&specPath='));
+    }
+    return new URLSearchParams(search ?? '/');
+  }, [location.location?.search]);
+
   const setSearchParams = useCallback(
     (searchParams: URLSearchParams) => {
       const newSearch = searchParams.toString();

--- a/framework/useView.tsx
+++ b/framework/useView.tsx
@@ -180,7 +180,12 @@ export function useView(options: ViewOptions): IView {
 
   useEffect(() => {
     if (disableQueryString) return;
-    const newSearchParams = new URLSearchParams(location.location?.search ?? '/');
+    /** Cypress component tests add a specPath param that must be ignored */
+    let search = location.location?.search;
+    if (search && search.includes('?specPath')) {
+      search = search.substring(0, search.indexOf('&specPath='));
+    }
+    const newSearchParams = new URLSearchParams(search ?? '/');
     newSearchParams.set('page', page.toString());
     newSearchParams.set('perPage', perPage.toString());
     newSearchParams.set('sort', sortDirection === 'asc' ? sort : `-${sort}`);

--- a/framework/useView.tsx
+++ b/framework/useView.tsx
@@ -182,7 +182,9 @@ export function useView(options: ViewOptions): IView {
     if (disableQueryString) return;
     /** Cypress component tests add a specPath param that must be ignored */
     let search = location.location?.search;
-    if (search && search.includes('?specPath')) {
+    if (search && search.includes('?specPath=')) {
+      search = search.substring(0, search.indexOf('?specPath='));
+    } else if (search && search.includes('&specPath=')) {
       search = search.substring(0, search.indexOf('&specPath='));
     }
     const newSearchParams = new URLSearchParams(search ?? '/');

--- a/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.tsx
@@ -9,7 +9,8 @@ export interface IJobOutputChildrenSummary {
 }
 
 export function useJobOutputChildrenSummary(job: Job, forceFlatMode: boolean) {
-  let isFlatMode = forceFlatMode || location.search.length > 1 || job.type !== 'job';
+  let isFlatMode = forceFlatMode || job.type !== 'job';
+
   const response = useGet<IJobOutputChildrenSummary>(
     `/api/v2/jobs/${job.id}/job_events/children_summary/`
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6585,9 +6585,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "18.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
-      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
+      "version": "18.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
+      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "@types/js-yaml": "4.0.7",
         "@typescript-eslint/eslint-plugin": "6.7.5",
         "@typescript-eslint/parser": "6.7.5",
-        "cypress": "12.17.4",
+        "cypress": "13.3.0",
         "cypress-react-selector": "3.0.0",
         "eslint": "8.51.0",
         "eslint-config-prettier": "9.0.0",
@@ -1952,9 +1952,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1970,7 +1970,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -6519,15 +6519,15 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.0.tgz",
+      "integrity": "sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -6573,7 +6573,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-react-selector": {
@@ -6585,9 +6585,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==",
+      "version": "18.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
+      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -10769,7 +10769,8 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@types/js-yaml": "4.0.7",
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
-    "cypress": "12.17.4",
+    "cypress": "13.3.0",
     "cypress-react-selector": "3.0.0",
     "eslint": "8.51.0",
     "eslint-config-prettier": "9.0.0",


### PR DESCRIPTION
This PR updates Cypress to version 13 and attempts to update the setting that permits tests to run on PRs when package.json is updated.

PR https://github.com/ansible/ansible-ui/pull/998 reverted the earlier Cypress upgrade to version 13 because a JobOutput component test was failing. The expand/collapse buttons in the job output screen were not being rendered. It did not get caught during the PR review stage because the package.json updates did not trigger component/E2E tests.

### Fixes:

1. @keithjgrant and I found that Cypress adds the `specFile` as a search param in the URL. This caused the JobOutput UI's dependency on `location.search` to show and hide the expand/collapse buttons to be affected. Since JobOutput already has access to the filtered state of the UI, the `location.search` check in this case was redundant so we removed it.
2. The new `specFile` query param affects the table state that we define using the `useView` and `useSearchParams` hooks. These hooks take in the search params and add them to the filters for the table. The unexpected `specPath` param from Cypress was causing failures in an EDA component test for the projects list. As a result we needed to remove the specFile query param from the URL in these hooks. This is a temporary solution until we can get the following bug addressed by Cypress: https://github.com/cypress-io/cypress/issues/28021


