### PR TITLE
Adds support for workflow approval list in AWX

### DIFF
--- a/cypress/fixtures/workflowApprovals.json
+++ b/cypress/fixtures/workflowApprovals.json
@@ -1,0 +1,496 @@
+{
+  "count": 6,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 130,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/130/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/10/",
+        "source_workflow_job": "/api/v2/workflow_jobs/129/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/10/",
+        "approve": "/api/v2/workflow_approvals/130/approve/",
+        "deny": "/api/v2/workflow_approvals/130/deny/",
+        "approved_or_denied_by": "/api/v2/users/2/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 129,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "timeout": 0
+        },
+        "unified_job_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "approved_or_denied_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": false,
+          "start": false
+        },
+        "source_workflow_job": {
+          "id": 129,
+          "name": "test wf",
+          "description": "",
+          "status": "failed",
+          "failed": true,
+          "elapsed": 26.803
+        }
+      },
+      "created": "2023-10-24T20:13:25.488787Z",
+      "modified": "2023-10-24T20:13:51.609468Z",
+      "name": "read only approval",
+      "description": "",
+      "unified_job_template": 10,
+      "launch_type": "workflow",
+      "status": "failed",
+      "execution_environment": null,
+      "failed": true,
+      "started": "2023-10-24T20:13:25.488787Z",
+      "finished": "2023-10-24T20:13:51.587179Z",
+      "canceled_on": null,
+      "elapsed": 26.098,
+      "job_explanation": "",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": false,
+      "approval_expiration": null,
+      "timed_out": false
+    },
+    {
+      "id": 131,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/131/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/11/",
+        "source_workflow_job": "/api/v2/workflow_jobs/129/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/11/",
+        "approve": "/api/v2/workflow_approvals/131/approve/",
+        "deny": "/api/v2/workflow_approvals/131/deny/",
+        "approved_or_denied_by": "/api/v2/users/2/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 129,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "timeout": 300
+        },
+        "unified_job_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "approved_or_denied_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": true,
+          "start": true
+        },
+        "source_workflow_job": {
+          "id": 129,
+          "name": "test wf",
+          "description": "",
+          "status": "failed",
+          "failed": true,
+          "elapsed": 26.803
+        }
+      },
+      "created": "2023-10-24T20:13:25.667326Z",
+      "modified": "2023-10-24T20:13:45.318191Z",
+      "name": "can delete approval",
+      "description": "",
+      "unified_job_template": 11,
+      "launch_type": "workflow",
+      "status": "successful",
+      "execution_environment": null,
+      "failed": false,
+      "started": "2023-10-24T20:13:25.667326Z",
+      "finished": "2023-10-24T20:13:45.294238Z",
+      "canceled_on": null,
+      "elapsed": 19.627,
+      "job_explanation": "",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": false,
+      "approval_expiration": null,
+      "timed_out": false
+    },
+    {
+      "id": 133,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/133/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/10/",
+        "source_workflow_job": "/api/v2/workflow_jobs/132/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/10/",
+        "approve": "/api/v2/workflow_approvals/133/approve/",
+        "deny": "/api/v2/workflow_approvals/133/deny/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 132,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "timeout": 0
+        },
+        "unified_job_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": true,
+          "start": true
+        },
+        "source_workflow_job": {
+          "id": 132,
+          "name": "test wf",
+          "description": "",
+          "status": "canceled",
+          "failed": true,
+          "elapsed": 74.658,
+          "canceled_on": "2023-10-24T20:15:11.273631Z"
+        }
+      },
+      "created": "2023-10-24T20:14:05.026277Z",
+      "modified": "2023-10-24T20:14:05.026357Z",
+      "name": "test approval",
+      "description": "",
+      "unified_job_template": 10,
+      "launch_type": "workflow",
+      "status": "canceled",
+      "execution_environment": null,
+      "failed": true,
+      "started": "2023-10-24T20:14:05.026277Z",
+      "finished": "2023-10-24T20:15:11.470637Z",
+      "canceled_on": "2023-10-24T20:15:11.439260Z",
+      "elapsed": 66.444,
+      "job_explanation": "",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": false,
+      "approval_expiration": null,
+      "timed_out": false
+    },
+    {
+      "id": 138,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/138/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/11/",
+        "source_workflow_job": "/api/v2/workflow_jobs/136/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/11/",
+        "approve": "/api/v2/workflow_approvals/138/approve/",
+        "deny": "/api/v2/workflow_approvals/138/deny/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 136,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "timeout": 300
+        },
+        "unified_job_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": true,
+          "start": true
+        },
+        "source_workflow_job": {
+          "id": 136,
+          "name": "test wf",
+          "description": "",
+          "status": "failed",
+          "failed": true,
+          "elapsed": 87.747
+        }
+      },
+      "created": "2023-10-24T20:15:42.681191Z",
+      "modified": "2023-10-24T20:15:42.681243Z",
+      "name": "approval with timeout",
+      "description": "",
+      "unified_job_template": 11,
+      "launch_type": "workflow",
+      "status": "failed",
+      "execution_environment": null,
+      "failed": true,
+      "started": "2023-10-24T20:15:42.681191Z",
+      "finished": "2023-10-24T20:16:59.197451Z",
+      "canceled_on": null,
+      "elapsed": 76.516,
+      "job_explanation": "The approval node approval with timeout (138) has expired after 60 seconds.",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": false,
+      "approval_expiration": null,
+      "timed_out": true
+    },
+    {
+      "id": 140,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/140/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/10/",
+        "source_workflow_job": "/api/v2/workflow_jobs/139/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/10/",
+        "approve": "/api/v2/workflow_approvals/140/approve/",
+        "deny": "/api/v2/workflow_approvals/140/deny/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 139,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "timeout": 0
+        },
+        "unified_job_template": {
+          "id": 10,
+          "name": "test approval",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": true,
+          "start": true
+        },
+        "source_workflow_job": {
+          "id": 139,
+          "name": "test wf",
+          "description": "",
+          "status": "running",
+          "failed": false,
+          "elapsed": 0.0
+        }
+      },
+      "created": "2023-10-24T20:17:43.019082Z",
+      "modified": "2023-10-24T20:17:43.019158Z",
+      "name": "cannot approve or deny",
+      "description": "",
+      "unified_job_template": 10,
+      "launch_type": "workflow",
+      "status": "pending",
+      "execution_environment": null,
+      "failed": false,
+      "started": "2023-10-24T20:17:43.019082Z",
+      "finished": null,
+      "canceled_on": null,
+      "elapsed": 7.428912,
+      "job_explanation": "",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": false,
+      "approval_expiration": null,
+      "timed_out": false
+    },
+    {
+      "id": 141,
+      "type": "workflow_approval",
+      "url": "/api/v2/workflow_approvals/141/",
+      "related": {
+        "created_by": "/api/v2/users/2/",
+        "unified_job_template": "/api/v2/workflow_approval_templates/11/",
+        "source_workflow_job": "/api/v2/workflow_jobs/139/",
+        "workflow_approval_template": "/api/v2/workflow_approval_templates/11/",
+        "approve": "/api/v2/workflow_approvals/141/approve/",
+        "deny": "/api/v2/workflow_approvals/141/deny/"
+      },
+      "summary_fields": {
+        "workflow_job_template": {
+          "id": 9,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_job": {
+          "id": 139,
+          "name": "test wf",
+          "description": ""
+        },
+        "workflow_approval_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "timeout": 300
+        },
+        "unified_job_template": {
+          "id": 11,
+          "name": "approval with timeout",
+          "description": "",
+          "unified_job_type": "workflow_approval"
+        },
+        "created_by": {
+          "id": 2,
+          "username": "test",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "delete": true,
+          "start": true
+        },
+        "source_workflow_job": {
+          "id": 139,
+          "name": "test wf",
+          "description": "",
+          "status": "running",
+          "failed": false,
+          "elapsed": 0.0
+        }
+      },
+      "created": "2023-10-24T20:17:43.257815Z",
+      "modified": "2023-10-24T20:17:43.257868Z",
+      "name": "can approve or deny",
+      "description": "",
+      "unified_job_template": 11,
+      "launch_type": "workflow",
+      "status": "pending",
+      "execution_environment": null,
+      "failed": false,
+      "started": "2023-10-24T20:17:43.257815Z",
+      "finished": null,
+      "canceled_on": null,
+      "elapsed": 7.26841,
+      "job_explanation": "",
+      "launched_by": {
+        "id": 2,
+        "name": "test",
+        "type": "user",
+        "url": "/api/v2/users/2/"
+      },
+      "work_unit_id": null,
+      "can_approve_or_deny": true,
+      "approval_expiration": "2023-10-24T20:22:43.257815Z",
+      "timed_out": false
+    }
+  ]
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -113,6 +113,8 @@ declare global {
       ): Chainable<void>;
       selectMultiSelectOption(selector: string, label: string | RegExp): Chainable<void>;
 
