### PR TITLE
Update css to avoid line to wrap text on MultiSelectDialog

### DIFF
--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -83,7 +83,9 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     >
       <ModalBoxBody style={{ overflow: 'hidden' }}>
         <Split hasGutter>
-          <SplitItem style={{ fontWeight: 'bold' }}>{translations.selectedText}</SplitItem>
+          <SplitItem style={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+            {translations.selectedText}
+          </SplitItem>
           {view.selectedItems.length > 0 ? (
             <LabelGroup>
               {view.selectedItems.map((item, i) => {


### PR DESCRIPTION
Update css to avoid line to wrap text on MultiSelectDialog

With this change

![image](https://github.com/ansible/ansible-ui/assets/9053044/803c8780-6ffe-4d96-83de-ae168f9cc83e)
