### PR TITLE
Awx credential types details

### DIFF
--- a/cypress/fixtures/credential_type.json
+++ b/cypress/fixtures/credential_type.json
@@ -1,0 +1,46 @@
+{
+  "id": 5,
+  "type": "credential_type",
+  "url": "/api/v2/credential_types/5/",
+  "related": {
+    "credentials": "/api/v2/credential_types/5/credentials/",
+    "activity_stream": "/api/v2/credential_types/5/activity_stream/"
+  },
+  "summary_fields": {
+    "user_capabilities": {
+      "edit": true,
+      "delete": true
+    }
+  },
+  "created": "2022-12-09T15:25:33.576122Z",
+  "modified": "2022-12-09T15:25:33.576122Z",
+  "name": "Amazon Web Services",
+  "description": "",
+  "kind": "cloud",
+  "namespace": "aws",
+  "managed": true,
+  "inputs": {
+    "fields": [
+      {
+        "id": "username",
+        "label": "Access Key",
+        "type": "string"
+      },
+      {
+        "id": "password",
+        "label": "Secret Key",
+        "type": "string",
+        "secret": true
+      },
+      {
+        "id": "security_token",
+        "label": "STS Token",
+        "type": "string",
+        "secret": true,
+        "help_text": "Security Token Service (STS) is a web service that enables you to request temporary, limited-privilege credentials for AWS Identity and Access Management (IAM) users."
+      }
+    ],
+    "required": ["username", "password"]
+  },
+  "injectors": {}
+}

