### PR TITLE
hub/api: deduplicate; fix HUB_API_PREFIX example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ UI projects for [Ansible](https://www.ansible.com).
 |            `HUB_SERVER` | The HUB server (protocol://host:port).              |
 |          `HUB_USERNAME` | The HUB server username. (only used by Cypress)     |
 |          `HUB_PASSWORD` | The HUB server password. (only used by Cypress)     |
-|        `HUB_API_PREFIX` | The HUB server API prefix. (`/api/automation-hub/`) |
+|        `HUB_API_PREFIX` | The HUB server API prefix. (`/api/automation-hub`)  |
 |      `HUB_ROUTE_PREFIX` | The HUB UI route prefix. (`/hub`)                   |
 | `HUB_GALAXYKIT_COMMAND` | The galaxykit command. (`galaxykit --ignore-certs`) |
 

--- a/frontend/hub/api/formatPath.tsx
+++ b/frontend/hub/api/formatPath.tsx
@@ -1,11 +1,3 @@
-export function getBaseAPIPath() {
-  return process.env.HUB_API_PREFIX;
-}
-
-export function getAPIHost() {
-  return process.env.HUB_SERVER;
-}
-
 export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   if (strings[0]?.[0] !== '/') {
     throw new Error('Invalid URL');
@@ -23,24 +15,11 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
 }
 
 export function hubAPI(strings: TemplateStringsArray, ...values: string[]) {
-  const base = getBaseAPIPath();
+  const base = process.env.HUB_API_PREFIX;
   return base + apiTag(strings, ...values);
 }
 
 export function pulpAPI(strings: TemplateStringsArray, ...values: string[]) {
-  const base = getBaseAPIPath();
+  const base = process.env.HUB_API_PREFIX;
   return base + '/pulp/api/v3' + apiTag(strings, ...values);
-}
-
-export function getRepoURL(distribution_base_path: string, view_published = false) {
-  // If the api is hosted on another URL, use API_HOST as the host part of the URL.
-  // Otherwise use the host that the UI is served from
-  const host = getAPIHost() ? getAPIHost() : window.location.origin;
-
-  // repo/distro "published" is special; not related to repo pipeline type
-  if (distribution_base_path === 'published' && view_published === false) {
-    return `${host}${getBaseAPIPath()}`;
-  }
-
-  return `${host}${getBaseAPIPath()}content/${distribution_base_path}/`;
 }

--- a/frontend/hub/api/utils.tsx
+++ b/frontend/hub/api/utils.tsx
@@ -76,22 +76,6 @@ function firstResult(results: Results) {
   return results.results[0];
 }
 
-export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
-  if (strings[0]?.[0] !== '/') {
-    throw new Error('Invalid URL');
-  }
-
-  let url = '';
-  strings.forEach((fragment, index) => {
-    url += fragment;
-    if (index !== strings.length - 1) {
-      url += encodeURIComponent(`${values.shift() ?? ''}`);
-    }
-  });
-
-  return url;
-}
-
 export type QueryParams = {
   [key: string]: string;
 };
@@ -293,15 +277,15 @@ export async function waitForTask(
 
 // Returns the API path for a specific repository
 export function getRepoURL(distribution_base_path: string, view_published = false) {
-  let HUB_SERVER;
   // If the api is hosted on another URL, use HUB_SERVER as the host part of the URL.
   // Otherwise use the host that the UI is served from
-  const host = HUB_SERVER ? HUB_SERVER : window.location.origin;
+  const host = process.env.HUB_SERVER ? process.env.HUB_SERVER : window.location.origin;
+  const base = process.env.HUB_API_PREFIX;
 
   // repo/distro "published" is special; not related to repo pipeline type
   if (distribution_base_path === 'published' && view_published === false) {
-    return `${host}${process.env.HUB_API_PREFIX}`;
+    return `${host}${base}/`;
   }
 
-  return `${host}${process.env.HUB_API_PREFIX}content/${distribution_base_path}/`;
+  return `${host}${base}/content/${distribution_base_path}/`;
 }

--- a/frontend/hub/collections/CollectionPage/CollectionDistributions.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDistributions.tsx
@@ -7,8 +7,7 @@ import { useMemo } from 'react';
 import { ITableColumn } from '../../../../framework';
 import { PageTable } from '../../../../framework';
 import { CopyCell } from '../../../../framework';
-
-import { getRepoURL } from '../../api/formatPath';
+import { getRepoURL } from '../../api/utils';
 
 export function CollectionDistributions() {
   const { t } = useTranslation();


### PR DESCRIPTION
`getBaseAPIPath`: never imported, inline
`getAPIHost`: never imported, inline
`getRepoURL`: duplicate between formatPath & utils, only one has the right trailing slashes to deal with no trailing slash on `HUB_API_PREFIX`, but only the other one respects `HUB_SERVER`, fix, merge
`apiTag`: duplicate between formatPath & utils, remove from utils

README: update HUB_API_PREFIX example to match the use - remove trailing slash