### PR TITLE
Remove warning related to fordwardRef on PageToggleGroupItem

### DIFF
--- a/framework/PageToolbar/PageToolbarView.tsx
+++ b/framework/PageToolbar/PageToolbarView.tsx
@@ -110,14 +110,12 @@ function PageToggleGroupItem(
   }
 ) {
   const { tooltip, ...rest } = props;
+  const tooltipRef = useRef<HTMLDivElement>(null);
   return (
-    <Tooltip
-      content={tooltip}
-      position="top-end"
-      enableFlip={false}
-      triggerRef={useRef<HTMLDivElement>(null)}
-    >
-      <ToggleGroupItem ref={useRef<HTMLDivElement>(null)} {...rest} />
+    <Tooltip content={tooltip} position="top-end" enableFlip={false} triggerRef={tooltipRef}>
+      <div ref={tooltipRef}>
+        <ToggleGroupItem {...rest} />
+      </div>
     </Tooltip>
   );
 }


### PR DESCRIPTION
Remove warning related to fordwardRef on PageToggleGroupItem