### PR TITLE
Support links on columns that are of type text

### DIFF
--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -126,7 +126,7 @@ export interface ITableColumnTypeReactNode<T extends object> extends ITableColum
 export interface ITableColumnTypeText<T extends object> extends ITableColumnCommon<T> {
   type: 'text';
   value: CellFn<T, string | null | undefined>;
-  to?: string;
+  to?: (item: T) => string | undefined;
 }
 
 // TODO - default ITableColumnTypeDateTime columns maxWidth. - this will need a helper function called from the table getColumnWidth(column)
@@ -175,7 +175,7 @@ export function TableColumnCell<T extends object>(props: {
   if (!column) return <></>;
   switch (column.type) {
     case 'text':
-      return <TextCell text={column.value(item)} to={column.to} />;
+      return <TextCell text={column.value(item)} to={column.to?.(item)} />;
     case 'description':
       return <div style={{ minWidth: 200, whiteSpace: 'normal' }}>{column.value(item)}</div>;
     case 'datetime':

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -116,15 +116,17 @@ interface ITableColumnCommon<T extends object> {
   modal?: ColumnModalOption;
 }
 
-//** Column that renders using a render function that returns a ReactNode. */
+/** Column that renders using a render function that returns a ReactNode. */
 export interface ITableColumnTypeReactNode<T extends object> extends ITableColumnCommon<T> {
   type?: undefined;
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value?: CellFn<T, string | string[] | number | boolean | undefined | null>;
   cell: CellFn<T, ReactNode | undefined>;
 }
 
 export interface ITableColumnTypeText<T extends object> extends ITableColumnCommon<T> {
   type: 'text';
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value: CellFn<T, string | null | undefined>;
   to?: (item: T) => string | undefined;
 }
@@ -133,12 +135,14 @@ export interface ITableColumnTypeText<T extends object> extends ITableColumnComm
 // TODO - default option table, card, list to 'description' and modal to 'hidden'. - this will need a helper function
 export interface ITableColumnTypeDescription<T extends object> extends ITableColumnCommon<T> {
   type: 'description';
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value: CellFn<T, string | undefined | null>;
 }
 
 // TODO - default option table, card, list to 'count' and modal to 'hidden'.
 export interface ITableColumnTypeCount<T extends object> extends ITableColumnCommon<T> {
   type: 'count';
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value: CellFn<T, number | undefined>;
   // TODO options for formatting number. i.e. should number be error/warning color if not 0?
 }
@@ -146,6 +150,7 @@ export interface ITableColumnTypeCount<T extends object> extends ITableColumnCom
 /** Table column that shows a count. In a card, this shows up in a count section at the bottom of the card. */
 export interface ITableColumnTypeLabels<T extends object> extends ITableColumnCommon<T> {
   type: 'labels';
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value: CellFn<T, string[] | undefined>;
   // TODO add use option indicating how many labels to show by default
 }
@@ -153,6 +158,7 @@ export interface ITableColumnTypeLabels<T extends object> extends ITableColumnCo
 // TODO - default ITableColumnTypeDateTime columns to sort 'desc'.
 export interface ITableColumnTypeDateTime<T extends object> extends ITableColumnCommon<T> {
   type: 'datetime';
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
   value: CellFn<T, number | string | undefined>;
   // TODO add format to datetime & allow user to change
 }

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -126,6 +126,7 @@ export interface ITableColumnTypeReactNode<T extends object> extends ITableColum
 export interface ITableColumnTypeText<T extends object> extends ITableColumnCommon<T> {
   type: 'text';
   value: CellFn<T, string | null | undefined>;
+  to?: string;
 }
 
 // TODO - default ITableColumnTypeDateTime columns maxWidth. - this will need a helper function called from the table getColumnWidth(column)
@@ -174,7 +175,7 @@ export function TableColumnCell<T extends object>(props: {
   if (!column) return <></>;
   switch (column.type) {
     case 'text':
-      return <TextCell text={column.value(item)} />;
+      return <TextCell text={column.value(item)} to={column.to} />;
     case 'description':
       return <div style={{ minWidth: 200, whiteSpace: 'normal' }}>{column.value(item)}</div>;
     case 'datetime':


### PR DESCRIPTION
Many of the columns in the UIs use the original method for columns that provide a `cell` function that returns a ReactNode.
- With a `cell` function, we do not have a good way to get the real `value` for the cell as it is a ReactNode.

There is a goal to update to move 95% of those columns to use the newer typed columns.
For the 'text' type column this adds the ability to put in a 'to' link into the output.

Example
```
{
  type: 'text',
  header: t('Username'),
  value: (user) => user.username,
  to: (user) => getPageUrl(AwxRoute.UserPage, { params: { id: user.id } }),
  card: 'name',
  list: 'name',
  sort: 'username',
}
```

These new column types have goals
- Make it easier to define the columns
- Make the columns more consistent
- Eventually allow the table contents to be copied or downloaded as a CSV
  - (hence why we need the real value and not a ReactNode)
  
Note: We still will support the `cell` columns long term, but they will also need to implement the `value` function on those columns so that we can get the real value for what is being rendered in the ReactNode.