### PR TITLE
[AAH-2529] Disable edit name for remote registries

### DIFF
--- a/frontend/hub/remote-registries/RemoteRegistryForm.tsx
+++ b/frontend/hub/remote-registries/RemoteRegistryForm.tsx
@@ -32,6 +32,10 @@ interface SecretInput {
   shouldHideField?: (name: string) => boolean;
 }
 
+interface IRemoteInputs extends SecretInput {
+  disableEditName?: boolean;
+}
+
 interface RemoteRegistryProps extends RemoteRegistry {
   client_key?: string | null;
   password?: string | null;
@@ -184,7 +188,7 @@ export function EditRemoteRegistry() {
         onCancel={() => navigate(-1)}
         defaultValue={remoteRegistryDefaultValues}
       >
-        <RemoteInputs onClear={handleOnClear} shouldHideField={shouldHideField} />
+        <RemoteInputs disableEditName onClear={handleOnClear} shouldHideField={shouldHideField} />
         <PageFormExpandableSection singleColumn>
           <ProxyAdvancedRemoteInputs onClear={handleOnClear} shouldHideField={shouldHideField} />
           <CertificatesAdvancedRemoteInputs
@@ -301,7 +305,7 @@ function MiscAdvancedRemoteInputs() {
   );
 }
 
-function RemoteInputs({ onClear, shouldHideField }: SecretInput) {
+function RemoteInputs({ onClear, shouldHideField, disableEditName }: IRemoteInputs) {
   const { t } = useTranslation();
   const isValidUrl = useIsValidUrl();
   return (
@@ -311,6 +315,7 @@ function RemoteInputs({ onClear, shouldHideField }: SecretInput) {
         label={t('Remote name')}
         placeholder={t('Enter a remote name')}
         isRequired
+        isDisabled={disableEditName}
       />
       <PageFormTextInput<RemoteRegistryProps>
         name="url"

--- a/frontend/hub/remotes/RemoteForm.tsx
+++ b/frontend/hub/remotes/RemoteForm.tsx
@@ -41,7 +41,7 @@ interface IRemoteInputs extends SecretInput {
   isCommunityRemote?: boolean;
   setIsCommunityRemote?: (isCommunityRemote: boolean) => void;
   collection_signing?: boolean;
-  allowEditName?: boolean;
+  disableEditName?: boolean;
 }
 
 interface IRequirementsFile {
@@ -313,7 +313,7 @@ export function EditRemote() {
         defaultValue={remoteDefaultValues}
       >
         <RemoteInputs
-          allowEditName
+          disableEditName
           collection_signing={collection_signing}
           isCommunityRemote={isCommunityRemote}
           onClear={handleOnClear}
@@ -439,7 +439,7 @@ function MiscAdvancedRemoteInputs() {
 }
 
 function RemoteInputs({
-  allowEditName,
+  disableEditName,
   collection_signing,
   isCommunityRemote,
   onClear,
@@ -475,7 +475,7 @@ function RemoteInputs({
         label={t('Remote name')}
         placeholder={t('Enter a remote name')}
         isRequired
-        isDisabled={allowEditName}
+        isDisabled={disableEditName}
       />
       <PageFormTextInput<RemoteFormProps>
         name="url"


### PR DESCRIPTION
Disable edit name for remote registries

Rename variable to reflect intent of the change

![image](https://github.com/ansible/ansible-ui/assets/9053044/d3ec2d2e-9327-4d30-8bbb-89672cdb77de)
