### PR TITLE
Fix back button on project details

### DIFF
--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
@@ -74,9 +74,9 @@ export function ProjectPage() {
 
       <PageRoutedTabs
         backTab={{
-          label: t('Back to Templates'),
-          page: AwxRoute.Templates,
-          persistentFilterKey: 'templates',
+          label: t('Back to Projects'),
+          page: AwxRoute.Projects,
+          persistentFilterKey: 'projects',
         }}
         tabs={tabs}
         params={{ id: project.id }}


### PR DESCRIPTION
When you go to the project details view there's a "Back to Templates" button in the tabs.  See this gif:

![project_back](https://github.com/ansible/ansible-ui/assets/9889020/999096d8-64d3-449b-9c97-377d65f55835)

The correct behavior should be that it navigates the user back to the projects list.