### PR TITLE
use approve and sign wording when autoSign is true

### DIFF
--- a/frontend/hub/approvals/hooks/useApproveCollections.tsx
+++ b/frontend/hub/approvals/hooks/useApproveCollections.tsx
@@ -41,7 +41,9 @@ export function useApproveCollections(
           : t('Yes, I confirm that I want to approve these {{count}} collections.', {
               count: collections.length,
             }),
-        actionButtonText: t('Approve collections', { count: collections.length }),
+        actionButtonText: autoSign
+          ? t('Approve and sign collections', { count: collections.length })
+          : t('Approve collections', { count: collections.length }),
         items: collections.sort((l, r) =>
           compareStrings(
             l.collection_version?.pulp_href || '' + l.repository?.name,


### PR DESCRIPTION
Hello @MilanPospisil ,

This pr is ancillary to your good work on the approve and sign feature and simply adds some ux consistency to the button, which should appear as "Approve and sign collections" if `autoSign` flag is true and just "Approve collections" if otherwise. Of course, this change applies with and without using the bulk action dialog.

Before:
<img width="568" alt="Screenshot 2023-11-27 at 2 45 32 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/5dbdf335-0ba3-4c87-8d11-e6eb768d508c">

After:
<img width="560" alt="Screenshot 2023-11-27 at 2 41 43 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/65b4ece9-4bd0-4360-85de-4733792ffc39">


