### PR TITLE
[AAP-17392] Update remote and remote registry to use PageHiddenInput

### DIFF
--- a/framework/PageForm/Inputs/PageFormSecret.cy.tsx
+++ b/framework/PageForm/Inputs/PageFormSecret.cy.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { PageHiddenInput } from './PageHiddenInput';
+import { PageFormSecret } from './PageFormSecret';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 const TestComponent = () => {
@@ -15,17 +15,17 @@ const TestComponent = () => {
   );
 };
 
-describe('PageHiddenInput Component Tests', () => {
+describe('PageFormSecret Component Tests', () => {
   it('should display hidden value and clear button when shouldHideField is true', () => {
     cy.mount(
-      <PageHiddenInput
+      <PageFormSecret
         shouldHideField={true}
         onClear={() => {}}
         label="Test label"
         labelHelp="Test label Help"
       >
         <TestComponent />
-      </PageHiddenInput>
+      </PageFormSecret>
     );
     cy.get('input[type="password"]').should('be.visible');
     cy.contains('Clear').should('be.visible');
@@ -34,14 +34,14 @@ describe('PageHiddenInput Component Tests', () => {
 
   it('should display children, and not display Clear button when shouldHideField is false', () => {
     cy.mount(
-      <PageHiddenInput
+      <PageFormSecret
         shouldHideField={false}
         onClear={() => {}}
         label="Test Label"
         labelHelp="Test Label Help"
       >
         <TestComponent />
-      </PageHiddenInput>
+      </PageFormSecret>
     );
 
     cy.get('input[type="text"]').should('be.visible');
@@ -53,14 +53,14 @@ describe('PageHiddenInput Component Tests', () => {
     const onClear = cy.stub().as('onClear');
 
     cy.mount(
-      <PageHiddenInput
+      <PageFormSecret
         shouldHideField={true}
         onClear={onClear}
         label="Test Label"
         labelHelp="Test Label Help"
       >
         <TestComponent />
-      </PageHiddenInput>
+      </PageFormSecret>
     );
     cy.contains('Clear').click();
     cy.get('@onClear').should('have.been.calledOnce');

--- a/framework/PageForm/Inputs/PageFormSecret.tsx
+++ b/framework/PageForm/Inputs/PageFormSecret.tsx
@@ -1,7 +1,7 @@
 import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageFormGroup } from '../PageForm/Inputs/PageFormGroup';
+import { PageFormGroup } from './PageFormGroup';
 
 interface ChildProps {
   labelHelp?: string;
@@ -9,7 +9,7 @@ interface ChildProps {
 }
 
 /**
- * Props for the PageHiddenInput component.
+ * Props for the PageFormSecret component.
  * @interface IProps
  */
 interface IProps {
@@ -18,7 +18,7 @@ interface IProps {
    * When true, the field value is masked and a clear button is displayed.
    * When false, children components are displayed for user interaction.
    */
-  shouldHideField: boolean;
+  shouldHideField: boolean | undefined;
 
   /**
    * Callback function triggered when the clear button is clicked.
@@ -45,7 +45,7 @@ interface IProps {
   label?: string;
 }
 
-export function PageHiddenInput({ onClear, shouldHideField, label, labelHelp, children }: IProps) {
+export function PageFormSecret({ onClear, shouldHideField, label, labelHelp, children }: IProps) {
   const { t } = useTranslation();
   const fieldLabel = label || children.props.label || '';
   const fieldLabelHelp = labelHelp || children.props.labelHelp || '';

--- a/framework/PageInputs/PageInputs.md
+++ b/framework/PageInputs/PageInputs.md
@@ -126,14 +126,14 @@ The toolbar filters define interfaces for filtering. When those interfaces are r
 - `IToolbarAsyncSingleSelect` uses `PageAsyncSingleSelect`
 - `IToolbarAsyncMultiSelect` uses `PageAsyncMultiSelect`
 
-### `PageHiddenInput`
+### `PageFormSecret`
 
 A component that conditionally renders a masked (password-type) input field based on the `shouldHideField` prop. If `shouldHideField` is `true`, a masked input with a "Clear" button is displayed. Otherwise, the children are rendered.
 
 Usage:
 
 ```tsx
-import { PageHiddenInput } from './path-to-your-file';
+import { PageFormSecret } from './path-to-your-file';
 
 function SomeComponent() {
   const handleClear = () => {
@@ -143,20 +143,20 @@ function SomeComponent() {
   return (
     <div>
       {/* Hidden input */}
-      <PageHiddenInput shouldHideField={true} onClear={handleClear}>
+      <PageFormSecret shouldHideField={true} onClear={handleClear}>
         {/* This will not be shown when shouldHideField is true */}
         <input type="text" placeholder="Enter something..." />
-      </PageHiddenInput>
+      </PageFormSecret>
 
       {/* Visible input */}
-      <PageHiddenInput shouldHideField={false} onClear={handleClear}>
+      <PageFormSecret shouldHideField={false} onClear={handleClear}>
         <input
           type="text"
           placeholder="Enter something..."
           label="Some Label"
           labelHelp="Some helpful text"
         />
-      </PageHiddenInput>
+      </PageFormSecret>
     </div>
   );
 }

--- a/frontend/hub/remotes/Remotes.tsx
+++ b/frontend/hub/remotes/Remotes.tsx
@@ -25,7 +25,7 @@ export interface IRemotes {
   signed_only: boolean;
   hidden_fields?: {
     is_set: boolean;
-    name: string;
+    name: 'client_key' | 'password' | 'proxy_username' | 'proxy_password' | 'token' | 'username';
   }[];
   my_permissions?: string[];
 }


### PR DESCRIPTION
For remote certain fields are hidden fields - once they are set the API returns `hidden_fields` only, and not the value of those fields.

For remote registry, similar concept is also present, but the API returns `write_only_fields`.

![image](https://github.com/ansible/ansible-ui/assets/9053044/f5c68565-d1c9-4daf-974d-1ff660b4014c)
