### PR TITLE
Workflow Visualizer State management and Delete nodes(s) functionality

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizerNodeDetails.cy.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizerNodeDetails.cy.tsx
@@ -16,13 +16,13 @@ describe('WorkflowVisualizerNodeDetails', () => {
     );
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             summary_fields: {
               unified_job_template: { unified_job_type: 'job', id: 7 },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );
@@ -43,13 +43,13 @@ describe('WorkflowVisualizerNodeDetails', () => {
 
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             summary_fields: {
               unified_job_template: { unified_job_type: 'workflow_job', id: 7 },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );
@@ -63,13 +63,13 @@ describe('WorkflowVisualizerNodeDetails', () => {
     cy.intercept({ method: 'GET', url: '/api/v2/projects/*/' }, { fixture: 'project.json' });
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             summary_fields: {
               unified_job_template: { unified_job_type: 'project_update', id: 7 },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );
@@ -85,13 +85,13 @@ describe('WorkflowVisualizerNodeDetails', () => {
     );
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             summary_fields: {
               unified_job_template: { unified_job_type: 'inventory_update', id: 7 },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );
@@ -104,7 +104,7 @@ describe('WorkflowVisualizerNodeDetails', () => {
   it('Should render system job details', () => {
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             all_parents_must_converge: false,
             summary_fields: {
@@ -115,8 +115,8 @@ describe('WorkflowVisualizerNodeDetails', () => {
                 name: 'System job',
               },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );
@@ -125,7 +125,7 @@ describe('WorkflowVisualizerNodeDetails', () => {
   it('Should render workflow approval details', () => {
     cy.mount(
       <WorkflowVisualizerNodeDetails
-        selectedNode={
+        selectedNode={[
           {
             all_parents_must_converge: false,
             summary_fields: {
@@ -136,8 +136,8 @@ describe('WorkflowVisualizerNodeDetails', () => {
                 name: 'Workflow approval',
               },
             },
-          } as WorkflowNode
-        }
+          } as WorkflowNode,
+        ]}
         setSelectedNode={() => {}}
       />
     );

--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizerNodeDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizerNodeDetails.tsx
@@ -10,8 +10,8 @@ const TopologySideBar = styled(PFTopologySideBar)`
   padding-left: 20px;
 `;
 export function WorkflowVisualizerNodeDetails(props: {
-  selectedNode: WorkflowNode;
-  setSelectedNode: (node: WorkflowNode | undefined) => void;
+  selectedNode: WorkflowNode[];
+  setSelectedNode: () => void;
 }) {
   const { selectedNode, setSelectedNode } = props;
   const { t } = useTranslation();
@@ -24,7 +24,7 @@ export function WorkflowVisualizerNodeDetails(props: {
       show
       header={<Title headingLevel="h1">{t('Node details')}</Title>}
       resizable
-      onClose={() => setSelectedNode(undefined)}
+      onClose={setSelectedNode}
     >
       {getDetails}
       <ActionList data-cy="workflow-topology-sidebar-actions" style={{ paddingBottom: '20px' }}>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/DeleteConfirmationModal.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/DeleteConfirmationModal.tsx
@@ -1,0 +1,92 @@
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { useTranslation } from 'react-i18next';
+import { WorkflowVisualizerDispatch, WorkflowVisualizerState } from '../types';
+import { stringIsUUID, toTitleCase } from '../../../../common/util/strings';
+import { WorkflowJobTemplate } from '../../../../interfaces/WorkflowJobTemplate';
+
+export function DeleteConfirmationModal(props: {
+  state: WorkflowVisualizerState;
+  dispatch: WorkflowVisualizerDispatch;
+  workflowJobTemplate: WorkflowJobTemplate;
+}) {
+  const { state, dispatch, workflowJobTemplate } = props;
+  const { t } = useTranslation();
+
+  const cancelDeleteAction = () =>
+    dispatch({
+      type: 'CANCEL_ACTION',
+      value: {
+        ...state,
+        showDeleteNodesModal: false,
+        selectedNode: [],
+        mode: undefined,
+      },
+    });
+  return (
+    <Modal
+      data-cy="workflow-delete-nodes-modal"
+      titleIconVariant={'warning'}
+      variant={ModalVariant.medium}
+      title={
+        state.selectedNode.length > 1
+          ? t('Are you sure you want to delete these nodes?')
+          : t('Are you sure you want to delete this node?')
+      }
+      isOpen={state.showDeleteNodesModal}
+      onClose={cancelDeleteAction}
+      actions={[
+        <Button
+          data-cy="workflow-delete-nodes-modal-confirm"
+          key="confirm"
+          variant="primary"
+          onClick={() => {
+            if (!state.selectedNode.length === undefined) return;
+            dispatch({
+              type: 'SET_NODES_TO_DELETE',
+              value: state.selectedNode,
+            });
+          }}
+        >
+          {t('Confirm')}
+        </Button>,
+        <Button
+          key="cancel"
+          data-cy="workflow-delete-nodes-modal-cancel"
+          variant="plain"
+          onClick={cancelDeleteAction}
+        >
+          {t('Cancel')}
+        </Button>,
+      ]}
+    >
+      {
+        <Table aria-label="Simple table" variant="compact">
+          <Thead>
+            <Tr>
+              <Th>{t('Name')}</Th>
+              <Th>{t('Node Type')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {state.selectedNode.map((node) => {
+              if (node === undefined) return null;
+              const nodeName = !stringIsUUID(node.identifier)
+                ? node.identifier
+                : node.summary_fields.unified_job_template.name;
+              const nodeType = toTitleCase(
+                node.summary_fields.unified_job_template.unified_job_type
+              );
+              return (
+                <Tr data-cy={`table-row-${nodeName}`} key={workflowJobTemplate?.name}>
+                  <Td dataLabel={nodeName}>{nodeName}</Td>
+                  <Td dataLabel={nodeType}>{nodeType}</Td>
+                </Tr>
+              );
+            })}
+          </Tbody>
+        </Table>
+      }
+    </Modal>
+  );
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/NodeContextMenu.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/NodeContextMenu.tsx
@@ -1,18 +1,28 @@
 import { ReactElement } from 'react';
-import { useTranslation } from 'react-i18next';
-import { ContextMenuSeparator, ContextMenuItem } from '@patternfly/react-topology';
+import {
+  ContextMenuSeparator,
+  ContextMenuItem,
+  ElementModel,
+  GraphElement,
+} from '@patternfly/react-topology';
 import { EditIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { WorkflowVisualizerDispatch, WorkflowVisualizerState } from '../types';
+import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
 
 interface MenuItem {
   key: string;
   label: string;
   icon?: ReactElement;
   isDanger?: boolean;
-  onClick?: () => void;
+  onClick?: (element: WorkflowNode) => void;
 }
-
-export function useNodeMenuItems(): MenuItem[] {
-  const { t } = useTranslation();
+export type WorkflowflowVisualizerTopologyState = WorkflowVisualizerState & {
+  dispatch: WorkflowVisualizerDispatch;
+};
+export function useNodeMenuItems(
+  dispatch: WorkflowVisualizerDispatch,
+  t: (string: string) => string
+): MenuItem[] {
   return [
     {
       key: 'edit-node',
@@ -41,13 +51,30 @@ export function useNodeMenuItems(): MenuItem[] {
       icon: <MinusCircleIcon />,
       isDanger: true,
       label: t('Remove node'),
-      onClick: () => alert(`Selected: Remove Node`),
+      onClick: (element: WorkflowNode) =>
+        dispatch({
+          type: 'TOGGLE_CONFIRM_DELETE_MODAL',
+          value: [element],
+        }),
     },
   ];
 }
 
-export function NodeContextMenu() {
-  const items = useNodeMenuItems();
+export function NodeContextMenu(
+  element: GraphElement<ElementModel, unknown>,
+  t: (string: string) => string
+) {
+  const controller = element.getController();
+  const { dispatch, nodes }: WorkflowflowVisualizerTopologyState = controller.getState();
+
+  const selectedNode = nodes.find((node: WorkflowNode) => {
+    if ('id' in element && node.id.toString() === element.id) {
+      return node;
+    }
+    return undefined;
+  });
+
+  const items = useNodeMenuItems(dispatch, t);
 
   return items.map((item) => {
     if (item.label === '-') {
@@ -60,7 +87,10 @@ export function NodeContextMenu() {
         key={item.key}
         icon={item.icon}
         isDanger={item.isDanger}
-        onClick={item.onClick}
+        onClick={() => {
+          if (selectedNode === undefined || !item.onClick) return null;
+          return item?.onClick(selectedNode);
+        }}
       >
         {item.label}
       </ContextMenuItem>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/VisualizerWrapper.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/VisualizerWrapper.tsx
@@ -26,7 +26,10 @@ function AppendBody(props: { children: ReactElement }) {
   return ReactDOM.createPortal(children, el);
 }
 
-export function VisualizerWrapper(props: { children: ReactElement; isExpanded: boolean }) {
+export function VisualizerWrapper(props: {
+  children: (ReactElement | null)[];
+  isExpanded: boolean;
+}) {
   const { children, isExpanded } = props;
   return (
     <>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetDetailComponent.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetDetailComponent.tsx
@@ -7,29 +7,26 @@ import { InventorySourceDetails } from '../../../inventories/inventorySources/In
 import { SystemJobNodeDetails } from '../components/SystemJobNodeDetails';
 import { WorkflowApprovalNodeDetails } from '../components/WorkflowApprovalNodeDetails';
 
-export function useGetDetailComponent(selectedNode: WorkflowNode) {
+export function useGetDetailComponent(selectedNode: WorkflowNode[]) {
+  const node = selectedNode[0];
   const detailsComponent = useCallback(() => {
     let component;
-    switch (selectedNode?.summary_fields.unified_job_template.unified_job_type) {
+    switch (node.summary_fields.unified_job_template.unified_job_type) {
       case 'project_update':
         component = (
-          <ProjectDetails
-            projectId={selectedNode?.summary_fields.unified_job_template.id.toString()}
-          />
+          <ProjectDetails projectId={node.summary_fields.unified_job_template.id.toString()} />
         );
         break;
       case 'job':
         component = (
-          <TemplateDetails
-            templateId={selectedNode?.summary_fields.unified_job_template.id.toString()}
-          />
+          <TemplateDetails templateId={node.summary_fields.unified_job_template.id.toString()} />
         );
 
         break;
       case 'workflow_job':
         component = (
           <WorkflowJobTemplateDetails
-            templateId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            templateId={node.summary_fields.unified_job_template.id.toString()}
           />
         );
 
@@ -37,21 +34,21 @@ export function useGetDetailComponent(selectedNode: WorkflowNode) {
       case 'inventory_update':
         component = (
           <InventorySourceDetails
-            inventorySourceId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            inventorySourceId={node.summary_fields.unified_job_template.id.toString()}
           />
         );
         break;
       case 'system_job':
-        component = <SystemJobNodeDetails selectedNode={selectedNode} />;
+        component = <SystemJobNodeDetails selectedNode={node} />;
         break;
       case 'workflow_approval':
-        component = <WorkflowApprovalNodeDetails selectedNode={selectedNode} />;
+        component = <WorkflowApprovalNodeDetails selectedNode={node} />;
         break;
 
       default:
         component = null;
     }
     return component;
-  }, [selectedNode]);
+  }, [node]);
   return detailsComponent();
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/workflowReducer.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/workflowReducer.ts
@@ -1,0 +1,56 @@
+import { WorkflowVisualizerAction, WorkflowVisualizerState } from '../types';
+export const initialState = {
+  showUnsavedChangesModal: false,
+  nodesToDelete: [],
+  unsavedChanges: false,
+  nodes: [],
+  showDeleteNodesModal: false,
+  isLoading: true,
+  isVisualizerExpanded: false,
+  isToolbarKebabOpen: false,
+  selectedNode: [],
+  mode: undefined,
+};
+
+export function workflowVisualizerReducer(
+  state: WorkflowVisualizerState,
+  action: WorkflowVisualizerAction
+): WorkflowVisualizerState {
+  switch (action.type) {
+    case 'CANCEL_ACTION':
+      return { ...state, ...action.value };
+    case 'SET_TOGGLE_VISUALIZER':
+      return { ...state, isVisualizerExpanded: !state.isVisualizerExpanded };
+    case 'SET_NODES':
+      return {
+        ...state,
+        isLoading: action.value ? false : true,
+        nodes: action.value,
+      };
+    case 'SET_TOOLBAR_KEBAB_OPEN':
+      return { ...state, isToolbarKebabOpen: !state.isToolbarKebabOpen };
+
+    case 'SET_NODES_TO_DELETE':
+      return {
+        ...state,
+        nodesToDelete: [...state.nodesToDelete, ...action.value],
+        nodes: state.nodes.filter((stateNode) => {
+          return action.value.map((actionNode) => actionNode.id !== stateNode.id);
+        }),
+        showDeleteNodesModal: false,
+        selectedNode: [],
+        unsavedChanges: true,
+      };
+    case 'TOGGLE_CONFIRM_DELETE_MODAL':
+      return {
+        ...state,
+        selectedNode: action.value,
+        showDeleteNodesModal: !state.showDeleteNodesModal,
+        mode: 'delete',
+      };
+    case 'SET_SELECTED_NODE':
+      return { ...state, selectedNode: action.value.node, mode: action.value.mode };
+    default:
+      throw new Error(`Unrecognized action type: ${action.type}`);
+  }
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
@@ -71,3 +71,50 @@ export enum EdgeStatus {
   success = NodeStatus.success,
   info = NodeStatus.info,
 }
+// WorkflowVisualizerState is used in WorkflowVisualizer.tsx and in the useReducer that handles state.  It does not contain a dispatch function.
+export type WorkflowVisualizerState = {
+  showUnsavedChangesModal: boolean;
+  nodesToDelete: WorkflowNode[] | []; // could be used for delete all nodes also
+  unsavedChanges: boolean;
+  nodes: WorkflowNode[] | [];
+  showDeleteNodesModal: boolean;
+  isLoading: boolean;
+  isVisualizerExpanded: boolean;
+  isToolbarKebabOpen: boolean;
+  selectedNode: WorkflowNode[] | [];
+  mode: 'edit' | 'view' | 'add-link' | 'add-node-and-link' | 'delete' | undefined;
+};
+
+export type WorkflowVisualizerAction =
+  | { type: 'CANCEL_ACTION'; value: WorkflowVisualizerState }
+  | {
+      type: 'TOGGLE_CONFIRM_DELETE_MODAL';
+      value: WorkflowNode[];
+    }
+  | {
+      type: 'SET_NODES_TO_DELETE';
+      value: WorkflowNode[];
+    }
+  | {
+      type: 'SET_NODES';
+      value: WorkflowNode[];
+    }
+  | {
+      type: 'SET_ALL_NODES_TO_DELETE';
+      value: {
+        nodesToDelete: WorkflowNode[] | [];
+        nodes: WorkflowNode[] | [];
+        unsavedChanges?: boolean;
+      };
+    }
+  | {
+      type: 'SET_SELECTED_NODE';
+      value: {
+        node: [WorkflowNode] | [];
+        mode: 'edit' | 'view' | 'add-link' | 'add-node-and-link' | undefined;
+      };
+    }
+  | { type: 'SET_TOGGLE_VISUALIZER' }
+  | { type: 'SET_TOOLBAR_KEBAB_OPEN' };
+
+export type WorkflowVisualizerDispatch = (action: WorkflowVisualizerAction) => void;


### PR DESCRIPTION
This adds a state management useReducer that will be built out over time.  For now, we use it to load nodes, manage state, and to add functionality to remove nodes.  Removing nodes does not include functionality for the persistence of removed nodes...IE no API request is made to remove nodes.