### PR TITLE
 Adds Total Nodes element to workflow visualizer toolbar

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
@@ -29,5 +29,9 @@ describe('WorkflowVisualizer', () => {
   it('Should show the visualizer screen', () => {
     cy.mount(<WorkflowVisualizer />);
     cy.get('[data-cy="workflow-visualizer"]').should('be.visible');
+    cy.get('[data-cy="workflow-visualizer-toolbar-total-nodes"]').should(
+      'have.text',
+      'Total nodes 0'
+    );
   });
 });

--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.tsx
@@ -14,7 +14,7 @@ const TopologyView = styled(PFTopologyView)`
 `;
 
 export function WorkflowVisualizer() {
-  const toolbarActions = useWorkflowVisualizerToolbarActions();
+  const toolbarActions = useWorkflowVisualizerToolbarActions([] as WorkflowNode[]); // The argument for this function will need to be the number of nodes.
 
   const { id } = useParams<{ id?: string }>();
   const { data: wfNodes } = useGet<AwxItemsResponse<WorkflowNode>>(

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useWorkflowVisualizerToolbarActions.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useWorkflowVisualizerToolbarActions.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Button, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import {
   CheckCircleIcon,
@@ -9,13 +8,14 @@ import {
   ExpandAltIcon,
   PlusCircleIcon,
 } from '@patternfly/react-icons';
-
+import { Badge, Button, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
 import { usePageNavigate } from '../../../../../../framework';
 import { AwxRoute } from '../../../../AwxRoutes';
 
-export function useWorkflowVisualizerToolbarActions() {
-  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+export function useWorkflowVisualizerToolbarActions(nodes: WorkflowNode[]) {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string }>();
 
@@ -43,6 +43,11 @@ export function useWorkflowVisualizerToolbarActions() {
         </ToolbarItem>
       </ToolbarGroup>
       <ToolbarGroup align={{ default: 'alignRight' }}>
+        <ToolbarItem style={{ alignSelf: 'center' }}>
+          <div data-cy="workflow-visualizer-toolbar-total-nodes">
+            {t('Total nodes')} <Badge isRead>{nodes?.length || 0}</Badge>
+          </div>
+        </ToolbarItem>
         <ToolbarItem>
           <Button
             data-cy="workflow-visualizer-toolbar-expand-compress"


### PR DESCRIPTION
Addresses `16333` and adds the Total nodes count and badge to the Visualizer toolbar

<img width="1536" alt="Screenshot 2023-10-18 at 2 10 19 PM" src="https://github.com/ansible/ansible-ui/assets/39280967/36e08633-3e47-4acd-b439-6cff81844bcb">
