### PR TITLE
[AAP-11584] Update enable/disable rulebook activation interactions

### DIFF
--- a/cypress/fixtures/edaDisabledRulebookActivation.json
+++ b/cypress/fixtures/edaDisabledRulebookActivation.json
@@ -1,0 +1,39 @@
+{
+  "id": 1,
+  "name": "Activation 1",
+  "description": "",
+  "is_enabled": false,
+  "decision_environment": {
+    "id": 1,
+    "name": "DE1",
+    "description": "",
+    "image_url": "quay.io/ansible/ansible-rulebook:main"
+  },
+  "status": "completed",
+  "git_hash": "09ec99f2304e5b78b3c88131d7313f63e38e29a4",
+  "project": null,
+  "rulebook": null,
+  "extra_var": null,
+  "instances": [
+    {
+      "id": 48,
+      "name": "Activation 1",
+      "status": "completed",
+      "git_hash": "09ec99f2304e5b78b3c88131d7313f63e38e29a4",
+      "status_message": "Activation has completed",
+      "activation_id": 1,
+      "started_at": "2023-10-27T21:38:51.660535Z",
+      "ended_at": "2023-10-27T21:38:56.566707Z"
+    }
+  ],
+  "restart_policy": "on-failure",
+  "restart_count": 1,
+  "rulebook_name": "multi_ruleset.yml",
+  "current_job_id": null,
+  "rules_count": 2,
+  "rules_fired_count": 2,
+  "created_at": "2023-10-16T22:33:57.606832Z",
+  "modified_at": "2023-10-27T21:38:56.567840Z",
+  "restarted_at": "2023-10-27T21:38:51.660535Z",
+  "status_message": "Activation has completed"
+}

--- a/cypress/fixtures/edaEnabledRulebookActivation.json
+++ b/cypress/fixtures/edaEnabledRulebookActivation.json
@@ -1,0 +1,139 @@
+{
+  "id": 5,
+  "name": "Activation 2",
+  "description": "",
+  "is_enabled": true,
+  "decision_environment": {
+    "id": 1,
+    "name": "DE1",
+    "description": "",
+    "image_url": "quay.io/ansible/ansible-rulebook:main"
+  },
+  "status": "completed",
+  "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+  "project": {
+    "id": 2,
+    "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+    "url": "https://github.com/ansible/ansible-ui",
+    "name": "Project 1",
+    "description": ""
+  },
+  "rulebook": {
+    "id": 11,
+    "name": "fail.yml",
+    "description": ""
+  },
+  "extra_var": null,
+  "instances": [
+    {
+      "id": 55,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-30T19:49:48.298274Z",
+      "ended_at": "2023-10-30T19:49:59.549997Z"
+    },
+    {
+      "id": 54,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-30T19:49:18.147834Z",
+      "ended_at": "2023-10-30T19:49:29.213237Z"
+    },
+    {
+      "id": 50,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-30T19:48:10.490148Z",
+      "ended_at": "2023-10-30T19:48:41.713824Z"
+    },
+    {
+      "id": 45,
+      "name": "Activation 2",
+      "status": "stopped",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has stopped",
+      "activation_id": 5,
+      "started_at": "2023-10-27T19:52:50.058327Z",
+      "ended_at": null
+    },
+    {
+      "id": 44,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-27T19:18:06.922274Z",
+      "ended_at": "2023-10-27T19:18:17.060915Z"
+    },
+    {
+      "id": 43,
+      "name": "Activation 2",
+      "status": "stopped",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has stopped",
+      "activation_id": 5,
+      "started_at": "2023-10-27T19:17:56.517341Z",
+      "ended_at": null
+    },
+    {
+      "id": 42,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-26T19:39:01.414799Z",
+      "ended_at": "2023-10-26T19:39:12.209406Z"
+    },
+    {
+      "id": 41,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-26T19:22:58.826848Z",
+      "ended_at": "2023-10-26T19:23:09.696430Z"
+    },
+    {
+      "id": 40,
+      "name": "Activation 2",
+      "status": "stopped",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has stopped",
+      "activation_id": 5,
+      "started_at": "2023-10-26T19:22:41.964064Z",
+      "ended_at": null
+    },
+    {
+      "id": 39,
+      "name": "Activation 2",
+      "status": "completed",
+      "git_hash": "1d1789a160fd0ff33f583582ba3d1eed20697971",
+      "status_message": "Activation has completed",
+      "activation_id": 5,
+      "started_at": "2023-10-26T19:21:40.834960Z",
+      "ended_at": "2023-10-26T19:21:52.057263Z"
+    }
+  ],
+  "restart_policy": "on-failure",
+  "restart_count": 2,
+  "rulebook_name": "fail.yml",
+  "current_job_id": null,
+  "rules_count": 1,
+  "rules_fired_count": 1,
+  "created_at": "2023-10-26T19:21:40.801669Z",
+  "modified_at": "2023-10-30T19:49:59.551090Z",
+  "restarted_at": "2023-10-30T19:49:48.298274Z",
+  "status_message": "Activation has completed"
+}

