### PR TITLE
Renaming UserDetails base component and its usages

### DIFF
--- a/frontend/awx/access/users/UserPage/AwxUserDetails.cy.tsx
+++ b/frontend/awx/access/users/UserPage/AwxUserDetails.cy.tsx
@@ -1,4 +1,4 @@
-import { UserDetails } from './UserDetails';
+import { AwxUserDetails } from './AwxUserDetails';
 import mockAwxUser from '../../../../../cypress/fixtures/awxUser.json';
 import { formatDateString } from '../../../../../framework/utils/formatDateString';
 
@@ -6,7 +6,7 @@ describe('User details', () => {
   it('Renders first & last name, username, email, orgs, last login, auth type, created & modified timestamps', () => {
     cy.intercept('/api/v2/users/*', { fixture: 'awxUser.json' });
     cy.intercept('/api/v2/users/*/organizations/', { fixture: 'organizations.json' });
-    cy.mount(<UserDetails />);
+    cy.mount(<AwxUserDetails />);
     cy.get('[data-cy="first-name"]').should('have.text', 'Org');
     cy.get('[data-cy="last-name"]').should('have.text', 'Admin');
     cy.get('[data-cy="email"]').should('have.text', 'firstname@lastname.com');

--- a/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
@@ -2,14 +2,14 @@
 import { useParams } from 'react-router-dom';
 import { User } from '../../../interfaces/User';
 import { useGet, useGetItem } from '../../../../common/crud/useGet';
-import { UserDetailsBase, UserDetailsType } from '../../../../common/access/UserDetailsBase';
+import { UserDetails, UserDetailsType } from '../../../../common/access/UserDetails';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { Organization } from '../../../interfaces/Organization';
 import { useMemo } from 'react';
 import { useGetPageUrl } from '../../../../../framework';
 import { AwxRoute } from '../../../AwxRoutes';
 
-export function UserDetails() {
+export function AwxUserDetails() {
   const params = useParams<{ id: string }>();
   const getPageUrl = useGetPageUrl();
   const { data: user } = useGetItem<User>('/api/v2/users', params.id);
@@ -39,7 +39,7 @@ export function UserDetails() {
 
   return (
     <>
-      <UserDetailsBase
+      <UserDetails
         user={user as UserDetailsType}
         organizations={organizations}
         options={{ showAuthType: true, showUserType: true }}

--- a/frontend/awx/routes/useAwxUsersRoutes.tsx
+++ b/frontend/awx/routes/useAwxUsersRoutes.tsx
@@ -5,7 +5,7 @@ import { AwxRoute } from '../AwxRoutes';
 import { CreateUser, EditUser } from '../access/users/UserForm';
 import { AddRolesToUser } from '../access/users/components/AddRolesToUser';
 import { UserPage } from '../access/users/UserPage/UserPage';
-import { UserDetails } from '../access/users/UserPage/UserDetails';
+import { AwxUserDetails } from '../access/users/UserPage/AwxUserDetails';
 import { UserOrganizations } from '../access/users/UserPage/UserOrganizations';
 import { UserTeams } from '../access/users/UserPage/UserTeams';
 import { UserRoles } from '../access/users/UserPage/UserRoles';
@@ -43,7 +43,7 @@ export function useAwxUsersRoutes() {
             {
               id: AwxRoute.UserDetails,
               path: 'details',
-              element: <UserDetails />,
+              element: <AwxUserDetails />,
             },
             {
               id: AwxRoute.UserOrganizations,

--- a/frontend/common/access/UserDetails.tsx
+++ b/frontend/common/access/UserDetails.tsx
@@ -26,7 +26,7 @@ export type UserDetailsType = {
   roles: RoleRef[];
 }>;
 
-export function UserDetailsBase<T extends UserDetailsType>(props: {
+export function UserDetails<T extends UserDetailsType>(props: {
   user: T;
   organizations?: {
     // Organization name

--- a/frontend/eda/UserAccess/Users/UserPage/EdaMyDetails.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/EdaMyDetails.tsx
@@ -5,7 +5,7 @@ import { useGet } from '../../../../common/crud/useGet';
 import { edaAPI } from '../../../api/eda-utils';
 import { EdaUser } from '../../../interfaces/EdaUser';
 
-export function MyDetails() {
+export function EdaMyDetails() {
   const { data: user } = useGet<EdaUser>(edaAPI`/users/me/`);
 
   if (!user) return <LoadingPage breadcrumbs tabs />;

--- a/frontend/eda/UserAccess/Users/UserPage/EdaUserDetails.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/EdaUserDetails.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable react/prop-types */
 import { useParams } from 'react-router-dom';
 import { LoadingPage } from '../../../../../framework/components/LoadingPage';
-import { UserDetailsBase, UserDetailsType } from '../../../../common/access/UserDetailsBase';
+import { UserDetails, UserDetailsType } from '../../../../common/access/UserDetails';
 import { useGet } from '../../../../common/crud/useGet';
 import { SWR_REFRESH_INTERVAL } from '../../../constants';
 import { EdaUser } from '../../../interfaces/EdaUser';
 import { edaAPI } from '../../../api/eda-utils';
 
-export function UserDetails() {
+export function EdaUserDetails() {
   const params = useParams<{ id: string }>();
   const { data: user } = useGet<EdaUser>(edaAPI`/users/${params.id ?? ''}/`, undefined, {
     refreshInterval: SWR_REFRESH_INTERVAL,
@@ -16,7 +16,7 @@ export function UserDetails() {
 
   return (
     <>
-      <UserDetailsBase user={user as UserDetailsType} />
+      <UserDetails user={user as UserDetailsType} />
     </>
   );
 }

--- a/frontend/eda/UserAccess/Users/UserPage/MyDetails.tsx
+++ b/frontend/eda/UserAccess/Users/UserPage/MyDetails.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { LoadingPage } from '../../../../../framework/components/LoadingPage';
-import { UserDetailsBase, UserDetailsType } from '../../../../common/access/UserDetailsBase';
+import { UserDetails, UserDetailsType } from '../../../../common/access/UserDetails';
 import { useGet } from '../../../../common/crud/useGet';
 import { edaAPI } from '../../../api/eda-utils';
 import { EdaUser } from '../../../interfaces/EdaUser';
@@ -12,7 +12,7 @@ export function MyDetails() {
 
   return (
     <>
-      <UserDetailsBase user={user as UserDetailsType} />
+      <UserDetails user={user as UserDetailsType} />
     </>
   );
 }

--- a/frontend/eda/useEdaNavigation.tsx
+++ b/frontend/eda/useEdaNavigation.tsx
@@ -41,7 +41,7 @@ import { DecisionEnvironmentPage } from './Resources/decision-environments/Decis
 import { ControllerTokens } from './UserAccess/Users/UserPage/ControllerTokens';
 import { UserPage } from './UserAccess/Users/UserPage/UserPage';
 import { MyPage } from './UserAccess/Users/UserPage/MyPage';
-import { MyDetails } from './UserAccess/Users/UserPage/MyDetails';
+import { EdaMyDetails } from './UserAccess/Users/UserPage/EdaMyDetails';
 import { EdaUserDetails } from './UserAccess/Users/UserPage/EdaUserDetails';
 import { RuleAuditPage } from './views/RuleAudit/RuleAuditPage/RuleAuditPage';
 import { RuleAuditActions } from './views/RuleAudit/RuleAuditPage/RuleAuditActions';
@@ -291,7 +291,7 @@ export function useEdaNavigation() {
                       {
                         id: EdaRoute.MyDetails,
                         path: 'details',
-                        element: <MyDetails />,
+                        element: <EdaMyDetails />,
                       },
                       {
                         id: EdaRoute.MyTokens,

--- a/frontend/eda/useEdaNavigation.tsx
+++ b/frontend/eda/useEdaNavigation.tsx
@@ -42,7 +42,7 @@ import { ControllerTokens } from './UserAccess/Users/UserPage/ControllerTokens';
 import { UserPage } from './UserAccess/Users/UserPage/UserPage';
 import { MyPage } from './UserAccess/Users/UserPage/MyPage';
 import { MyDetails } from './UserAccess/Users/UserPage/MyDetails';
-import { UserDetails } from './UserAccess/Users/UserPage/UserDetails';
+import { EdaUserDetails } from './UserAccess/Users/UserPage/EdaUserDetails';
 import { RuleAuditPage } from './views/RuleAudit/RuleAuditPage/RuleAuditPage';
 import { RuleAuditActions } from './views/RuleAudit/RuleAuditPage/RuleAuditActions';
 import { RuleAuditEvents } from './views/RuleAudit/RuleAuditPage/RuleAuditEvents';
@@ -327,7 +327,7 @@ export function useEdaNavigation() {
                       {
                         id: EdaRoute.UserDetails,
                         path: 'details',
-                        element: <UserDetails />,
+                        element: <EdaUserDetails />,
                       },
                       {
                         id: EdaRoute.UserTokens,


### PR DESCRIPTION
PR to adopt the convention recommended by Keith:

Renames the "base" component `UserDetailsBase` to `UserDetails`, and then each platform component's specific wrapper `AwxUserDetails`, `EdaUserDetails` etc. 