+      clickTableHeader(name: string | RegExp): Chainable<void>;
+
       // --- TABLE COMMANDS ---
 
       /** Change the current filter type in the table toolbar. */

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -140,3 +140,7 @@ Cypress.Commands.add('selectMultiSelectOption', (selector: string, label: string
         });
     });
 });
+
+Cypress.Commands.add('clickTableHeader', (text: string | RegExp) => {
+  cy.get('thead').find('th').contains(text).click();
+});

--- a/framework/PageActions/PageActionDropdown.tsx
+++ b/framework/PageActions/PageActionDropdown.tsx
@@ -15,6 +15,7 @@ import { getID } from '../hooks/useID';
 import { IPageAction, PageActionSelection, PageActionType } from './PageAction';
 import { PageActionSwitch } from './PageActionSwitch';
 import { isPageActionHidden, usePageActionDisabled } from './PageActionUtils';
+import { useTranslation } from 'react-i18next';
 
 const IconSpan = styled.span`
   padding-right: 4px;
@@ -177,6 +178,7 @@ function PageDropdownActionItem<T extends object>(props: {
   index: number;
 }): JSX.Element {
   const { action, selectedItems, selectedItem, hasIcons, hasSwitches, index } = props;
+  const { t } = useTranslation();
   const isPageActionDisabled = usePageActionDisabled<T>();
   const isDisabled = isPageActionDisabled(action, selectedItem, selectedItems);
 
@@ -187,7 +189,7 @@ function PageDropdownActionItem<T extends object>(props: {
       let tooltip = isDisabled ?? action.tooltip;
       let isButtonDisabled = !!isDisabled;
       if (action.selection === PageActionSelection.Multiple && !selectedItems.length) {
-        tooltip = 'No selections';
+        tooltip = t(`Select at least one item from the list`);
         isButtonDisabled = true;
       }
       return (

--- a/frontend/awx/AwxRoutes.tsx
+++ b/frontend/awx/AwxRoutes.tsx
@@ -18,6 +18,8 @@ export enum AwxRoute {
 
   WorkflowApprovals = 'awx-workflow-approvals',
   WorkflowApprovalPage = 'awx-workflow-approval-page',
+  WorkflowApprovalDetails = 'awx-workflow-approval-details',
+  WorkflowApprovalWorkflowJobDetails = 'awx-workflow-approval-workflow-job-details',
 
   // Resources
 

--- a/frontend/awx/interfaces/WorkflowApproval.ts
+++ b/frontend/awx/interfaces/WorkflowApproval.ts
@@ -1,0 +1,41 @@
+import { WorkflowApproval as SwaggerWorkflowApproval } from './generated-from-swagger/api';
+import {
+  SummaryFieldJob,
+  SummaryFieldsByUser,
+  SummaryFieldWorkflowJob,
+  SummaryFieldWorkflowJobTemplate,
+  SummaryFieldWorkflowApprovalTemplate,
+  SummaryFieldUnifiedJobTemplate,
+} from './summary-fields/summary-fields';
+
+export interface WorkflowApproval
+  extends Omit<
+    SwaggerWorkflowApproval,
+    'id' | 'name' | 'summary_fields' | 'status' | 'timed_out' | 'elapsed'
+  > {
+  id: number;
+  name: string;
+  summary_fields: {
+    workflow_job_template: SummaryFieldWorkflowJobTemplate;
+    workflow_job: SummaryFieldWorkflowJob;
+    workflow_approval_template: SummaryFieldWorkflowApprovalTemplate;
+    unified_job_template: SummaryFieldUnifiedJobTemplate;
+    created_by: SummaryFieldsByUser;
+    user_capabilities: {
+      delete: boolean;
+      start: boolean;
+    };
+    source_workflow_job: SummaryFieldJob;
+  };
+  status:
+    | 'new'
+    | 'pending'
+    | 'waiting'
+    | 'running'
+    | 'successful'
+    | 'failed'
+    | 'error'
+    | 'canceled';
+  timed_out: boolean;
+  elapsed: number;
+}

--- a/frontend/awx/interfaces/WorkflowJob.ts
+++ b/frontend/awx/interfaces/WorkflowJob.ts
@@ -1,0 +1,40 @@
+import { Label } from './Label';
+import { WorkflowJob as SwaggerWorkflowJob } from './generated-from-swagger/api';
+
+import {
+  SummaryFieldsByUser,
+  SummaryFieldWorkflowJobTemplate,
+  SummaryFieldUnifiedJobTemplate,
+  SummaryFieldInventory,
+} from './summary-fields/summary-fields';
+
+export interface WorkflowJob
+  extends Omit<
+    SwaggerWorkflowJob,
+    'id' | 'name' | 'summary_fields' | 'launched_by' | 'extra_vars'
+  > {
+  id: number;
+  name: string;
+  summary_fields: {
+    inventory?: SummaryFieldInventory;
+    workflow_job_template: SummaryFieldWorkflowJobTemplate;
+    unified_job_template: SummaryFieldUnifiedJobTemplate;
+    created_by: SummaryFieldsByUser;
+    modified_by: SummaryFieldsByUser;
+    user_capabilities: {
+      delete: boolean;
+      start: boolean;
+    };
+    labels: {
+      count: number;
+      results: Label[];
+    };
+  };
+  launched_by: {
+    id?: number;
+    name?: string;
+    type?: string;
+    url?: string;
+  };
+  extra_vars: string;
+}

--- a/frontend/awx/interfaces/summary-fields/summary-fields.tsx
+++ b/frontend/awx/interfaces/summary-fields/summary-fields.tsx
@@ -57,6 +57,47 @@ export interface SummaryFieldInventory {
   total_inventory_sources: number;
 }
 
+export interface SummaryFieldWorkflowJob {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export interface SummaryFieldWorkflowJobTemplate {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export interface SummaryFieldWorkflowApprovalTemplate {
+  id: number;
+  name: string;
+  description: string;
+  timeout: number;
+}
+
+export interface SummaryFieldUnifiedJobTemplate {
+  id: number;
+  name: string;
+  description: string;
+  unified_job_type: string;
+}
+
+export interface SummaryFieldInventory {
+  id: number;
+  name: string;
+  description: string;
+  has_active_failures: boolean;
+  total_hosts: number;
+  hosts_with_active_failures: number;
+  total_groups: number;
+  has_inventory_sources: boolean;
+  total_inventory_sources: number;
+  inventory_sources_with_failures: number;
+  organization_id: number;
+  kind: string;
+}
+
 export interface JobSummaryFields {
   organization?: SummaryFieldsOrganization;
   inventory?: {

--- a/frontend/awx/routes/useAwxWorkflowApprovalRoutes.tsx
+++ b/frontend/awx/routes/useAwxWorkflowApprovalRoutes.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { PageNavigationItem } from '../../../framework';
 import { PageNotImplemented } from '../../../framework/PageEmptyStates/PageNotImplemented';
 import { AwxRoute } from '../AwxRoutes';
+import { WorkflowApprovalPage } from '../views/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalPage';
+import WorkflowApprovals from '../views/workflow-approvals/WorkflowApprovals';
 
 export function useAwxWorkflowApprovalRoutes() {
   const { t } = useTranslation();
@@ -15,11 +17,23 @@ export function useAwxWorkflowApprovalRoutes() {
         {
           id: AwxRoute.WorkflowApprovalPage,
           path: ':id/',
-          element: <PageNotImplemented />,
+          element: <WorkflowApprovalPage />,
+          children: [
+            {
+              id: AwxRoute.WorkflowApprovalDetails,
+              path: 'details',
+              element: <PageNotImplemented />,
+            },
+            {
+              id: AwxRoute.WorkflowApprovalWorkflowJobDetails,
+              path: 'workflow-job-details',
+              element: <PageNotImplemented />,
+            },
+          ],
         },
         {
           path: '',
-          element: <PageNotImplemented />,
+          element: <WorkflowApprovals />,
         },
       ],
     }),

--- a/frontend/awx/views/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalPage.tsx
+++ b/frontend/awx/views/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalPage.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { PageHeader, PageLayout } from '../../../../../framework';
+import { PageRoutedTabs } from '../../../../../framework/PageTabs/PageRoutedTabs';
+import { LoadingPage } from '../../../../../framework/components/LoadingPage';
+import { AwxRoute } from '../../../AwxRoutes';
+import { useGetItem } from '../../../../common/crud/useGet';
+import { AwxError } from '../../../common/AwxError';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+
+export function WorkflowApprovalPage() {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const {
+    error,
+    data: workflow_approval,
+    refresh,
+  } = useGetItem<WorkflowApproval>('/api/v2/workflow_approvals', params.id);
+
+  if (error) return <AwxError error={error} handleRefresh={refresh} />;
+  if (!workflow_approval) return <LoadingPage breadcrumbs tabs />;
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={workflow_approval?.name}
+        breadcrumbs={[
+          { label: t('Workflow Approvals'), to: AwxRoute.WorkflowApprovals },
+          { label: workflow_approval?.name },
+        ]}
+      />
+      <PageRoutedTabs
+        backTab={{
+          label: t('Back to Workflow Approvals'),
+          page: AwxRoute.WorkflowApprovals,
+          persistentFilterKey: 'workflow-approvals',
+        }}
+        tabs={[
+          { label: t('Details'), page: AwxRoute.WorkflowApprovalDetails },
+          { label: t('Jobs'), page: AwxRoute.WorkflowApprovalWorkflowJobDetails },
+        ]}
+        params={{ id: params.id || 0 }}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/awx/views/workflow-approvals/WorkflowApprovals.cy.tsx
+++ b/frontend/awx/views/workflow-approvals/WorkflowApprovals.cy.tsx
@@ -1,0 +1,216 @@
+// import * as useOptions from '../../../common/crud/useOptions';
+import WorkflowApprovals from './WorkflowApprovals';
+
+describe('Workflow Approvals List', () => {
+  describe('Non-empty list', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/workflow_approvals/*',
+        },
+        {
+          fixture: 'workflowApprovals.json',
+        }
+      );
+    });
+
+    it('Workflow approvals list renders', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.verifyPageTitle('Workflow Approvals');
+      cy.get('tbody').find('tr').should('have.length', 6);
+    });
+
+    it('Workflow approvals list has filters for Name and ID', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.openToolbarFilterTypeSelect().within(() => {
+        cy.contains(/^Name$/).should('be.visible');
+        cy.contains(/^ID$/).should('be.visible');
+      });
+    });
+
+    it('Filter workflow approvals by name', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/?name__icontains=foo*').as('nameFilterRequest');
+      cy.filterTableByTypeAndText(/^Name$/, 'foo');
+      cy.wait('@nameFilterRequest');
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Filter workflow approvals by id', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/?id=1*').as('idFilterRequest');
+      cy.filterTableByTypeAndText(/^ID$/, '1');
+      cy.wait('@idFilterRequest');
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Clicking name table header sorts workflow approvals by name', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/?order_by=-name*').as('nameDescSortRequest');
+      cy.clickTableHeader(/^Name$/);
+      cy.wait('@nameDescSortRequest');
+      cy.intercept('api/v2/workflow_approvals/?order_by=name*').as('nameAscSortRequest');
+      cy.clickTableHeader(/^Name$/);
+      cy.wait('@nameAscSortRequest');
+    });
+
+    it('Clicking started table header sorts workflow approvals by start time', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/?order_by=-started*').as('startedDescSortRequest');
+      cy.clickTableHeader(/^Started$/);
+      cy.wait('@startedDescSortRequest');
+      cy.intercept('api/v2/workflow_approvals/?order_by=started*').as('startedAscSortRequest');
+      cy.clickTableHeader(/^Started$/);
+      cy.wait('@startedAscSortRequest');
+    });
+
+    it('Clicking status table header sorts workflow approvals by status', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/?order_by=-status*').as('statusDescSortRequest');
+      cy.clickTableHeader(/^Status$/);
+      cy.wait('@statusDescSortRequest');
+      cy.intercept('api/v2/workflow_approvals/?order_by=status*').as('statusAscSortRequest');
+      cy.clickTableHeader(/^Status$/);
+      cy.wait('@statusAscSortRequest');
+    });
+
+    it('Delete workflow approval row action is disabled if the user does not have permission to delete workflow approvals', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'read only approval').within(() => {
+        // user_capabilities.delete: false
+        cy.get('button.toggle-kebab').click();
+        cy.contains('.pf-v5-c-dropdown__menu-item', /^Delete workflow approval$/).should(
+          'have.attr',
+          'aria-disabled',
+          'true'
+        );
+      });
+    });
+
+    it('Delete workflow approval row action is enabled if the user has permission to delete workflow approvals', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'can delete approval').within(() => {
+        // user_capabilities.delete: true
+        cy.get('button.toggle-kebab').click();
+        cy.contains('.pf-v5-c-dropdown__menu-item', /^Delete workflow approval$/).should(
+          'have.attr',
+          'aria-disabled',
+          'false'
+        );
+      });
+    });
+
+    it('Approve row action is enabled if the user has permission to approve', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'can approve or deny').within(() => {
+        // can_approve_or_deny: true
+        cy.get('[data-cy="actions-column-cell"]').within(() => {
+          cy.get(`[data-cy="approve"]`).should('have.attr', 'aria-disabled', 'false');
+        });
+      });
+    });
+
+    it('Deny row action is enabled if the user has permission to deny', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'can approve or deny').within(() => {
+        // can_approve_or_deny: true
+        cy.get('[data-cy="actions-column-cell"]').within(() => {
+          cy.get(`[data-cy="deny"]`).should('have.attr', 'aria-disabled', 'false');
+        });
+      });
+    });
+
+    it('Approve row action is disabled if the user does not have permission to approve', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'cannot approve or deny').within(() => {
+        // can_approve_or_deny: false
+        cy.get('[data-cy="actions-column-cell"]').within(() => {
+          cy.get(`[data-cy="approve"]`).should('have.attr', 'aria-disabled', 'true');
+        });
+      });
+    });
+
+    it('Deny row action is disabled if the user does not have permission to deny', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('tr', 'cannot approve or deny').within(() => {
+        // can_approve_or_deny: false
+        cy.get('[data-cy="actions-column-cell"]').within(() => {
+          cy.get(`[data-cy="deny"]`).should('have.attr', 'aria-disabled', 'true');
+        });
+      });
+    });
+
+    it('Approve row action calls correct API endpoint', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/141/approve/', {
+        statusCode: 200,
+      }).as('approveRequest');
+      cy.clickTableRowPinnedAction('can approve or deny', 'approve');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Approve workflow approvals/);
+      cy.wait('@approveRequest');
+      cy.clickButton(/^Close/);
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Deny row action calls correct API endpoint', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/141/deny/', {
+        statusCode: 200,
+      }).as('denyRequest');
+      cy.clickTableRowPinnedAction('can approve or deny', 'deny');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Deny workflow approvals/);
+      cy.wait('@denyRequest');
+      cy.clickButton(/^Close/);
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Delete row action calls correct API endpoint', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.intercept('api/v2/workflow_approvals/131/', {
+        statusCode: 204,
+      }).as('deleteRequest');
+      cy.clickTableRowKebabAction('can delete approval', 'Delete workflow approval');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete workflow approvals/);
+      cy.wait('@deleteRequest');
+      cy.clickButton(/^Close/);
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Displays error if workflow approvals are not successfully loaded', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/workflow_approvals/*',
+        },
+        {
+          statusCode: 500,
+        }
+      );
+      cy.mount(<WorkflowApprovals />);
+      cy.contains('Error loading workflow approvals');
+    });
+  });
+
+  describe('Empty list', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/workflow_approvals/*',
+        },
+        {
+          fixture: 'emptyList.json',
+        }
+      ).as('emptyList');
+    });
+    it('Empty state is displayed correctly', () => {
+      cy.mount(<WorkflowApprovals />);
+      cy.contains(/^There are currently no workflow approvals$/);
+      cy.contains(/^Past and pending workflow approvals will appear here when available$/);
+    });
+  });
+});

--- a/frontend/awx/views/workflow-approvals/WorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/WorkflowApprovals.tsx
@@ -1,0 +1,81 @@
+import { PageHeader, PageLayout, PageTable } from '../../../../framework';
+import { useTranslation } from 'react-i18next';
+import { usePersistentFilters } from '../../../common/PersistentFilters';
+import { WorkflowApproval } from '../../interfaces/WorkflowApproval';
+import { useAwxView } from '../../useAwxView';
+import { useWorkflowApprovalsRowActions } from './hooks/useWorkflowApprovalsRowActions';
+import { useWorkflowApprovalToolbarActions } from './hooks/useWorkflowApprovalToolbarActions';
+import { useWorkflowApprovalsColumns } from './hooks/useWorkflowApprovalsColumns';
+import { useWorkflowApprovalsFilters } from './hooks/useWorkflowApprovalsFilters';
+import { useAwxConfig } from '../../common/useAwxConfig';
+import getDocsBaseUrl from '../../common/util/getDocsBaseUrl';
+import { useCallback } from 'react';
+import { useAwxWebSocketSubscription } from '../../common/useAwxWebSocket';
+
+export default function WorkflowApprovals() {
+  const { t } = useTranslation();
+  const product: string = process.env.PRODUCT ?? t('AWX');
+  const toolbarFilters = useWorkflowApprovalsFilters();
+  const tableColumns = useWorkflowApprovalsColumns();
+  const view = useAwxView<WorkflowApproval>({
+    url: '/api/v2/workflow_approvals/',
+    toolbarFilters,
+    tableColumns,
+  });
+  const toolbarActions = useWorkflowApprovalToolbarActions(view);
+  const rowActions = useWorkflowApprovalsRowActions(view.unselectItemsAndRefresh);
+  usePersistentFilters('jobs');
+  const config = useAwxConfig();
+
+  const { refresh } = view;
+  const handleWebSocketMessage = useCallback(
+    (message?: { group_name?: string; type?: string }) => {
+      switch (message?.group_name) {
+        case 'jobs':
+          switch (message?.type) {
+            case 'workflow_approval':
+              void refresh();
+              break;
+          }
+          break;
+      }
+    },
+    [refresh]
+  );
+
+  useAwxWebSocketSubscription(
+    { control: ['limit_reached_1'], jobs: ['status_changed'] },
+    handleWebSocketMessage as (data: unknown) => void
+  );
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Workflow Approvals')}
+        titleHelpTitle={t('Workflow Approvals')}
+        titleHelp={t(
+          `A workflow approval represents a pause in a workflow where approval is needed before the workflow continues executing.`,
+          { product }
+        )}
+        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/workflows.html`}
+        description={t(
+          `A workflow approval represents a pause in a workflow where approval is needed before the workflow continues executing.`,
+          { product }
+        )}
+      />
+      <PageTable
+        toolbarFilters={toolbarFilters}
+        tableColumns={tableColumns}
+        toolbarActions={toolbarActions}
+        rowActions={rowActions}
+        errorStateTitle={t('Error loading workflow approvals')}
+        emptyStateTitle={t('There are currently no workflow approvals')}
+        emptyStateDescription={t(
+          'Past and pending workflow approvals will appear here when available'
+        )}
+        {...view}
+        defaultSubtitle={t('Workflow Approval')}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/awx/views/workflow-approvals/components/WorkflowApprovalStatusCell.tsx
+++ b/frontend/awx/views/workflow-approvals/components/WorkflowApprovalStatusCell.tsx
@@ -1,0 +1,89 @@
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import { TextCell } from '../../../../../framework';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { WorkflowApprovalTimeRemaining } from './WorkflowApprovalTimeRemaining';
+
+export function WorkflowApprovalStatusCell(props: { workflow_approval: WorkflowApproval }) {
+  const { t } = useTranslation();
+
+  if (props.workflow_approval.timed_out) {
+    return (
+      <TextCell
+        text={t`Timed out`}
+        color={'red'}
+        iconColor={'danger'}
+        icon={<ExclamationCircleIcon />}
+      />
+    );
+  }
+
+  if (props.workflow_approval.canceled_on) {
+    return (
+      <TextCell
+        text={t`Canceled`}
+        color={'orange'}
+        iconColor={'warning'}
+        icon={<ExclamationTriangleIcon />}
+      />
+    );
+  }
+
+  switch (props.workflow_approval.status) {
+    case 'new':
+    case 'pending':
+    case 'waiting':
+    case 'running':
+      if (props.workflow_approval.approval_expiration) {
+        return (
+          <WorkflowApprovalTimeRemaining
+            approval_expiration={props.workflow_approval.approval_expiration}
+          />
+        );
+      }
+      return (
+        <TextCell text={t`Never expires`} color={'blue'} iconColor={'info'} icon={<ClockIcon />} />
+      );
+    case 'successful':
+      return (
+        <TextCell
+          text={t`Approved`}
+          color={'green'}
+          iconColor={'success'}
+          icon={<CheckCircleIcon />}
+        />
+      );
+    case 'failed':
+      return (
+        <TextCell
+          text={t`Denied`}
+          color={'red'}
+          iconColor={'danger'}
+          icon={<ExclamationCircleIcon />}
+        />
+      );
+    case 'error':
+      return (
+        <TextCell
+          text={t`Error`}
+          color={'red'}
+          iconColor={'danger'}
+          icon={<ExclamationCircleIcon />}
+        />
+      );
+    default:
+      return (
+        <TextCell
+          text={t`Unknown`}
+          color={'yellow'}
+          iconColor={'warning'}
+          icon={<ExclamationTriangleIcon />}
+        />
+      );
+  }
+}