--- a/cypress/fixtures/edaRulebookActivations.json
+++ b/cypress/fixtures/edaRulebookActivations.json
@@ -6,7 +6,7 @@
   "page": 1,
   "results": [
     {
-      "id": 5,
+      "id": 1,
       "name": "Activation 1",
       "description": "",
       "is_enabled": true,
@@ -25,7 +25,7 @@
       "modified_at": "2023-10-02T13:34:28.742952Z"
     },
     {
-      "id": 5,
+      "id": 11,
       "name": "Activation 2",
       "description": "",
       "is_enabled": true,

--- a/frontend/common/Routes.ts
+++ b/frontend/common/Routes.ts
@@ -78,4 +78,7 @@ export const RouteObj = {
 
   // EDA
   EdaUserDetailsTokens: `${edaRoutePrefix}/access/users/details/:id/tokens`,
+  EdaRulebookActivationPage: `${edaRoutePrefix}/views/rulebook-activations/:id/*`,
+  EdaRulebookActivationDetails: `${edaRoutePrefix}/views/rulebook-activations/:id/details`,
+  EdaRulebookActivationHistory: `${edaRoutePrefix}/views/rulebook-activations/:id/history`,
 };

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable i18next/no-literal-string */
+
+import { RulebookActivationPage } from './RulebookActivationPage';
+import { RouteObj } from '../../../common/Routes';
+
+describe('RulebookActivationPage', () => {
+  beforeEach(() => {
+    cy.intercept(
+      { method: 'GET', url: '/api/eda/v1/activations/1/' },
+      { fixture: 'edaDisabledRulebookActivation.json' }
+    );
+    cy.intercept(
+      { method: 'GET', url: '/api/eda/v1/activations/5/' },
+      { fixture: 'edaEnabledRulebookActivation.json' }
+    );
+  });
+
+  it('Component renders and displays the rulebook activation', () => {
+    cy.intercept(
+      { method: 'GET', url: '/api/eda/v1/activations/1/' },
+      { fixture: 'edaDisabledRulebookActivation.json' }
+    );
+    cy.mount(<RulebookActivationPage />, {
+      path: RouteObj.EdaRulebookActivationPage,
+      initialEntries: [RouteObj.EdaRulebookActivationDetails.replace(':id', '1')],
+    });
+    cy.get('h1').should('have.text', 'Activation 1');
+  });
+
+  it('Should render all the tabs', () => {
+    const tabNames: string[] = ['Back to Rulebook Activations', 'Details', 'History'];
+    cy.mount(<RulebookActivationPage />);
+
+    cy.get('.pf-v5-c-tabs__list').within(() => {
+      cy.get('.pf-v5-c-tabs__item').should('have.length', 3);
+      cy.get('.pf-v5-c-tabs__item').each((tab, index) => {
+        cy.wrap(tab).should('contain', tabNames[index]);
+      });
+    });
+  });
+});

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
@@ -13,6 +13,9 @@ describe('RulebookActivationPage', () => {
       { method: 'GET', url: '/api/eda/v1/activations/5/' },
       { fixture: 'edaEnabledRulebookActivation.json' }
     );
+    cy.intercept('POST', '/api/eda/v1/activations/1/enable/', (req) => {
+      return req.reply({ statusCode: 204 });
+    }).as('enableActivation');
   });
 
   it('Component renders and displays the rulebook activation', () => {
@@ -25,6 +28,51 @@ describe('RulebookActivationPage', () => {
       initialEntries: [RouteObj.EdaRulebookActivationDetails.replace(':id', '1')],
     });
     cy.get('h1').should('have.text', 'Activation 1');
+  });
+
+  it('Can enable the rulebook activation', () => {
+    cy.intercept(
+      { method: 'GET', url: '/api/eda/v1/activations/1/' },
+      { fixture: 'edaDisabledRulebookActivation.json' }
+    );
+    cy.intercept(
+      { method: 'GET', url: '/api/eda/v1/activations/1/*' },
+      { fixture: 'edaDisabledRulebookActivation.json' }
+    );
+    cy.intercept('POST', '/api/eda/v1/activations/1/enable/', (req) => {
+      return req.reply({ statusCode: 204 });
+    }).as('enableActivation');
+
+    cy.mount(<RulebookActivationPage />, {
+      path: RouteObj.EdaRulebookActivationPage,
+      initialEntries: [RouteObj.EdaRulebookActivationDetails.replace(':id', '1')],
+    });
+    cy.get('.pf-v5-c-switch__toggle').click();
+    cy.wait('@enableActivation');
+    cy.get('.pf-v5-c-alert__title').should('contain', 'Activation 1 enabled');
+  });
+
+  it('Can disable the rulebook activation', () => {
+    cy.intercept('POST', '/api/eda/v1/activations/5/disable/', (req) => {
+      return req.reply({ statusCode: 204 });
+    }).as('disableActivation');
+
+    cy.mount(<RulebookActivationPage />, {
+      path: RouteObj.EdaRulebookActivationPage,
+      initialEntries: [RouteObj.EdaRulebookActivationDetails.replace(':id', '5')],
+    });
+
+    cy.get('.pf-v5-c-switch__toggle').click();
+    cy.get('div[role="dialog"]').within(() => {
+      cy.get('.pf-v5-c-check__label').should(
+        'contain',
+        `Yes, I confirm that I want to disable these 1 rulebook activation`
+      );
+      cy.get('td').should('contain', 'Activation 2');
+      cy.get('input[id="confirm"]').click();
+      cy.get('button').contains('Disable rulebook activations').click();
+      cy.get('td').should('contain', 'Success');
+    });
   });
 
   it('Should render all the tabs', () => {

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -67,7 +67,7 @@ export function RulebookActivationPage() {
           title: `${activation.name} ${t('enabled')}.`,
           timeout: 5000,
         };
-        await postRequest(edaApi`/activations/${activation.id}/enable/`, undefined)
+        await postRequest(edaAPI`/activations/${activation.id.toString()}/enable/`, undefined)
           .then(() => alertToaster.addAlert(alert))
           .catch(() => {
             alertToaster.addAlert({

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -80,9 +80,11 @@ export function RulebookActivationPage() {
       },
       [alertToaster, refresh, t]
     );
-  const isActionTab =
-    location.pathname ===
-    getPageUrl(EdaRoute.RulebookActivationDetails, { params: { id: rulebookActivation?.id } });
+
+  const isActionTab = location.href.includes(
+    getPageUrl(EdaRoute.RulebookActivationDetails, { params: { id: rulebookActivation?.id } })
+  );
+
   const itemActions = useMemo<IPageAction<EdaRulebookActivation>[]>(() => {
     const actions: IPageAction<EdaRulebookActivation>[] = isActionTab
       ? [

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -1,4 +1,3 @@
-import { AlertProps } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { RedoIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
@@ -12,19 +11,23 @@ import {
   PageHeader,
   PageLayout,
   useGetPageUrl,
-  usePageAlertToaster,
   usePageNavigate,
+  usePageAlertToaster,
 } from '../../../../framework';
 import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
-import { postRequest } from '../../../common/crud/Data';
 import { useGet } from '../../../common/crud/useGet';
 import { EdaRoute } from '../../EdaRoutes';
 import { edaAPI } from '../../api/eda-utils';
 import { SWR_REFRESH_INTERVAL } from '../../constants';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { Status906Enum } from '../../interfaces/generated/eda-api';
-import { useRestartRulebookActivations } from '../hooks/useControlRulebookActivations';
+import {
+  useDisableRulebookActivations,
+  useRestartRulebookActivations,
+} from '../hooks/useControlRulebookActivations';
 import { useDeleteRulebookActivations } from '../hooks/useDeleteRulebookActivations';
+import { postRequest } from '../../../common/crud/Data';
+import { AlertProps } from '@patternfly/react-core';
 
 export function RulebookActivationPage() {
   const { t } = useTranslation();
@@ -38,6 +41,12 @@ export function RulebookActivationPage() {
     { refreshInterval: SWR_REFRESH_INTERVAL }
   );
 
+  const disableRulebookActivation = useDisableRulebookActivations((disabled) => {
+    if (disabled.length > 0) {
+      refresh();
+    }
+  });
+
   const restartRulebookActivation = useRestartRulebookActivations((restarted) => {
     if (restarted.length > 0) {
       refresh();
@@ -50,25 +59,20 @@ export function RulebookActivationPage() {
     }
   });
 
-  const handleToggle: (activation: EdaRulebookActivation, enabled: boolean) => Promise<void> =
+  const enableRulebookActivation: (activation: EdaRulebookActivation) => Promise<void> =
     useCallback(
-      async (activation, enabled) => {
+      async (activation) => {
         const alert: AlertProps = {
           variant: 'success',
-          title: `${activation.name} ${enabled ? t('enabled') : t('disabled')}.`,
+          title: `${activation.name} ${t('enabled')}.`,
           timeout: 5000,
         };
-        await postRequest(
-          edaAPI`/activations/${activation.id.toString()}/${enabled ? 'enable/' : 'disable/'}`,
-          undefined
-        )
+        await postRequest(edaApi`/activations/${activation.id}/enable/`, undefined)
           .then(() => alertToaster.addAlert(alert))
           .catch(() => {
             alertToaster.addAlert({
               variant: 'danger',
-              title: `${t('Failed to ')} ${enabled ? t('enable') : t('disable')} ${
-                activation.name
-              }`,
+              title: `${t('Failed to enable')} ${activation.name}`,
               timeout: 5000,
             });
           });
@@ -90,8 +94,10 @@ export function RulebookActivationPage() {
             isPinned: true,
             label: t('Rulebook activation enabled'),
             labelOff: t('Rulebook activation disabled'),
-            onToggle: (activation: EdaRulebookActivation, activate: boolean) =>
-              handleToggle(activation, activate),
+            onToggle: (activation: EdaRulebookActivation, activate: boolean) => {
+              if (activate) void enableRulebookActivation(activation);
+              else void disableRulebookActivation([activation]);
+            },
             isSwitchOn: (activation: EdaRulebookActivation) => activation.is_enabled ?? false,
             isDisabled: (activation: EdaRulebookActivation) =>
               activation.status === Status906Enum.Stopping
@@ -119,7 +125,14 @@ export function RulebookActivationPage() {
         ]
       : [];
     return actions;
-  }, [handleToggle, isActionTab, restartRulebookActivation, deleteRulebookActivations, t]);
+  }, [
+    isActionTab,
+    enableRulebookActivation,
+    disableRulebookActivation,
+    restartRulebookActivation,
+    deleteRulebookActivations,
+    t,
+  ]);
 
   return (
     <PageLayout>

--- a/frontend/eda/rulebook-activations/hooks/useControlRulebookActivations.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useControlRulebookActivations.tsx
@@ -21,7 +21,10 @@ export function useEnableRulebookActivations(
           title: `${activation.name} ${t('enabled')}.`,
           timeout: 5000,
         };
-        await postRequest(edaApi`/activations/${activation.id}/enable/`, undefined)
+        await postRequest(
+          edaAPI`/activations/${activation?.id ? activation?.id.toString() : ''}/enable/`,
+          undefined
+        )
           .then(() => alertToaster.addAlert(alert))
           .catch(() => {
             alertToaster.addAlert({

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationActions.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationActions.tsx
@@ -32,7 +32,7 @@ export function useRulebookActivationActions(view: IEdaView<EdaRulebookActivatio
         title: `${activation.name} ${t('enabled')}.`,
         timeout: 5000,
       };
-      await postRequest(edaApi`/activations/${activation.id}/${'enable/'}`, undefined)
+      await postRequest(edaAPI`/activations/${activation.id.toString()}/${'enable/'}`, undefined)
         .then(() => alertToaster.addAlert(alert))
         .catch(() => {
           alertToaster.addAlert({

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationsActions.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationsActions.tsx
@@ -15,7 +15,7 @@ import { IEdaView } from '../../useEventDrivenView';
 import { useDisableRulebookActivations } from './useControlRulebookActivations';
 import { useDeleteRulebookActivations } from './useDeleteRulebookActivations';
 import { postRequest } from '../../../common/crud/Data';
-import { API_PREFIX } from '../../constants';
+import { edaAPI } from '../../api/eda-utils';
 
 export function useRulebookActivationsActions(view: IEdaView<EdaRulebookActivation>) {
   const { t } = useTranslation();
@@ -32,7 +32,7 @@ export function useRulebookActivationsActions(view: IEdaView<EdaRulebookActivati
           title: `${activation.name} ${t('enabled')}.`,
           timeout: 5000,
         };
-        await postRequest(`${API_PREFIX}/activations/${activation.id}/enable/`, undefined)
+        await postRequest(edaAPI`/activations/${activation.id.toString()}/enable/`, undefined)
           .then(() => alertToaster.addAlert(alert))
           .catch(() => {
             alertToaster.addAlert({

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationsActions.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationsActions.tsx
@@ -44,8 +44,12 @@ export function useRulebookActivationsActions(view: IEdaView<EdaRulebookActivati
       },
       [alertToaster, t]
     );
-  const enableRulebookActivations = (activations: EdaRulebookActivation[]) =>
-    activations.map((activation) => enableRulebookActivation(activation));
+  const enableRulebookActivations: (activations: EdaRulebookActivation[]) => void = useCallback(
+    (activations) => {
+      activations.map((activation) => enableRulebookActivation(activation));
+    },
+    [enableRulebookActivation]
+  );
 
   return useMemo<IPageAction<EdaRulebookActivation>[]>(() => {
     const actions: IPageAction<EdaRulebookActivation>[] = [

--- a/webpack/environment.cjs
+++ b/webpack/environment.cjs
@@ -12,7 +12,7 @@ const EDA_HOST = process.env.EDA_HOST || 'localhost:8000';
 const EDA_SERVER =
   process.env.EDA_SERVER || process.env.CYPRESS_EDA_SERVER || `${EDA_PROTOCOL}://${EDA_HOST}`;
 const EDA_USERNAME = process.env.EDA_USERNAME || process.env.CYPRESS_EDA_USERNAME || 'admin';
-const EDA_PASSWORD = process.env.EDA_PASSWORD || process.env.CYPRESS_EDA_PASSWORD || 'password';
+const EDA_PASSWORD = process.env.EDA_PASSWORD || process.env.CYPRESS_EDA_PASSWORD || 'testpass';
 const EDA_API_PREFIX = process.env.EDA_API_PREFIX || '/api/eda/v1';
 const EDA_ROUTE_PREFIX = process.env.EDA_ROUTE_PREFIX || '/eda';
 

--- a/webpack/environment.cjs
+++ b/webpack/environment.cjs
@@ -12,7 +12,7 @@ const EDA_HOST = process.env.EDA_HOST || 'localhost:8000';
 const EDA_SERVER =
   process.env.EDA_SERVER || process.env.CYPRESS_EDA_SERVER || `${EDA_PROTOCOL}://${EDA_HOST}`;
 const EDA_USERNAME = process.env.EDA_USERNAME || process.env.CYPRESS_EDA_USERNAME || 'admin';
-const EDA_PASSWORD = process.env.EDA_PASSWORD || process.env.CYPRESS_EDA_PASSWORD || 'testpass';
+const EDA_PASSWORD = process.env.EDA_PASSWORD || process.env.CYPRESS_EDA_PASSWORD || 'password';
 const EDA_API_PREFIX = process.env.EDA_API_PREFIX || '/api/eda/v1';
 const EDA_ROUTE_PREFIX = process.env.EDA_ROUTE_PREFIX || '/eda';
 


### PR DESCRIPTION
Update enable/disable rulebook activation interactions:

The following applies to both single rulebook activation action as wel as bulk:

Enable will not display a confirmation modal.
Disable will display a confirmation modal 
![Screenshot from 2023-10-30 15-49-49](https://github.com/ansible/ansible-ui/assets/12769982/fd87054f-530d-4701-adaf-a2dab93cba97)
![Screenshot from 2023-10-30 15-49-35](https://github.com/ansible/ansible-ui/assets/12769982/ecb3e0c7-f0d9-4848-b82d-4f5143a6d5f6)
![Screenshot from 2023-10-30 15-49-14](https://github.com/ansible/ansible-ui/assets/12769982/ddf359c3-0b35-4d88-bbb3-59df103679ec)
![Screenshot from 2023-10-30 15-48-49](https://github.com/ansible/ansible-ui/assets/12769982/51571d78-8290-461a-bc2d-76a1f174cc3f)
