### PR TITLE
Continuing data-cy refactoring

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -225,7 +225,7 @@ describe('teams', () => {
 
   it('can navigate to the edit form from the team list row item', () => {
     cy.navigateTo('awx', 'teams');
-    cy.clickTableRowPinnedAction(team.name, 'Edit team');
+    cy.clickTableRowPinnedAction(team.name, 'edit-team');
     cy.verifyPageTitle('Edit Team');
   });
 

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -71,7 +71,7 @@ describe('Users List Actions', () => {
 
   it('navigates to the edit form from the users list row item', () => {
     cy.navigateTo('awx', 'users');
-    cy.clickTableRowPinnedAction(user.username, 'Edit user');
+    cy.clickTableRowPinnedAction(user.username, 'edit-user');
     cy.verifyPageTitle('Edit User');
   });
 });

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -91,7 +91,7 @@ describe('credentials', () => {
 
   it('credentials table row edit credential', () => {
     cy.navigateTo('awx', 'credentials');
-    cy.clickTableRowPinnedAction(credential.name, 'Edit credential');
+    cy.clickTableRowPinnedAction(credential.name, 'edit-credential');
     cy.verifyPageTitle('Edit Credential');
   });
 

--- a/cypress/e2e/awx/resources/workflowJobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/workflowJobTemplates.cy.ts
@@ -3,7 +3,7 @@ import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Label } from '../../../../frontend/awx/interfaces/Label';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 
-describe.skip('Workflow Job templates form', () => {
+describe('Workflow Job templates form', () => {
   //these tests need to be enabled when workflow job templates are working
   let organization: Organization;
   let inventory: Inventory;
@@ -38,8 +38,8 @@ describe.skip('Workflow Job templates form', () => {
     cy.get('[data-cy="name"]').type(jtName);
     cy.get('[data-cy="description"]').type('this is a description');
     cy.selectDropdownOptionByResourceName('labels', label.name.toString());
-    cy.addAndSelectItemFromMulitSelectDropdown('Job tags', 'test job tag');
-    cy.addAndSelectItemFromMulitSelectDropdown(/^Skip tags$/, 'test skip tag');
+    cy.get('[data-cy="job_tags-form-group"]').find('input').eq(1).type('test job tag');
+    cy.get('[data-cy="skip_tags-form-group"]').find('input').eq(1).type('test skip tag');
     cy.get('[data-cy="Submit"]').click();
     cy.verifyPageTitle(jtName);
   });
@@ -53,7 +53,7 @@ describe.skip('Workflow Job templates form', () => {
       const newName = (workflowJobTemplate.name ?? '') + ' edited';
       if (!workflowJobTemplate.name) return;
 
-      cy.clickTableRowPinnedAction(workflowJobTemplate?.name, 'Edit template', true);
+      cy.clickTableRowPinnedAction(workflowJobTemplate?.name, 'edit-template', true);
       cy.get('[data-cy="name"]').type(newName);
       cy.get('[data-cy="description"]').type('this is a new description');
       cy.clickButton(/^Save workflow job template$/);

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -42,7 +42,6 @@ describe('jobs', () => {
   after(() => {
     const jobId = jobList?.id ? jobList?.id.toString() : '';
     cy.awxRequestDelete(`/api/v2/jobs/${jobId}/`, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization);
   });
 
   it('renders jobs list', () => {
@@ -59,7 +58,7 @@ describe('jobs', () => {
     const jobId = jobList.id ? jobList.id.toString() : '';
     const jobName = jobList.name ? jobList.name : '';
     cy.filterTableByTypeAndText('ID', jobId);
-    cy.clickTableRowPinnedAction(jobName, 'Relaunch job', false);
+    cy.clickTableRowPinnedAction(jobName, 'relaunch-job', false);
     cy.verifyPageTitle(jobName);
     cy.contains('.pf-c-tabs a', 'Output').should('have.attr', 'aria-selected', 'true');
   });

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -22,10 +22,6 @@ import './rest-commands';
 
 //  AWX related custom command implementation
 
-Cypress.Commands.add('getFormGroupByLabel', (label: string | RegExp) => {
-  cy.contains('.pf-c-form__label-text', label).parent().parent().parent();
-});
-
 Cypress.Commands.add('getInputByLabel', (label: string | RegExp) => {
   cy.contains('.pf-c-form__label-text', label)
     .parent()
@@ -174,12 +170,11 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'clickTableRowPinnedAction',
-  (name: string | RegExp, label: string, filter?: boolean) => {
+  (name: string | RegExp, iconDataCy: string, filter?: boolean) => {
     cy.getTableRowByText(name, filter).within(() => {
-      cy.get(`#${label.toLowerCase().split(' ').join('-')}`)
-        .should('not.be.disabled')
-        .should('not.have.attr', 'aria-disabled', 'true')
-        .click();
+      cy.get('[data-cy="actions-column-cell"]').within(() => {
+        cy.get(`[data-cy="${iconDataCy}"]`).click();
+      });
     });
   }
 );
@@ -199,21 +194,6 @@ Cypress.Commands.add('selectTableRow', (name: string | RegExp, filter?: boolean)
 Cypress.Commands.add('getDialog', () => {
   cy.get('div[data-ouia-component-type="PF4/ModalContent"]');
 });
-
-Cypress.Commands.add(
-  'selectRowItemInFormGroupLookupModal',
-  (label: string | RegExp, rowItem: string) => {
-    cy.getFormGroupByLabel(label)
-      .within(() => {
-        cy.get('button[aria-label="Options menu"]').click();
-      })
-      .then(() => {
-        cy.selectTableRowInDialog(rowItem, true);
-      });
-
-    cy.clickModalButton('Confirm');
-  }
-);
 
 Cypress.Commands.add(
   'selectTableRowInDialog',

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -61,9 +61,6 @@ declare global {
 
       // --- INPUT COMMANDS ---
 
-      /** Get a FormGroup by it's label. A FormGroup is the PF component that wraps an input and provides a label. */
-      getFormGroupByLabel(label: string | RegExp): Chainable<JQuery<HTMLElement>>;
-
       /** Get an input by its label. */
       getInputByLabel(label: string | RegExp): Chainable<JQuery<HTMLElement>>;
 
@@ -89,10 +86,6 @@ declare global {
         label: string | RegExp
       ): Chainable<void>;
       selectMultiSelectOption(selector: string, label: string | RegExp): Chainable<void>;
-      addAndSelectItemFromMulitSelectDropdown(
-        label: string | RegExp,
-        itemText: string
-      ): Chainable<void>;
 
       // --- TABLE COMMANDS ---
 
@@ -180,7 +173,7 @@ declare global {
       /** Finds a table row containing text and clicks action specified by label. */
       clickTableRowPinnedAction(
         name: string | RegExp,
-        label: string,
+        iconDataCy: string,
         filter?: boolean
       ): Chainable<void>;
 
@@ -197,12 +190,6 @@ declare global {
 
       /** Get the active modal dialog. */
       getDialog(): Chainable<void>;
-
-      /** Opens a lookup dialaog and selects the desired row item **/
-      selectRowItemInFormGroupLookupModal: (
-        label: string | RegExp,
-        rowItem: string
-      ) => Chainable<void>;
 
       /** Clicks a button in the active modal dialog. */
       clickModalButton(label: string | RegExp): Chainable<void>;

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -130,26 +130,3 @@ Cypress.Commands.add('selectMultiSelectOption', (selector: string, label: string
         });
     });
 });
-
-Cypress.Commands.add(
-  'addAndSelectItemFromMulitSelectDropdown',
-  (label: string | RegExp, itemText: string) => {
-    cy.getFormGroupByLabel(label)
-      .parent()
-      .within(() => {
-        cy.get('.pf-c-form__group-control').within(() => {
-          cy.get("input[type='text']")
-            .click()
-            .type(itemText)
-            .parent()
-            .parent()
-            .parent()
-            .within(() => {
-              cy.get('.pf-c-select__menu').within(() => {
-                cy.get('button').contains(itemText).click();
-              });
-            });
-        });
-      });
-  }
-);


### PR DESCRIPTION
removes unnecessary command cy.addAndSelectItemFromMulitSelectDropdown()
removes unnecessary command cy.getFormGroupByLabel()
removes cy.selectRowItemInFormGroupLookupModal()

Reactivates tests that were skipped on workflowJobTemplates.cy.ts

refactors cy.clickTableRowPinnedAction() to use data-cy locators