### PR TITLE
[AAH-2532] Add sync per row for remote registry

### DIFF
--- a/frontend/hub/remote-registries/hooks/useRemoteRegistryActions.tsx
+++ b/frontend/hub/remote-registries/hooks/useRemoteRegistryActions.tsx
@@ -1,26 +1,59 @@
-import { ButtonVariant } from '@patternfly/react-core';
-import { EditIcon, TrashIcon } from '@patternfly/react-icons';
+import { AlertProps, ButtonVariant } from '@patternfly/react-core';
+import { EditIcon, SyncIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   IPageAction,
   PageActionSelection,
   PageActionType,
+  usePageAlertToaster,
   usePageNavigate,
 } from '../../../../framework';
 import { HubRoute } from '../../HubRoutes';
+import { hubAPI } from '../../api/formatPath';
+import { hubAPIPost } from '../../api/utils';
 import { RemoteRegistry } from '../RemoteRegistry';
 import { useDeleteRemoteRegistries } from './useDeleteRemoteRegistries';
+
+const syncRemoteRegistry = async (remoteRegistry: RemoteRegistry) => {
+  const syncURL = hubAPI`/_ui/v1/execution-environments/registries/${remoteRegistry.id}/sync/`;
+  return hubAPIPost(syncURL, {});
+};
 
 export function useRemoteRegistryActions(options: {
   onRemoteRegistryDeleted: (remoteRegistry: RemoteRegistry[]) => void;
 }) {
   const { onRemoteRegistryDeleted } = options;
   const { t } = useTranslation();
+  const alertToaster = usePageAlertToaster();
   const pageNavigate = usePageNavigate();
   const deleteRemoteRegistries = useDeleteRemoteRegistries(onRemoteRegistryDeleted);
   const actions = useMemo<IPageAction<RemoteRegistry>[]>(
     () => [
+      {
+        icon: SyncIcon,
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        label: t('Sync remote registry'),
+        onClick: (remoteRegistry) => {
+          const alert: AlertProps = {
+            variant: 'info',
+            title: t(`Syncing remote registry ${remoteRegistry.name}`),
+            timeout: 2000,
+          };
+          void syncRemoteRegistry(remoteRegistry)
+            .then(() => {
+              alertToaster.addAlert(alert);
+            })
+            .catch((error) => {
+              alertToaster.addAlert({
+                variant: 'danger',
+                title: t('Failed to sync remote registry'),
+                children: error instanceof Error && error.message,
+              });
+            });
+        },
+      },
       {
         icon: EditIcon,
         isPinned: true,
@@ -42,7 +75,7 @@ export function useRemoteRegistryActions(options: {
         isDanger: true,
       },
     ],
-    [t, pageNavigate, deleteRemoteRegistries]
+    [t, pageNavigate, deleteRemoteRegistries, alertToaster]
   );
   return actions;
 }


### PR DESCRIPTION
Add sync per row for remote registry.

Also, modify task system to the return the task response.

After

![image](https://github.com/ansible/ansible-ui/assets/9053044/0a2842bf-0df6-451c-ac55-b0663e9e4962)


Before

![image](https://github.com/ansible/ansible-ui/assets/9053044/1f75b2a6-034d-4ad7-9a94-9d066e852691)
