### PR TITLE
fix table border issues when horizontally scrolling

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -638,7 +638,7 @@ function TableHead<T extends object>(props: {
             stickyMinWidth="0px"
             hasRightBorder={props.scrollLeft}
             data-cy={'selections-column-header'}
-            className={props.scrollLeft ? 'bg-lighten-2 border-left' : 'bg-lighten'}
+            className={props.scrollLeft ? 'bg-lighten-2' : 'bg-lighten'}
           >
             &nbsp;
           </Th>
@@ -825,7 +825,12 @@ function TableRow<T extends object>(props: {
         <Tr isRowSelected={isItemSelected} isExpanded={expanded} style={{ boxShadow: 'unset' }}>
           <Td />
           {showSelect && (
-            <Th isStickyColumn stickyMinWidth="0px" hasRightBorder={props.scrollLeft} />
+            <Th
+              isStickyColumn
+              stickyMinWidth="0px"
+              hasRightBorder={props.scrollLeft}
+              className={props.scrollLeft ? 'bg-lighten' : undefined}
+            />
           )}
           {onSelect && <Td isStickyColumn stickyMinWidth="0px" hasRightBorder={props.scrollLeft} />}
           <Td


### PR DESCRIPTION
the table header cell had a border on the left which causes visual issues with horizontal scrolling and [border collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse). 
in addition the expanded row did not have the right styling for dark theme.

![Screenshot 2023-11-07 at 10 53 48 AM](https://github.com/ansible/ansible-ui/assets/6277895/b2f1233c-8c46-4bfe-afed-3a571270264c)
