### PR TITLE
[DO NOT MERGE} Reverts monaco editor upgrade back to v0.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "luxon": "3.4.3",
         "merge-jsons-webpack-plugin": "2.0.1",
         "mini-css-extract-plugin": "2.7.6",
-        "monaco-editor": "0.44.0",
+        "monaco-editor": "0.41.0",
         "monaco-editor-webpack-plugin": "7.1.0",
         "monaco-yaml": "5.1.0",
         "p-limit": "4.0.0",
@@ -12325,9 +12325,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
-      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
+      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "luxon": "3.4.3",
     "merge-jsons-webpack-plugin": "2.0.1",
     "mini-css-extract-plugin": "2.7.6",
-    "monaco-editor": "0.44.0",
+    "monaco-editor": "0.41.0",
     "monaco-editor-webpack-plugin": "7.1.0",
     "monaco-yaml": "5.1.0",
     "p-limit": "4.0.0",


### PR DESCRIPTION
This is a trial.  It looks like we upgrade monaco editor last week, and reverting back to the version we were running seems to resolve test failures locally. 