### PR TITLE
add file-upload plugin for cypress

### DIFF
--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -163,7 +163,7 @@ describe('job delete', () => {
           .prev()
           .find('td[data-cy="status-column-cell"]')
           .within(() => {
-            cy.contains('Sucessful').should('be.visible');
+            cy.contains('Successful').should('be.visible');
           });
         cy.get('input[id="confirm"]').should('be.visible');
         cy.get('#confirm').click();
@@ -196,7 +196,7 @@ describe('job delete', () => {
         .prev()
         .find('td[data-cy="status-column-cell"]')
         .within(() => {
-          cy.contains('Sucessful').should('be.visible');
+          cy.contains('Successful').should('be.visible');
         });
       cy.get('input[id="confirm"]').should('be.visible');
       cy.get('#confirm').click();

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -159,6 +159,13 @@ describe('job delete', () => {
         const jobName = testJob.name ? testJob.name : '';
         cy.waitForJobToProcessEvents(jobId);
         cy.clickTableRowKebabAction(jobName, 'delete-job', false);
+        cy.get('.pf-v5-c-modal-box__footer')
+          .prev()
+          .find('td[data-cy="status-column-cell"]')
+          .within(() => {
+            cy.contains('Sucessful').should('be.visible');
+          });
+        cy.get('input[id="confirm"]').should('be.visible');
         cy.get('#confirm').click();
         cy.clickButton(/^Delete job/);
         cy.contains(/^Success$/);
@@ -185,6 +192,13 @@ describe('job delete', () => {
       cy.waitForJobToProcessEvents(jobId);
       cy.selectTableRow(jobName, false);
       cy.clickToolbarKebabAction('delete-selected-jobs');
+      cy.get('.pf-v5-c-modal-box__footer')
+        .prev()
+        .find('td[data-cy="status-column-cell"]')
+        .within(() => {
+          cy.contains('Sucessful').should('be.visible');
+        });
+      cy.get('input[id="confirm"]').should('be.visible');
       cy.get('#confirm').click();
       cy.clickButton(/^Delete job/);
       cy.contains(/^Success$/);

--- a/cypress/e2e/hub/collections.cy.ts
+++ b/cypress/e2e/hub/collections.cy.ts
@@ -1,6 +1,6 @@
 import { Collections } from './constants';
 
-describe('Collections List View', () => {
+describe('Collections- List View', () => {
   before(() => {
     cy.hubLogin();
   });

--- a/cypress/e2e/hub/collections.cy.ts
+++ b/cypress/e2e/hub/collections.cy.ts
@@ -1,6 +1,6 @@
 import { Collections } from './constants';
 
-describe('Collections', () => {
+describe('Collections List View', () => {
   before(() => {
     cy.hubLogin();
   });
@@ -9,4 +9,62 @@ describe('Collections', () => {
     cy.navigateTo('hub', Collections.url);
     cy.verifyPageTitle(Collections.title);
   });
+
+  it.skip('user can upload a new collection', () => {});
+
+  it.skip('user can delete a collection using the list toolbar', () => {});
+
+  it.skip('user can delete selected entire collections from repository using the list toolbar', () => {});
+
+  it.skip('user can deprecate selected collections using the list toolbar', () => {});
+});
+
+describe('Collections List- Line Item Kebab Menu', () => {
+  before(() => {
+    cy.hubLogin();
+  });
+
+  it.skip('user can upload a new version to an existing collection', () => {});
+
+  it.skip('user can delete entire collection from system', () => {});
+
+  it.skip('user can delete entire collection from repository', () => {});
+
+  it.skip('user can deprecate a collection', () => {});
+
+  it.skip('user can copy a version to repository', () => {});
+});
+
+describe('Collections Details View', () => {
+  before(() => {
+    cy.hubLogin();
+  });
+
+  it.skip('user can upload a new version to an existing collection', () => {});
+
+  it.skip('user can delete entire collection from system', () => {});
+
+  it.skip('user can delete entire collection from repository', () => {});
+
+  it.skip('user can deprecate a collection', () => {});
+
+  it.skip('user can delete version from system', () => {});
+
+  it.skip('user can delete version from repository', () => {});
+
+  it.skip('user can copy a version to repository', () => {});
+
+  it.skip('user can access the Install tab and download a tarball', () => {});
+});
+
+describe('Collection Approvals List', () => {
+  before(() => {
+    cy.hubLogin();
+  });
+
+  it.skip('user can approve a collection', () => {});
+
+  it.skip('user can reject a collection', () => {});
+
+  it.skip('user can upload a signature to a collection', () => {});
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -46,6 +46,7 @@ import './e2e';
 import './eda-commands';
 import './hub-commands';
 import './rest-commands';
+import 'cypress-file-upload';
 
 declare global {
   namespace Cypress {

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "@typescript-eslint/eslint-plugin": "6.10.0",
         "@typescript-eslint/parser": "6.11.0",
         "cypress": "13.5.1",
+        "cypress-file-upload": "^5.0.8",
         "cypress-react-selector": "3.0.0",
         "eslint": "8.54.0",
         "eslint-config-prettier": "9.0.0",
@@ -6421,6 +6422,18 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-file-upload": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
+      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.2.1"
+      },
+      "peerDependencies": {
+        "cypress": ">3.0.0"
       }
     },
     "node_modules/cypress-react-selector": {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@typescript-eslint/eslint-plugin": "6.10.0",
     "@typescript-eslint/parser": "6.11.0",
     "cypress": "13.5.1",
+    "cypress-file-upload": "^5.0.8",
     "cypress-react-selector": "3.0.0",
     "eslint": "8.54.0",
     "eslint-config-prettier": "9.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ES2020",
     "jsx": "react-jsx",
     "lib": ["ES2021", "DOM"],
-    "types": ["cypress", "cypress-react-selector", "@4tw/cypress-drag-drop"],
+    "types": ["cypress", "cypress-react-selector", "@4tw/cypress-drag-drop", "cypress-file-upload"],
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
     "sourceMap": true,


### PR DESCRIPTION
This PR adds a plugin: https://www.npmjs.com/package/cypress-file-upload
This will enable file attachment for Hub tests.

This PR also adds and organizes test stubs for Hub Collections.