### PR TITLE
Restructure oauth options to allow duplicate types

### DIFF
--- a/frontend/awx/AwxLogin.tsx
+++ b/frontend/awx/AwxLogin.tsx
@@ -1,13 +1,30 @@
 import { useGetPageUrl } from '../../framework/PageNavigation/useGetPageUrl';
 import { Login } from '../common/Login';
-import type { AuthOptions } from '../common/SocialAuthLogin';
+import type { AuthOption } from '../common/SocialAuthLogin';
 import { useGet } from '../common/crud/useGet';
 import { AwxRoute } from './AwxRoutes';
 
+type AwxAuthOptions = {
+  [key: string]: {
+    login_url: string;
+  };
+};
+
 export function AwxLogin() {
-  const { data: options } = useGet<AuthOptions>('/api/v2/auth/');
+  const { data: options } = useGet<AwxAuthOptions>('/api/v2/auth/');
   const getPageUrl = useGetPageUrl();
+
+  const authOptions: AuthOption[] = [];
+  if (options) {
+    Object.keys(options).forEach((key) => {
+      authOptions.push({
+        login_url: options[key].login_url,
+        type: key,
+      });
+    });
+  }
+
   return (
-    <Login authOptions={options} apiUrl="/api/login/" onLoginUrl={getPageUrl(AwxRoute.Login)} />
+    <Login authOptions={authOptions} apiUrl="/api/login/" onLoginUrl={getPageUrl(AwxRoute.Login)} />
   );
 }

--- a/frontend/common/Login.tsx
+++ b/frontend/common/Login.tsx
@@ -5,7 +5,7 @@ import background from '../../node_modules/@patternfly/patternfly/assets/images/
 import { useFrameworkTranslations } from '../../framework/useFrameworkTranslations';
 import ErrorBoundary from '../../framework/components/ErrorBoundary';
 import { LoginForm } from './LoginForm';
-import type { AuthOptions } from './SocialAuthLogin';
+import type { AuthOption } from './SocialAuthLogin';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
@@ -34,7 +34,7 @@ const Heading = styled(Title)`
 `;
 
 type LoginProps = {
-  authOptions?: AuthOptions;
+  authOptions?: AuthOption[];
   apiUrl?: string;
   onLoginUrl?: string;
 };

--- a/frontend/common/Login.tsx
+++ b/frontend/common/Login.tsx
@@ -34,6 +34,7 @@ const Heading = styled(Title)`
 `;
 
 type LoginProps = {
+  hideInputs?: boolean;
   authOptions?: AuthOption[];
   apiUrl?: string;
   onLoginUrl?: string;
@@ -61,6 +62,7 @@ export function Login(props: LoginProps) {
             authOptions={props.authOptions}
             onLoginUrl={props.onLoginUrl}
             onLogin={navigateBack}
+            hideInputs={props.hideInputs}
           />
         </Inner>
       </Wrapper>

--- a/frontend/common/LoginForm.tsx
+++ b/frontend/common/LoginForm.tsx
@@ -23,6 +23,7 @@ type LoginFormProps = {
   authOptions?: AuthOption[];
   onLoginUrl?: string;
   onLogin?: () => void;
+  hideInputs?: boolean;
 };
 
 export function LoginForm(props: LoginFormProps) {
@@ -138,6 +139,10 @@ export function LoginForm(props: LoginFormProps) {
     },
     [pageNavigate, navigate, props, t]
   );
+
+  if (props.hideInputs) {
+    return <SocialAuthLogin options={authOptions} />;
+  }
 
   return (
     <GenericForm onSubmit={onSubmit}>

--- a/frontend/common/LoginForm.tsx
+++ b/frontend/common/LoginForm.tsx
@@ -16,11 +16,11 @@ import { HubRoute } from '../hub/HubRoutes';
 import { RequestError, createRequestError } from './crud/RequestError';
 import { setCookie } from './crud/cookie';
 import { useInvalidateCacheOnUnmount } from './useInvalidateCache';
-import { AuthOptions, SocialAuthLogin } from './SocialAuthLogin';
+import { AuthOption, SocialAuthLogin } from './SocialAuthLogin';
 
 type LoginFormProps = {
   apiUrl?: string;
-  authOptions?: AuthOptions;
+  authOptions?: AuthOption[];
   onLoginUrl?: string;
   onLogin?: () => void;
 };

--- a/frontend/common/SocialAuthLogin.tsx
+++ b/frontend/common/SocialAuthLogin.tsx
@@ -20,14 +20,14 @@ const Grid = styled.div`
   gap: 30px 50px;
 `;
 
-export type AuthOptions = {
-  [key: string]: {
-    login_url: string;
-  };
+export type AuthOption = {
+  name?: string;
+  login_url: string;
+  type: string;
 };
 
 type SocialAuthLoginProps = {
-  options?: AuthOptions;
+  options?: AuthOption[];
 };
 
 export function SocialAuthLogin(props: SocialAuthLoginProps) {
@@ -42,8 +42,8 @@ export function SocialAuthLogin(props: SocialAuthLoginProps) {
     <Container>
       <Heading>{t`Log in with`}</Heading>
       <Grid>
-        {Object.keys(options).map((key) => (
-          <SocialAuthLink key={key} authKey={key} options={options[key]} />
+        {options.map((option) => (
+          <SocialAuthLink key={option.login_url} option={option} />
         ))}
       </Grid>
     </Container>
@@ -63,8 +63,8 @@ const icons: { [key: string]: typeof GithubIcon } = {
   saml: UserCircleIcon,
 };
 
-function SocialAuthLink(props: { authKey: string; options: { login_url: string } }) {
-  const { options } = props;
+function SocialAuthLink(props: { option: AuthOption }) {
+  const { option } = props;
   const { t } = useTranslation();
 
   const labels: { [key: string]: string } = {
@@ -80,17 +80,17 @@ function SocialAuthLink(props: { authKey: string; options: { login_url: string }
     saml: t('SAML'),
   };
 
-  const Icon = icons[props.authKey] ?? UserCircleIcon;
+  const Icon = icons[option.type] ?? UserCircleIcon;
 
   return (
     <Button
-      data-cy={`social-auth-${props.authKey}`}
+      data-cy={`social-auth-${option.type}`}
       component="a"
-      href={options.login_url}
+      href={option.login_url}
       variant="secondary"
     >
       <Icon height="20" width="20" style={{ verticalAlign: '-0.25em', marginRight: '0.5em' }} />
-      {labels[props.authKey] ?? ''}
+      {option.name || labels[option.type] || ''}
     </Button>
   );
 }


### PR DESCRIPTION
Instead of an object keyed by the oAuth type, this restructures the auth options to an array of objects where `type` is an item in the object. This way two different auth options can use the same type

This also adds a flag for hiding the username/password field in cases when only oAuth login should be allowed