### PR TITLE
Upgrade package p-limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "monaco-editor": "0.44.0",
         "monaco-editor-webpack-plugin": "7.1.0",
         "monaco-yaml": "5.1.0",
-        "p-limit": "4.0.0",
+        "p-limit": "5.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-dropzone": "14.2.3",
@@ -11775,13 +11775,14 @@
       "license": "MIT"
     },
     "node_modules/p-limit": {
-      "version": "4.0.0",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12044,6 +12045,20 @@
       "license": "MIT",
       "dependencies": {
         "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "monaco-editor": "0.44.0",
     "monaco-editor-webpack-plugin": "7.1.0",
     "monaco-yaml": "5.1.0",
-    "p-limit": "4.0.0",
+    "p-limit": "5.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "14.2.3",


### PR DESCRIPTION
This was a major version bump from 4.0.0 to 5.0.0.
Looking at the [release notes](https://github.com/sindresorhus/p-limit/releases/tag/v5.0.0), nothing to worry about with the way we are using it.

We use it when running a bunch of batch REST operations.
We limit the active number to 5 as the browser can only have 6 active requests at a time and would otherwise queue up requests and block more important calls the page may need to make.

Tested it out by deleting more than 5 items. It works well.