### PR TITLE
PageSelect components update to handle keyboard accessibility

### DIFF
--- a/frontend/awx/access/users/UserForm.tsx
+++ b/frontend/awx/access/users/UserForm.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 import {
-  PageFormSelect,
   PageFormSubmitHandler,
   PageHeader,
   PageLayout,
   useGetPageUrl,
 } from '../../../../framework';
+import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { PageFormTextInput } from '../../../../framework/PageForm/Inputs/PageFormTextInput';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 import { RouteObj } from '../../../common/Routes';
@@ -184,10 +184,10 @@ function UserInputs(props: { mode: 'create' | 'edit' }) {
           }
         }}
       />
-      <PageFormSelect<IUserInput>
+      <PageFormSingleSelect<IUserInput>
         name="userType"
         label={t('User type')}
-        placeholderText={t('Select user type')}
+        placeholder={t('Select user type')}
         options={[
           {
             label: t('System administrator'),


### PR DESCRIPTION
By default the PF5 Select uses a menu underneath.
If has keyboard navigation support for a basic select.
We needed extra navigation handling for the search at the top of the select and typeahead search.

- tab focus
- keyboard navigation
- typeahead search