### PR TITLE
PF5 Fix multiple ToolbarToggleGroups

### DIFF
--- a/framework/PageToolbar/PageToolbar.css
+++ b/framework/PageToolbar/PageToolbar.css
@@ -1,12 +1,35 @@
-.pf-v5-c-toolbar__expandable-content.pf-m-expanded {
-  z-index: 400;
-}
-
+/*
 .pf-v5-c-options-menu__menu {
   z-index: 400;
-}
+} */
 
 /* This is a workaround to handle when the content of the toolbar wraps */
 .pf-v5-c-toolbar__content-section {
   justify-content: start !important;
+}
+
+.pf-v5-c-toolbar__expandable-content.pf-m-expanded {
+  z-index: 400;
+  inset-block-start: 100%;
+}
+
+.pf-v5-c-toolbar__expandable-content .pf-v5-c-toolbar__item.pf-m-label {
+  margin-block-end: unset;
+}
+
+.pf-v5-c-toolbar__expandable-content .pf-v5-c-toolbar__item {
+  flex-wrap: wrap;
+}
+
+.pf-v5-c-toolbar__expandable-content.pf-m-expanded {
+  padding-top: 8px;
+  flex-wrap: wrap;
+  border-bottom: thin solid #0003;
+}
+:root:where(.pf-v5-theme-dark) .pf-v5-c-toolbar__expandable-content.pf-m-expanded {
+  border-bottom: thin solid #fff3;
+}
+
+.pf-v5-c-toolbar__group .pf-m-toggle-group {
+  margin-inline-end: 0;
 }

--- a/framework/PageToolbar/PageToolbar.tsx
+++ b/framework/PageToolbar/PageToolbar.tsx
@@ -4,11 +4,11 @@ import {
   ToolbarContent as PFToolbarContent,
   Pagination,
   PaginationVariant,
+  PerPageOptions,
   Skeleton,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
-  PerPageOptions,
 } from '@patternfly/react-core';
 import React, { Dispatch, Fragment, SetStateAction, useCallback } from 'react';
 import styled from 'styled-components';
@@ -115,7 +115,8 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
     }
   }, [setFilterState, clearAllFiltersProp]);
 
-  const sm = useBreakpoint('md');
+  const isMdOrLarger = useBreakpoint('md');
+  const isXxlOrLarger = useBreakpoint('xxl');
 
   const { viewType, setViewType } = props;
   let { toolbarActions } = props;
