### PR TITLE
Repair delete collection from repository

### DIFF
--- a/frontend/hub/api/request.ts
+++ b/frontend/hub/api/request.ts
@@ -2,6 +2,7 @@ import { createRequestError } from '../../common/crud/RequestError';
 import { getCookie } from '../../common/crud/cookie';
 import { TaskResponse } from '../tasks/Task';
 import { parseTaskResponse } from './utils';
+import { requestGet } from '../../common/crud/Data';
 
 interface Options {
   method: string;
@@ -178,4 +179,24 @@ export async function getHubRequest<ResponseBody extends object | TaskResponse>(
     signal,
   };
   return hubRequestCommon<ResponseBody>(url, options);
+}
+
+export async function getHubAllItems<ResponseBody, ResponseItem>(
+  url: string,
+  settings: {
+    getData: (res: ResponseBody) => ResponseItem[] | undefined;
+    getNextUrl: (res: ResponseBody) => string | undefined;
+  }
+) {
+  let actualUrl = url;
+  let results: ResponseItem[] = [];
+
+  while (actualUrl) {
+    const data = await requestGet<ResponseBody>(actualUrl);
+
+    actualUrl = settings.getNextUrl(data) || '';
+    results = [...results, ...(settings.getData(data) || [])];
+  }
+
+  return results;
 }

--- a/frontend/hub/api/request.ts
+++ b/frontend/hub/api/request.ts
@@ -194,12 +194,21 @@ export async function getHubAllItems<ResponseBody, ResponseItem>(
   let actualUrl = url;
   let results: ResponseItem[] = [];
 
+  let count = 0;
+  let loadedAll = true;
+
   while (actualUrl) {
+    count++;
+    if (count > 3) {
+      loadedAll = false;
+      break;
+    }
+
     const data = await requestGet<ResponseBody>(actualUrl);
 
     actualUrl = settings.getNextUrl(data) || '';
     results = [...results, ...(settings.getData(data) || [])];
   }
 
-  return results;
+  return { results, loadedAll };
 }

--- a/frontend/hub/api/request.ts
+++ b/frontend/hub/api/request.ts
@@ -181,6 +181,9 @@ export async function getHubRequest<ResponseBody extends object | TaskResponse>(
   return hubRequestCommon<ResponseBody>(url, options);
 }
 
+/*
+Use this function carefuly, can be only used in situations where there are not tons of data
+*/
 export async function getHubAllItems<ResponseBody, ResponseItem>(
   url: string,
   settings: {

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -87,8 +87,8 @@ async function deleteCollectionFromRepository(
 
   if (!version) {
     // load all associated collection versions
-
-    const url = hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${
+    // TODO - waiting for API
+    const url = hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${
       collection.collection_version?.name || ''
     }&repository_name=${collection.repository.name}`;
 

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -86,6 +86,7 @@ async function deleteCollectionFromRepository(
 
   if (!version) {
     // load all associated collection versions
+    // TODO - we are not loading all of them! Implement bulk request get
     const results = await requestGet<HubItemsResponse<CollectionVersionSearch>>(
       hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${
         collection.collection_version?.name || ''
@@ -96,6 +97,7 @@ async function deleteCollectionFromRepository(
     itemsToDelete.push(collection.collection_version?.pulp_href || '');
   }
 
+  // TODO - implement error messages
   const res: { task: string } = await postRequest(
     pulpAPI`/repositories/ansible/ansible/${
       parsePulpIDFromURL(collection.repository.pulp_href) || ''


### PR DESCRIPTION
Loads all collection versions that needs to be deleted.

However, there can be hundreds of collections and API can return only 100 in one call. So we make repeated calls that can load 300 of them at max. When there are more, it will throw this exception and notify user:

![image](https://github.com/ansible/ansible-ui/assets/23277791/9cbd2f84-9d96-4d9d-9e70-c58970983c3f)
