### PR TITLE
Add context to PageRoutedTabs child component

### DIFF
--- a/framework/PageTabs/PageRoutedTabs.tsx
+++ b/framework/PageTabs/PageRoutedTabs.tsx
@@ -8,6 +8,8 @@ export function PageRoutedTabs(props: {
   backTab?: { label: string; page: string; persistentFilterKey: string };
   tabs: ({ label: string; page: string } | false)[];
   params?: { [key: string]: string | number | undefined };
+  // Use to pass data to tab's component. To access data in that component use useOutletContext()
+  componentParams?: { [key: string]: string | number | undefined };
 }) {
   const pageNavigate = usePageNavigate();
   const navigate = useNavigate();
@@ -75,7 +77,7 @@ export function PageRoutedTabs(props: {
       <div style={{ flexGrow: 1, overflow: 'hidden' }}>
         {/* PageLayout now sets its max height to 100% which is 100% of the div above, which allows it's contents to scroll. */}
         <PageLayout>
-          <Outlet />
+          <Outlet context={props.componentParams} />
         </PageLayout>
       </div>
     </>


### PR DESCRIPTION
Example of use:
Parent component
```js
<PageRoutedTabs
          tabs={[
            {
              label: 'Details',
              page: HubRoute.RepositoryDetails,
            },
            {
              label: 'Access',
              page: HubRoute.RepositoryAccess,
            },
            {
              label: 'Collection version',
              page: HubRoute.RepositoryCollectionVersion,
            },
            {
              label: 'Versions',
              page: HubRoute.RepositoryVersions,
            },
          ]}
          params={{ id: params.id }}
          // Here you pass all the data you need
          componentParams={{ repo_id: repo_id }}
/>
```

Child component:
```js
const props = useOutletContext();
console.log(props.repo_id);
```

