### PR TITLE
Switch to use a fullscreen loading state until context is established

### DIFF
--- a/frontend/hub/useHubContext.tsx
+++ b/frontend/hub/useHubContext.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
-import { LoadingPage } from '../../framework/components/LoadingPage';
-import { useGet } from '../common/crud/useGet';
-import { hubAPI } from './api/formatPath';
 import { Page } from '@patternfly/react-core';
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { PageLayout } from '../../framework';
 import { LoadingState } from '../../framework/components/LoadingState';
+import { useGet } from '../common/crud/useGet';
+import { hubAPI } from './api/formatPath';
 
 type HubFeatureFlags = {
   // execution environments

--- a/frontend/hub/useHubContext.tsx
+++ b/frontend/hub/useHubContext.tsx
@@ -2,6 +2,9 @@ import { ReactNode, createContext, useContext, useEffect, useState } from 'react
 import { LoadingPage } from '../../framework/components/LoadingPage';
 import { useGet } from '../common/crud/useGet';
 import { hubAPI } from './api/formatPath';
+import { Page } from '@patternfly/react-core';
+import { PageLayout } from '../../framework';
+import { LoadingState } from '../../framework/components/LoadingState';
 
 type HubFeatureFlags = {
   // execution environments
@@ -129,7 +132,11 @@ export const HubContextProvider = ({ children }: { children: ReactNode }) => {
       {children}
     </HubContext.Provider>
   ) : (
-    <LoadingPage />
+    <Page>
+      <PageLayout>
+        <LoadingState />
+      </PageLayout>
+    </Page>
   );
 };
 


### PR DESCRIPTION
This uses a fullscreen loading state until the app is loaded and context is established.
This loading state is affecting downstream and this is the fix.

Will have to consider optimizations later so we can load several context in parallel.