### PR TITLE
[AAP-15696] Add default timeout to failure toast for job relaunch

### DIFF
--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -90,7 +90,7 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
         variant: 'danger',
         title: t('Failed to relaunch job'),
         children: error instanceof Error && error.message,
-        timeout: true,
+        timeout: 2000,
       });
     }
   };

--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -90,6 +90,7 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
         variant: 'danger',
         title: t('Failed to relaunch job'),
         children: error instanceof Error && error.message,
+        timeout: true,
       });
     }
   };


### PR DESCRIPTION
This PR is regarding [AAP-15696](https://issues.redhat.com/browse/AAP-15696), it fixes the issue with the failure toast not fading away by adding a timeout. 