### PR TITLE
Fix EDA Dashboard Flaky Tests

### DIFF
--- a/cypress/e2e/eda/General-UI/dashboard.cy.ts
+++ b/cypress/e2e/eda/General-UI/dashboard.cy.ts
@@ -66,17 +66,22 @@ describe('EDA Dashboard', () => {
       .its('response.body.results')
       .then((results: Array<EdaProject>) => {
         if (results.length === 0) {
-          cy.verifyPageTitle('There are currently no projects');
-          cy.contains(
-            'div.pf-v5-c-empty-state__body',
-            'Create a project by clicking the button below.'
-          );
-          cy.clickButton(/^Create project$/);
+          cy.get('#projects')
+            .scrollIntoView()
+            .within(() => {
+              cy.verifyPageTitle('There are currently no projects');
+              cy.contains(
+                'div.pf-v5-c-empty-state__body',
+                'Create a project by clicking the button below.'
+              );
+              cy.clickButton(/^Create project$/);
+            });
           cy.verifyPageTitle('Create project');
         } else if (results.length >= 1) {
-          cy.contains('h3', 'Projects')
-            .parents('.pf-v5-c-card')
+          cy.get('#projects')
+            .scrollIntoView()
             .within(() => {
+              cy.contains('h3', 'Projects');
               cy.get('tbody tr').should('have.lengthOf.lessThan', 8);
             });
         }
@@ -90,19 +95,23 @@ describe('EDA Dashboard', () => {
       .its('response.body.results')
       .then((results: Array<EdaRulebookActivation>) => {
         if (results.length === 0) {
-          cy.contains('h3', 'Rulebook Activations').scrollIntoView();
-          cy.verifyPageTitle('There are currently no rulebook activations');
-          cy.contains(
-            'div.pf-v5-c-empty-state__body',
-            'Create a rulebook activation by clicking the button below.'
-          );
-          cy.clickButton(/^Create rulebook activation$/);
+          cy.get('#rulebook-activations')
+            .scrollIntoView()
+            .within(() => {
+              cy.contains('h3', 'Rulebook Activations');
+              cy.contains('There are currently no rulebook activations');
+              cy.contains(
+                'div.pf-v5-c-empty-state__body',
+                'Create a rulebook activation by clicking the button below.'
+              );
+              cy.clickButton(/^Create rulebook activation$/);
+            });
           cy.verifyPageTitle('Create Rulebook Activation');
         } else if (results.length >= 1) {
-          cy.contains('h3', 'Rulebook Activations')
+          cy.get('#rulebook-activations')
             .scrollIntoView()
-            .parents('.pf-v5-c-card')
             .within(() => {
+              cy.contains('h3', 'Rulebook Activations');
               cy.get('tbody tr').should('have.lengthOf.lessThan', 8);
             });
         }
@@ -116,17 +125,23 @@ describe('EDA Dashboard', () => {
       .its('response.body.results')
       .then((results: Array<EdaDecisionEnvironment>) => {
         if (results.length === 0) {
-          cy.verifyPageTitle('There are currently no decision environments');
-          cy.contains(
-            'div.pf-v5-c-empty-state__body',
-            'Create a decision environment by clicking the button below.'
-          );
-          cy.clickButton(/^Create decision environment$/);
+          cy.get('#decision-environments')
+            .scrollIntoView()
+            .within(() => {
+              cy.contains('h3', 'Decision Environments');
+              cy.contains('There are currently no decision environments');
+              cy.contains(
+                'div.pf-v5-c-empty-state__body',
+                'Create a decision environment by clicking the button below.'
+              );
+              cy.clickButton(/^Create decision environment$/);
+            });
           cy.verifyPageTitle('Create decision environment');
         } else if (results.length >= 1) {
-          cy.contains('h3', 'Decision Environments')
-            .parents('.pf-v5-c-card')
+          cy.get('#decision-environments')
+            .scrollIntoView()
             .within(() => {
+              cy.contains('h3', 'Decision Environments');
               cy.get('tbody tr').should('have.lengthOf.lessThan', 8);
             });
         }


### PR DESCRIPTION
The tests are calling cy.verifyPageTitle which sometimes were failing.
Updated the tests to get the card by id and call the commands within that card.

This seems to fix the flaky tests.