### PR TITLE
UX fix in Collection Details

### DIFF
--- a/frontend/hub/collections/CollectionDetails.tsx
+++ b/frontend/hub/collections/CollectionDetails.tsx
@@ -202,7 +202,7 @@ export function CollectionDetails() {
         }
         description={t('Repository: ') + collection?.repository?.name}
         footer={
-          <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gridGap: '8px' }}>
             {t('Version')}
             <PageSingleSelect<string>
               options={


### PR DESCRIPTION
Add spacing around version information in Collection Details. 

Before:
<img width="823" alt="Screenshot 2023-11-15 at 11 17 28 AM" src="https://github.com/ansible/ansible-ui/assets/64337863/584fcb71-027b-4cfb-866c-26ef4862f222">

After:
<img width="829" alt="Screenshot 2023-11-15 at 11 14 15 AM" src="https://github.com/ansible/ansible-ui/assets/64337863/4b4deeaa-0b36-41c7-938e-5b110989f07b">
