### PR TITLE
Monaco Webpack Update to fix hot reload for development

### DIFF
--- a/framework/PageForm/Inputs/DataEditor.tsx
+++ b/framework/PageForm/Inputs/DataEditor.tsx
@@ -87,16 +87,25 @@ export function DataEditor<
 
       editorRef.current.editor = editor;
     }
-
     window.MonacoEnvironment = {
-      getWorkerUrl(moduleId, label) {
+      getWorker(moduleId, label) {
         switch (label) {
+          case 'editorWorkerService':
+            return new Worker(
+              new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url),
+              { type: 'module' }
+            );
           case 'json':
-            return '/json.worker.js';
+            return new Worker(
+              new URL('monaco-editor/esm/vs/language/json/json.worker', import.meta.url),
+              { type: 'module' }
+            );
           case 'yaml':
-            return '/yaml.worker.js';
+            return new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url), {
+              type: 'module',
+            });
           default:
-            return '/editor.worker.js';
+            throw new Error(`Unknown label ${label}`);
         }
       },
     };

--- a/webpack/webpack.awx.cjs
+++ b/webpack/webpack.awx.cjs
@@ -5,12 +5,7 @@ const proxyUrl = new URL(AWX_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
 
-  config.entry = {
-    app: './frontend/awx/Awx.tsx',
-    'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker',
-    'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
-    'yaml.worker': 'monaco-yaml/yaml.worker',
-  };
+  config.entry = './frontend/awx/Awx.tsx';
 
   config.devServer.proxy = {
     '/api': {

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -7,6 +7,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const path = require('path');
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 const {
   AWX_ROUTE_PREFIX,
@@ -90,6 +91,9 @@ module.exports = function (env, argv) {
       ],
     },
     plugins: [
+      new MonacoWebpackPlugin({
+        languages: ['yaml', 'json'],
+      }),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': isProduction
           ? JSON.stringify('production')
@@ -131,12 +135,7 @@ module.exports = function (env, argv) {
     ].filter(Boolean),
     output: {
       clean: true,
-      filename: (pathData, _assetInfo) => {
-        if (pathData.chunk.name === 'app') return '[contenthash].js';
-        return '[name].js';
-      },
-      chunkFilename: '[contenthash].js',
-      assetModuleFilename: '[contenthash][ext][query]',
+      filename: isProduction ? '[contenthash].js' : undefined,
       path: path.resolve(__dirname, '../build/public'),
       publicPath: process.env.PUBLIC_PATH || '/',
     },

--- a/webpack/webpack.eda.cjs
+++ b/webpack/webpack.eda.cjs
@@ -5,12 +5,7 @@ const proxyUrl = new URL(EDA_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
 
-  config.entry = {
-    app: './frontend/eda/Eda.tsx',
-    'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker',
-    'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
-    'yaml.worker': 'monaco-yaml/yaml.worker',
-  };
+  config.entry = './frontend/eda/Eda.tsx';
 
   config.devServer.proxy = {
     '/api': {

--- a/webpack/webpack.hub.cjs
+++ b/webpack/webpack.hub.cjs
@@ -5,12 +5,7 @@ const proxyUrl = new URL(HUB_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
 
-  config.entry = {
-    app: './frontend/hub/Hub.tsx',
-    'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker',
-    'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
-    'yaml.worker': 'monaco-yaml/yaml.worker',
-  };
+  config.entry = './frontend/hub/Hub.tsx';
 
   config.devServer.proxy = {
     '/api': {


### PR DESCRIPTION
This switches back to using `MonacoWebpackPlugin` which fixes development hot reloading.
It does setup the loading of the webworkers differently based on the documentation for monaco-yaml.
https://github.com/remcohaszing/monaco-yaml#usage

I've tested in development and a production build.
The hot reloading is working and the workers are loading properly.

Working with QE to make sure that is resolves the issues they were seeing during testing. 