### PR TITLE
Fix EDA credentials bulk delete test

### DIFF
--- a/cypress/e2e/eda/Credentials/credentials-list.cy.ts
+++ b/cypress/e2e/eda/Credentials/credentials-list.cy.ts
@@ -37,6 +37,7 @@ describe('EDA Credentials List', () => {
       cy.createEdaCredential().then((testCredential) => {
         cy.navigateTo('eda', 'credentials');
         cy.selectTableRow(edaCredential.name);
+        cy.clearAllFilters();
         cy.selectTableRow(testCredential.name);
         cy.clickToolbarKebabAction('delete-selected-credentials');
         cy.intercept('DELETE', edaAPI`/credentials/${edaCredential.id.toString()}/`).as(


### PR DESCRIPTION
EDA does not seem to be able to filter on two items.
This resets the filter when trying to select the second item.
Fixes the tests, but EDA needs to support the filters correctly.