### PR TITLE
[Analytics] Add error state to Analytics builder

### DIFF
--- a/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
+++ b/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
@@ -77,6 +77,7 @@ import {
   getClickableText,
   renderAllTasksStatus,
 } from './AnalyticsReportBuilderUtils';
+import { AnalyticsErrorState } from '../Reports/ErrorStates';
 
 type KeyValue = { key: string; value: string };
 
@@ -339,10 +340,14 @@ export function AnalyticsReportBuilder(props: AnalyticsReportBuilderProps) {
   // build the table columns
   const columns = buildTableColumns({ ...newProps });
 
+  // Render error state based on the error message
+  if (error) {
+    return <AnalyticsErrorState error={error?.body?.error?.keyword || 'unknown'} />;
+  }
+
   // and finaly, render the table with chart and filters
   return (
     <>
-      {error}
       {mainData && options && view.pageItems?.length > 0 && (
         <AnalyticsReportBuilderTable
           {...newProps}

--- a/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
+++ b/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
@@ -50,7 +50,13 @@ import { useGetRequest } from '../../../common/crud/useGet';
 import { useState, useEffect } from 'react';
 import { useAnalyticsView, IAnalyticsView } from '../useAnalyticsView';
 import { PageTable } from '../../../../framework/PageTable/PageTable';
-import { ITableColumn, ITableColumnTypeText, LoadingPage } from '../../../../framework';
+import {
+  ITableColumn,
+  ITableColumnTypeText,
+  LoadingPage,
+  PageHeader,
+  PageLayout,
+} from '../../../../framework';
 import {
   IToolbarFilter,
   ToolbarFilterType,
@@ -349,11 +355,17 @@ export function AnalyticsReportBuilder(props: AnalyticsReportBuilderProps) {
   return (
     <>
       {mainData && options && view.pageItems?.length > 0 && (
-        <AnalyticsReportBuilderTable
-          {...newProps}
-          tableColumns={columns}
-          toolbarFilters={filters}
-        ></AnalyticsReportBuilderTable>
+        <PageLayout>
+          <PageHeader
+            title={mainData?.report?.name || ''}
+            description={mainData?.report?.description || ''}
+          />
+          <AnalyticsReportBuilderTable
+            {...newProps}
+            tableColumns={columns}
+            toolbarFilters={filters}
+          ></AnalyticsReportBuilderTable>
+        </PageLayout>
       )}
       {(!mainData || !options) && view.pageItems?.length === 0 && <LoadingPage />}
     </>

--- a/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
+++ b/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilder.tsx
@@ -50,7 +50,7 @@ import { useGetRequest } from '../../../common/crud/useGet';
 import { useState, useEffect } from 'react';
 import { useAnalyticsView, IAnalyticsView } from '../useAnalyticsView';
 import { PageTable } from '../../../../framework/PageTable/PageTable';
-import { ITableColumn, ITableColumnTypeText } from '../../../../framework';
+import { ITableColumn, ITableColumnTypeText, LoadingPage } from '../../../../framework';
 import {
   IToolbarFilter,
   ToolbarFilterType,
@@ -355,6 +355,7 @@ export function AnalyticsReportBuilder(props: AnalyticsReportBuilderProps) {
           toolbarFilters={filters}
         ></AnalyticsReportBuilderTable>
       )}
+      {(!mainData || !options) && view.pageItems?.length === 0 && <LoadingPage />}
     </>
   );
 }


### PR DESCRIPTION
## Error state:
Before:
<img width="1717" alt="Screenshot 2023-11-01 at 14 16 19" src="https://github.com/ansible/ansible-ui/assets/9210860/610df157-a47d-436c-9ef6-56860671992c">

After:
<img width="1709" alt="Screenshot 2023-11-01 at 14 07 53" src="https://github.com/ansible/ansible-ui/assets/9210860/796d32cf-2775-4b14-9837-9a76b43b20c2">

## Loading state:
<img width="1711" alt="Screenshot 2023-11-01 at 14 39 52" src="https://github.com/ansible/ansible-ui/assets/9210860/be9dd1a5-42a8-43d3-b4cc-d5a1268fec60">

## PageHeader:
<img width="735" alt="Screenshot 2023-11-01 at 15 14 25" src="https://github.com/ansible/ansible-ui/assets/9210860/f817b6b6-e3c1-47b2-b93c-0e625fd1be48">
