### PR TITLE
[AAP-18762] Unique Key Prop Console Warning Fix

### DIFF
--- a/framework/PageToolbar/PageToolbarView.tsx
+++ b/framework/PageToolbar/PageToolbarView.tsx
@@ -66,6 +66,7 @@ export function PageToolbarView(props: PageToolbarViewProps) {
                             aria-label="card view"
                             data-cy={'card-view'}
                             tooltip={translations.cardView}
+                            key={'card-view'}
                           />
                         );
                       case PageTableViewTypeE.List:
@@ -77,6 +78,7 @@ export function PageToolbarView(props: PageToolbarViewProps) {
                             aria-label="list view"
                             data-cy={'list-view'}
                             tooltip={translations.listView}
+                            key={'list-view'}
                           />
                         );
                       case PageTableViewTypeE.Table:
@@ -88,6 +90,7 @@ export function PageToolbarView(props: PageToolbarViewProps) {
                             aria-label="table view"
                             data-cy={'table-view'}
                             tooltip={translations.tableView}
+                            key={'table-view'}
                           />
                         );
                     }


### PR DESCRIPTION
This PR is regarding [AAP-18762](https://issues.redhat.com/browse/AAP-18762) which fixes a console warning about unique key props for the `PageToolbarToggleGroup` items.