### PR TITLE
[AAP-15657] - Update eda details routes. Action menu only in details pages.

### DIFF
--- a/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
@@ -82,7 +82,8 @@ export function UserPage() {
               selection: PageActionSelection.Single,
               icon: TrashIcon,
               label: t('Delete user'),
-              isHidden: (_user: EdaUser) => isViewingSelf,
+              isDisabled: (_user: EdaUser) =>
+                isViewingSelf ? t('Current user cannot be deleted') : undefined,
               onClick: (user: EdaUser) => deleteUsers([user]),
               isDanger: true,
             },

--- a/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
@@ -85,6 +85,7 @@ export function UserPage() {
     [canEditUser, deleteUsers, isViewingSelf, pageNavigate, t]
   );
   if (!activeUser) return <LoadingPage breadcrumbs tabs />;
+  console.log('Debug - location: ', location);
   const tabs = isViewingSelf
     ? [
         { label: t('Details'), page: EdaRoute.UserDetails },

--- a/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/UserPage.tsx
@@ -47,45 +47,50 @@ export function UserPage() {
     activeUser?.is_superuser ||
     activeUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
 
+  const isActionTab =
+    location.pathname === getPageUrl(EdaRoute.UserDetails, { params: { id: user?.id } });
   const itemActions = useMemo<IPageAction<EdaUser>[]>(
-    () => [
-      {
-        type: PageActionType.Button,
-        variant: ButtonVariant.primary,
-        selection: PageActionSelection.Single,
-        icon: PencilAltIcon,
-        isPinned: true,
-        label: t('Edit user'),
-        isHidden: (_user: EdaUser) => !canEditUser,
-        onClick: (user: EdaUser) => pageNavigate(EdaRoute.EditUser, { params: { id: user.id } }),
-      },
-      {
-        type: PageActionType.Button,
-        variant: ButtonVariant.primary,
-        selection: PageActionSelection.Single,
-        icon: PencilAltIcon,
-        isPinned: true,
-        isHidden: (_user: EdaUser) => canEditUser || !isViewingSelf,
-        label: t('Edit user'),
-        onClick: () => pageNavigate(EdaRoute.EditCurrentUser),
-      },
-      {
-        type: PageActionType.Seperator,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete user'),
-        isHidden: (_user: EdaUser) => isViewingSelf,
-        onClick: (user: EdaUser) => deleteUsers([user]),
-        isDanger: true,
-      },
-    ],
-    [canEditUser, deleteUsers, isViewingSelf, pageNavigate, t]
+    () =>
+      isActionTab
+        ? [
+            {
+              type: PageActionType.Button,
+              variant: ButtonVariant.primary,
+              selection: PageActionSelection.Single,
+              icon: PencilAltIcon,
+              isPinned: true,
+              label: t('Edit user'),
+              isHidden: (_user: EdaUser) => !canEditUser,
+              onClick: (user: EdaUser) =>
+                pageNavigate(EdaRoute.EditUser, { params: { id: user.id } }),
+            },
+            {
+              type: PageActionType.Button,
+              variant: ButtonVariant.primary,
+              selection: PageActionSelection.Single,
+              icon: PencilAltIcon,
+              isPinned: true,
+              isHidden: (_user: EdaUser) => canEditUser || !isViewingSelf,
+              label: t('Edit user'),
+              onClick: () => pageNavigate(EdaRoute.EditCurrentUser),
+            },
+            {
+              type: PageActionType.Seperator,
+            },
+            {
+              type: PageActionType.Button,
+              selection: PageActionSelection.Single,
+              icon: TrashIcon,
+              label: t('Delete user'),
+              isHidden: (_user: EdaUser) => isViewingSelf,
+              onClick: (user: EdaUser) => deleteUsers([user]),
+              isDanger: true,
+            },
+          ]
+        : [],
+    [canEditUser, deleteUsers, isActionTab, isViewingSelf, pageNavigate, t]
   );
   if (!activeUser) return <LoadingPage breadcrumbs tabs />;
-  console.log('Debug - location: ', location);
   const tabs = isViewingSelf
     ? [
         { label: t('Details'), page: EdaRoute.UserDetails },

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -75,46 +75,50 @@ export function RulebookActivationPage() {
       },
       [alertToaster, refresh, t]
     );
-
+  const isActionTab =
+    location.pathname ===
+    getPageUrl(EdaRoute.RulebookActivationDetails, { params: { id: rulebookActivation?.id } });
   const itemActions = useMemo<IPageAction<EdaRulebookActivation>[]>(() => {
-    const actions: IPageAction<EdaRulebookActivation>[] = [
-      {
-        type: PageActionType.Switch,
-        selection: PageActionSelection.Single,
-        ariaLabel: (isEnabled) =>
-          isEnabled ? t('Click to disable instance') : t('Click to enable instance'),
-        isPinned: true,
-        label: t('Rulebook activation enabled'),
-        labelOff: t('Rulebook activation disabled'),
-        onToggle: (activation: EdaRulebookActivation, activate: boolean) =>
-          handleToggle(activation, activate),
-        isSwitchOn: (activation: EdaRulebookActivation) => activation.is_enabled ?? false,
-        isDisabled: (activation: EdaRulebookActivation) =>
-          activation.status === Status906Enum.Stopping
-            ? t('Cannot change activation status while stopping')
-            : undefined,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: RedoIcon,
-        label: t('Restart rulebook activation'),
-        isDanger: false,
-        isHidden: (activation: EdaRulebookActivation) => !activation.is_enabled,
-        onClick: (activation: EdaRulebookActivation) => restartRulebookActivation([activation]),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete rulebook activation'),
-        onClick: (rulebookActivation: EdaRulebookActivation) =>
-          deleteRulebookActivations([rulebookActivation]),
-        isDanger: true,
-      },
-    ];
+    const actions: IPageAction<EdaRulebookActivation>[] = isActionTab
+      ? [
+          {
+            type: PageActionType.Switch,
+            selection: PageActionSelection.Single,
+            ariaLabel: (isEnabled) =>
+              isEnabled ? t('Click to disable instance') : t('Click to enable instance'),
+            isPinned: true,
+            label: t('Rulebook activation enabled'),
+            labelOff: t('Rulebook activation disabled'),
+            onToggle: (activation: EdaRulebookActivation, activate: boolean) =>
+              handleToggle(activation, activate),
+            isSwitchOn: (activation: EdaRulebookActivation) => activation.is_enabled ?? false,
+            isDisabled: (activation: EdaRulebookActivation) =>
+              activation.status === Status906Enum.Stopping
+                ? t('Cannot change activation status while stopping')
+                : undefined,
+          },
+          {
+            type: PageActionType.Button,
+            selection: PageActionSelection.Single,
+            icon: RedoIcon,
+            label: t('Restart rulebook activation'),
+            isDanger: false,
+            isHidden: (activation: EdaRulebookActivation) => !activation.is_enabled,
+            onClick: (activation: EdaRulebookActivation) => restartRulebookActivation([activation]),
+          },
+          {
+            type: PageActionType.Button,
+            selection: PageActionSelection.Single,
+            icon: TrashIcon,
+            label: t('Delete rulebook activation'),
+            onClick: (rulebookActivation: EdaRulebookActivation) =>
+              deleteRulebookActivations([rulebookActivation]),
+            isDanger: true,
+          },
+        ]
+      : [];
     return actions;
-  }, [handleToggle, restartRulebookActivation, deleteRulebookActivations, t]);
+  }, [handleToggle, isActionTab, restartRulebookActivation, deleteRulebookActivations, t]);
 
   return (
     <PageLayout>

--- a/frontend/eda/useEdaNavigation.tsx
+++ b/frontend/eda/useEdaNavigation.tsx
@@ -72,7 +72,7 @@ export function useEdaNavigation() {
                 children: [
                   {
                     id: EdaRoute.RuleAuditPage,
-                    path: 'details/:id',
+                    path: ':id',
                     element: <RuleAuditPage />,
                     children: [
                       {
@@ -178,7 +178,7 @@ export function useEdaNavigation() {
                   },
                   {
                     id: EdaRoute.ProjectPage,
-                    path: 'details/:id',
+                    path: ':id',
                     element: <ProjectPage />,
                     children: [
                       {
@@ -215,7 +215,7 @@ export function useEdaNavigation() {
                   },
                   {
                     id: EdaRoute.DecisionEnvironmentPage,
-                    path: 'details/:id',
+                    path: ':id',
                     element: <DecisionEnvironmentPage />,
                     children: [
                       {
@@ -252,7 +252,7 @@ export function useEdaNavigation() {
                   },
                   {
                     id: EdaRoute.CredentialPage,
-                    path: 'details/:id',
+                    path: ':id',
                     element: <CredentialPage />,
                     children: [
                       {
@@ -322,7 +322,7 @@ export function useEdaNavigation() {
                   {
                     id: EdaRoute.UserPage,
                     element: <UserPage />,
-                    path: 'details/:id',
+                    path: ':id',
                     children: [
                       {
                         id: EdaRoute.UserDetails,
@@ -373,7 +373,7 @@ export function useEdaNavigation() {
                   },
                   {
                     id: EdaRoute.RolePage,
-                    path: 'details/:id',
+                    path: ':id',
                     element: <RoleDetails />,
                   },
                   {


### PR DESCRIPTION
Update eda details routes. 
Action menu only in details pages for User and Rulebook activations:

![Screenshot from 2023-10-26 16-44-00](https://github.com/ansible/ansible-ui/assets/12769982/958958dc-1b80-42cb-8f36-38a67578a666)
![Screenshot from 2023-10-26 16-43-53](https://github.com/ansible/ansible-ui/assets/12769982/0e07882c-097f-4371-8680-2649eba30468)
![Screenshot from 2023-10-26 16-40-11](https://github.com/ansible/ansible-ui/assets/12769982/a3f91151-aa95-4a7a-bffe-4759efb17826)
![Screenshot from 2023-10-27 10-42-44](https://github.com/ansible/ansible-ui/assets/12769982/0dc2a010-50c4-4565-b2a2-608c36817fd0)
