### PR TITLE
Add activity column for Templates list.

### DIFF
--- a/frontend/awx/interfaces/summary-fields/summary-fields.tsx
+++ b/frontend/awx/interfaces/summary-fields/summary-fields.tsx
@@ -1,3 +1,10 @@
+export interface SummaryFieldRecentJob {
+  id: number;
+  status: string;
+  finished: string | null;
+  canceled_on: string | null;
+  type: string;
+}
 export interface SummaryFieldsOrganization {
   id: number;
   name: string;
@@ -176,4 +183,5 @@ export interface JobSummaryFields {
     description: string;
     next_run: string;
   };
+  recent_jobs?: SummaryFieldRecentJob[];
 }

--- a/frontend/awx/resources/templates/components/Sparkline.tsx
+++ b/frontend/awx/resources/templates/components/Sparkline.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import { formatDateString } from '../../../../../framework/utils/formatDateString';
+import { Tooltip } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { StatusCell } from '../../../../common/Status';
+import { SummaryFieldRecentJob } from '../../../interfaces/summary-fields/summary-fields';
+
+const Wrapper = styled.div`
+  display: inline-flex;
+  flex-wrap: wrap;
+`;
+export const Sparkline = ({ jobs }: { jobs: SummaryFieldRecentJob[] }) => {
+  const JOB_TYPE_URL_SEGMENTS: { [char: string]: string } = {
+    job: 'playbook',
+    project_update: 'project',
+    system_job: 'management',
+    inventory_update: 'inventory',
+    ad_hoc_command: 'command',
+    workflow_job: 'workflow',
+  };
+  const { t } = useTranslation();
+  const generateTooltip = (job: SummaryFieldRecentJob) => (
+    <>
+      <div>
+        {t`JOB ID:`} {job.id}
+      </div>
+      <div>
+        {t`STATUS:`} {job.status?.toUpperCase()}
+      </div>
+      {job.finished && (
+        <div>
+          {t`FINISHED:`} {formatDateString(job.finished)}
+        </div>
+      )}
+    </>
+  );
+
+  const statusIcons = jobs?.map((job) => (
+    <Tooltip position="top" content={generateTooltip(job)} key={job.id}>
+      <Link
+        aria-label={t(`View job ${job.id}`)}
+        to={`/jobs/${JOB_TYPE_URL_SEGMENTS[job.type]}/${job.id}/output`}
+      >
+        <StatusCell status={job.status} hideLabel={true} />
+      </Link>
+    </Tooltip>
+  ));
+
+  return <Wrapper>{statusIcons}</Wrapper>;
+};

--- a/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateColumns.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, usePageNavigate } from '../../../../../framework';
+import {
+  ColumnModalOption,
+  ColumnTableOption,
+  ITableColumn,
+  usePageNavigate,
+} from '../../../../../framework';
 import {
   useCreatedColumn,
   useDescriptionColumn,
@@ -11,6 +16,29 @@ import {
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { AwxRoute } from '../../../AwxRoutes';
+import { SummaryFieldRecentJob } from '../../../interfaces/summary-fields/summary-fields';
+import { Sparkline } from '../components/Sparkline';
+
+function useActivityColumn() {
+  const { t } = useTranslation();
+  const column: ITableColumn<{
+    summary_fields?: { recent_jobs?: SummaryFieldRecentJob[] };
+  }> = useMemo(
+    () => ({
+      header: t('Activity'),
+      cell: (item) => {
+        if (!item.summary_fields?.recent_jobs) return <></>;
+        return <Sparkline jobs={item.summary_fields?.recent_jobs} />;
+      },
+      table: ColumnTableOption.Expanded,
+      card: 'hidden',
+      list: 'hidden',
+      modal: ColumnModalOption.Hidden,
+    }),
+    [t]
+  );
+  return column;
+}
 
 export function useTemplateColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -38,14 +66,22 @@ export function useTemplateColumns(options?: { disableSort?: boolean; disableLin
   };
   const createdColumn = useCreatedColumn(options);
   const descriptionColumn = useDescriptionColumn();
+  const activityColumn = useActivityColumn();
   const modifiedColumn = useModifiedColumn(options);
   const typeOfTemplate = useTypeColumn<JobTemplate | WorkflowJobTemplate>({
     ...options,
     makeReadable,
   });
   const tableColumns = useMemo<ITableColumn<JobTemplate | WorkflowJobTemplate>[]>(
-    () => [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn],
-    [nameColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn]
+    () => [
+      nameColumn,
+      activityColumn,
+      descriptionColumn,
+      typeOfTemplate,
+      createdColumn,
+      modifiedColumn,
+    ],
+    [nameColumn, activityColumn, descriptionColumn, typeOfTemplate, createdColumn, modifiedColumn]
   );
   return tableColumns;
 }

--- a/frontend/common/Status.tsx
+++ b/frontend/common/Status.tsx
@@ -13,7 +13,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { RunningIcon, TextCell } from '../../framework';
 
-export function StatusCell(props: { status?: string; disableLinks?: boolean; to?: string }) {
+export function StatusCell(props: {
+  status?: string;
+  disableLinks?: boolean;
+  to?: string;
+  hideLabel?: boolean;
+}) {
   const { t } = useTranslation();
   const status = props.status || 'default';
 
@@ -23,7 +28,7 @@ export function StatusCell(props: { status?: string; disableLinks?: boolean; to?
 
   return (
     <TextCell
-      text={label}
+      text={props.hideLabel ? '' : label}
       color={color}
       icon={Icon ? <Icon /> : null}
       to={props.to}


### PR DESCRIPTION
This PR adds the Activity column to the AWX Templates list. You can find it under the expanded section.

Before:
![Screenshot 2023-12-06 at 7 13 10 PM](https://github.com/ansible/ansible-ui/assets/2293210/b5a2f5e3-5f0b-4dd2-8191-cd3aaa87fa4a)


After:
![Screenshot 2023-12-06 at 7 08 00 PM](https://github.com/ansible/ansible-ui/assets/2293210/6ef89c31-90e9-4f69-93e5-c53ae3f12d1f)

Old UI:
![Screenshot 2023-12-06 at 7 08 18 PM](https://github.com/ansible/ansible-ui/assets/2293210/7ce2a715-ae14-4658-955f-81afdcb36e53)

