### PR TITLE
E2E clear table filters at the beginning of each test on navigateTo

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -113,6 +113,7 @@ Cypress.Commands.add('navigateTo', (component: string, label: string) => {
       cy.get(`[data-cy="${component}-${label}"]`).click();
     }
   });
+  cy.clearAllFilters();
   cy.get('[data-cy="refresh"]').click();
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -10,6 +10,7 @@ import { Credential } from '../../frontend/awx/interfaces/Credential';
 import { ExecutionEnvironment } from '../../frontend/awx/interfaces/ExecutionEnvironment';
 import { InstanceGroup } from '../../frontend/awx/interfaces/InstanceGroup';
 import { Inventory } from '../../frontend/awx/interfaces/Inventory';
+import { InventorySource } from '../../frontend/awx/interfaces/InventorySource';
 import { JobEvent } from '../../frontend/awx/interfaces/JobEvent';
 import { JobTemplate } from '../../frontend/awx/interfaces/JobTemplate';
 import { Label } from '../../frontend/awx/interfaces/Label';
@@ -18,7 +19,6 @@ import { Project } from '../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../frontend/awx/interfaces/Schedule';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { User } from '../../frontend/awx/interfaces/User';
-import { InventorySource } from '../../frontend/awx/interfaces/InventorySource';
 import {
   CredentialType,
   Group,
@@ -139,6 +139,8 @@ declare global {
 
       /** Filter the table using specified filter and text. */
       filterTableByTypeAndText(filterLabel: string | RegExp, text: string): Chainable<void>;
+
+      clearAllFilters(): Chainable<void>;
 
       selectDetailsPageKebabAction(dataCy: string): Chainable<void>;
 

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -43,6 +43,17 @@ Cypress.Commands.add('filterTableByTypeAndText', (filterLabel: string | RegExp, 
   cy.filterTableByText(text);
 });
 
+Cypress.Commands.add('clearAllFilters', () => {
+  cy.get('button').then((buttons) => {
+    for (let i = 0; i <= buttons.length; i++) {
+      const button = buttons[i];
+      if (button?.innerText === 'Clear all filters') {
+        cy.wrap(button).click();
+      }
+    }
+  });
+});
+
 Cypress.Commands.add(
   'filterBySingleSelection',
   (filterType: RegExp | string, selectLabel: RegExp | string) => {


### PR DESCRIPTION
Test should expect that there are no active filters from previous tests.
There are test cases and retries that leave old filters active.
This clears the filters at the beginning of each test when the test uses cy.navigateTo