### PR TITLE
Fix scrolling in the Activation Instance history and details pages

### DIFF
--- a/framework/PageTabs/PageRoutedTabs.tsx
+++ b/framework/PageTabs/PageRoutedTabs.tsx
@@ -8,6 +8,7 @@ export function PageRoutedTabs(props: {
   backTab?: { label: string; page: string; persistentFilterKey: string };
   tabs: ({ label: string; page: string } | false)[];
   params?: { [key: string]: string | number | undefined };
+  hasOverflowScroll?: boolean;
 }) {
   const pageNavigate = usePageNavigate();
   const navigate = useNavigate();
@@ -70,7 +71,12 @@ export function PageRoutedTabs(props: {
         )}
         {tabs}
       </Tabs>
-      <PageSection variant="light" isFilled padding={{ default: 'noPadding' }}>
+      <PageSection
+        variant="light"
+        isFilled
+        hasOverflowScroll={props?.hasOverflowScroll === true}
+        padding={{ default: 'noPadding' }}
+      >
         <Outlet />
       </PageSection>
     </>

--- a/frontend/eda/rulebook-activations/ActivationInstancePage/ActivationInstancePage.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstancePage/ActivationInstancePage.tsx
@@ -47,6 +47,7 @@ export function ActivationInstancePage() {
       <PageRoutedTabs
         tabs={[{ label: t('Details'), page: EdaRoute.RulebookActivationInstanceDetails }]}
         params={{ id: activationInstance?.activation_id, instanceId: params.instanceId }}
+        hasOverflowScroll
       />
     </PageLayout>
   );

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -148,6 +148,7 @@ export function RulebookActivationPage() {
           { label: t('History'), page: EdaRoute.RulebookActivationHistory },
         ]}
         params={{ id: params.id }}
+        hasOverflowScroll
       />
     </PageLayout>
   );


### PR DESCRIPTION
Add hasOverflowScroll parameter to the PageRoutedTabs.
Use the hasOverflowScroll parameter in the Activation Instance history and details pages

![Screenshot from 2023-11-02 11-53-56](https://github.com/ansible/ansible-ui/assets/12769982/73e41907-6b85-4e79-8494-13cdd829e339)
![Screenshot from 2023-11-02 11-54-06](https://github.com/ansible/ansible-ui/assets/12769982/cf052721-26d5-4d1f-8d50-b1b8203d94c9)
