### PR TITLE
add conditional to disable approve button

### DIFF
--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -57,7 +57,8 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         onClick: (collection) => approveCollections([collection]),
         isDanger: false,
         isDisabled: (collection) =>
-          can_upload_signatures && require_upload_signatures && collection.is_signed
+          (can_upload_signatures && require_upload_signatures && collection.is_signed) ||
+          (collection.repository?.name !== 'staging' && collection?.repository?.name !== 'rejected')
             ? t`You do not have rights to this operation`
             : undefined,
       },

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -58,8 +58,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         isDanger: false,
         isDisabled: (collection) =>
           (can_upload_signatures && require_upload_signatures && collection.is_signed) ||
-          (collection?.repository?.name !== 'rejected' &&
-            collection?.repository?.pulp_labels?.pipeline !== 'staging')
+          collection?.repository?.pulp_labels?.pipeline === 'approved'
             ? t`You do not have rights to this operation`
             : undefined,
       },
@@ -73,8 +72,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         onClick: (collection) => rejectCollections([collection]),
         isDanger: true,
         isDisabled: (collection) =>
-          collection?.repository?.name === 'rejected' ||
-          collection?.repository?.pulp_labels?.pipeline === 'staging'
+          collection?.repository?.pulp_labels?.pipeline === 'rejected'
             ? t`You do not have rights to this operation`
             : undefined,
       },

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -72,6 +72,11 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         label: t('Reject'),
         onClick: (collection) => rejectCollections([collection]),
         isDanger: true,
+        isDisabled: (collection) =>
+          collection?.repository?.name === 'rejected' ||
+          collection?.repository?.pulp_labels?.pipeline === 'staging'
+            ? t`You do not have rights to this operation`
+            : undefined,
       },
     ],
     [

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -58,7 +58,8 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         isDanger: false,
         isDisabled: (collection) =>
           (can_upload_signatures && require_upload_signatures && collection.is_signed) ||
-          (collection.repository?.name !== 'staging' && collection?.repository?.name !== 'rejected')
+          (collection?.repository?.name !== 'rejected' &&
+            collection?.repository?.pulp_labels?.pipeline !== 'staging')
             ? t`You do not have rights to this operation`
             : undefined,
       },

--- a/frontend/hub/approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalActions.tsx
@@ -57,9 +57,10 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         onClick: (collection) => approveCollections([collection]),
         isDanger: false,
         isDisabled: (collection) =>
-          (can_upload_signatures && require_upload_signatures && collection.is_signed) ||
           collection?.repository?.pulp_labels?.pipeline === 'approved'
-            ? t`You do not have rights to this operation`
+            ? t`Collection is already approved`
+            : can_upload_signatures && require_upload_signatures && !collection.is_signed
+            ? t`Signature must be uploaded first`
             : undefined,
       },
       { type: PageActionType.Seperator },
@@ -73,7 +74,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         isDanger: true,
         isDisabled: (collection) =>
           collection?.repository?.pulp_labels?.pipeline === 'rejected'
-            ? t`You do not have rights to this operation`
+            ? t`Collection is already rejected`
             : undefined,
       },
     ],


### PR DESCRIPTION
Hello @MilanPospisil,

Here is another quick fix to help with the Approvals buttons. This pr adds the conditional that the "Approve and sign" thumb button is enabled when a collection is in the `staging` or `rejected` repository, but not otherwise. This prevents the user from trying to approve collections that are already approved. 

Note in the "After" image that the thumbs up button on an approved collection has been greyed out.

Before:
<img width="825" alt="Screenshot 2023-11-28 at 3 25 50 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/2d821ab8-3b70-4bdd-b389-89425b072056">

After:
<img width="826" alt="Screenshot 2023-11-28 at 3 25 21 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/677324fa-7046-4481-9664-a1ef3307cae4">


