### PR TITLE
fix approvals icons

### DIFF
--- a/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
+++ b/frontend/hub/approvals/hooks/useApprovalsColumns.tsx
@@ -1,4 +1,8 @@
-import { ExclamationTriangleIcon, ThumbsDownIcon, ThumbsUpIcon } from '@patternfly/react-icons';
+import {
+  ExclamationTriangleIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateTimeCell, ITableColumn, PFColorE, TextCell } from '../../../../framework';
@@ -54,20 +58,30 @@ export function useApprovalsColumns(_options?: { disableSort?: boolean; disableL
             if (approval.is_signed && display_signatures) {
               return (
                 <TextCell
-                  icon={<ThumbsUpIcon />}
+                  icon={<CheckCircleIcon />}
                   text={t('Signed and Approved')}
                   color={PFColorE.Success}
                 />
               );
             } else {
               return (
-                <TextCell icon={<ThumbsUpIcon />} text={t('Approved')} color={PFColorE.Success} />
+                <TextCell
+                  icon={<CheckCircleIcon />}
+                  text={t('Approved')}
+                  color={PFColorE.Success}
+                />
               );
             }
           }
 
           if (approval.repository?.pulp_labels?.pipeline === 'rejected') {
-            return <TextCell icon={<ThumbsDownIcon />} text={t('Rejected')} color={PFColorE.Red} />;
+            return (
+              <TextCell
+                icon={<ExclamationCircleIcon />}
+                text={t('Rejected')}
+                color={PFColorE.Red}
+              />
+            );
           }
         },
       },


### PR DESCRIPTION
This pr fixes the "rejected-approved-needs review" icons per UX protocol. 
Needs review: ExclamationTriangleIcon
Approved: CheckCircleIcon
Rejected: ExclamationCircleIcon

These photos are both "after" photos to show examples of each.

<img width="831" alt="Screenshot 2023-12-20 at 2 33 39 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/6ce94021-5e43-4755-afbf-de92dbde78ea">
<img width="821" alt="Screenshot 2023-12-20 at 2 35 19 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/487769a6-758a-43fa-bb7e-0a025cfb648b">