@@ -151,7 +152,10 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
     return (
       <Toolbar
         className="page-table-toolbar border-bottom"
-        style={{ paddingBottom: sm ? undefined : 8, paddingTop: sm ? undefined : 8 }}
+        style={{
+          paddingBottom: isMdOrLarger ? undefined : 8,
+          paddingTop: isMdOrLarger ? undefined : 8,
+        }}
       >
         <ToolbarContent>
           <ToolbarItem style={{ width: '100%' }}>
@@ -166,7 +170,10 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
     <Toolbar
       clearAllFilters={clearAllFilters}
       className="page-table-toolbar border-bottom"
-      style={{ paddingBottom: sm ? undefined : 8, paddingTop: sm ? undefined : 8 }}
+      style={{
+        paddingBottom: isMdOrLarger ? undefined : 8,
+        paddingTop: isMdOrLarger ? undefined : 8,
+      }}
       inset={{
         default: 'insetMd',
         sm: 'insetMd',
@@ -176,7 +183,7 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
         '2xl': 'insetLg',
       }}
     >
-      <ToolbarContent>
+      <ToolbarContent style={{ paddingRight: isXxlOrLarger ? 12 : 4 }}>
         {/* Selection */}
         {showSelect && (
           <ToolbarGroup>
@@ -230,7 +237,7 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
           )}
 
           {/* Pagination */}
-          {!props.disablePagination && (
+          {!props.disablePagination && isXxlOrLarger && (
             <ToolbarItem
               visibility={{ default: 'hidden', '2xl': 'visible' }}
               style={{ marginLeft: 24, alignSelf: 'center' }}

--- a/framework/PageToolbar/PageToolbar.tsx
+++ b/framework/PageToolbar/PageToolbar.tsx
@@ -10,7 +10,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import React, { Dispatch, Fragment, SetStateAction, useCallback } from 'react';
+import React, { Dispatch, Fragment, SetStateAction, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { IPageAction, PageActionSelection } from '../PageActions/PageAction';
 import { PageActions } from '../PageActions/PageActions';
@@ -20,6 +20,7 @@ import { PageTableViewType } from './PageTableViewType';
 import './PageToolbar.css';
 import { IFilterState, IToolbarFilter, PageToolbarFilters } from './PageToolbarFilter';
 import { PageTableSortOption, PageToolbarSort } from './PageToolbarSort';
+import { PageToolbarToggleGroupContext } from './PageToolbarToggleGroup';
 import { PageToolbarView } from './PageToolbarView';
 
 const FlexGrowDiv = styled.div`
@@ -122,6 +123,8 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
   let { toolbarActions } = props;
   toolbarActions = toolbarActions ?? [];
 
+  const [activeGroup, setActiveGroup] = useState('');
+
   const onSetPage = useCallback<OnSetPage>(
     (_event, page) => (setPage ? setPage(page) : null),
     [setPage]
@@ -167,96 +170,98 @@ export function PageToolbar<T extends object>(props: PageToolbarProps<T>) {
   }
 
   return (
-    <Toolbar
-      clearAllFilters={clearAllFilters}
-      className="page-table-toolbar border-bottom"
-      style={{
-        paddingBottom: isMdOrLarger ? undefined : 8,
-        paddingTop: isMdOrLarger ? undefined : 8,
-      }}
-      inset={{
-        default: 'insetMd',
-        sm: 'insetMd',
-        md: 'insetMd',
-        lg: 'insetMd',
-        xl: 'insetLg',
-        '2xl': 'insetLg',
-      }}
-    >
-      <ToolbarContent style={{ paddingRight: isXxlOrLarger ? 12 : 4 }}>
-        {/* Selection */}
-        {showSelect && (
-          <ToolbarGroup>
-            <ToolbarItem variant="bulk-select">
-              <BulkSelector {...props} />
-            </ToolbarItem>
-          </ToolbarGroup>
-        )}
+    <PageToolbarToggleGroupContext.Provider value={{ activeGroup, setActiveGroup }}>
+      <Toolbar
+        clearAllFilters={clearAllFilters}
+        className="page-table-toolbar border-bottom"
+        style={{
+          paddingBottom: isMdOrLarger ? undefined : 8,
+          paddingTop: isMdOrLarger ? undefined : 8,
+        }}
+        inset={{
+          default: 'insetMd',
+          sm: 'insetMd',
+          md: 'insetMd',
+          lg: 'insetMd',
+          xl: 'insetLg',
+          '2xl': 'insetLg',
+        }}
+      >
+        <ToolbarContent style={{ paddingRight: isXxlOrLarger ? 12 : 4 }}>
+          {/* Selection */}
+          {showSelect && (
+            <ToolbarGroup>
+              <ToolbarItem variant="bulk-select">
+                <BulkSelector {...props} />
+              </ToolbarItem>
+            </ToolbarGroup>
+          )}
 
-        {/* Filters */}
-        {filterState && setFilterState && (
-          <PageToolbarFilters
-            toolbarFilters={toolbarFilters}
-            filterState={filterState}
-            setFilterState={setFilterState}
-          />
-        )}
-
-        {props.toolbarContent}
-
-        {/* Actions */}
-        <ToolbarGroup variant="button-group">
-          <PageActions
-            actions={toolbarActions}
-            selectedItems={selectedItems}
-            wrapper={ToolbarItem}
-          />
-        </ToolbarGroup>
-
-        {/* The flex below is needed to make the toolbar wrap elements properly */}
-        <FlexGrowDiv>
-          {/* Sort */}
-          <PageToolbarSort
-            sort={sort}
-            setSort={setSort}
-            sortDirection={sortDirection}
-            setSortDirection={setSortDirection}
-            sortOptions={sortOptions}
-          />
-
-          {/* View */}
-          {viewType && setViewType && (
-            <PageToolbarView
-              disableTableView={props.disableTableView}
-              disableListView={props.disableListView}
-              disableCardView={props.disableCardView}
-              viewType={viewType}
-              setViewType={setViewType}
-              openColumnModal={openColumnModal}
+          {/* Filters */}
+          {filterState && setFilterState && (
+            <PageToolbarFilters
+              toolbarFilters={toolbarFilters}
+              filterState={filterState}
+              setFilterState={setFilterState}
             />
           )}
 
-          {/* Pagination */}
-          {!props.disablePagination && isXxlOrLarger && (
-            <ToolbarItem
-              visibility={{ default: 'hidden', '2xl': 'visible' }}
-              style={{ marginLeft: 24, alignSelf: 'center' }}
-            >
-              <Pagination
-                variant={PaginationVariant.top}
-                isCompact
-                itemCount={itemCount}
-                perPage={perPage}
-                page={page}
-                onSetPage={onSetPage}
-                onPerPageSelect={onPerPageSelect}
-                perPageOptions={perPageOptions}
-                style={{ marginTop: -8, marginBottom: -8 }}
+          {props.toolbarContent}
+
+          {/* Actions */}
+          <ToolbarGroup variant="button-group">
+            <PageActions
+              actions={toolbarActions}
+              selectedItems={selectedItems}
+              wrapper={ToolbarItem}
+            />
+          </ToolbarGroup>
+
+          {/* The flex below is needed to make the toolbar wrap elements properly */}
+          <FlexGrowDiv>
+            {/* Sort */}
+            <PageToolbarSort
+              sort={sort}
+              setSort={setSort}
+              sortDirection={sortDirection}
+              setSortDirection={setSortDirection}
+              sortOptions={sortOptions}
+            />
+
+            {/* View */}
+            {viewType && setViewType && (
+              <PageToolbarView
+                disableTableView={props.disableTableView}
+                disableListView={props.disableListView}
+                disableCardView={props.disableCardView}
+                viewType={viewType}
+                setViewType={setViewType}
+                openColumnModal={openColumnModal}
               />
-            </ToolbarItem>
-          )}
-        </FlexGrowDiv>
-      </ToolbarContent>
-    </Toolbar>
+            )}
+
+            {/* Pagination */}
+            {!props.disablePagination && isXxlOrLarger && (
+              <ToolbarItem
+                visibility={{ default: 'hidden', '2xl': 'visible' }}
+                style={{ marginLeft: 24, alignSelf: 'center' }}
+              >
+                <Pagination
+                  variant={PaginationVariant.top}
+                  isCompact
+                  itemCount={itemCount}
+                  perPage={perPage}
+                  page={page}
+                  onSetPage={onSetPage}
+                  onPerPageSelect={onPerPageSelect}
+                  perPageOptions={perPageOptions}
+                  style={{ marginTop: -8, marginBottom: -8 }}
+                />
+              </ToolbarItem>
+            )}
+          </FlexGrowDiv>
+        </ToolbarContent>
+      </Toolbar>
+    </PageToolbarToggleGroupContext.Provider>
   );
 }

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -144,7 +144,7 @@ export function PageToolbarFilters(props: PageToolbarFiltersProps) {
   });
 
   return (
-    <PageToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
+    <PageToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md" id="filters">
       <ToolbarGroup variant="filter-group" style={{ flexWrap: 'wrap', gap: 8 }}>
         {showFilterLabel && <ToolbarItem variant="label">{translations.filter}</ToolbarItem>}
         <FiltersToolbarItem

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  ToolbarFilter,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarToggleGroup,
-} from '@patternfly/react-core';
+import { Button, ToolbarFilter, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { PageAsyncMultiSelect } from '../PageInputs/PageAsyncMultiSelect';
@@ -22,6 +16,7 @@ import {
 import { IToolbarMultiSelectFilter } from './PageToolbarFilters/ToolbarMultiSelectFilter';
 import { IToolbarSingleSelectFilter } from './PageToolbarFilters/ToolbarSingleSelectFilter';
 import { IToolbarTextFilter, ToolbarTextFilter } from './PageToolbarFilters/ToolbarTextFilter';
+import { PageToolbarToggleGroup } from './PageToolbarToggleGroup';
 
 /** Represents the types of filters that can be used in the toolbar */
 export enum ToolbarFilterType {
@@ -149,8 +144,8 @@ export function PageToolbarFilters(props: PageToolbarFiltersProps) {
   });
 
   return (
-    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
-      <ToolbarGroup variant="filter-group" style={{ flexWrap: 'wrap', gap: 16 }}>
+    <PageToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
+      <ToolbarGroup variant="filter-group" style={{ flexWrap: 'wrap', gap: 8 }}>
         {showFilterLabel && <ToolbarItem variant="label">{translations.filter}</ToolbarItem>}
         <FiltersToolbarItem
           toolbarFilters={groupedFilters}
@@ -225,7 +220,7 @@ export function PageToolbarFilters(props: PageToolbarFiltersProps) {
           );
         })}
       </ToolbarGroup>
-    </ToolbarToggleGroup>
+    </PageToolbarToggleGroup>
   );
 }
 

--- a/framework/PageToolbar/PageToolbarSort.tsx
+++ b/framework/PageToolbar/PageToolbarSort.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Split,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarToggleGroup,
-} from '@patternfly/react-core';
+import { Button, Split, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import {
   SortAlphaDownAltIcon,
   SortAlphaUpIcon,
@@ -17,6 +11,7 @@ import { useCallback, useMemo } from 'react';
 import { PageSingleSelect } from '../PageInputs/PageSingleSelect';
 import { ITableColumn } from '../PageTable/PageTableColumn';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { PageToolbarToggleGroup } from './PageToolbarToggleGroup';
 
 export type PageToolbarSortProps = {
   sort?: string;
@@ -74,8 +69,8 @@ export function PageToolbarSort(props: PageToolbarSortProps) {
   if (!sortOptions || sortOptions.length <= 0) return <></>;
 
   return (
-    <ToolbarToggleGroup breakpoint="md" toggleIcon={undefined}>
-      <ToolbarGroup variant="filter-group">
+    <PageToolbarToggleGroup breakpoint="2xl" toggleIcon={sortDirectionIcon}>
+      <ToolbarGroup variant="filter-group" style={{ flexWrap: 'wrap', gap: 8 }}>
         <ToolbarItem variant="label">{translations.sort}</ToolbarItem>
         <ToolbarItem>
           <Split>
@@ -96,7 +91,7 @@ export function PageToolbarSort(props: PageToolbarSortProps) {
           </Split>
         </ToolbarItem>
       </ToolbarGroup>
-    </ToolbarToggleGroup>
+    </PageToolbarToggleGroup>
   );
 }
 

--- a/framework/PageToolbar/PageToolbarSort.tsx
+++ b/framework/PageToolbar/PageToolbarSort.tsx
@@ -69,7 +69,7 @@ export function PageToolbarSort(props: PageToolbarSortProps) {
   if (!sortOptions || sortOptions.length <= 0) return <></>;
 
   return (
-    <PageToolbarToggleGroup breakpoint="2xl" toggleIcon={sortDirectionIcon}>
+    <PageToolbarToggleGroup breakpoint="2xl" toggleIcon={sortDirectionIcon} id="sort">
       <ToolbarGroup variant="filter-group" style={{ flexWrap: 'wrap', gap: 8 }}>
         <ToolbarItem variant="label">{translations.sort}</ToolbarItem>
         <ToolbarItem>

--- a/framework/PageToolbar/PageToolbarToggleGroup.tsx
+++ b/framework/PageToolbar/PageToolbarToggleGroup.tsx
@@ -1,10 +1,37 @@
 import { ToolbarToggleGroup, ToolbarToggleGroupProps } from '@patternfly/react-core';
-import { useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { SetRequired } from 'type-fest';
 
-export function PageToolbarToggleGroup(props: ToolbarToggleGroupProps) {
+export function PageToolbarToggleGroup(props: SetRequired<ToolbarToggleGroupProps, 'id'>) {
   const [isExpanded, setIsExpanded] = useState(false);
   const onToggle = (_event: React.MouseEvent) => {
     setIsExpanded(!isExpanded);
   };
+  const { activeGroup, setActiveGroup } = useContext(PageToolbarToggleGroupContext);
+
+  useEffect(() => {
+    if (isExpanded) {
+      setActiveGroup(props.id);
+    }
+  }, [isExpanded, setActiveGroup, props.id]);
+
+  useEffect(() => {
+    if (activeGroup !== props.id) {
+      setIsExpanded(false);
+    }
+  }, [activeGroup, props.id]);
+
   return <ToolbarToggleGroup {...props} isExpanded={isExpanded} onToggle={onToggle} />;
 }
+
+interface PageToolbarToggleGroupContextProps {
+  activeGroup: string;
+  setActiveGroup: (group: string) => void;
+}
+
+// context that will clost other open groups when a new one is opened
+// Path: framework/PageToolbar/PageToolbarToggleGroup.tsx
+export const PageToolbarToggleGroupContext = createContext<PageToolbarToggleGroupContextProps>({
+  activeGroup: '',
+  setActiveGroup: () => {},
+});

--- a/framework/PageToolbar/PageToolbarToggleGroup.tsx
+++ b/framework/PageToolbar/PageToolbarToggleGroup.tsx
@@ -1,0 +1,10 @@
+import { ToolbarToggleGroup, ToolbarToggleGroupProps } from '@patternfly/react-core';
+import { useState } from 'react';
+
+export function PageToolbarToggleGroup(props: ToolbarToggleGroupProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const onToggle = (_event: React.MouseEvent) => {
+    setIsExpanded(!isExpanded);
+  };
+  return <ToolbarToggleGroup {...props} isExpanded={isExpanded} onToggle={onToggle} />;
+}

--- a/framework/PageToolbar/PageToolbarView.tsx
+++ b/framework/PageToolbar/PageToolbarView.tsx
@@ -8,7 +8,7 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { CogIcon, ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
+import { ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
 import { useRef } from 'react';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
@@ -33,8 +33,12 @@ export function PageToolbarView(props: PageToolbarViewProps) {
   if (!props.disableCardView) viewTypeCount++;
   if (!props.disableListView) viewTypeCount++;
 
+  let icon = <TableIcon />;
+  if (viewType === PageTableViewTypeE.Cards) icon = <ThLargeIcon />;
+  if (viewType === PageTableViewTypeE.List) icon = <ListIcon />;
+
   return (
-    <PageToolbarToggleGroup breakpoint="md" toggleIcon={<CogIcon />}>
+    <PageToolbarToggleGroup breakpoint="md" toggleIcon={icon}>
       <ToolbarGroup variant="button-group" style={{ justifyContent: 'end', marginRight: 0 }}>
         <ToolbarItem>
           <Split hasGutter>

--- a/framework/PageToolbar/PageToolbarView.tsx
+++ b/framework/PageToolbar/PageToolbarView.tsx
@@ -1,14 +1,18 @@
 import {
   Button,
+  Split,
   ToggleGroup,
   ToggleGroupItem,
+  ToggleGroupItemProps,
   ToolbarGroup,
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
+import { CogIcon, ColumnsIcon, ListIcon, TableIcon, ThLargeIcon } from '@patternfly/react-icons';
+import { useRef } from 'react';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { PageTableViewType, PageTableViewTypeE } from './PageTableViewType';
+import { PageToolbarToggleGroup } from './PageToolbarToggleGroup';
 
 export type PageToolbarViewProps = {
   disableTableView?: boolean;
@@ -30,81 +34,83 @@ export function PageToolbarView(props: PageToolbarViewProps) {
   if (!props.disableListView) viewTypeCount++;
 
   return (
-    <ToolbarGroup variant="button-group" style={{ justifyContent: 'end', marginRight: 0 }}>
-      {openColumnModal && (
+    <PageToolbarToggleGroup breakpoint="md" toggleIcon={<CogIcon />}>
+      <ToolbarGroup variant="button-group" style={{ justifyContent: 'end', marginRight: 0 }}>
         <ToolbarItem>
-          <Tooltip content={translations.manageColumns}>
-            <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
-          </Tooltip>
+          <Split hasGutter>
+            {openColumnModal && (
+              <Tooltip content={translations.manageColumns}>
+                <Button variant="plain" icon={<ColumnsIcon />} onClick={openColumnModal} />
+              </Tooltip>
+            )}
+            {viewTypeCount > 1 && (
+              <ToggleGroup data-cy={'table-view-toggle'} aria-label="table view toggle">
+                {[
+                  !props.disableTableView && PageTableViewTypeE.Table,
+                  !props.disableListView && PageTableViewTypeE.List,
+                  !props.disableCardView && PageTableViewTypeE.Cards,
+                ]
+                  .filter((i) => i)
+                  .map((vt) => {
+                    switch (vt) {
+                      case PageTableViewTypeE.Cards:
+                        return (
+                          <PageToggleGroupItem
+                            icon={<ThLargeIcon />}
+                            isSelected={viewType === PageTableViewTypeE.Cards}
+                            onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
+                            aria-label="card view"
+                            data-cy={'card-view'}
+                            tooltip={translations.cardView}
+                          />
+                        );
+                      case PageTableViewTypeE.List:
+                        return (
+                          <PageToggleGroupItem
+                            icon={<ListIcon />}
+                            isSelected={viewType === PageTableViewTypeE.List}
+                            onClick={() => setViewType?.(PageTableViewTypeE.List)}
+                            aria-label="list view"
+                            data-cy={'list-view'}
+                            tooltip={translations.listView}
+                          />
+                        );
+                      case PageTableViewTypeE.Table:
+                        return (
+                          <PageToggleGroupItem
+                            icon={<TableIcon />}
+                            isSelected={viewType === PageTableViewTypeE.Table}
+                            onClick={() => setViewType?.(PageTableViewTypeE.Table)}
+                            aria-label="table view"
+                            data-cy={'table-view'}
+                            tooltip={translations.tableView}
+                          />
+                        );
+                    }
+                  })}
+              </ToggleGroup>
+            )}
+          </Split>
         </ToolbarItem>
-      )}
-      {viewTypeCount > 1 && (
-        <ToolbarItem>
-          <ToggleGroup data-cy={'table-view-toggle'} aria-label="table view toggle">
-            {[
-              !props.disableTableView && PageTableViewTypeE.Table,
-              !props.disableListView && PageTableViewTypeE.List,
-              !props.disableCardView && PageTableViewTypeE.Cards,
-            ]
-              .filter((i) => i)
-              .map((vt) => {
-                switch (vt) {
-                  case PageTableViewTypeE.Cards:
-                    return (
-                      <Tooltip
-                        content={translations.cardView}
-                        key={vt}
-                        position="top-end"
-                        enableFlip={false}
-                      >
-                        <ToggleGroupItem
-                          icon={<ThLargeIcon />}
-                          isSelected={viewType === PageTableViewTypeE.Cards}
-                          onClick={() => setViewType?.(PageTableViewTypeE.Cards)}
-                          aria-label="card view"
-                          data-cy={'card-view'}
-                        />
-                      </Tooltip>
-                    );
-                  case PageTableViewTypeE.List:
-                    return (
-                      <Tooltip
-                        content={translations.listView}
-                        key={vt}
-                        position="top-end"
-                        enableFlip={false}
-                      >
-                        <ToggleGroupItem
-                          icon={<ListIcon />}
-                          isSelected={viewType === PageTableViewTypeE.List}
-                          onClick={() => setViewType?.(PageTableViewTypeE.List)}
-                          aria-label="list view"
-                          data-cy={'list-view'}
-                        />
-                      </Tooltip>
-                    );
-                  case PageTableViewTypeE.Table:
-                    return (
-                      <Tooltip
-                        content={translations.tableView}
-                        key={vt}
-                        position="top-end"
-                        enableFlip={false}
-                      >
-                        <ToggleGroupItem
-                          icon={<TableIcon />}
-                          isSelected={viewType === PageTableViewTypeE.Table}
-                          onClick={() => setViewType?.(PageTableViewTypeE.Table)}
-                          aria-label="table view"
-                          data-cy={'table-view'}
-                        />
-                      </Tooltip>
-                    );
-                }
-              })}
-          </ToggleGroup>
-        </ToolbarItem>
-      )}
-    </ToolbarGroup>
+      </ToolbarGroup>
+    </PageToolbarToggleGroup>
+  );
+}
+
+function PageToggleGroupItem(
+  props: ToggleGroupItemProps & {
+    tooltip: string;
+  }
+) {
+  const { tooltip, ...rest } = props;
+  return (
+    <Tooltip
+      content={tooltip}
+      position="top-end"
+      enableFlip={false}
+      triggerRef={useRef<HTMLDivElement>(null)}
+    >
+      <ToggleGroupItem ref={useRef<HTMLDivElement>(null)} {...rest} />
+    </Tooltip>
   );
 }

--- a/framework/PageToolbar/PageToolbarView.tsx
+++ b/framework/PageToolbar/PageToolbarView.tsx
@@ -38,7 +38,7 @@ export function PageToolbarView(props: PageToolbarViewProps) {
   if (viewType === PageTableViewTypeE.List) icon = <ListIcon />;
 
   return (
-    <PageToolbarToggleGroup breakpoint="md" toggleIcon={icon}>
+    <PageToolbarToggleGroup breakpoint="md" toggleIcon={icon} id="view">
       <ToolbarGroup variant="button-group" style={{ justifyContent: 'end', marginRight: 0 }}>
         <ToolbarItem>
           <Split hasGutter>


### PR DESCRIPTION
PF4 used to allow for multiple ToolbarToggleGroups and when expanded they would all show in the expansion.
We had 2 - one for filters and one for sorting.

PF5 made it so each one shows independently, but... the two expansions both always open and the last one renders on top of the other.
The PF5 team said to manage the open state explicitly and it will work correctly,
so now we have a PageToolbarToggleGroup that manages it's open state.
PF5 didn't want to fix it as they are worried fixing it would cause a breaking change in existing open state functionality.


https://github.com/ansible/ansible-ui/assets/6277895/797c6cb7-562d-4e39-9a8e-db7632522070

