### PR TITLE
Fix for failing E2E tests on hub

### DIFF
--- a/cypress/e2e/hub/hub-dashboard.cy.ts
+++ b/cypress/e2e/hub/hub-dashboard.cy.ts
@@ -70,7 +70,9 @@ describe('hub dashboard', () => {
       .within(() => {
         cy.contains('a', collectionNames.eda.collection1).click();
       });
-    cy.url().should('contain', `collections/details/?name=${collectionNames.eda.collection1}`);
+    cy.url()
+      .should('include', '/collections/')
+      .should('include', `?name=${collectionNames.eda.collection1}`);
   });
   it('clicking on "Go to collections" opens collections UI filtered by EDA collections', () => {
     cy.visit(HubRoutes.dashboard);
@@ -104,7 +106,10 @@ describe('hub dashboard', () => {
       cy.contains('tr', 'Event-Driven Ansible content').find('input').uncheck();
       cy.clickModalButton('Apply');
       cy.get('div.pf-v5-c-empty-state__content').within(() => {
-        cy.verifyPageTitle('There is currently no content selected to be shown on the dashboard.');
+        cy.get(`[data-cy="empty-state-title"]`).should(
+          'contain',
+          'There is currently no content selected to be shown on the dashboard.'
+        );
         cy.contains('button', 'Manage view').should('be.visible');
         cy.clickButton('Manage view');
       });

--- a/framework/components/EmptyStateCustom.tsx
+++ b/framework/components/EmptyStateCustom.tsx
@@ -23,7 +23,7 @@ export function EmptyStateCustom(props: {
   return (
     <EmptyState variant={variant || EmptyStateVariant.full} style={style} isFullHeight>
       {icon && <EmptyStateIcon icon={icon} />}
-      <EmptyStateHeader titleText={<>{title}</>} headingLevel="h4" />
+      <EmptyStateHeader titleText={<>{title}</>} headingLevel="h4" data-cy="empty-state-title" />
       <EmptyStateBody data-cy={props.description}>{description}</EmptyStateBody>
       <EmptyStateFooter>
         {button && <EmptyStateActions>{button}</EmptyStateActions>}


### PR DESCRIPTION
Thanks to @nixocio for bringing these failures to my attention!

These failures were caused by recent routing updates and changes to the cypress commands like 'verifyPageTitle'. They did not get caught because these tests don't run in the CI pipeline yet.
