### PR TITLE
[AAP-18147] Display the status_message as an alert for a rulebook activation Failed status 

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
@@ -44,7 +44,8 @@ export function RulebookActivationDetails() {
     <Scrollable>
       <PageDetails
         alertPrompts={
-          rulebookActivation.status === Status906Enum.Error
+          rulebookActivation.status === Status906Enum.Error ||
+          rulebookActivation.status === Status906Enum.Failed
             ? [
                 `${t('Rulebook Activation create error: ')}${
                   rulebookActivation?.status_message || ''
@@ -102,6 +103,13 @@ export function RulebookActivationDetails() {
         <PageDetail label={t('Activation status')}>
           <StatusCell status={rulebookActivation?.status || ''} />
         </PageDetail>
+        {rulebookActivation.status !== Status906Enum.Error &&
+          rulebookActivation.status !== Status906Enum.Failed &&
+          !!rulebookActivation?.status_message && (
+            <PageDetail label={t('Status message')}>
+              {rulebookActivation?.status_message}
+            </PageDetail>
+          )}
         <PageDetail label={t('Project git hash')}>
           <CopyCell text={rulebookActivation?.git_hash ?? ''} />
         </PageDetail>

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
@@ -77,7 +77,7 @@ export function RulebookActivationDetails() {
           label={t('Rulebook')}
           helpText={t('Rulebooks will be shown according to the project selected.')}
         >
-          {rulebookActivation?.rulebook?.name || ''}
+          {rulebookActivation?.rulebook?.name || rulebookActivation?.rulebook_name || ''}
         </PageDetail>
         <PageDetail
           label={t('Decision environment')}


### PR DESCRIPTION
Display the status_message as an alert for a rulebook activation Failed status and as a regular field in the rulebook activation details page for every status other than Error or Failed

![Screenshot from 2023-11-09 17-13-05](https://github.com/ansible/ansible-ui/assets/12769982/f2c9c95b-047a-44ed-a436-bacf387bcf5b)
![Screenshot from 2023-11-09 17-12-56](https://github.com/ansible/ansible-ui/assets/12769982/b38bf187-fa06-4de1-a944-4dc396e8cc0e)
