### PR TITLE
Add pf-5 utility classes to correctly render screen reader text.

### DIFF
--- a/frontend/awx/AwxMain.tsx
+++ b/frontend/awx/AwxMain.tsx
@@ -1,5 +1,6 @@
 import '@patternfly/patternfly/patternfly-base.css';
 import '@patternfly/patternfly/patternfly-charts.css';
+import '@patternfly/patternfly/patternfly-addons.css';
 
 import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 

--- a/frontend/awx/administration/topology/Legend.tsx
+++ b/frontend/awx/administration/topology/Legend.tsx
@@ -29,7 +29,7 @@ const Panel = styled(PFPanel)`
   width: 240px;
   min-height: 300px;
   position: absolute;
-  left: 555px;
+  left: 255px;
   bottom: 60px;
   border-radius: var(--pf-v5-global--BorderRadius--sm);
   box-shadow: var(--pf-v5-global--BoxShadow--sm);


### PR DESCRIPTION
React-topology uses a series of Patternfly utility classes that aren't included by default. This PR imports the utility classes to our codebase so we can properly render screen reader text in the topology control bar.
Before:
![Screenshot 2023-11-20 at 9 39 21 AM](https://github.com/ansible/ansible-ui/assets/2293210/eafe99e4-643d-483e-974c-9e961bdec274)
After:
![Screenshot 2023-11-20 at 11 34 16 AM](https://github.com/ansible/ansible-ui/assets/2293210/7b083912-5ca1-492d-8ea1-3a3c074b450a)
