### PR TITLE
Dockerfile refactor certs directory

### DIFF
--- a/nginx/awx.conf
+++ b/nginx/awx.conf
@@ -12,8 +12,8 @@ server {
     server_name _;
     server_tokens off;
 
-    ssl_certificate /etc/ssl/nginx-selfsigned.crt;
-    ssl_certificate_key /etc/ssl/nginx-selfsigned.key;
+    ssl_certificate /certs/cert.pem;
+    ssl_certificate_key /certs/cert.key;
 
     access_log off;
     # error_log off;

--- a/nginx/eda.conf
+++ b/nginx/eda.conf
@@ -12,8 +12,8 @@ server {
     server_name _;
     server_tokens off;
 
-    ssl_certificate /etc/ssl/nginx-selfsigned.crt;
-    ssl_certificate_key /etc/ssl/nginx-selfsigned.key;
+    ssl_certificate /certs/cert.pem;
+    ssl_certificate_key /certs/cert.key;
 
     access_log off;
     # error_log off;

--- a/nginx/hub.conf
+++ b/nginx/hub.conf
@@ -12,8 +12,8 @@ server {
     server_name _;
     server_tokens off;
 
-    ssl_certificate /etc/ssl/nginx-selfsigned.crt;
-    ssl_certificate_key /etc/ssl/nginx-selfsigned.key;
+    ssl_certificate /certs/cert.pem;
+    ssl_certificate_key /certs/cert.key;
 
     access_log off;
     # error_log off;


### PR DESCRIPTION
This will allow users of the image to mount new certs into the `/certs` directory.