### PR TITLE
Replace project sync with project cancel when a project is syncing

### DIFF
--- a/frontend/awx/resources/projects/Projects.cy.tsx
+++ b/frontend/awx/resources/projects/Projects.cy.tsx
@@ -211,17 +211,20 @@ describe('projects.cy.ts', () => {
         });
     });
 
-    it('Sync project kebab button is disabled for project with active sync status', () => {
+    it('Sync project kebab button is visible for project with non-active sync status and is hidden for project with active sync status', () => {
       cy.mount(<Projects />);
+      // select prorject with non-active sync status
+      cy.contains('td', ' Project 1 Org 0')
+        .parent()
+        .within(() => {
+          cy.get('#sync-project').should('exist');
+        });
+      // select project with active sync status
       cy.contains('td', ' Project 3 Org 0')
         .parent()
         .within(() => {
-          cy.get('#sync-project').trigger('mouseenter');
-          cy.get('#sync-project').should('have.attr', 'aria-disabled', 'true');
+          cy.get('#sync-project').should('not.exist');
         });
-      cy.get('.pf-v5-c-tooltip')
-        .contains(/^The project cannot be synced because a sync job is currently running$/)
-        .should('be.visible');
     });
 
     it('Cancel project sync kebab button is visible for project with active sync status and is hidden for project with non active sync status', () => {

--- a/frontend/awx/resources/projects/hooks/useProjectActions.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectActions.tsx
@@ -88,6 +88,7 @@ export function useProjectActions(
         icon: SyncIcon,
         label: t('Sync project'),
         isDisabled: cannotSyncProject,
+        isHidden: (project: Project) => Boolean(!cannotCancelProjectDueToStatus(project)),
         onClick: (project: Project) => {
           const alert: AlertProps = {
             variant: 'success',


### PR DESCRIPTION
Per convo with UXD, we now replace the sync icon with the cancel icon when a project is syncing:
![project-detail-sync](https://github.com/ansible/ansible-ui/assets/2293210/44a690b6-69a7-4912-96bf-e89c996962e4)
![project-list-sync](https://github.com/ansible/ansible-ui/assets/2293210/e8b71d28-a024-4dd9-97f4-80e7ea7c7af4)