--- a/framework/PageDetails/PageDetailCodeEditor.tsx
+++ b/framework/PageDetails/PageDetailCodeEditor.tsx
@@ -15,6 +15,7 @@ export function PageDetailCodeEditor(props: {
   value: string;
   helpText?: string;
   showCopyToClipboard?: boolean;
+  toggleLanguage?: boolean;
 }) {
   const { value, label, helpText } = props;
   const { id } = useParams();

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.cy.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.cy.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable i18next/no-literal-string */
+import { CredentialType } from '../../../interfaces/CredentialType';
+import { CredentialTypeDetailInner as CredentialTypeDetails } from './CredentialTypeDetails';
+import mockCredentialType from '../../../../../cypress/fixtures/credential_type.json';
+import { DateTime } from 'luxon';
+
+describe('CredentialDetails', () => {
+  it('Component renders and displays CredentialType', () => {
+    cy.mount(<CredentialTypeDetails credentialType={mockCredentialType as CredentialType} />);
+  });
+  it('Renders name, input config, injector config, created, and modified by fields', () => {
+    cy.mount(<CredentialTypeDetails credentialType={mockCredentialType as CredentialType} />);
+    cy.get('[data-cy="name"]').should('have.text', 'Amazon Web ServicesRead only');
+    cy.get('[data-cy="input-configuration"]').should('exist');
+    cy.get('[data-cy="injector-configuration"]').should('exist');
+    cy.get('[data-cy="created"]').should(
+      'have.text',
+      DateTime.fromISO(mockCredentialType.created).toRelative()
+    );
+    cy.get('[data-cy="last-modified"]').should(
+      'have.text',
+      DateTime.fromISO(mockCredentialType.modified).toRelative()
+    );
+  });
+});

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.cy.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.cy.tsx
@@ -11,7 +11,7 @@ describe('CredentialDetails', () => {
   });
   it('Renders name, input config, injector config, created, and modified by fields', () => {
     cy.mount(<CredentialTypeDetails credentialType={mockCredentialType as CredentialType} />);
-    cy.get('[data-cy="name"]').should('have.text', 'Amazon Web ServicesRead only');
+    cy.get('[data-cy="name"]').should('have.text', 'Amazon Web ServicesRead-only');
     cy.get('[data-cy="input-configuration"]').should('exist');
     cy.get('[data-cy="injector-configuration"]').should('exist');
     cy.get('[data-cy="created"]').should(

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
@@ -17,34 +17,36 @@ export function CredentialTypeDetails() {
   return credentialType ? <CredentialTypeDetailInner credentialType={credentialType} /> : null;
 }
 
-function renderCredentialTypeName(credentialType: CredentialType) {
-  if (credentialType.managed) {
-    return (
-      <>
-        {credentialType.name}
-        <Label disabled style={{ marginLeft: '10px' }}>
-          Read only
-        </Label>
-      </>
-    );
-  } else {
-    return <>{credentialType.name}</>;
-  }
-}
 export function CredentialTypeDetailInner(props: { credentialType: CredentialType }) {
   const { t } = useTranslation();
   const history = useNavigate();
   const getPageUrl = useGetPageUrl();
+  function renderCredentialTypeName(credentialType: CredentialType) {
+    if (credentialType.managed) {
+      return (
+        <>
+          {credentialType.name}
+          <Label style={{ marginLeft: '10px' }}>{t('Read-only')}</Label>
+        </>
+      );
+    } else {
+      return <>{credentialType.name}</>;
+    }
+  }
 
   return (
     <PageDetails>
       <PageDetail label={t('Name')}>{renderCredentialTypeName(props.credentialType)}</PageDetail>
       <PageDetail label={t('Description')}>{props.credentialType.description}</PageDetail>
       <PageDetailCodeEditor
+        helpText={t('Input schema which defines a set of ordered fields for that type.')}
         label={t('Input configuration')}
         value={jsonToYaml(JSON.stringify(props.credentialType.inputs))}
       />
       <PageDetailCodeEditor
+        helpText={t(
+          'Environment variables or extra variables that specify the values a credential type can inject.'
+        )}
         label={t('Injector configuration')}
         value={jsonToYaml(JSON.stringify(props.credentialType.injectors))}
       />

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from 'react-i18next';
+import { DateTimeCell, PageDetail, PageDetails, useGetPageUrl } from '../../../../../framework';
+import { useGetItem } from '../../../../common/crud/useGet';
+import { useNavigate, useParams } from 'react-router-dom';
+import { CredentialType } from '../../../interfaces/CredentialType';
+import { AwxRoute } from '../../../AwxRoutes';
+import { PageDetailCodeEditor } from '../../../../../framework/PageDetails/PageDetailCodeEditor';
+import { Label } from '@patternfly/react-core';
+import { jsonToYaml } from '../../../../../framework/utils/codeEditorUtils';
+
+export function CredentialTypeDetails() {
+  const params = useParams<{ id: string }>();
+  const { data: credentialType } = useGetItem<CredentialType>(
+    '/api/v2/credential_types/',
+    params.id
+  );
+  return credentialType ? <CredentialTypeDetailInner credentialType={credentialType} /> : null;
+}
+
+function renderCredentialTypeName(credentialType: CredentialType) {
+  if (credentialType.managed) {
+    return (
+      <>
+        {credentialType.name}
+        <Label disabled style={{ marginLeft: '10px' }}>
+          Read only
+        </Label>
+      </>
+    );
+  } else {
+    return <>{credentialType.name}</>;
+  }
+}
+export function CredentialTypeDetailInner(props: { credentialType: CredentialType }) {
+  const { t } = useTranslation();
+  const history = useNavigate();
+  const getPageUrl = useGetPageUrl();
+
+  return (
+    <PageDetails>
+      <PageDetail label={t('Name')}>{renderCredentialTypeName(props.credentialType)}</PageDetail>
+      <PageDetail label={t('Description')}>{props.credentialType.description}</PageDetail>
+      <PageDetailCodeEditor
+        label={t('Input configuration')}
+        value={jsonToYaml(JSON.stringify(props.credentialType.inputs))}
+      />
+      <PageDetailCodeEditor
+        label={t('Injector configuration')}
+        value={jsonToYaml(JSON.stringify(props.credentialType.injectors))}
+      />
+      <PageDetail label={t('Created')}>
+        <DateTimeCell
+          format="since"
+          value={props.credentialType.created}
+          author={props.credentialType.summary_fields?.created_by?.username}
+          onClick={() =>
+            history(
+              getPageUrl(AwxRoute.UserDetails, {
+                params: {
+                  id: (props.credentialType.summary_fields?.created_by?.id ?? 0).toString(),
+                },
+              })
+            )
+          }
+        />
+      </PageDetail>
+      <PageDetail label={t('Last modified')}>
+        <DateTimeCell
+          format="since"
+          value={props.credentialType.modified}
+          author={props.credentialType.summary_fields?.modified_by?.username}
+          onClick={() =>
+            history(
+              getPageUrl(AwxRoute.UserDetails, {
+                params: {
+                  id: (props.credentialType.summary_fields?.modified_by?.id ?? 0).toString(),
+                },
+              })
+            )
+          }
+        />
+      </PageDetail>
+    </PageDetails>
+  );
+}

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.cy.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.cy.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable i18next/no-literal-string */
+import { RouteObj } from '../../../../common/Routes';
+import { CredentialType } from '../../../interfaces/CredentialType';
+import { CredentialTypePage } from './CredentialTypePage';
+
+describe('CredentialTypePage', () => {
+  beforeEach(() => {
+    cy.intercept(
+      { method: 'GET', url: '/api/v2/credential_types/*/', hostname: 'localhost' },
+      { fixture: 'credential_type.json' }
+    );
+    cy.mount(<CredentialTypePage />, {
+      path: RouteObj.CredentialTypePage,
+      initialEntries: [RouteObj.CredentialTypeDetails.replace(':id', '1')],
+    });
+  });
+  it('Displays breadcrumbs back to Credential Types list page', () => {
+    cy.get('.pf-v5-c-tabs__item').eq(0).should('have.text', 'Back to Credential Types');
+  });
+  it('Should show disabled edit button', () => {
+    cy.fixture('credentialType').then((credentialType: CredentialType) => {
+      credentialType.summary_fields.user_capabilities.delete = false;
+    });
+    cy.mount(<CredentialTypePage />, {
+      path: RouteObj.CredentialTypePage,
+      initialEntries: [RouteObj.CredentialTypeDetails.replace(':id', '1')],
+    });
+    cy.get('[data-cy="edit-credential-type"]').should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('Should show disabled delete button', () => {
+    cy.fixture('credentialType').then((credentialType: CredentialType) => {
+      credentialType.summary_fields.user_capabilities.delete = false;
+    });
+    cy.mount(<CredentialTypePage />, {
+      path: RouteObj.CredentialTypePage,
+      initialEntries: [RouteObj.CredentialTypeDetails.replace(':id', '1')],
+    });
+    cy.get('button[aria-label="Actions"]').click();
+    cy.contains('a.pf-v5-c-dropdown__menu-item', 'Delete credential type').should(
+      'have.attr',
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.tsx
@@ -1,22 +1,15 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import {
-  PageActions,
-  PageHeader,
-  PageLayout,
-  useGetPageUrl,
-  usePageNavigate,
-} from '../../../../../framework';
+import { PageActions, PageHeader, PageLayout, useGetPageUrl } from '../../../../../framework';
 import { LoadingPage } from '../../../../../framework/components/LoadingPage';
 import { PageRoutedTabs } from '../../../../../framework/PageTabs/PageRoutedTabs';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { AwxRoute } from '../../../AwxRoutes';
 import { AwxError } from '../../../common/AwxError';
 import { CredentialType } from '../../../interfaces/CredentialType';
-// import { useCredentialActions } from '../hooks/useCredentialTypeActions';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
-import { useCredentialTypeToolbarActions } from '../hooks/useCredentialTypeActions';
+import { useCredentialTypeRowActions } from '../hooks/useCredentialTypeActions';
 import { useAwxView } from '../../../useAwxView';
 import { useCredentialTypesFilters } from '../hooks/useCredentialTypesFilters';
 import { useCredentialTypesColumns } from '../hooks/useCredentialTypesColumns';
@@ -29,7 +22,6 @@ export function CredentialTypePage() {
     data: credentialType,
     refresh,
   } = useGetItem<CredentialType>('/api/v2/credential_types', params.id);
-  // const pageNavigate = usePageNavigate();
   const toolbarFilters = useCredentialTypesFilters();
   const tableColumns = useCredentialTypesColumns();
   const view = useAwxView<CredentialType>({
@@ -37,7 +29,7 @@ export function CredentialTypePage() {
     toolbarFilters,
     tableColumns,
   });
-  const actions = useCredentialTypeToolbarActions(view);
+  const actions = useCredentialTypeRowActions(view);
 
   const getPageUrl = useGetPageUrl();
 

--- a/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.tsx
+++ b/frontend/awx/administration/credential-types/CredentialTypePage/CredentialTypePage.tsx
@@ -1,13 +1,25 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { PageHeader, PageLayout, useGetPageUrl } from '../../../../../framework';
+import {
+  PageActions,
+  PageHeader,
+  PageLayout,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../../framework';
 import { LoadingPage } from '../../../../../framework/components/LoadingPage';
 import { PageRoutedTabs } from '../../../../../framework/PageTabs/PageRoutedTabs';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { AwxRoute } from '../../../AwxRoutes';
 import { AwxError } from '../../../common/AwxError';
 import { CredentialType } from '../../../interfaces/CredentialType';
+// import { useCredentialActions } from '../hooks/useCredentialTypeActions';
+import { DropdownPosition } from '@patternfly/react-core/deprecated';
+import { useCredentialTypeToolbarActions } from '../hooks/useCredentialTypeActions';
+import { useAwxView } from '../../../useAwxView';
+import { useCredentialTypesFilters } from '../hooks/useCredentialTypesFilters';
+import { useCredentialTypesColumns } from '../hooks/useCredentialTypesColumns';
 
 export function CredentialTypePage() {
   const { t } = useTranslation();
@@ -17,6 +29,15 @@ export function CredentialTypePage() {
     data: credentialType,
     refresh,
   } = useGetItem<CredentialType>('/api/v2/credential_types', params.id);
+  // const pageNavigate = usePageNavigate();
+  const toolbarFilters = useCredentialTypesFilters();
+  const tableColumns = useCredentialTypesColumns();
+  const view = useAwxView<CredentialType>({
+    url: '/api/v2/credential_types/',
+    toolbarFilters,
+    tableColumns,
+  });
+  const actions = useCredentialTypeToolbarActions(view);
 
   const getPageUrl = useGetPageUrl();
 
@@ -31,7 +52,13 @@ export function CredentialTypePage() {
           { label: t('Credential Types'), to: getPageUrl(AwxRoute.CredentialTypes) },
           { label: credentialType?.name },
         ]}
-        headerActions={[]}
+        headerActions={
+          <PageActions<CredentialType>
+            actions={actions}
+            position={DropdownPosition.right}
+            selectedItem={credentialType}
+          />
+        }
       />
       <PageRoutedTabs
         backTab={{

--- a/frontend/awx/administration/credential-types/hooks/useCredentialTypeActions.tsx
+++ b/frontend/awx/administration/credential-types/hooks/useCredentialTypeActions.tsx
@@ -1,10 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { CredentialType } from '../../../interfaces/CredentialType';
 import { IAwxView } from '../../../useAwxView';
-// import { ButtonVariant } from '@patternfly/react-core';
-// import { EditIcon, TrashIcon } from '@patternfly/react-icons';
-// import { useMemo } from 'react';
-// import { useTranslation } from 'react-i18next';
 import {
   IPageAction,
   PageActionSelection,

--- a/frontend/awx/administration/credential-types/hooks/useCredentialTypeActions.tsx
+++ b/frontend/awx/administration/credential-types/hooks/useCredentialTypeActions.tsx
@@ -1,6 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import { CredentialType } from '../../../interfaces/CredentialType';
 import { IAwxView } from '../../../useAwxView';
+// import { ButtonVariant } from '@patternfly/react-core';
+// import { EditIcon, TrashIcon } from '@patternfly/react-icons';
+// import { useMemo } from 'react';
+// import { useTranslation } from 'react-i18next';
 import {
   IPageAction,
   PageActionSelection,

--- a/frontend/awx/interfaces/CredentialType.ts
+++ b/frontend/awx/interfaces/CredentialType.ts
@@ -2,7 +2,7 @@ import { CredentialType as SwaggerCredentialType } from './generated-from-swagge
 import { SummaryFieldsByUser } from './summary-fields/summary-fields';
 
 export interface CredentialType
-  extends Omit<SwaggerCredentialType, 'id' | 'name' | 'managed' | 'summary_fields'> {
+  extends Omit<SwaggerCredentialType, 'id' | 'name' | 'managed' | 'related' | 'summary_fields'> {
   id: number;
   name: string;
   description: string;
@@ -23,7 +23,11 @@ export interface CredentialType
       label: string;
       type: string;
       help_text: string;
-      ask_at_runtime: boolean;
+      ask_at_runtime?: boolean;
     }[];
+  };
+  related: {
+    credentials: string;
+    activity_stream: string;
   };
 }

--- a/frontend/awx/resources/credentials/components/CredentialTypeDetail.tsx
+++ b/frontend/awx/resources/credentials/components/CredentialTypeDetail.tsx
@@ -8,7 +8,7 @@ import { PageDetailCodeEditor } from '../../../../../framework/PageDetails/PageD
 
 export function CredentialTypeDetail(props: {
   inputs: Record<string, string | number>;
-  field: { id: string; label: string; type: string; ask_at_runtime: boolean; help_text: string };
+  field: { id: string; label: string; type: string; ask_at_runtime?: boolean; help_text: string };
   inputSources?: Record<string, CredentialInputSource>;
 }) {
   const { inputs, field, inputSources } = props;

--- a/frontend/awx/useAwxNavigation.tsx
+++ b/frontend/awx/useAwxNavigation.tsx
@@ -37,6 +37,7 @@ import {
 } from './administration/credential-types/CredentialTypeForm';
 import { CredentialTypePage } from './administration/credential-types/CredentialTypePage/CredentialTypePage';
 import { CredentialTypeCredentials } from './administration/credential-types/CredentialTypePage/CredentialTypeCredentials';
+import { CredentialTypeDetails } from './administration/credential-types/CredentialTypePage/CredentialTypeDetails';
 import { CredentialTypes } from './administration/credential-types/CredentialTypes';
 import { ExecutionEnvironments } from './administration/execution-environments/ExecutionEnvironments';
 import { InstanceGroups } from './administration/instance-groups/InstanceGroups';
@@ -898,7 +899,7 @@ export function useAwxNavigation() {
                       {
                         id: AwxRoute.CredentialTypeDetails,
                         path: 'details',
-                        element: <PageNotImplemented />,
+                        element: <CredentialTypeDetails />,
                       },
                       {
                         id: AwxRoute.CredentialTypeCredentials,

--- a/frontend/common/Routes.ts
+++ b/frontend/common/Routes.ts
@@ -38,6 +38,9 @@ export const RouteObj = {
   CredentialPage: `${awxRoutePrefix}/resources/credentials/:id/*`,
   CredentialDetails: `${awxRoutePrefix}/resources/credentials/:id/details`,
 
+  CredentialTypePage: `${awxRoutePrefix}/resources/credential-types/:id/*`,
+  CredentialTypeDetails: `${awxRoutePrefix}/resources/credential-types/:id/details`,
+
   Projects: `${awxRoutePrefix}/resources/projects`,
   ProjectDetails: `${awxRoutePrefix}/resources/projects/:id/details`,
   ProjectSchedules: `${awxRoutePrefix}/resources/projects/:id/schedules`,


### PR DESCRIPTION
<img width="2140" alt="Screenshot 2023-10-19 at 11 19 23 AM" src="https://github.com/ansible/ansible-ui/assets/2293210/dd9d5a24-8c6f-4b32-8414-3a8500b5745d">

Note: existing detail page code editor comes from PF and does not have a JSON|YAML toggle. We can try to refactor the editor to use the Monaco editor, or we can try to add the toggle to the PF component, however that is beyond the scope of this PR.