### PR TITLE
Repair failing approval repository filter

### DIFF
--- a/frontend/hub/repositories/hooks/useRepositorySelector.tsx
+++ b/frontend/hub/repositories/hooks/useRepositorySelector.tsx
@@ -25,7 +25,7 @@ function useParameters(): AsyncSelectFilterBuilderProps<Repository> {
       toolbarFilters,
       tableColumns,
       disableQueryString: true,
-      keyFn: (item) => item.name,
+      keyFn: (item) => item?.name,
     },
   };
 }


### PR DESCRIPTION
Error appeared when user selected Repository dropdown and clicked browse.

![image](https://github.com/ansible/ansible-ui/assets/23277791/18aa7139-d1ef-4776-aa4e-646a6d862d6c)

There was exception in keyFn, it was null, so I added ? optional chaining operator, so if item was null, no item.name was called.