### PR TITLE
[Do Not Merge] CICD Testing Parallelization for Issues

### DIFF
--- a/.github/workflows/awx-e2e.yml
+++ b/.github/workflows/awx-e2e.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1]
+        containers: [1,2,3,4,5,6,7]
     steps:
       - name: Download container image
         if: ${{ !inputs.SKIP_JOB }}


### PR DESCRIPTION
Just a PR for testing the CICD pipeline. No plans to merge.
Bumping up Cypress Parallelization to a crazy amount (7) to see if any issues are seen.

![Screenshot 2023-10-30 at 11 31 45 AM](https://github.com/ansible/ansible-ui/assets/6277895/015d375e-9456-46a9-b443-79396a412f6b)

The Projects tests take the longest with 9 tests waiting on projects to sync.

The reenabling of parallelization to the optimal values is in this PR: https://github.com/ansible/ansible-ui/pull/1112

