### PR TITLE
Add subtitle support in navigation items

### DIFF
--- a/framework/PageNavigation/PageNavigation.tsx
+++ b/framework/PageNavigation/PageNavigation.tsx
@@ -107,7 +107,7 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
           <div>
             <div style={{ textAlign: 'left' }}>{item.label}</div>
             {item.subtitle && (
-              <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
+              <div style={{ fontSize: 'small', opacity: 0.5, textAlign: 'left' }}>
                 {item.subtitle}
               </div>
             )}

--- a/framework/PageNavigation/PageNavigation.tsx
+++ b/framework/PageNavigation/PageNavigation.tsx
@@ -17,17 +17,15 @@ export function PageNavigation(props: { navigation: PageNavigationItem[] }) {
   const navBar = usePageNavSideBar();
 
   return (
-    <>
-      <PageSidebar isSidebarOpen={navBar.isOpen} className="bg-lighten">
-        <PageSidebarBody>
-          <Nav data-cy="page-navigation" className="side-nav">
-            <NavList>
-              <PageNavigationItems baseRoute={''} items={navigationItems} />
-            </NavList>
-          </Nav>
-        </PageSidebarBody>
-      </PageSidebar>
-    </>
+    <PageSidebar isSidebarOpen={navBar.isOpen} className="bg-lighten">
+      <PageSidebarBody>
+        <Nav data-cy="page-navigation" className="side-nav">
+          <NavList>
+            <PageNavigationItems baseRoute={''} items={navigationItems} />
+          </NavList>
+        </Nav>
+      </PageSidebarBody>
+    </PageSidebar>
   );
 }
 
@@ -107,7 +105,7 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
       title={
         (
           <div>
-            <div>{item.label}</div>
+            <div style={{ textAlign: 'left' }}>{item.label}</div>
             {item.subtitle && (
               <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
                 {item.subtitle}

--- a/framework/PageNavigation/PageNavigation.tsx
+++ b/framework/PageNavigation/PageNavigation.tsx
@@ -5,6 +5,7 @@ import {
   NavList,
   PageSidebar,
   PageSidebarBody,
+  Stack,
 } from '@patternfly/react-core';
 import { useState } from 'react';
 import { usePageNavBarClick, usePageNavSideBar } from './PageNavSidebar';
@@ -73,7 +74,7 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
   const hasChildNavItems = 'children' in item && item.children?.find((child) => child.label);
 
   if (!hasChildNavItems && 'label' in item) {
-    const isActive = location.pathname.includes(route);
+    const isActive = location.pathname.endsWith(route);
     return (
       <NavItem
         id={id}
@@ -83,7 +84,14 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
         onClick={() => onClickNavItem(route)}
         data-cy={id}
       >
-        {item.label}
+        <Stack>
+          <div>{item.label}</div>
+          {item.subtitle && (
+            <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
+              {item.subtitle}
+            </div>
+          )}
+        </Stack>
       </NavItem>
     );
   }
@@ -98,8 +106,18 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
 
   return (
     <NavExpandable
-      title={item.label}
-      isActive={location.pathname.includes(route)}
+      title={
+        (
+          <div>
+            <div>{item.label}</div>
+            {item.subtitle && (
+              <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
+                {item.subtitle}
+              </div>
+            )}
+          </div>
+        ) as unknown as string
+      }
       isExpanded={isExpanded}
       onExpand={(_e, expanded: boolean) => setExpanded(expanded)}
     >

--- a/framework/PageNavigation/PageNavigation.tsx
+++ b/framework/PageNavigation/PageNavigation.tsx
@@ -5,7 +5,6 @@ import {
   NavList,
   PageSidebar,
   PageSidebarBody,
-  Stack,
 } from '@patternfly/react-core';
 import { useState } from 'react';
 import { usePageNavBarClick, usePageNavSideBar } from './PageNavSidebar';
@@ -83,15 +82,14 @@ function PageNavigationItemComponent(props: { item: PageNavigationItem; baseRout
         className={isActive ? 'bg-lighten' : undefined}
         onClick={() => onClickNavItem(route)}
         data-cy={id}
+        style={{ display: 'flex', alignItems: 'left', flexDirection: 'column' }}
       >
-        <Stack>
-          <div>{item.label}</div>
-          {item.subtitle && (
-            <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
-              {item.subtitle}
-            </div>
-          )}
-        </Stack>
+        {item.label}
+        {item.subtitle && (
+          <div style={{ fontSize: 'x-small', opacity: 0.5, textAlign: 'left' }}>
+            {item.subtitle}
+          </div>
+        )}
       </NavItem>
     );
   }

--- a/framework/PageNavigation/PageNavigationItem.tsx
+++ b/framework/PageNavigation/PageNavigationItem.tsx
@@ -1,6 +1,7 @@
 interface PageNavigationGroup {
   id?: string;
   label?: string;
+  subtitle?: string;
   path: string;
   children: PageNavigationItem[];
 }
@@ -8,6 +9,7 @@ interface PageNavigationGroup {
 interface PageNavigationComponent {
   id?: string;
   label?: string;
+  subtitle?: string;
   path: string;
   element: JSX.Element;
 }


### PR DESCRIPTION
This is needed to give some context to nav items as we transition to new terminology in the navigation.
i.e. Helps the user understand the terminology change.