### PR TITLE
[WIP] Enable global organization in orgs spec file

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -121,7 +121,6 @@ describe('organizations', function () {
 
   it('deletes an organization from the organizations list toolbar', function () {
     const endOfName = organization.name.split(' ').slice(-1).toString();
-    cy.log('STRING', typeof endOfName);
     cy.navigateTo('awx', 'organizations');
     cy.intercept(
       'GET',

--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -5,14 +5,8 @@ import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 
 describe('organizations', () => {
-  let organization: Organization;
-
   before(() => {
     cy.awxLogin();
-
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
-    });
   });
 
   it('renders the organizations list page', () => {
@@ -35,67 +29,109 @@ describe('organizations', () => {
     cy.verifyPageTitle('Organizations');
   });
 
-  it('renders the organization details page', () => {
+  it('renders the organization details page', function () {
     cy.navigateTo('awx', 'organizations');
-    cy.clickTableRow(organization.name);
-    cy.verifyPageTitle(organization.name);
+    cy.clickTableRow(`${(this.globalProjectOrg as Organization).name}`);
+    cy.verifyPageTitle(`${(this.globalProjectOrg as Organization).name}`);
     cy.clickLink(/^Details$/);
-    cy.contains('#name', organization.name);
+    cy.contains('#name', `${(this.globalProjectOrg as Organization).name}`);
   });
 
-  it('edits an organization from the details page', () => {
+  it('edits an organization from the list view', function () {
+    const stringRandom = randomString(4);
     cy.navigateTo('awx', 'organizations');
-    cy.clickTableRow(organization.name);
-    cy.verifyPageTitle(organization.name);
-    cy.clickButton(/^Edit organization$/);
-    cy.verifyPageTitle('Edit Organization');
-    cy.get('[data-cy="organization-name"]').type(organization.name + 'a');
-    cy.clickButton(/^Save organization$/);
-    cy.verifyPageTitle(`${organization.name}a`);
-  });
-
-  it('deletes an organization from the details page', () => {
-    cy.createAwxOrganization().then((testOrganization) => {
-      cy.navigateTo('awx', 'organizations');
-      cy.clickTableRow(testOrganization.name);
-      cy.verifyPageTitle(testOrganization.name);
-      cy.clickPageAction(/^Delete organization/);
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', '/api/v2/organizations/*').as('delete');
-      cy.clickButton(/^Delete organization/);
-      cy.wait('@delete');
-      cy.verifyPageTitle('Organizations');
-    });
-  });
-
-  it('navigates to the edit form from the organizations list row item', () => {
-    cy.navigateTo('awx', 'organizations');
-    cy.getTableRowByText(organization.name).within(() => {
+    cy.getTableRowByText(`${(this.globalProjectOrg as Organization).name}`).within(() => {
       cy.get('#edit-organization').click();
     });
     cy.verifyPageTitle('Edit Organization');
+    cy.get('[data-cy="organization-name"]')
+      .clear()
+      .type('now-edited ' + `${stringRandom}`);
+    cy.clickButton(/^Save organization$/);
+    cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
+    cy.get('[data-cy="edit-organization"]').click();
+    cy.get('[data-cy="organization-name"]')
+      .clear()
+      .type(`${(this.globalProjectOrg as Organization).name}`);
+    cy.clickButton(/^Save organization$/);
+    cy.verifyPageTitle(`${(this.globalProjectOrg as Organization).name}`);
   });
 
-  it('deletes an organization from the organizations list row item', () => {
-    cy.createAwxOrganization().then((testOrganization) => {
-      cy.navigateTo('awx', 'organizations');
-      cy.searchAndDisplayResource(testOrganization.name);
-      cy.get(`[data-cy="row-id-${testOrganization.id}"]`).within(() => {
-        cy.get('[data-cy="actions-dropdown"]').click();
-        cy.get('[data-cy="delete-organization"]').click();
-      });
-      cy.get('#confirm').click();
-      cy.clickButton(/^Delete organization/);
-      cy.contains(/^Success$/);
-      cy.clickButton(/^Close$/);
+  it('edits an organization from the details page', function () {
+    const stringRandom = randomString(4);
+    cy.navigateTo('awx', 'organizations');
+    cy.clickTableRow(`${(this.globalProjectOrg as Organization).name}`);
+    cy.verifyPageTitle(`${(this.globalProjectOrg as Organization).name}`);
+    cy.clickButton(/^Edit organization$/);
+    cy.verifyPageTitle('Edit Organization');
+    cy.get('[data-cy="organization-name"]')
+      .clear()
+      .type('now-edited ' + `${stringRandom}`);
+    cy.clickButton(/^Save organization$/);
+    cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
+    cy.get('[data-cy="edit-organization"]').click();
+    cy.get('[data-cy="organization-name"]')
+      .clear()
+      .type(`${(this.globalProjectOrg as Organization).name}`);
+    cy.clickButton(/^Save organization$/);
+    cy.verifyPageTitle(`${(this.globalProjectOrg as Organization).name}`);
+  });
+});
+
+describe('organizations', function () {
+  let organization: Organization;
+
+  before(function () {
+    cy.awxLogin();
+  });
+
+  beforeEach(function () {
+    const stringRandom = randomString(4);
+    const orgName = 'E2E Organization ' + `${stringRandom}`;
+    cy.createAwxOrganization(orgName).then((testOrganization) => {
+      organization = testOrganization;
     });
   });
 
-  it('deletes an organization from the organizations list toolbar', () => {
-    cy.createAwxOrganization().then((testOrganization) => {
-      cy.navigateTo('awx', 'organizations');
-      // cy.searchAndDisplayResource(testOrganization.name);
-      cy.selectTableRow(testOrganization.name);
+  it('deletes an organization from the details page', function () {
+    cy.navigateTo('awx', 'organizations');
+    cy.clickTableRow(organization.name);
+    cy.verifyPageTitle(organization.name);
+    cy.clickPageAction(/^Delete organization/);
+    cy.get('#confirm').click();
+    cy.intercept('DELETE', '/api/v2/organizations/*').as('delete');
+    cy.clickButton(/^Delete organization/);
+    cy.wait('@delete');
+    cy.verifyPageTitle('Organizations');
+  });
+
+  it('deletes an organization from the organizations list row item', function () {
+    cy.navigateTo('awx', 'organizations');
+    cy.searchAndDisplayResource(organization.name);
+    cy.get(`[data-cy="row-id-${organization.id}"]`).within(() => {
+      cy.get('[data-cy="actions-dropdown"]').click();
+      cy.get('[data-cy="delete-organization"]').click();
+    });
+    cy.get('#confirm').click();
+    cy.clickButton(/^Delete organization/);
+    cy.contains(/^Success$/);
+    cy.clickButton(/^Close$/);
+    cy.clickButton(/^Clear all filters$/);
+  });
+
+  it('deletes an organization from the organizations list toolbar', function () {
+    const endOfName = organization.name.split(' ').slice(-1).toString();
+    cy.log('STRING', typeof endOfName);
+    cy.navigateTo('awx', 'organizations');
+    cy.intercept(
+      'GET',
+      `/api/v2/organizations/?name__icontains=${endOfName}&order_by=name&page=1&page_size=10`
+    ).as('orgResult');
+    cy.searchAndDisplayResource(`${endOfName}`);
+    cy.wait('@orgResult').then(() => {
+      cy.get(`[data-cy="row-id-${organization.id}"]`).within(() => {
+        cy.get('input').click();
+      });
       cy.clickToolbarKebabAction(/^Delete selected organizations$/);
       cy.get('#confirm').click();
       cy.clickButton(/^Delete organization/);

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -1,62 +1,25 @@
 import { randomString } from '../../../../framework/utils/random-string';
-// import { Credential } from '../../../../frontend/awx/interfaces/Credential';
-// import { ExecutionEnvironment } from '../../../../frontend/awx/interfaces/ExecutionEnvironment';
-// import { InstanceGroup } from '../../../../frontend/awx/interfaces/InstanceGroup';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
-// import { Label } from '../../../../frontend/awx/interfaces/Label';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 
-describe('Job templates form Create, Edit, Delete', () => {
-  let organization: Organization;
-  let project: Project;
+describe('Job templates form Create, Edit, Delete', function () {
   let inventory: Inventory;
   const executionEnvironment = 'Control Plane Execution Environment';
   const machineCredential = 'Demo Credential';
   const instanceGroup = 'default';
 
-  before(() => {
+  before(function () {
     cy.awxLogin();
 
-    cy.createAwxOrganization().then((o) => {
-      organization = o;
-
-      cy.createAwxProject({ organization: organization.id }).then((p) => {
-        project = p;
-      });
-
-      cy.createAwxInventory({ organization: organization.id }).then((i) => {
+    cy.createAwxInventory({ organization: (this.globalProjectOrg as Organization).id }).then(
+      (i) => {
         inventory = i;
-      });
-
-      // cy.createAwxExecutionEnvironment({ organization: organization.id }).then((ee) => {
-      //   executionEnvironment = ee;
-      // });
-
-      // cy.createAWXCredential({
-      //   kind: 'machine',
-      //   organization: organization.id,
-      //   credential_type: 1,
-      // }).then((cred) => {
-      //   machineCredential = cred;
-      // });
-
-      // cy.createAwxInstanceGroup().then((ig) => {
-      //   instanceGroup = ig;
-      // });
-
-      // cy.createAwxLabel({ organization: organization.id }).then((l) => {
-      //   label = l;
-      // });
-    });
+      }
+    );
   });
 
-  after(() => {
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    // cy.deleteAwxInstanceGroup(instanceGroup);
-  });
-
-  it('should create a job template with all fields without prompt on launch option', () => {
+  it('should create a job template with all fields without prompt on launch option', function () {
     cy.intercept('POST', `/api/v2/job_templates`).as('createJT');
     const jtName = 'E2E-JT ' + randomString(4);
     cy.navigateTo('awx', 'templates');
@@ -65,7 +28,7 @@ describe('Job templates form Create, Edit, Delete', () => {
     cy.get('[data-cy="name"]').type(jtName);
     cy.get('[data-cy="description"]').type('This is a JT description');
     cy.selectDropdownOptionByResourceName('inventory', inventory.name);
-    cy.selectDropdownOptionByResourceName('project', project.name);
+    cy.selectDropdownOptionByResourceName('project', `${(this.globalProject as Project).name}`);
     cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
     cy.selectDropdownOptionByResourceName(
       'execution-environment-select',
@@ -105,7 +68,7 @@ describe('Job templates form Create, Edit, Delete', () => {
       });
   });
 
-  it('creation of job template using the prompt on launch wizard', () => {
+  it('creation of job template using the prompt on launch wizard', function () {
     cy.intercept('POST', `/api/v2/job_templates`).as('createPOLJT');
     const jtName = 'E2E-POLJT ' + randomString(4);
 
@@ -115,7 +78,7 @@ describe('Job templates form Create, Edit, Delete', () => {
     cy.get('[data-cy="name"]').type(jtName);
     cy.get('[data-cy="description"]').type('This is a JT with POL wizard description');
     cy.selectPromptOnLaunch('inventory');
-    cy.selectDropdownOptionByResourceName('project', project.name);
+    cy.selectDropdownOptionByResourceName('project', `${(this.globalProject as Project).name}`);
     cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
     cy.selectPromptOnLaunch('execution_environment');
     cy.selectPromptOnLaunch('credential');
@@ -133,11 +96,15 @@ describe('Job templates form Create, Edit, Delete', () => {
         });
         cy.selectDropdownOptionByResourceName('inventory', inventory.name);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('credential-select', machineCredential);
+        cy.selectDropdownOptionByResourceName('credential-select', machineCredential, true);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('execution-environment-select', executionEnvironment);
+        cy.selectDropdownOptionByResourceName(
+          'execution-environment-select',
+          executionEnvironment,
+          true
+        );
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('instance-group-select', instanceGroup);
+        cy.selectDropdownOptionByResourceName('instance-group-select', instanceGroup, true);
         cy.clickButton(/^Next/);
         cy.intercept('POST', `api/v2/job_templates/${id}/launch/`).as('postLaunch');
         cy.clickButton(/^Finish/);
@@ -161,7 +128,7 @@ describe('Job templates form Create, Edit, Delete', () => {
       });
   });
 
-  it('launch a job template from the details page launch cta using the prompt on launch', () => {
+  it('launch a job template from the details page launch cta using the prompt on launch', function () {
     cy.intercept('POST', `/api/v2/job_templates`).as('createPOLJT');
     const jtName = 'E2E-POLJT ' + randomString(4);
 
@@ -171,7 +138,7 @@ describe('Job templates form Create, Edit, Delete', () => {
     cy.get('[data-cy="name"]').type(jtName);
     cy.get('[data-cy="description"]').type('This is a JT with POL wizard description');
     cy.selectPromptOnLaunch('inventory');
-    cy.selectDropdownOptionByResourceName('project', project.name);
+    cy.selectDropdownOptionByResourceName('project', `${(this.globalProject as Project).name}`);
     cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
     cy.selectPromptOnLaunch('execution_environment');
     cy.selectPromptOnLaunch('credential');
@@ -184,11 +151,15 @@ describe('Job templates form Create, Edit, Delete', () => {
         cy.clickButton(/^Launch template$/);
         cy.selectDropdownOptionByResourceName('inventory', inventory.name);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('credential-select', machineCredential);
+        cy.selectDropdownOptionByResourceName('credential-select', machineCredential, true);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('execution-environment-select', executionEnvironment);
+        cy.selectDropdownOptionByResourceName(
+          'execution-environment-select',
+          executionEnvironment,
+          true
+        );
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('instance-group-select', instanceGroup);
+        cy.selectDropdownOptionByResourceName('instance-group-select', instanceGroup, true);
         cy.clickButton(/^Next/);
         cy.intercept('POST', `api/v2/job_templates/${id}/launch/`).as('postLaunch');
         cy.clickButton(/^Finish/);
@@ -211,10 +182,10 @@ describe('Job templates form Create, Edit, Delete', () => {
       });
   });
 
-  it('should edit a job template using the kebab menu of the template list page page', () => {
+  it('should edit a job template using the kebab menu of the template list page page', function () {
     cy.createAwxJobTemplate({
-      organization: organization.id,
-      project: project.id,
+      organization: (this.globalProjectOrg as Organization).id,
+      project: (this.globalProject as Project).id,
       inventory: inventory.id,
     }).then((jobTemplate) => {
       cy.navigateTo('awx', 'templates');
@@ -243,10 +214,10 @@ describe('Job templates form Create, Edit, Delete', () => {
     });
   });
 
-  it('should edit a job template using the edit template cta on details page', () => {
+  it('should edit a job template using the edit template cta on details page', function () {
     cy.createAwxJobTemplate({
-      organization: organization.id,
-      project: project.id,
+      organization: (this.globalProjectOrg as Organization).id,
+      project: (this.globalProject as Project).id,
       inventory: inventory.id,
     }).then((jobTemplate) => {
       cy.navigateTo('awx', 'templates');
@@ -277,10 +248,10 @@ describe('Job templates form Create, Edit, Delete', () => {
     });
   });
 
-  it('should delete a job template from the details page', () => {
+  it('should delete a job template from the details page', function () {
     cy.createAwxJobTemplate({
-      organization: organization.id,
-      project: project.id,
+      organization: (this.globalProjectOrg as Organization).id,
+      project: (this.globalProject as Project).id,
       inventory: inventory.id,
     }).then((jobTemplate) => {
       cy.navigateTo('awx', 'templates');
@@ -297,15 +268,15 @@ describe('Job templates form Create, Edit, Delete', () => {
     });
   });
 
-  it('should bulk delete job templates from the list page', () => {
+  it('should bulk delete job templates from the list page', function () {
     cy.createAwxJobTemplate({
-      organization: organization.id,
-      project: project.id,
+      organization: (this.globalProjectOrg as Organization).id,
+      project: (this.globalProject as Project).id,
       inventory: inventory.id,
     }).then((jobTemplate1) => {
       cy.createAwxJobTemplate({
-        organization: organization.id,
-        project: project.id,
+        organization: (this.globalProjectOrg as Organization).id,
+        project: (this.globalProject as Project).id,
         inventory: inventory.id,
       }).then((jobTemplate2) => {
         cy.navigateTo('awx', 'templates');

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -6,17 +6,15 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 
 describe('projects', () => {
-  let organization: Organization;
   let project: Project;
 
-  before(() => {
+  before(function () {
     cy.awxLogin();
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
-      cy.createAwxProject({ organization: organization.id }).then((proj) => {
+    cy.createAwxProject({ organization: (this.globalProjectOrg as Organization).id }).then(
+      (proj) => {
         project = proj;
-      });
-    });
+      }
+    );
   });
 
   it('can render the projects list page', function () {
@@ -29,13 +27,16 @@ describe('projects', () => {
     cy.navigateTo('awx', 'projects');
     cy.clickLink(/^Create project$/);
     cy.get('[data-cy="project-name"]').type(projectName);
-    cy.selectDropdownOptionByResourceName('organization', `${organization.name}`);
+    cy.selectDropdownOptionByResourceName(
+      'organization',
+      `${(this.globalProjectOrg as Organization).name}`
+    );
     cy.selectDropdownOptionByResourceName('source_control_type', 'Git');
     cy.get('[data-cy="project-scm-url"]').type('https://github.com/ansible/ansible-ui');
     cy.get('[data-cy="option-allow-override"]').click();
     cy.clickButton(/^Create project$/);
     cy.verifyPageTitle(projectName);
-    cy.hasDetail(/^Organization$/, `${organization.name}`);
+    cy.hasDetail(/^Organization$/, `${(this.globalProjectOrg as Organization).name}`);
     cy.hasDetail(/^Source control type$/, 'Git');
     cy.hasDetail(/^Enabled options$/, 'Allow branch override');
     cy.clickPageAction(/^Delete project/);
@@ -55,18 +56,6 @@ describe('projects', () => {
     cy.wait('@projectUpdateRequest');
   });
 
-  it('can sync project from projects list table row kebab menu', function () {
-    cy.navigateTo('awx', 'projects');
-    cy.filterTableByText(`${project.name}`);
-    cy.intercept(`api/v2/projects/${project.name}/update/`).as('projectUpdateRequest');
-    cy.contains('td', `${project.name}`)
-      .parent()
-      .within(() => {
-        cy.get('#sync-project').click();
-      });
-    cy.hasAlert(`Syncing ${project.name}`).should('be.visible');
-  });
-
   it('can edit a project from the project details tab', () => {
     cy.navigateTo('awx', 'projects');
     cy.clickTableRow(project.name);
@@ -74,10 +63,27 @@ describe('projects', () => {
     cy.clickButton(/^Edit project$/);
     cy.verifyPageTitle('Edit Project');
     cy.get('[data-cy="project-name"]').clear().type(`${project.name} - edited`);
-    cy.get('[data-cy="project-scm-branch"]').clear().type('foobar');
     cy.clickButton(/^Save project$/);
     cy.verifyPageTitle(`${project.name} - edited`);
-    cy.hasDetail(/^Source control branch$/, 'foobar');
+    cy.clickButton(/^Edit project$/);
+    cy.get('[data-cy="project-name"]').clear().type(`${project.name}`);
+    cy.clickButton(/^Save project$/);
+    cy.verifyPageTitle(project.name);
+  });
+
+  it('can sync project from projects list table row kebab menu', function () {
+    cy.navigateTo('awx', 'projects');
+    cy.filterTableByText(`${(this.globalProject as Project).name}`);
+    cy.intercept(`api/v2/projects/${(this.globalProject as Project).id}/update/`).as(
+      'projectUpdateRequest'
+    );
+    cy.contains('td', `${(this.globalProject as Project).name}`)
+      .parent()
+      .within(() => {
+        cy.get('#sync-project').click();
+      });
+    cy.hasAlert(`Syncing ${(this.globalProject as Project).name}`).should('be.visible');
+    cy.wait('@projectUpdateRequest');
   });
 
   it('can edit a project from the project list row action', () => {
@@ -87,8 +93,13 @@ describe('projects', () => {
       cy.get('[data-cy="edit-project"]').click();
     });
     cy.verifyPageTitle('Edit Project');
-    cy.clickButton(/^Cancel$/);
-    cy.verifyPageTitle('Projects');
+    cy.get('[data-cy="project-name"]').clear().type(`${project.name} - edited`);
+    cy.clickButton(/^Save project$/);
+    cy.verifyPageTitle(`${project.name} - edited`);
+    cy.clickButton(/^Edit project$/);
+    cy.get('[data-cy="project-name"]').clear().type(`${project.name}`);
+    cy.clickButton(/^Save project$/);
+    cy.verifyPageTitle(project.name);
   });
 
   it('can navigate to project details tab', function () {
@@ -106,6 +117,39 @@ describe('projects', () => {
     cy.clickTab(/^Access$/, true);
   });
 
+  it('can copy project from project details page', function () {
+    const endOfProject = project.name.split(' ').slice(-1).toString();
+    cy.navigateTo('awx', 'projects');
+    cy.searchAndDisplayResource(endOfProject);
+    cy.get('[data-cy="page-title"]').should('contain', 'Projects');
+    cy.get(`[data-cy="row-id-${project.id}"]`).within(() => {
+      cy.get('[data-cy="name-column-cell"]').click();
+    });
+    cy.intercept('POST', `/api/v2/projects/${project.id}/copy/`).as('copiedProject');
+    cy.get('[data-cy="actions-dropdown"]')
+      .click()
+      .then(() => {
+        cy.get('[data-cy="copy-project"]').click();
+      });
+    cy.wait('@copiedProject')
+      .its('response')
+      .then((response) => {
+        expect(response.statusCode).to.eq(201);
+        cy.get('[data-cy="Projects"]').eq(1).click();
+        cy.intercept(
+          'GET',
+          `/api/v2/projects/?name__icontains=${endOfProject}&order_by=name&page=1&page_size=10`
+        ).as('searchResults');
+        cy.searchAndDisplayResource(endOfProject);
+        cy.wait('@searchResults')
+          .its('response.body.count')
+          .then((response) => {
+            expect(response).to.equal(2);
+          });
+        cy.clickButton(/^Clear all filters$/);
+      });
+  });
+
   it('can navigate to project job templates tab', function () {
     cy.navigateTo('awx', 'projects');
     cy.clickTableRow(`${(this.globalProject as Project).name}`);
@@ -120,6 +164,36 @@ describe('projects', () => {
     cy.clickTab(/^Notifications$/, true);
   });
 
+  it('can copy project from projects list table row kebab menu', function () {
+    const endOfProject = project.name.split(' ').slice(-1).toString();
+    cy.navigateTo('awx', 'projects');
+    cy.searchAndDisplayResource(endOfProject);
+    cy.intercept('POST', `/api/v2/projects/${project.id}/copy/`).as('copiedProject');
+    cy.get(`[data-cy="row-id-${project.id}"]`).within(() => {
+      cy.get('[data-cy="actions-dropdown"]')
+        .click()
+        .then(() => {
+          cy.get('[data-cy="copy-project"]').click();
+        });
+    });
+    cy.wait('@copiedProject')
+      .its('response')
+      .then((response) => {
+        expect(response.statusCode).to.eq(201);
+        cy.intercept(
+          'GET',
+          `/api/v2/projects/?or__name__icontains=${endOfProject}&or__name__icontains=${endOfProject}&order_by=name&page=1&page_size=10`
+        ).as('searchResults');
+        cy.searchAndDisplayResource(endOfProject);
+        cy.wait('@searchResults')
+          .its('response.body.count')
+          .then((response) => {
+            expect(response).to.equal(3);
+          });
+        cy.clickButton(/^Clear all filters$/);
+      });
+  });
+
   it('can navigate to project schedules tab', function () {
     cy.navigateTo('awx', 'projects');
     cy.clickTableRow(`${(this.globalProject as Project).name}`);
@@ -127,21 +201,31 @@ describe('projects', () => {
     cy.clickTab(/^Schedules$/, true);
   });
 
-  it('can copy project from project details page', function () {
+  it('can delete project from projects list table row kebab menu', function () {
+    const endOfProject = project.name.split(' ').slice(-1).toString();
     cy.navigateTo('awx', 'projects');
-    cy.clickTableRow(project.name);
-    cy.get('[data-cy="page-title"]').should('contain', project.name);
-    cy.clickPageAction(/^Copy project$/);
-    cy.get('[data-cy="page-title"]')
-      .should('contain', `${project.name} - edited`)
-      .should('be.visible');
-  });
-
-  it('can copy project from projects list table row kebab menu', function () {
-    cy.navigateTo('awx', 'projects');
-    cy.searchAndDisplayResource(`${project.name} - edited`);
-    cy.clickTableRowKebabAction(`${project.name} - edited`, /^Copy project$/);
-    cy.getTableRowByText(`${project.name} - edited @`).should('be.visible');
+    cy.searchAndDisplayResource(endOfProject);
+    cy.get('[data-cy="checkbox-column-cell"]').eq(0).click();
+    cy.get('[data-cy="checkbox-column-cell"]').eq(1).click();
+    cy.get('[data-cy="checkbox-column-cell"]').eq(2).click();
+    cy.get('[data-cy="actions-dropdown"]')
+      .eq(0)
+      .click()
+      .then(() => {
+        cy.get('[data-cy="delete-selected-projects"]').click();
+      });
+    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+      cy.get('[data-ouia-component-id="confirm"]').click();
+      cy.get('[data-ouia-component-id="submit"]').click();
+      cy.get('[data-cy="status-column-cell"]').eq(0).should('contain', 'Success');
+      cy.get('[data-cy="status-column-cell"]').eq(1).should('contain', 'Success');
+      cy.get('[data-cy="status-column-cell"]').eq(2).should('contain', 'Success');
+      cy.clickButton('Close');
+    });
+    cy.clickButton(/^Clear all filters$/);
+    cy.searchAndDisplayResource(endOfProject);
+    cy.contains('h2', 'No results found').should('be.visible');
+    cy.clickButton(/^Clear all filters$/);
   });
 
   // TODO - Move this to a unit test as on an e2e server the project might sync too fast and cancel will not be avail/enabled
@@ -207,18 +291,6 @@ describe('projects', () => {
         project = proj;
       });
     });
-  });
-
-  it('can delete project from projects list table row kebab menu', function () {
-    cy.navigateTo('awx', 'projects');
-    cy.clickTableRowKebabAction(`${project.name}`, /^Delete project$/);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete project/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
-    cy.getTableRowByText(`${project.name}`).should('not.exist');
-    cy.clickButton(/^Clear all filters$/);
   });
 
   it('can delete project from projects list toolbar ', function () {

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -134,7 +134,7 @@ describe('projects', () => {
     cy.wait('@copiedProject')
       .its('response')
       .then((response) => {
-        expect(response.statusCode).to.eq(201);
+        expect(response?.statusCode).to.eq(201);
         cy.get('[data-cy="Projects"]').eq(1).click();
         cy.intercept(
           'GET',
@@ -179,7 +179,7 @@ describe('projects', () => {
     cy.wait('@copiedProject')
       .its('response')
       .then((response) => {
-        expect(response.statusCode).to.eq(201);
+        expect(response?.statusCode).to.eq(201);
         cy.intercept(
           'GET',
           `/api/v2/projects/?or__name__icontains=${endOfProject}&or__name__icontains=${endOfProject}&order_by=name&page=1&page_size=10`

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -102,21 +102,6 @@ describe('projects', () => {
     cy.verifyPageTitle(project.name);
   });
 
-  it('can navigate to project details tab', function () {
-    cy.navigateTo('awx', 'projects');
-    cy.clickTableRow(`${(this.globalProject as Project).name}`);
-    cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
-    cy.clickLink(/^Details$/);
-    cy.get('#name').should('contain', `${(this.globalProject as Project).name}`);
-  });
-
-  it('can navigate to project access tab', function () {
-    cy.navigateTo('awx', 'projects');
-    cy.clickTableRow(`${(this.globalProject as Project).name}`);
-    cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
-    cy.clickTab(/^Access$/, true);
-  });
-
   it('can copy project from project details page', function () {
     const endOfProject = project.name.split(' ').slice(-1).toString();
     cy.navigateTo('awx', 'projects');
@@ -150,18 +135,19 @@ describe('projects', () => {
       });
   });
 
-  it('can navigate to project job templates tab', function () {
+  it('can navigate to project details tab', function () {
     cy.navigateTo('awx', 'projects');
     cy.clickTableRow(`${(this.globalProject as Project).name}`);
     cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
-    cy.clickTab(/^Job templates$/, true);
+    cy.clickLink(/^Details$/);
+    cy.get('#name').should('contain', `${(this.globalProject as Project).name}`);
   });
 
-  it('can navigate to project notifications tab', function () {
+  it('can navigate to project access tab', function () {
     cy.navigateTo('awx', 'projects');
     cy.clickTableRow(`${(this.globalProject as Project).name}`);
     cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
-    cy.clickTab(/^Notifications$/, true);
+    cy.clickTab(/^Access$/, true);
   });
 
   it('can copy project from projects list table row kebab menu', function () {
@@ -192,6 +178,20 @@ describe('projects', () => {
           });
         cy.clickButton(/^Clear all filters$/);
       });
+  });
+
+  it('can navigate to project job templates tab', function () {
+    cy.navigateTo('awx', 'projects');
+    cy.clickTableRow(`${(this.globalProject as Project).name}`);
+    cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
+    cy.clickTab(/^Job templates$/, true);
+  });
+
+  it('can navigate to project notifications tab', function () {
+    cy.navigateTo('awx', 'projects');
+    cy.clickTableRow(`${(this.globalProject as Project).name}`);
+    cy.verifyPageTitle(`${(this.globalProject as Project).name}`);
+    cy.clickTab(/^Notifications$/, true);
   });
 
   it('can navigate to project schedules tab', function () {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -45,28 +45,32 @@ Cypress.Commands.add('selectPromptOnLaunch', (resourceName: string) => {
   cy.get(`[data-cy="ask_${resourceName}_on_launch"]`).click();
 });
 
-Cypress.Commands.add('selectDropdownOptionByResourceName', (resource: string, itemName: string) => {
-  cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
-    cy.get('[data-ouia-component-id="menu-select"] button')
-      .click()
-      .then(() => {
-        cy.contains('li', itemName).scrollIntoView().click();
+Cypress.Commands.add(
+  'selectDropdownOptionByResourceName',
+  (resource: string, itemName: string, spyglass?: boolean) => {
+    if (spyglass === undefined) {
+      spyglass === false;
+    }
+    if (spyglass) {
+      cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
+        cy.get('button').eq(1).click();
       });
-  });
-});
-
-Cypress.Commands.add('selectItemFromLookupModal', (resource: string, itemName: string) => {
-  cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
-    cy.get('button').eq(1).click();
-  });
-  cy.get('.pf-v5-c-modal-box').within(() => {
-    cy.searchAndDisplayResource(itemName);
-    cy.get('[data-ouia-component-id="simple-table"] tbody').within(() => {
-      cy.get('[data-cy="checkbox-column-cell"]').click();
-    });
-    cy.clickButton(/^Confirm/);
-  });
-});
+      cy.get('.pf-v5-c-modal-box').within(() => {
+        cy.searchAndDisplayResource(itemName);
+        cy.get('tbody tr input').click();
+        cy.clickButton('Confirm');
+      });
+    } else {
+      cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
+        cy.get('[data-ouia-component-id="menu-select"] button')
+          .click()
+          .then(() => {
+            cy.contains('li', itemName).click();
+          });
+      });
+    }
+  }
+);
 
 Cypress.Commands.add('setTablePageSize', (text: '10' | '20' | '50' | '100') => {
   cy.get('.pf-v5-c-pagination')

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -41,6 +41,10 @@ Cypress.Commands.add('getCheckboxByLabel', (label: string | RegExp) => {
     });
 });
 
+Cypress.Commands.add('selectPromptOnLaunch', (resourceName: string) => {
+  cy.get(`[data-cy="ask_${resourceName}_on_launch"]`).click();
+});
+
 Cypress.Commands.add('selectDropdownOptionByResourceName', (resource: string, itemName: string) => {
   cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
     cy.get('[data-ouia-component-id="menu-select"] button')
@@ -50,37 +54,6 @@ Cypress.Commands.add('selectDropdownOptionByResourceName', (resource: string, it
       });
   });
 });
-
-Cypress.Commands.add('selectPromptOnLaunch', (resourceName: string) => {
-  cy.get(`[data-cy="ask_${resourceName}_on_launch"]`).click();
-});
-
-Cypress.Commands.add(
-  'selectDropdownOptionByResourceName',
-  (resource: string, itemName: string, spyglass?: boolean) => {
-    if (spyglass === undefined) {
-      spyglass === false;
-    }
-    if (spyglass) {
-      cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
-        cy.get('button').eq(1).click();
-      });
-      cy.get('.pf-v5-c-modal-box').within(() => {
-        cy.searchAndDisplayResource(itemName);
-        cy.get('tbody tr input').click();
-        cy.clickButton('Confirm');
-      });
-    } else {
-      cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {
-        cy.get('[data-ouia-component-id="menu-select"] button')
-          .click()
-          .then(() => {
-            cy.contains('li', itemName).click();
-          });
-      });
-    }
-  }
-);
 
 Cypress.Commands.add('selectItemFromLookupModal', (resource: string, itemName: string) => {
   cy.get(`[data-cy*="${resource}-form-group"]`).within(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -71,8 +71,11 @@ declare global {
       getCheckboxByLabel(label: string | RegExp): Chainable<JQuery<HTMLElement>>;
 
       /**
-       * @param {String} resource: The name of a resource. IE: credentials, execution-environments, etc.
-       * @param {String} itemName: The specific name of that resource.
+       * This command works for a form field that can show up either as a drop down
+       * or as a spyglass lookup.
+       *
+       * @param {String} resource: The name of a resource entered as a string. IE: credentials, execution-environments, etc.
+       * @param {String} itemName: The specific name of that resource entered as a string.
        * @param {Boolean} spyglass: This is an optional boolean value, and will default to false. Set as a third param
        * to 'true' if the formgroup contains a spyglass to be clicked on.
        * Finds a dropdown/select component by its data-cy form-group and clicks on the option
@@ -172,8 +175,6 @@ declare global {
         label: string | RegExp,
         filter?: boolean
       ): Chainable<void>;
-
-      selectItemFromLookupModal(resource: string, itemName: string): Chainable<void>;
 
       /**
        * Finds a list card containing text and clicks action specified by label.

--- a/cypress/support/global-project.ts
+++ b/cypress/support/global-project.ts
@@ -151,7 +151,3 @@ export function createGlobalProject() {
       }
     });
 }
-
-module.exports = {
-  createGlobalProject,
-};

--- a/cypress/support/global-project.ts
+++ b/cypress/support/global-project.ts
@@ -5,6 +5,7 @@ import { Project } from '../../frontend/awx/interfaces/Project';
 const GLOBAL_PROJECT_NAME = 'Global Project for E2E tests';
 const GLOBAL_PROJECT_DESCRIPTION = 'Global Read Only Project for E2E tests';
 const GLOBAL_PROJECT_SCM_URL = 'https://github.com/ansible/ansible-ui';
+const GLOBAL_ORG_NAME = 'Global Project Org';
 
 /**
  * Check if the Global Project exists in controller.
@@ -26,27 +27,32 @@ const GLOBAL_PROJECT_SCM_URL = 'https://github.com/ansible/ansible-ui';
 
 export function createGlobalProject() {
   cy.log('👀<<CHECKING EXISTENCE OF GLOBAL PROJECT>>👀');
-  cy.awxRequestGet<AwxItemsResponse<Project>>(`/api/v2/projects?name__startswith=Global&page=1`);
+
   cy.awxRequestGet<AwxItemsResponse<Project>>(`/api/v2/projects?name=${GLOBAL_PROJECT_NAME}&page=1`)
     .its('results')
-    .then((results: Project[]) => {
-      if (results.length === 0) {
+    .then((projectResults: Project[]) => {
+      //if no global project is returned from the API, then:
+      if (projectResults.length === 0) {
+        //check to see if a global org exists
         cy.log('👀<<CHECKING EXISTENCE OF GLOBAL ORGANIZATION>>👀');
         cy.awxRequestGet<AwxItemsResponse<Organization>>(
           `/api/v2/organizations?name__startswith=Global&page=1`
         )
           .its('results')
-          .then((orgs: Organization[]) => {
-            if (orgs.length === 0) {
+          .then((orgResults: Organization[]) => {
+            //if no global org or global project exist:
+            if (orgResults.length === 0) {
               cy.log('🚨GLOBAL ORG AND GLOBAL PROJECT NOT FOUND🚨.....🚧CREATING BOTH🚧');
-              cy.createAwxOrganization('Global Project Org').then((newGlobalProjectOrg) => {
+              //create the global org
+              cy.createAwxOrganization('Global Project Org').then((globalProjectOrg) => {
                 cy.log(
                   '🎉GLOBAL ORG CREATED🎉....ACCESS IT USING this.globalProjectOrg IN THE TESTS.'
                 );
+                //create the global project
                 cy.awxRequestPost<Partial<Project>, Project>('/api/v2/projects/', {
                   name: GLOBAL_PROJECT_NAME,
                   description: GLOBAL_PROJECT_DESCRIPTION,
-                  organization: newGlobalProjectOrg.id,
+                  organization: globalProjectOrg.id,
                   scm_type: 'git',
                   scm_url: GLOBAL_PROJECT_SCM_URL,
                 }).then((globalProject: Project) => {
@@ -55,18 +61,21 @@ export function createGlobalProject() {
                   cy.log(
                     '🎉GLOBAL PROJECT CREATED🎉....ACCESS IT USING this.globalProject IN THE TESTS.'
                   );
-                  cy.wrap(newGlobalProjectOrg).as('globalProjectOrg');
-                  return cy.wrap(globalProject).as('globalProject');
+                  //return the global org and global project
+                  cy.wrap(globalProject).as('globalProject');
+                  cy.wrap(globalProjectOrg).as('globalProjectOrg');
                 });
               });
-            } else {
+            } else if (orgResults.length === 1) {
+              //if a global org is found but no global project is found, then:
               cy.log('🎉GLOBAL ORG FOUND🎉....ACCESS IT USING this.globalProjectOrg IN THE TESTS.');
-              cy.wrap(orgs[0]).then((foundGlobalProjectOrg) => {
+              cy.wrap(orgResults[0]).then((globalProjectOrg) => {
                 cy.log('🚨GLOBAL PROJECT NOT FOUND🚨......🚧CREATING🚧');
+                //create a new global project using the found global org
                 cy.awxRequestPost<Partial<Project>, Project>('/api/v2/projects/', {
                   name: GLOBAL_PROJECT_NAME,
                   description: GLOBAL_PROJECT_DESCRIPTION,
-                  organization: foundGlobalProjectOrg.id,
+                  organization: globalProjectOrg.id,
                   scm_type: 'git',
                   scm_url: GLOBAL_PROJECT_SCM_URL,
                 }).then((globalProject: Project) => {
@@ -75,29 +84,70 @@ export function createGlobalProject() {
                   cy.log(
                     '🎉GLOBAL PROJECT CREATED🎉....ACCESS IT USING this.globalProject IN THE TESTS.'
                   );
-                  cy.wrap(foundGlobalProjectOrg).as('globalProjectOrg');
-                  return cy.wrap(globalProject).as('globalProject');
+                  //return the global org and global project
+                  cy.wrap(globalProject).as('globalProject');
+                  cy.wrap(globalProjectOrg).as('globalProjectOrg');
                 });
               });
             }
           });
       } else {
-        cy.log('🎉GLOBAL ORG FOUND🎉....ACCESS IT USING this.globalProjectOrg IN THE TESTS.');
+        //if the API request returns a global project, check to see if there is a global org:
+        cy.log('👀<<CHECKING EXISTENCE OF GLOBAL ORGANIZATION>>👀');
         cy.awxRequestGet<AwxItemsResponse<Organization>>(
           `/api/v2/organizations?name__startswith=Global&page=1`
         )
           .its('results')
-          .then((orgs: Organization[]) => {
-            cy.wrap(orgs[0]).as('globalProjectOrg');
+          .then((orgResults: Organization[]) => {
+            //if no global org exists:
+            if (orgResults.length === 0) {
+              //create a global org
+              cy.createAwxOrganization('Global Project Org').then((globalProjectOrg) => {
+                cy.log(
+                  '🎉GLOBAL ORG CREATED🎉....ACCESS IT USING this.globalProjectOrg IN THE TESTS.'
+                );
+                //delete the global project
+                cy.awxRequestDelete(`/api/v2/projects/${projectResults[0].id}/`);
+                //create a new global project using the global org
+                cy.awxRequestPost<Partial<Project>, Project>('/api/v2/projects/', {
+                  name: GLOBAL_PROJECT_NAME,
+                  description: GLOBAL_PROJECT_DESCRIPTION,
+                  organization: globalProjectOrg.id,
+                  scm_type: 'git',
+                  scm_url: GLOBAL_PROJECT_SCM_URL,
+                }).then((globalProject: Project) => {
+                  cy.log('🕓<<WAITING FOR PROJECT TO SYNC>>🕓');
+                  cy.waitForProjectToFinishSyncing(globalProject.id);
+                  cy.log(
+                    '🎉GLOBAL PROJECT CREATED🎉....ACCESS IT USING this.globalProject IN THE TESTS.'
+                  );
+                  //return the global org and the global project
+                  cy.wrap(globalProject).as('globalProject');
+                  cy.wrap(globalProjectOrg).as('globalProjectOrg');
+                });
+              });
+            } else if (orgResults.length === 1) {
+              //if one global org is returned from the API, get it:
+              cy.log('🎉GLOBAL ORG FOUND🎉....ACCESS IT USING this.globalProjectOrg IN THE TESTS.');
+              cy.wrap(orgResults[0])
+                .as('globalProjectOrg')
+                //get the global project
+                .then((globalProjectOrg) => {
+                  cy.log(
+                    '🎉GLOBAL PROJECT FOUND🎉....ACCESS IT USING this.globalProject IN THE TESTS.',
+                    projectResults[0]
+                  );
+                  //assert properties of the global org and global project
+                  expect(orgResults[0].name).to.equal(GLOBAL_ORG_NAME);
+                  expect(projectResults[0].name).to.equal(GLOBAL_PROJECT_NAME);
+                  expect(projectResults[0].description).to.equal(GLOBAL_PROJECT_DESCRIPTION);
+                  expect(projectResults[0].scm_url).to.equal(GLOBAL_PROJECT_SCM_URL);
+                  //return the global org and global project
+                  cy.wrap(projectResults[0]).as('globalProject');
+                  cy.wrap(globalProjectOrg).as('globalProjectOrg');
+                });
+            }
           });
-        cy.log(
-          '🎉GLOBAL PROJECT FOUND🎉....ACCESS IT USING this.globalProject IN THE TESTS.',
-          results[0]
-        );
-        expect(results[0].name).to.equal(GLOBAL_PROJECT_NAME);
-        expect(results[0].description).to.equal(GLOBAL_PROJECT_DESCRIPTION);
-        expect(results[0].scm_url).to.equal(GLOBAL_PROJECT_SCM_URL);
-        return cy.wrap(results[0]).as('globalProject');
       }
     });
 }


### PR DESCRIPTION
This PR:

- utilizes the global organization in the organization spec file for AWX
- utilizes the global org and global project in the job templates spec file for AWX
- refactors the tests on the projects spec file to use the global org and global project
- refactors the projects tests so that the extra projects that are created get deleted after the tests run
- deletes some extra custom commands that were added erroneously
- adds pseudo code to the global-project.cy.ts file that explains what the code is doing