### PR TITLE
Fix: Hide overflow on app and main as the page should have a scrollable area

### DIFF
--- a/framework/PageFramework.css
+++ b/framework/PageFramework.css
@@ -1,5 +1,6 @@
 #app {
   min-block-size: 100dvh;
+  overflow: hidden;
 }
 
 .border-top {
@@ -53,3 +54,7 @@
 .pf-v5-c-page__sidebar-body {
   padding-top: 0;
 } */
+
+.pf-v5-c-page__main {
+  overflow: hidden;
+}


### PR DESCRIPTION

![Screenshot 2023-10-31 at 11 35 45 AM](https://github.com/ansible/ansible-ui/assets/6277895/50bd362c-7b4e-4eea-abf5-f6aa2543fe0f)

vs

![Screenshot 2023-10-31 at 11 36 13 AM](https://github.com/ansible/ansible-ui/assets/6277895/6975a393-d1c3-4c67-95b4-d5d8d5190249)
