### PR TITLE
Fix a couple template form credential field errors

### DIFF
--- a/frontend/awx/adapters/awxErrorAdapter.cy.tsx
+++ b/frontend/awx/adapters/awxErrorAdapter.cy.tsx
@@ -65,4 +65,18 @@ describe('awxErrorAdapter', () => {
     expect(result.fieldErrors.length).equal(0);
     expect(result.genericErrors).to.deep.equal([{ message: 'Error' }]);
   });
+
+  it('should deal with {error: "error msg"} as generic errors', () => {
+    const error = new RequestError(
+      'Validation failed',
+      undefined,
+      400,
+      {},
+      { error: ['Cannot assign type of galaxy'] }
+    );
+    const result = awxErrorAdapter(error);
+    expect(result.genericErrors.length).equal(1);
+    expect(result.fieldErrors.length).equal(0);
+    expect(result.genericErrors).to.deep.equal([{ message: 'Cannot assign type of galaxy' }]);
+  });
 });

--- a/frontend/awx/adapters/awxErrorAdapter.tsx
+++ b/frontend/awx/adapters/awxErrorAdapter.tsx
@@ -17,6 +17,14 @@ export const awxErrorAdapter = (error: unknown): ErrorOutput => {
       } else {
         genericErrors.push({ message: data['__all__'] as string });
       }
+    }
+    // handle API responses {error: 'Cannot assign a Credential of kind `galaxy`.'}
+    if ('error' in data) {
+      if (Array.isArray(data['error'])) {
+        genericErrors.push({ message: data['error'][0] as string });
+      } else {
+        genericErrors.push({ message: data['error'] as string });
+      }
     } else {
       for (const key in data) {
         let value = (data as Record<string, unknown>)[key];
@@ -32,6 +40,5 @@ export const awxErrorAdapter = (error: unknown): ErrorOutput => {
   } else if (error instanceof Error) {
     genericErrors.push({ message: error.message });
   }
-
   return { genericErrors, fieldErrors };
 };

--- a/frontend/awx/adapters/awxErrorAdapter.tsx
+++ b/frontend/awx/adapters/awxErrorAdapter.tsx
@@ -19,7 +19,7 @@ export const awxErrorAdapter = (error: unknown): ErrorOutput => {
       }
     }
     // handle API responses {error: 'Cannot assign a Credential of kind `galaxy`.'}
-    if ('error' in data) {
+    else if ('error' in data) {
       if (Array.isArray(data['error'])) {
         genericErrors.push({ message: data['error'][0] as string });
       } else {

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -178,7 +178,7 @@ async function submitCredentials(
   );
 
   const disassociateCredentials = removed.map((cred) =>
-    postRequest(awxAPI`/job_templates/${template?.id?.toString()}/credentials`, {
+    postRequest(awxAPI`/job_templates/${template?.id?.toString()}/credentials/`, {
       id: cred.id,
       disassociate: true,
     })


### PR DESCRIPTION
This PR adds the following fixes to the `credentials` field in the Template form:
1. Fix field error not showing up when trying to associate an incorrect credential type to a template.
2. Fix incorrect API call to dissociate a credential.

Before:

![cred-error-before](https://github.com/ansible/ansible-ui/assets/2293210/3f005dec-3cfc-4470-ad1f-da71900d9705)

After:
![cred-error-after](https://github.com/ansible/ansible-ui/assets/2293210/ded97d09-60a4-461a-bfa8-5240bcabc5d1)