--- a/frontend/awx/views/workflow-approvals/components/WorkflowApprovalTimeRemaining.tsx
+++ b/frontend/awx/views/workflow-approvals/components/WorkflowApprovalTimeRemaining.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable i18next/no-literal-string */
+import { Flex, FlexItem, Split, SplitItem } from '@patternfly/react-core';
+import { useEffect, useMemo, useState } from 'react';
+import { IconWrapper } from '../../../../../framework/components/IconWrapper';
+import { ClockIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { TextCell, getPatternflyColor } from '../../../../../framework';
+import { Trans, useTranslation } from 'react-i18next';
+
+export function WorkflowApprovalTimeRemaining(props: { approval_expiration: string }) {
+  const { t } = useTranslation();
+  const approvalExpiration = useMemo(
+    () => new Date(props.approval_expiration ?? 0).valueOf(),
+    [props.approval_expiration]
+  );
+
+  const [timeRemaining, setTimeRemaining] = useState(
+    Math.max(0, approvalExpiration - Date.now().valueOf())
+  );
+
+  useEffect(() => {
+    if (timeRemaining === 0) return;
+    const timeout = setInterval(() => {
+      setTimeRemaining(Math.max(0, approvalExpiration - Date.now().valueOf()));
+    }, 1000);
+    return () => clearTimeout(timeout);
+  }, [approvalExpiration, timeRemaining]);
+
+  const totalSeconds = Math.floor(timeRemaining / 1000);
+  const seconds = Math.floor(totalSeconds % 60);
+  const minutes = Math.floor((totalSeconds / 60) % 60);
+  const hours = Math.floor((totalSeconds / 60 / 60) % 24);
+  const days = Math.floor(totalSeconds / 60 / 60 / 24);
+
+  const abbreviatedDays = t(`${days}d`);
+  const abbreviatedHours = t(`${hours}h`);
+  const abbreviatedMinutes = t(`${minutes}m`);
+  const abbreviatedSeconds = t(`${seconds}s`);
+
+  if (totalSeconds === 0)
+    return (
+      <TextCell
+        text={t`Timed out`}
+        color={'red'}
+        iconColor={'danger'}
+        icon={<ExclamationCircleIcon />}
+      />
+    );
+  return (
+    <Flex
+      spaceItems={{ default: 'spaceItemsNone' }}
+      flexWrap={{ default: 'nowrap' }}
+      alignItems={{ default: 'alignItemsBaseline' }}
+    >
+      <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+        <IconWrapper size="sm" color="blue" padRight>
+          <ClockIcon />
+        </IconWrapper>
+      </FlexItem>
+      <FlexItem style={{ maxWidth: '100%' }}>
+        <div
+          style={{
+            minWidth: 200,
+            maxWidth: '100%',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            color: getPatternflyColor('blue'),
+          }}
+        >
+          <Trans>
+            <Split>
+              <SplitItem>Expires in&nbsp;</SplitItem>
+              {days !== 0 && <SplitItem>{abbreviatedDays}&nbsp;</SplitItem>}
+              {hours !== 0 && <SplitItem>{abbreviatedHours}&nbsp;</SplitItem>}
+              {minutes !== 0 && <SplitItem>{abbreviatedMinutes}&nbsp;</SplitItem>}
+              {<SplitItem>{abbreviatedSeconds}&nbsp;</SplitItem>}
+            </Split>
+          </Trans>
+        </div>
+      </FlexItem>
+    </Flex>
+  );
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useApproveWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useApproveWorkflowApprovals.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { useNameColumn } from '../../../../common/columns';
+import { getItemKey } from '../../../../common/crud/Data';
+import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
+
+export function useApproveWorkflowApprovals(
+  onComplete: (workflow_approvals: WorkflowApproval[]) => void
+) {
+  const { t } = useTranslation();
+  const confirmationColumns = useWorkflowApprovalsColumns({
+    disableLinks: true,
+    disableSort: true,
+  });
+  const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
+  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const postRequest = usePostRequest();
+  const cannotApprove = (workflow_approval: WorkflowApproval) => {
+    if (workflow_approval.timed_out)
+      return t(`The workflow approval cannot be approved because it has timed out`);
+
+    switch (workflow_approval.status) {
+      case 'canceled':
+        return t(`The workflow approval cannot be approved because the workflow has been canceled`);
+      case 'successful':
+        return t(`The workflow approval cannot be approved because it has already been approved`);
+      case 'failed':
+        return t(`The workflow approval cannot be approved because it has already been denied`);
+      case 'error':
+        return t(`The workflow approval cannot be approved because it is in an error state`);
+      default:
+        if (!workflow_approval.can_approve_or_deny)
+          return t(`The workflow approval cannot be approved due to insufficient permissions`);
+        return '';
+    }
+  };
+
+  const approveWorkflowApprovals = (workflow_approvals: WorkflowApproval[]) => {
+    const unapproveableWorkflowApprovals: WorkflowApproval[] =
+      workflow_approvals.filter(cannotApprove);
+
+    bulkAction({
+      title: t('Approve workflow approvals', { count: workflow_approvals.length }),
+      confirmText: t('Yes, I confirm that I want to approve these {{count}} workflow approvals.', {
+        count: workflow_approvals.length - unapproveableWorkflowApprovals.length,
+      }),
+      actionButtonText: t('Approve workflow approvals', { count: workflow_approvals.length }),
+      items: workflow_approvals.sort((l, r) => compareStrings(l.name, r.name)),
+      alertPrompts: unapproveableWorkflowApprovals.length
+        ? [
+            ...(unapproveableWorkflowApprovals.length
+              ? [
+                  t('{{count}} of the selected workflow approvals cannot be approved.', {
+                    count: unapproveableWorkflowApprovals.length,
+                  }),
+                ]
+              : []),
+          ]
+        : undefined,
+      isItemNonActionable: (item: WorkflowApproval) => cannotApprove(item),
+      keyFn: getItemKey,
+      confirmationColumns,
+      actionColumns,
+      onComplete,
+      actionFn: (workflow_approval: WorkflowApproval) =>
+        postRequest(`/api/v2/workflow_approvals/${workflow_approval.id}/approve/`, {}),
+    });
+  };
+  return approveWorkflowApprovals;
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useDeleteWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useDeleteWorkflowApprovals.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { useNameColumn } from '../../../../common/columns';
+import { getItemKey, requestDelete } from '../../../../common/crud/Data';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
+
+export function useDeleteWorkflowApprovals(
+  onComplete: (workflow_approvals: WorkflowApproval[]) => void
+) {
+  const { t } = useTranslation();
+  const confirmationColumns = useWorkflowApprovalsColumns({
+    disableLinks: true,
+    disableSort: true,
+  });
+  const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
+  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const cannotDeleteDueToPermissions = (workflow_approval: WorkflowApproval) => {
+    if (!workflow_approval.summary_fields.user_capabilities.delete)
+      return t(`The workflow approval cannot be deleted due to insufficient permission`);
+    return '';
+  };
+
+  const deleteWorkflowApprovals = (workflow_approvals: WorkflowApproval[]) => {
+    const undeletableWorkflowApprovalsDueToPermissions: WorkflowApproval[] =
+      workflow_approvals.filter(cannotDeleteDueToPermissions);
+
+    bulkAction({
+      title: t('Delete workflow approvals', { count: workflow_approvals.length }),
+      confirmText: t('Yes, I confirm that I want to delete these {{count}} workflow approvals.', {
+        count: workflow_approvals.length - undeletableWorkflowApprovalsDueToPermissions.length,
+      }),
+      actionButtonText: t('Delete workflow approvals', { count: workflow_approvals.length }),
+      items: workflow_approvals.sort((l, r) => compareStrings(l.name, r.name)),
+      alertPrompts: undeletableWorkflowApprovalsDueToPermissions.length
+        ? [
+            ...(undeletableWorkflowApprovalsDueToPermissions.length
+              ? [
+                  t(
+                    '{{count}} of the selected workflow approvals cannot be deleted due to insufficient permissions.',
+                    {
+                      count: undeletableWorkflowApprovalsDueToPermissions.length,
+                    }
+                  ),
+                ]
+              : []),
+          ]
+        : undefined,
+      isItemNonActionable: (item: WorkflowApproval) => cannotDeleteDueToPermissions(item),
+      keyFn: getItemKey,
+      confirmationColumns,
+      actionColumns,
+      onComplete,
+      actionFn: (workflow_approval: WorkflowApproval) =>
+        requestDelete(`/api/v2/workflow_approvals/${workflow_approval.id}/`),
+    });
+  };
+  return deleteWorkflowApprovals;
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useDenyWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useDenyWorkflowApprovals.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { useNameColumn } from '../../../../common/columns';
+import { getItemKey } from '../../../../common/crud/Data';
+import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
+
+export function useDenyWorkflowApprovals(
+  onComplete: (workflow_approvals: WorkflowApproval[]) => void
+) {
+  const { t } = useTranslation();
+  const confirmationColumns = useWorkflowApprovalsColumns({
+    disableLinks: true,
+    disableSort: true,
+  });
+  const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
+  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const postRequest = usePostRequest();
+  const cannotDeny = (workflow_approval: WorkflowApproval) => {
+    if (workflow_approval.timed_out)
+      return t(`The workflow approval cannot be denied because it has timed out`);
+
+    switch (workflow_approval.status) {
+      case 'canceled':
+        return t(`The workflow approval cannot be denied because the workflow has been canceled`);
+      case 'successful':
+        return t(`The workflow approval cannot be denied because it has already been approved`);
+      case 'failed':
+        return t(`The workflow approval cannot be denied because it has already been denied`);
+      case 'error':
+        return t(`The workflow approval cannot be denied because it is in an error state`);
+      default:
+        if (!workflow_approval.can_approve_or_deny)
+          return t(`The workflow approval cannot be denied due to insufficient permissions`);
+        return '';
+    }
+  };
+
+  const denyWorkflowApprovals = (workflow_approvals: WorkflowApproval[]) => {
+    const undeniableWorkflowApprovalsDueToPermissions: WorkflowApproval[] =
+      workflow_approvals.filter(cannotDeny);
+
+    bulkAction({
+      title: t('Deny workflow approvals', { count: workflow_approvals.length }),
+      confirmText: t('Yes, I confirm that I want to deny these {{count}} workflow approvals.', {
+        count: workflow_approvals.length - undeniableWorkflowApprovalsDueToPermissions.length,
+      }),
+      actionButtonText: t('Deny workflow approvals', { count: workflow_approvals.length }),
+      items: workflow_approvals.sort((l, r) => compareStrings(l.name, r.name)),
+      alertPrompts: undeniableWorkflowApprovalsDueToPermissions.length
+        ? [
+            ...(undeniableWorkflowApprovalsDueToPermissions.length
+              ? [
+                  t('{{count}} of the selected workflow approvals cannot be denied.', {
+                    count: undeniableWorkflowApprovalsDueToPermissions.length,
+                  }),
+                ]
+              : []),
+          ]
+        : undefined,
+      isItemNonActionable: (item: WorkflowApproval) => cannotDeny(item),
+      keyFn: getItemKey,
+      confirmationColumns,
+      actionColumns,
+      onComplete,
+      actionFn: (workflow_approval: WorkflowApproval) =>
+        postRequest(`/api/v2/workflow_approvals/${workflow_approval.id}/deny/`, {}),
+    });
+  };
+  return denyWorkflowApprovals;
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalActions.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalActions.tsx
@@ -1,0 +1,47 @@
+import { ThumbsDownIcon, ThumbsUpIcon, TrashIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useDeleteWorkflowApprovals } from './useDeleteWorkflowApprovals';
+import { useDenyWorkflowApprovals } from './useDenyWorkflowApprovals';
+import { useApproveWorkflowApprovals } from './useApproveWorkflowApprovals';
+import { useMemo } from 'react';
+
+export function useWorkflowApprovalActions(
+  onComplete: (workflow_approvals: WorkflowApproval[]) => void
+) {
+  const { t } = useTranslation();
+  const approveWorkflowApprovals = useApproveWorkflowApprovals(() => {});
+  const denyWorkflowApprovals = useDenyWorkflowApprovals(() => {});
+  const deleteWorkflowApprovals = useDeleteWorkflowApprovals(onComplete);
+
+  return useMemo<IPageAction<WorkflowApproval>[]>(() => {
+    return [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: ThumbsUpIcon,
+        label: t('Approve'),
+        onClick: approveWorkflowApprovals,
+        isPinned: true,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: ThumbsDownIcon,
+        label: t('Deny'),
+        onClick: denyWorkflowApprovals,
+        isDanger: true,
+        isPinned: true,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: TrashIcon,
+        label: t('Delete'),
+        onClick: deleteWorkflowApprovals,
+        isDanger: true,
+      },
+    ];
+  }, [deleteWorkflowApprovals, denyWorkflowApprovals, approveWorkflowApprovals, t]);
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalToolbarActions.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalToolbarActions.tsx
@@ -1,0 +1,57 @@
+import { ThumbsDownIcon, ThumbsUpIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useApproveWorkflowApprovals } from './useApproveWorkflowApprovals';
+import { useDenyWorkflowApprovals } from './useDenyWorkflowApprovals';
+import { useDeleteWorkflowApprovals } from './useDeleteWorkflowApprovals';
+import { IAwxView } from '../../../useAwxView';
+
+export function useWorkflowApprovalToolbarActions(view: IAwxView<WorkflowApproval>) {
+  const { t } = useTranslation();
+  const approveWorkflowApprovals = useApproveWorkflowApprovals(view.unselectItemsAndRefresh);
+  const denyWorkflowApprovals = useDenyWorkflowApprovals(view.unselectItemsAndRefresh);
+  const deleteWorkflowApprovals = useDeleteWorkflowApprovals(view.unselectItemsAndRefresh);
+
+  return useMemo<IPageAction<WorkflowApproval>[]>(
+    () => [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: ThumbsUpIcon,
+        label: t('Approve'),
+        onClick: approveWorkflowApprovals,
+        isPinned: true,
+        isDisabled:
+          view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: ThumbsDownIcon,
+        label: t('Deny'),
+        onClick: denyWorkflowApprovals,
+        isDanger: true,
+        isPinned: true,
+        isDisabled:
+          view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: TrashIcon,
+        label: t('Delete'),
+        onClick: deleteWorkflowApprovals,
+        isDanger: true,
+      },
+    ],
+    [
+      t,
+      approveWorkflowApprovals,
+      view.selectedItems.length,
+      denyWorkflowApprovals,
+      deleteWorkflowApprovals,
+    ]
+  );
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsColumns.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsColumns.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ColumnModalOption,
+  DateTimeCell,
+  ITableColumn,
+  TextCell,
+  usePageNavigate,
+} from '../../../../../framework';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { WorkflowApprovalStatusCell } from '../components/WorkflowApprovalStatusCell';
+import { AwxRoute } from '../../../AwxRoutes';
+import { useIdColumn, useNameColumn } from '../../../../common/columns';
+import { RouteObj } from '../../../../common/Routes';
+
+export function useWorkflowApprovalsColumns(options?: {
+  disableSort?: boolean;
+  disableLinks?: boolean;
+}) {
+  const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
+  const idColumn = useIdColumn();
+  const nameClick = useCallback(
+    (workflow_approval: WorkflowApproval) =>
+      pageNavigate(AwxRoute.WorkflowApprovalDetails, { params: { id: workflow_approval.id } }),
+    [pageNavigate]
+  );
+  const nameColumn = useNameColumn({
+    ...options,
+    onClick: nameClick,
+  });
+  const tableColumns = useMemo<ITableColumn<WorkflowApproval>[]>(
+    () => [
+      idColumn,
+      nameColumn,
+      {
+        header: t('Workflow Job'),
+        cell: (workflow_approval: WorkflowApproval) => {
+          return (
+            <TextCell
+              text={`${workflow_approval.summary_fields.source_workflow_job.id} - ${workflow_approval.summary_fields.source_workflow_job.name}`}
+              to={RouteObj.JobOutput.replace(':job_type', 'workflow').replace(
+                ':id',
+                workflow_approval.summary_fields.source_workflow_job.id.toString()
+              )}
+              disableLinks={options?.disableLinks}
+            />
+          );
+        },
+        sort: undefined,
+        list: 'secondary',
+      },
+      {
+        header: t('Started'),
+        cell: (workflow_approval: WorkflowApproval) =>
+          workflow_approval.started && (
+            <DateTimeCell format="date-time" value={workflow_approval.started} />
+          ),
+        sort: 'started',
+        list: 'secondary',
+        defaultSortDirection: 'desc',
+        modal: ColumnModalOption.Hidden,
+      },
+      {
+        header: t('Status'),
+        cell: (workflow_approval: WorkflowApproval) => (
+          <WorkflowApprovalStatusCell workflow_approval={workflow_approval} />
+        ),
+        sort: 'status',
+        defaultSortDirection: 'desc',
+      },
+    ],
+    [idColumn, nameColumn, options?.disableLinks, t]
+  );
+  return tableColumns;
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsFilters.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsFilters.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IToolbarFilter, ToolbarFilterType } from '../../../../../framework';
+import { useNameToolbarFilter } from '../../../common/awx-toolbar-filters';
+
+export function useWorkflowApprovalsFilters() {
+  const { t } = useTranslation();
+  const nameToolbarFilter = useNameToolbarFilter();
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      nameToolbarFilter,
+      {
+        key: 'id',
+        label: t('ID'),
+        type: ToolbarFilterType.Text,
+        query: 'id',
+        comparison: 'equals',
+      },
+    ],
+    [nameToolbarFilter, t]
+  );
+  return toolbarFilters;
+}

--- a/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsRowActions.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useWorkflowApprovalsRowActions.tsx
@@ -1,0 +1,86 @@
+import { ButtonVariant } from '@patternfly/react-core';
+import { ThumbsDownIcon, ThumbsUpIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useApproveWorkflowApprovals } from './useApproveWorkflowApprovals';
+import { useDeleteWorkflowApprovals } from './useDeleteWorkflowApprovals';
+import { useDenyWorkflowApprovals } from './useDenyWorkflowApprovals';
+
+export function useWorkflowApprovalsRowActions(
+  onComplete: (workflow_approvals: WorkflowApproval[]) => void
+) {
+  const { t } = useTranslation();
+  const approveWorkflowApprovals = useApproveWorkflowApprovals(onComplete);
+  const deleteWorkflowApprovals = useDeleteWorkflowApprovals(onComplete);
+  const denyWorkflowApprovals = useDenyWorkflowApprovals(onComplete);
+
+  return useMemo<IPageAction<WorkflowApproval>[]>(() => {
+    const cannotDeleteWorkflowApproval = (workflow_approval: WorkflowApproval) => {
+      if (!['successful', 'failed', 'error', 'canceled'].includes(workflow_approval.status)) {
+        return t(
+          `The workflow approval cannot be deleted because the workflow job is still running`
+        );
+      }
+      if (!workflow_approval.summary_fields.user_capabilities.delete)
+        return t(`The workflow approval cannot be deleted due to insufficient permissions`);
+      return '';
+    };
+
+    const cannotApprove = (workflow_approval: WorkflowApproval) => {
+      if (!workflow_approval.can_approve_or_deny) {
+        return t(`The workflow approval cannot be approved due to insufficient permissions`);
+      }
+      return '';
+    };
+
+    const cannotDeny = (workflow_approval: WorkflowApproval) => {
+      if (!workflow_approval.can_approve_or_deny) {
+        return t(`The workflow approval cannot be denied due to insufficient permissions`);
+      }
+      return '';
+    };
+
+    const actions: IPageAction<WorkflowApproval>[] = [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.secondary,
+        isPinned: true,
+        icon: ThumbsUpIcon,
+        label: t(`Approve`),
+        isDisabled: (workflow_approval: WorkflowApproval) => cannotApprove(workflow_approval),
+        isHidden: (workflow_approval: WorkflowApproval) =>
+          ['successful', 'failed', 'error', 'canceled'].includes(workflow_approval.status),
+        onClick: (workflow_approval: WorkflowApproval) =>
+          approveWorkflowApprovals([workflow_approval]),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.secondary,
+        isPinned: true,
+        icon: ThumbsDownIcon,
+        label: t(`Deny`),
+        isDisabled: (workflow_approval: WorkflowApproval) => cannotDeny(workflow_approval),
+        isHidden: (workflow_approval: WorkflowApproval) =>
+          ['successful', 'failed', 'error', 'canceled'].includes(workflow_approval.status),
+        onClick: (workflow_approval: WorkflowApproval) =>
+          denyWorkflowApprovals([workflow_approval]),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t(`Delete workflow approval`),
+        isDisabled: (workflow_approval: WorkflowApproval) =>
+          cannotDeleteWorkflowApproval(workflow_approval),
+        onClick: (workflow_approval: WorkflowApproval) =>
+          deleteWorkflowApprovals([workflow_approval]),
+        isDanger: true,
+      },
+    ];
+    return actions;
+  }, [deleteWorkflowApprovals, denyWorkflowApprovals, approveWorkflowApprovals, t]);
+}


### PR DESCRIPTION
Adds the workflow approval list including support for row and table level approve, deny and delete.  The list comes with two basic filters (name and id).  Three of the columns are sortable (name, started and status).  I'm planning on a follow-on PR with the details view implemented.  Here's a screenshot of the list:

<img width="1719" alt="Screenshot 2023-10-25 at 12 44 39 PM" src="https://github.com/ansible/ansible-ui/assets/9889020/364d4a59-de76-473a-80cf-c85ca1ba1d6d">

I've included component tests for the following scenarios:
    Workflow approvals list renders
    Workflow approvals list has filters for Name and ID
    Filter workflow approvals by name
    Filter workflow approvals by id
    Clicking name table header sorts workflow approvals by name
    Clicking started table header sorts workflow approvals by start time
    Clicking status table header sorts workflow approvals by status
    Delete workflow approval row action is disabled if the user does not have permission to delete workflow approvals
    Delete workflow approval row action is enabled if the user has permission to delete workflow approvals
    Approve row action is enabled if the user has permission to approve
    Deny row action is enabled if the user has permission to deny
    Approve row action is disabled if the user does not have permission to approve
    Deny row action is disabled if the user does not have permission to deny
    Approve row action calls correct API endpoint
    Deny row action calls correct API endpoint
    Delete row action calls correct API endpoint
    Displays error if workflow approvals are not successfully loaded
    Empty state is displayed correctly

