### PR TITLE
Remove mobx-react

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomEdge.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomEdge.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useEffect, FunctionComponent } from 'react';
-import { observer } from 'mobx-react';
 import {
   Layer,
   StatusModifier,
   TOP_LAYER,
   integralShapePath,
   isEdge,
+  observer,
 } from '@patternfly/react-topology';
 import { CustomLabel } from './CustomLabel';
 import type { CustomEdgeProps, CustomEdgeInnerProps } from '../types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "luxon": "3.4.4",
         "merge-jsons-webpack-plugin": "2.0.1",
         "mini-css-extract-plugin": "2.7.6",
-        "mobx-react": "7.6.0",
         "monaco-editor": "0.44.0",
         "monaco-editor-webpack-plugin": "7.1.0",
         "monaco-yaml": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "luxon": "3.4.4",
     "merge-jsons-webpack-plugin": "2.0.1",
     "mini-css-extract-plugin": "2.7.6",
-    "mobx-react": "7.6.0",
     "monaco-editor": "0.44.0",
     "monaco-editor-webpack-plugin": "7.1.0",
     "monaco-yaml": "5.1.0",


### PR DESCRIPTION
* Remove mobx-react dependency. React-topology exports `observer` and `action` from mobx and mobx-react. 