### PR TITLE
[AAP-18357] Fix help icon for expandable Variables field. Add yaml/json toggle. 

### DIFF
--- a/framework/PageForm/Inputs/PageFormGroup.tsx
+++ b/framework/PageForm/Inputs/PageFormGroup.tsx
@@ -39,12 +39,17 @@ export function PageFormGroup(props: PageFormGroupProps) {
           <Split hasGutter>
             {props.icon}
             {label}
+            {labelHelp ? (
+              <Help title={labelHelpTitle} help={labelHelp} marginLeft={'0px'} />
+            ) : undefined}
           </Split>
         ) : (
           label
         )
       }
-      labelIcon={labelHelp ? <Help title={labelHelpTitle} help={labelHelp} /> : undefined}
+      labelIcon={
+        labelHelp && !props.icon ? <Help title={labelHelpTitle} help={labelHelp} /> : undefined
+      }
       labelInfo={props.additionalControls}
       isRequired={isRequired}
       data-cy={`${props.fieldId}-form-group`}

--- a/framework/components/Help.tsx
+++ b/framework/components/Help.tsx
@@ -7,8 +7,9 @@ export function Help(props: {
   title?: string;
   help?: string | string[] | ReactNode;
   docLink?: string;
+  marginLeft?: string;
 }) {
-  const { help, title, docLink } = props;
+  const { help, title, docLink, marginLeft } = props;
   const [translations] = useFrameworkTranslations();
   if (!help) return <></>;
   return (
@@ -36,7 +37,10 @@ export function Help(props: {
         </Stack>
       }
     >
-      <Button variant="plain" style={{ padding: 0, marginLeft: '8px', verticalAlign: 'middle' }}>
+      <Button
+        variant="plain"
+        style={{ padding: 0, marginLeft: marginLeft || '8px', verticalAlign: 'middle' }}
+      >
         <OutlinedQuestionCircleIcon />
       </Button>
     </Popover>

--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -218,9 +218,10 @@ export function RulebookActivationInputs() {
           name="variables"
           label={t('Variables')}
           isExpandable
-          defaultExpanded={false}
+          toggleLanguages={['yaml', 'json']}
           labelHelp={t(
-            `The variables for the rulebook are in a JSON or YAML format. The content would be equivalent to the file passed through the '--vars' flag of ansible-rulebook command.`
+            `The variables for the rulebook are in a JSON or YAML format. 
+            The content would be equivalent to the file passed through the '--vars' flag of ansible-rulebook command.`
           )}
           labelHelpTitle={t('Variables')}
         />

--- a/frontend/eda/rulebook-activations/components/EdaExtraVarCell.tsx
+++ b/frontend/eda/rulebook-activations/components/EdaExtraVarCell.tsx
@@ -22,7 +22,7 @@ export function EdaExtraVarsCell(props: {
   }
   return (
     <PageDetailCodeEditor
-      value={JSON.stringify(data?.extra_var)}
+      value={data?.extra_var}
       showCopyToClipboard={true}
       label={props.label}
       helpText={props.helpText}


### PR DESCRIPTION
- Fix help icon for expandable Variables field. 
- Add yaml/json toggle to the Variables input field.
- Fix the display for the Variables field in the Rulebook Activation details page.

Help icon before:
![Screenshot from 2023-12-07 15-04-59](https://github.com/ansible/ansible-ui/assets/12769982/8e787f27-322a-47cb-aa01-4c8f029b0569)

Fixed help icon:
![Screenshot from 2023-12-07 15-03-01](https://github.com/ansible/ansible-ui/assets/12769982/d70492ab-9b81-4e6a-9d27-a489d626e25d)

![Screenshot from 2023-12-07 15-03-08](https://github.com/ansible/ansible-ui/assets/12769982/3bd36dc0-e408-4577-826e-18fda385053c)

![Screenshot from 2023-12-07 15-03-20](https://github.com/ansible/ansible-ui/assets/12769982/5a53d498-1c0f-4f8c-92a2-8db98fadbb73)
