### PR TITLE
Collection tab dependencies

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
@@ -17,6 +17,7 @@ import { IToolbarFilter } from '../../../../framework';
 import { requestGet } from '../../../common/crud/Data';
 import { ToolbarFilterType } from '../../../../framework';
 import { usePageNavigate } from '../../../../framework';
+import styled from 'styled-components';
 
 export function CollectionDependencies() {
   const { collection } = useOutletContext<{ collection: CollectionVersionSearch }>();
@@ -63,9 +64,9 @@ export function CollectionDependencies() {
         <Title headingLevel="h2">{t('Dependencies')}</Title>
         {t`This collections requires the following collections for use`}
         <br></br>
-        <span style={{ color: PFColorE.Red }}>
+        <WarningMessage>
           {missingCollection && t`Collection was not found in the system`}
-        </span>
+        </WarningMessage>
         <br></br>
         {Object.keys(collection.collection_version.dependencies).map((key) => {
           return (
@@ -108,7 +109,7 @@ function UsedByDependenciesTable(props: { collection: CollectionVersionSearch })
       tableColumns={tableColumns}
       toolbarFilters={filters}
       errorStateTitle={t('Error loading used by dependencies')}
-      emptyStateTitle={t('No collections yet')}
+      emptyStateTitle={t('No dependencies')}
       compact={true}
       {...view}
     />
@@ -169,3 +170,7 @@ export function useCollectionFilters() {
     return filters;
   }, [t]);
 }
+
+const WarningMessage = styled.span`
+  color: ${PFColorE.Red};
+`;

--- a/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
@@ -21,6 +21,8 @@ import { useMemo } from 'react';
 import { HubRoute } from '../../HubRoutes';
 import { TextCell } from '../../../../framework';
 import { hubAPI } from '../../api/formatPath';
+import { IToolbarFilter } from '../../../../framework';
+import { ToolbarFilterType } from '../../../../framework';
 
 export function CollectionDependencies() {
   const { collection } = useOutletContext<{ collection: CollectionVersionSearch }>();
@@ -61,6 +63,7 @@ function UsedByDependenciesTable(props: { collection: CollectionVersionSearch })
   const version = props.collection.collection_version;
   const { t } = useTranslation();
   const tableColumns = useCollectionColumns();
+  const filters = useCollectionFilters();
 
   const view = useHubView<UsedByDependenciesTableType>({
     url: hubAPI`/_ui/v1/collection-versions/`,
@@ -74,6 +77,7 @@ function UsedByDependenciesTable(props: { collection: CollectionVersionSearch })
     <PageTable<UsedByDependenciesTableType>
       id="hub-used-by-dependencies-table"
       tableColumns={tableColumns}
+      toolbarFilters={filters}
       errorStateTitle={t('Error loading used by dependencies')}
       emptyStateTitle={t('No collections yet')}
       compact={true}
@@ -86,6 +90,7 @@ type UsedByDependenciesTableType = {
   name: string;
   namespace: string;
   repository_list: string[];
+  version: string;
 };
 
 function useCollectionColumns() {
@@ -99,7 +104,7 @@ function useCollectionColumns() {
         value: (collection) => collection.namespace + '_' + collection.name,
         cell: (collection) => (
           <TextCell
-            text={collection.name}
+            text={`${collection.namespace}.${collection.name}.v${collection.version}`}
             to={getPageUrl(HubRoute.CollectionPage, {
               params: {
                 name: collection.name,
@@ -117,4 +122,21 @@ function useCollectionColumns() {
     ],
     [getPageUrl, t]
   );
+}
+
+export function useCollectionFilters() {
+  const { t } = useTranslation();
+
+  return useMemo<IToolbarFilter[]>(() => {
+    const filters: IToolbarFilter[] = [
+      {
+        key: 'name__icontains',
+        label: t('Name'),
+        type: ToolbarFilterType.Text,
+        query: 'keywords',
+        comparison: 'contains',
+      },
+    ];
+    return filters;
+  }, [t]);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2464

Showing collection dependencies with link that leads to particular collection detail, if collection not found, it
will inform user that collection is not in the system.

It also shows all collections that are using this collection, there is API for it, so it is in PageTable.

![image](https://github.com/ansible/ansible-ui/assets/23277791/f00f158a-4708-49b8-8210-47285db92303)

![image](https://github.com/ansible/ansible-ui/assets/23277791/1f4072f9-6bf3-4d19-a03f-0102baff0343)
