### PR TITLE
Truncate node hostname in mesh viz

### DIFF
--- a/frontend/awx/administration/topology/components/MeshNode.tsx
+++ b/frontend/awx/administration/topology/components/MeshNode.tsx
@@ -92,6 +92,7 @@ const MeshNode: React.FC<CustomNodeProps & WithSelectionProps> = ({
       onSelect={onSelect}
       selected={selected}
       onStatusDecoratorClick={onSelect}
+      truncateLength={20}
     >
       <g transform={`translate(13, 13)`}>
         {Icon && <Icon style={{ color: '#393F44' }} width={25} height={25} />}


### PR DESCRIPTION
Align with WF Viz pattern of truncating node names to 20 characters.

Before:
![Screenshot 2023-11-28 at 10 44 05 AM](https://github.com/ansible/ansible-ui/assets/2293210/be3dbac9-4a65-421f-b89b-f0ba57aade47)

After:
![Screenshot 2023-11-28 at 10 43 47 AM](https://github.com/ansible/ansible-ui/assets/2293210/41f3f415-8f44-4af8-8a92-8d0dbd4678da)

