### PR TITLE
[AAP-12326] Remove modal dialog for rulebook activation enable/disable

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -1,6 +1,6 @@
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { RedoIcon, TrashIcon } from '@patternfly/react-icons';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -14,39 +14,25 @@ import {
   usePageNavigate,
 } from '../../../../framework';
 import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
-import { useGetItem } from '../../../common/crud/useGet';
+import { useGet } from '../../../common/crud/useGet';
 import { EdaRoute } from '../../EdaRoutes';
-import { API_PREFIX } from '../../constants';
+import { API_PREFIX, SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { Status906Enum } from '../../interfaces/generated/eda-api';
-import {
-  useDisableRulebookActivations,
-  useEnableRulebookActivations,
-  useRestartRulebookActivations,
-} from '../hooks/useControlRulebookActivations';
+import { useRestartRulebookActivations } from '../hooks/useControlRulebookActivations';
 import { useDeleteRulebookActivations } from '../hooks/useDeleteRulebookActivations';
+import { postRequest } from '../../../common/crud/Data';
 
 export function RulebookActivationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const { data: rulebookActivation, refresh } = useGetItem<EdaRulebookActivation>(
-    `${API_PREFIX}/activations/`,
-    params.id
+  const { data: rulebookActivation, refresh } = useGet<EdaRulebookActivation>(
+    `${API_PREFIX}/activations/${params.id}/`,
+    undefined,
+    { refreshInterval: SWR_REFRESH_INTERVAL }
   );
-
-  const enableRulebookActivation = useEnableRulebookActivations((enabled) => {
-    if (enabled.length > 0) {
-      refresh();
-    }
-  });
-
-  const disableRulebookActivation = useDisableRulebookActivations((disabled) => {
-    if (disabled.length > 0) {
-      refresh();
-    }
-  });
 
   const restartRulebookActivation = useRestartRulebookActivations((restarted) => {
     if (restarted.length > 0) {
@@ -59,6 +45,19 @@ export function RulebookActivationPage() {
       pageNavigate(EdaRoute.RulebookActivations);
     }
   });
+
+  const handleToggle: (activation: EdaRulebookActivation, enabled: boolean) => Promise<void> =
+    useCallback(
+      async (activation, enabled) => {
+        await postRequest(
+          `${API_PREFIX}/activations/${activation.id}/${enabled ? 'enable/' : 'disable/'}`,
+          undefined
+        );
+        refresh();
+      },
+      [refresh]
+    );
+
   const itemActions = useMemo<IPageAction<EdaRulebookActivation>[]>(() => {
     const actions: IPageAction<EdaRulebookActivation>[] = [
       {
@@ -69,10 +68,8 @@ export function RulebookActivationPage() {
         isPinned: true,
         label: t('Rulebook activation enabled'),
         labelOff: t('Rulebook activation disabled'),
-        onToggle: (activation: EdaRulebookActivation, activate: boolean) => {
-          if (activate) void enableRulebookActivation([activation]);
-          else void disableRulebookActivation([activation]);
-        },
+        onToggle: (activation: EdaRulebookActivation, activate: boolean) =>
+          handleToggle(activation, activate),
         isSwitchOn: (activation: EdaRulebookActivation) => activation.is_enabled ?? false,
         isDisabled: (activation: EdaRulebookActivation) =>
           activation.status === Status906Enum.Stopping
@@ -99,13 +96,7 @@ export function RulebookActivationPage() {
       },
     ];
     return actions;
-  }, [
-    enableRulebookActivation,
-    disableRulebookActivation,
-    restartRulebookActivation,
-    deleteRulebookActivations,
-    t,
-  ]);
+  }, [handleToggle, restartRulebookActivation, deleteRulebookActivations, t]);
 
   return (
     <PageLayout>

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationActions.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationActions.tsx
@@ -5,19 +5,13 @@ import { IPageAction, PageActionSelection, PageActionType } from '../../../../fr
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { Status906Enum } from '../../interfaces/generated/eda-api';
 import { IEdaView } from '../../useEventDrivenView';
-import {
-  useDisableRulebookActivations,
-  useEnableRulebookActivations,
-  useRestartRulebookActivations,
-} from './useControlRulebookActivations';
+import { useRestartRulebookActivations } from './useControlRulebookActivations';
 import { useDeleteRulebookActivations } from './useDeleteRulebookActivations';
 import { postRequest } from '../../../common/crud/Data';
 import { API_PREFIX } from '../../constants';
 
 export function useRulebookActivationActions(view: IEdaView<EdaRulebookActivation>) {
   const { t } = useTranslation();
-  const enableActivations = useEnableRulebookActivations(view.unselectItemsAndRefresh);
-  const disableActivations = useDisableRulebookActivations(view.unselectItemsAndRefresh);
   const restartActivations = useRestartRulebookActivations(view.unselectItemsAndRefresh);
   const deleteRulebookActivations = useDeleteRulebookActivations(view.unselectItemsAndRefresh);
 
@@ -78,5 +72,5 @@ export function useRulebookActivationActions(view: IEdaView<EdaRulebookActivatio
       },
     ];
     return actions;
-  }, [t, restartActivations, enableActivations, disableActivations, deleteRulebookActivations]);
+  }, [t, restartActivations, deleteRulebookActivations, handleToggle]);
 }


### PR DESCRIPTION
Remove modal dialog for rulebook activation enable/disable and add an alert that the activation was enabled/disabled successfully or an error alert if the enable/disable fails.

![Screenshot from 2023-10-25 16-08-54](https://github.com/ansible/ansible-ui/assets/12769982/5fc00707-18da-4d40-b37d-6c43e7ca16ec)
![Screenshot from 2023-10-25 16-08-45](https://github.com/ansible/ansible-ui/assets/12769982/0d7f590f-6d43-444e-a58d-794c7e4d0591)
