### PR TITLE
Fix DataEditor to support two editors on the same page (credential-type)

### DIFF
--- a/framework/PageForm/Inputs/DataEditor.tsx
+++ b/framework/PageForm/Inputs/DataEditor.tsx
@@ -117,16 +117,20 @@ export function DataEditor<
 
   useEffect(() => {
     const editor = editorRef?.current?.editor;
-    const uri = monaco.editor.getModels()[0];
-    if (editor && uri && language) {
-      monaco.editor.setModelLanguage(uri, language);
+    if (!editor) return;
+
+    const model = editor.getModel();
+    if (!model) return;
+
+    if (language) {
+      monaco.editor.setModelLanguage(model, language);
     }
-    editorRef.current?.editor?.getModel()?.onDidChangeContent(() => {
-      onChange(editorRef.current?.editor?.getValue() ?? '');
+    model.onDidChangeContent(() => {
+      onChange(editor.getValue() ?? '');
     });
-    const currentValue = editorRef.current?.editor?.getValue();
-    if (editorRef.current?.editor && currentValue !== props.value) {
-      editorRef.current?.editor?.setValue(props.value);
+    const currentValue = editor.getValue();
+    if (currentValue !== props.value) {
+      editor.setValue(props.value);
     }
     const valueArray = props.value.split('\n');
     const element = document.getElementById(idDataEditorElement);
@@ -151,9 +155,16 @@ export function DataEditor<
   }, [settings.activeTheme]);
 
   useEffect(() => {
+    const editor = editorRef?.current?.editor;
+    if (!editor) return;
+
+    const model = editor.getModel();
+    if (!model) return;
+
     monaco.editor.onDidChangeMarkers(() => {
       const markers = monaco.editor.getModelMarkers({
-        owner: monaco.editor?.getModels()[0]?.getLanguageId(),
+        owner: model.getLanguageId(),
+        resource: model.uri,
       });
       if (markers.length > 0) {
         setError(name, { message: markers.map((marker) => marker.message).join('\n') });

--- a/framework/PageForm/Inputs/DataEditor.tsx
+++ b/framework/PageForm/Inputs/DataEditor.tsx
@@ -125,7 +125,7 @@ export function DataEditor<
     if (language) {
       monaco.editor.setModelLanguage(model, language);
     }
-    model.onDidChangeContent(() => {
+    const didChangeContentDisposable = model.onDidChangeContent(() => {
       onChange(editor.getValue() ?? '');
     });
     const currentValue = editor.getValue();
@@ -138,6 +138,10 @@ export function DataEditor<
       element.style.minHeight = '75px';
       element.style.height = `${(valueArray.length + 3) * 19}` + 'px';
     }
+
+    return () => {
+      didChangeContentDisposable.dispose();
+    };
   }, [props.value, language, onChange, idDataEditorElement]);
 
   useResizeObserver(divEl, () => {
@@ -161,7 +165,7 @@ export function DataEditor<
     const model = editor.getModel();
     if (!model) return;
 
-    monaco.editor.onDidChangeMarkers(() => {
+    const disChangeMarkersDisposable = monaco.editor.onDidChangeMarkers(() => {
       const markers = monaco.editor.getModelMarkers({
         owner: model.getLanguageId(),
         resource: model.uri,
@@ -172,6 +176,10 @@ export function DataEditor<
         clearErrors(name);
       }
     });
+
+    return () => {
+      disChangeMarkersDisposable.dispose();
+    };
   }, [setError, clearErrors, name]);
 
   return (


### PR DESCRIPTION
The data editor was referencing the the first editor model using
```
monaco.editor.getModels()[0]
```

When there were two editors on the page, this was causing errors and highlighting based on the first editor.
This fixes that issue.

This was found because the tests on this page were marked Flaky by Cypress.
Hopefully this resolves that.

![Screenshot 2023-11-16 at 10 21 37 AM](https://github.com/ansible/ansible-ui/assets/6277895/5ac2f178-ad72-47de-b81f-8ce57fac9cb5)