### PR TITLE
Repair routing in collections

### DIFF
--- a/framework/PageNavigation/useGetPageUrl.tsx
+++ b/framework/PageNavigation/useGetPageUrl.tsx
@@ -21,7 +21,10 @@ export function useGetPageUrl() {
             let value = params[key];
             if (value === undefined) return acc;
             value = encodeURIComponent(value.toString());
-            return acc.replace(`:${key}`, value);
+            const stringToReplace = ':' + key;
+            // search for longest string is necessary, because without it, we can replace substring
+            const regex = new RegExp(stringToReplace + '(?!.*' + stringToReplace + ')', 'g');
+            return acc.replace(regex, value);
           }, url);
         }
         if (query) {

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -17,18 +17,14 @@ import { CollectionVersionSearch } from '../Collection';
 import { useCollectionActions } from '../hooks/useCollectionActions';
 import { usePageNavigate } from '../../../../framework';
 import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
+import { useParams } from 'react-router-dom';
 
 export function CollectionPage() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { name, namespace, repository, version } = useParams();
 
-  const name = searchParams.get('name') || '';
-  const namespace = searchParams.get('namespace') || '';
-  const repository = searchParams.get('repository') || '';
   const redirectIfEmpty = searchParams.get('redirectIfEmpty') || '';
-
-  // load collection by search params
-  const version = searchParams.get('version');
 
   const collectionsRequest = useGet<HubItemsResponse<CollectionVersionSearch>>(
     hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name || ''}&namespace=${
@@ -182,7 +178,12 @@ export function CollectionPage() {
           { label: t('Dependencies'), page: HubRoute.CollectionDependencies },
           { label: t('Distributions'), page: HubRoute.CollectionDistributions },
         ]}
-        params={{ id: collection?.collection_version?.name || '' }}
+        params={{
+          name: collection?.collection_version?.name || '',
+          namespace: collection?.collection_version?.namespace || '',
+          version: collection?.collection_version?.version || '',
+          repository: collection?.repository?.name || '',
+        }}
         componentParams={{ collection: collection }}
       />
     </PageLayout>

--- a/frontend/hub/collections/hooks/useCollectionColumns.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.tsx
@@ -22,10 +22,11 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
           <TextCell
             text={collection.collection_version?.name}
             to={getPageUrl(HubRoute.CollectionPage, {
-              query: {
+              params: {
                 name: collection.collection_version?.name,
                 namespace: collection.collection_version?.namespace,
                 repository: collection.repository?.name,
+                version: collection.collection_version?.version,
               },
             })}
           />

--- a/frontend/hub/useHubNavigation.tsx
+++ b/frontend/hub/useHubNavigation.tsx
@@ -101,7 +101,7 @@ export function useHubNavigation() {
         },
         {
           id: HubRoute.CollectionPage,
-          path: ':id',
+          path: ':repository/:namespace/:name/:version',
           element: <CollectionPage />,
           children: [
             {


### PR DESCRIPTION
Repaired routing in the collection detail. Now it has params :repo/:namespace/:name/:version

Because there was error in framework, that matched and replaced first occurence of param key, :namespace was replaced as {replaced}space, and :name was left unchanged. So I changed the framework function to replace longest occurence of key, rather than first occurence, which did not work if there was some valid prefix of the key.