### PR TITLE
Scrollable dark theme shadows - make a little more subtle

### DIFF
--- a/framework/components/Scrollable.css
+++ b/framework/components/Scrollable.css
@@ -22,7 +22,7 @@
 }
 :root:where(.pf-v5-theme-dark) .scrollable-shadow-top {
   height: 14px;
-  background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+  background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
 }
 
 .scrollable-shadow-bottom {
@@ -34,5 +34,5 @@
 }
 :root:where(.pf-v5-theme-dark) .scrollable-shadow-bottom {
   height: 14px;
-  background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.7));
+  background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.5));
 }


### PR DESCRIPTION
In my last PR that updated dark theme shadows so that they could be seen on a dark background, I ended up making them too dark and pronounced. This changes them from 70% to 50% which makes the shadows more subtle.