### PR TITLE
[AAP-15815][AAP-18277] Follow-up - Rename first column to 'ID'. Add truncate for the extended status_message column

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivations.cy.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivations.cy.tsx
@@ -109,7 +109,7 @@ describe('RulebookActivations.cy.ts', () => {
     cy.contains(/^Rulebook activations are rulebooks that have been activated to run.$/).should(
       'be.visible'
     );
-    cy.get('[data-cy="activation-id-column-header"]').should('be.visible');
+    cy.get('[data-cy="id-column-header"]').should('be.visible');
     cy.get('[data-cy="name-column-header"]').should('be.visible');
     cy.get('[data-cy="activation-status-column-header"]').should('be.visible');
     cy.get('[data-cy="number-of-rules-column-header"]').should('be.visible');

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationColumns.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationColumns.tsx
@@ -20,7 +20,7 @@ export function useRulebookActivationColumns() {
   return useMemo<ITableColumn<EdaRulebookActivation>[]>(
     () => [
       {
-        header: t('Activation ID'),
+        header: t('ID'),
         type: 'text',
         value: (activation) => activation.id.toString(),
         modal: ColumnModalOption.Hidden,

--- a/frontend/eda/rulebook-activations/hooks/useRulebookActivationColumns.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useRulebookActivationColumns.tsx
@@ -11,7 +11,7 @@ import { StatusCell } from '../../../common/Status';
 import { EdaRoute } from '../../EdaRoutes';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { Status906Enum } from '../../interfaces/generated/eda-api';
-import { Label } from '@patternfly/react-core';
+import { Label, Truncate } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 export function useRulebookActivationColumns() {
@@ -81,8 +81,7 @@ export function useRulebookActivationColumns() {
       },
       {
         header: t('Status message'),
-        type: 'text',
-        value: (activation) => activation?.status_message || '',
+        cell: (activation) => <Truncate content={activation?.status_message || ''} />,
         table: ColumnTableOption.Expanded,
         card: 'hidden',
         list: 'secondary',


### PR DESCRIPTION
Rename the first column to ID.
follow up to https://github.com/ansible/ansible-ui/pull/1229
Add truncate for the extended status_message column

![Screenshot from 2023-11-17 15-51-42](https://github.com/ansible/ansible-ui/assets/12769982/3b2f45ef-06ef-4e6f-8f2b-7a24b26912ac)

![Screenshot from 2023-11-17 15-59-06](https://github.com/ansible/ansible-ui/assets/12769982/ac460c7a-1362-45ee-8d3b-5f5a59d95f95)

