### PR TITLE
Move WF route outside of workflow template page

### DIFF
--- a/frontend/awx/useGetAwxTemplateRoutes.tsx
+++ b/frontend/awx/useGetAwxTemplateRoutes.tsx
@@ -194,6 +194,11 @@ export function useGetAwxTemplateRoutes() {
               ],
             },
             {
+              id: AwxRoute.WorkflowVisualizer,
+              path: ':id/visualizer',
+              element: <WorkflowVisualizer />,
+            },
+            {
               id: AwxRoute.WorkflowJobTemplatePage,
               path: ':id',
               element: <WorkflowJobTemplatePage />,
@@ -217,11 +222,6 @@ export function useGetAwxTemplateRoutes() {
                   id: AwxRoute.WorkflowJobTemplateSurvey,
                   path: 'survey',
                   element: <PageNotImplemented />,
-                },
-                {
-                  id: AwxRoute.WorkflowVisualizer,
-                  path: 'visualizer',
-                  element: <WorkflowVisualizer />,
                 },
                 {
                   id: AwxRoute.WorkflowJobTemplateSchedules,


### PR DESCRIPTION
The workflow visualizer route should not include the breadcrumbs and tabs. 

**_After fix_**
<img width="579" alt="Screenshot 2023-10-25 at 3 07 40 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/cc413e97-e72c-4c51-aed8-b0a25e4ad87d">



**_Before_** 
<img width="579" alt="Screenshot 2023-10-25 at 3 08 12 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/ebde5e6e-579b-4920-b106-61cc3297eef7">


