### PR TITLE
[AAH-2532] Update how to display  tooltip for dropdown actions

### DIFF
--- a/framework/PageActions/PageActionButton.tsx
+++ b/framework/PageActions/PageActionButton.tsx
@@ -34,13 +34,18 @@ export function PageActionButton<T extends object>(props: {
 
   const Wrapper = wrapper ?? Fragment;
   const Icon = action.icon;
-  const tooltip = isDisabled
-    ? isDisabled
-    : action.tooltip
-    ? action.tooltip
-    : iconOnly
-    ? action.label
-    : undefined;
+
+  let tooltip;
+
+  if (isDisabled) {
+    tooltip = isDisabled;
+  } else if (action.tooltip) {
+    tooltip = action.tooltip;
+  } else if (iconOnly) {
+    tooltip = action.label;
+  } else {
+    tooltip = undefined;
+  }
 
   let variant = action.variant ?? ButtonVariant.secondary;
   if (isSecondary && [ButtonVariant.primary, ButtonVariant.danger].includes(variant)) {

--- a/framework/PageActions/PageActionDropdown.tsx
+++ b/framework/PageActions/PageActionDropdown.tsx
@@ -64,6 +64,7 @@ export function PageActionDropdown<T extends object>(props: PageActionDropdownPr
   } = props;
 
   let { actions } = props;
+
   actions = actions.filter((action) => !isPageActionHidden(action, selectedItem));
   actions = filterActionSeperators(actions);
 
@@ -160,12 +161,22 @@ export function PageActionDropdown<T extends object>(props: PageActionDropdownPr
       style={{ zIndex: dropdownOpen ? 400 : undefined }}
     />
   );
-  return tooltip && (iconOnly || isDisabled) ? (
-    <Tooltip content={tooltip} trigger={tooltip ? undefined : 'manual'}>
+  let tooltipContent;
+
+  if (isDisabled) {
+    tooltipContent = isDisabled;
+  } else if (tooltip) {
+    tooltipContent = tooltip;
+  } else if (iconOnly) {
+    tooltipContent = label;
+  } else {
+    tooltipContent = undefined;
+  }
+
+  return (
+    <Tooltip content={tooltipContent} trigger={tooltipContent ? undefined : 'manual'}>
       {dropdown}
     </Tooltip>
-  ) : (
-    { ...dropdown }
   );
 }
 
@@ -186,7 +197,18 @@ function PageDropdownActionItem<T extends object>(props: {
     case PageActionType.Button: {
       let Icon: ComponentClass | FunctionComponent | undefined = action.icon;
       if (!Icon && hasIcons) Icon = TransparentIcon;
-      let tooltip = isDisabled ?? action.tooltip;
+      let tooltip;
+
+      if (isDisabled) {
+        tooltip = isDisabled;
+      } else if (action.tooltip) {
+        tooltip = action.tooltip;
+      } else if (action.icon) {
+        tooltip = action.label;
+      } else {
+        tooltip = undefined;
+      }
+
       let isButtonDisabled = !!isDisabled;
       if (action.selection === PageActionSelection.Multiple && !selectedItems.length) {
         tooltip = t(`Select at least one item from the list`);

--- a/framework/PageActions/PageActionsPinned.tsx
+++ b/framework/PageActions/PageActionsPinned.tsx
@@ -98,7 +98,16 @@ export function PageActionPinned<T extends object>(props: PageActionPinnedProps<
 
     case PageActionType.Dropdown: {
       const isDisabled = isPageActionDisabled(action, selectedItem, selectedItems);
-      const tooltip = isDisabled ? isDisabled : action.tooltip ? action.tooltip : action.label;
+      let tooltip;
+
+      if (isDisabled) {
+        tooltip = isDisabled;
+      } else if (action.tooltip) {
+        tooltip = action.tooltip;
+      } else {
+        tooltip = action.label;
+      }
+
       return (
         <PageActionDropdown<T>
           icon={action.icon}

--- a/frontend/hub/remote-registries/hooks/useRemoteRegistryActions.tsx
+++ b/frontend/hub/remote-registries/hooks/useRemoteRegistryActions.tsx
@@ -90,6 +90,7 @@ export function useRemoteRegistryActions(options: {
         type: PageActionType.Button,
         variant: ButtonVariant.primary,
         isDisabled: (remoteRegistry) => isIndexableItem(remoteRegistry),
+        tooltip: t('Find execution environments in this registry'),
       },
       {
         icon: PencilAltIcon,


### PR DESCRIPTION
Update how to display tooltip for dropdown actions

Enabled button

<img width="1442" alt="image" src="https://github.com/ansible/ansible-ui/assets/9053044/5b4526f4-8c5c-4955-8803-69c6ee2f23f4">

Disabled button

<img width="1436" alt="image" src="https://github.com/ansible/ansible-ui/assets/9053044/cecdcdfa-9e66-4717-8fbc-0c5e079eec93">

