### PR TITLE
Switch count bar to pie charts

### DIFF
--- a/framework/PageDashboard/PageDashboardCountBar.cy.tsx
+++ b/framework/PageDashboard/PageDashboardCountBar.cy.tsx
@@ -22,7 +22,7 @@ describe('PageDashboardCountBar', () => {
     ];
     cy.mount(<PageDashboardCountBar counts={counts} />);
 
-    cy.get('#inventories-chart').should('contain', 13);
+    cy.get('#inventories a').should('contain', '13 Inventories');
     cy.get('#inventories-legend-synced-count').should('contain', 11);
     cy.get('#inventories-legend-synced-failures-count').should('contain', 2);
   });
@@ -48,7 +48,7 @@ describe('PageDashboardCountBar', () => {
     ];
     cy.mount(<PageDashboardCountBar counts={counts} />);
 
-    cy.get('#hosts-chart').should('contain', 113);
+    cy.get('#hosts a').should('contain', '113 Hosts');
     cy.get('#hosts-legend-ready-count').should('contain', 100);
     cy.get('#hosts-legend-failed-count').should('contain', 13);
   });
@@ -74,7 +74,7 @@ describe('PageDashboardCountBar', () => {
     ];
     cy.mount(<PageDashboardCountBar counts={counts} />);
 
-    cy.get('#projects-chart').should('contain', 13);
+    cy.get('#projects a').should('contain', '13 Projects');
     cy.get('#projects-legend-synced-count').should('contain', 11);
     cy.get('#projects-legend-synced-failures-count').should('contain', 2);
   });

--- a/framework/PageDashboard/PageDashboardCountBar.tsx
+++ b/framework/PageDashboard/PageDashboardCountBar.tsx
@@ -1,6 +1,5 @@
-import { ChartDonut, ChartLabel, ChartLabelProps } from '@patternfly/react-charts';
+import { ChartPie } from '@patternfly/react-charts';
 import { CardBody, Title } from '@patternfly/react-core';
-import { CSSProperties } from 'react';
 import { Link } from 'react-router-dom';
 import { PageChartLegend } from './PageChartLegend';
 import { PageDashboardCard } from './PageDashboardCard';
@@ -48,7 +47,7 @@ export function PageDashboardCountBar(props: PageDashboardCountBarProps) {
                     size="xl"
                     style={{ whiteSpace: 'nowrap', textDecoration: 'none' }}
                   >
-                    {item.title}
+                    {total} {item.title}
                   </Title>
                 </Link>
 
@@ -61,11 +60,7 @@ export function PageDashboardCountBar(props: PageDashboardCountBarProps) {
                       id={`${id}-chart`}
                       style={{ maxHeight: 64, marginTop: -4, marginBottom: -4 }}
                     >
-                      <ChartDonut
-                        title={item.counts
-                          .reduce<number>((acc, curr) => acc + curr.count, 0)
-                          .toString()}
-                        titleComponent={<PageChartLabel to={item.to} />}
+                      <ChartPie
                         padding={{ top: 0, left: 0, right: 0, bottom: 0 }}
                         width={64}
                         height={64}
@@ -89,36 +84,5 @@ export function PageDashboardCountBar(props: PageDashboardCountBarProps) {
         </div>
       </CardBody>
     </PageDashboardCard>
-  );
-}
-
-function PageChartLabel(props: ChartLabelProps & { to?: string }) {
-  if (props.to) {
-    return (
-      <Link to={props.to} style={{ textDecoration: 'none' }}>
-        <ChartLabel
-          {...props}
-          style={
-            {
-              ...props.style,
-              fill: 'var(--pf-v5-global--link--Color)',
-              stroke: 'var(--pf-v5-global--link--Color)',
-            } as CSSProperties
-          }
-        />
-      </Link>
-    );
-  }
-  return (
-    <ChartLabel
-      {...props}
-      style={
-        {
-          ...props.style,
-          fill: 'var(--pf-v5-global--text--Color)',
-          stroke: 'var(--pf-v5-global--text--Color)',
-        } as CSSProperties
-      }
-    />
   );
 }


### PR DESCRIPTION
Switches the AWX dashboard counts bar to pie charts and moves the number of items out of the chart (addresses #856)

<img width="1284" alt="Screenshot 2023-10-18 at 3 53 30 PM" src="https://github.com/ansible/ansible-ui/assets/410794/d581b287-ff5b-45c8-84ad-8bb098fd4b80">
