### PR TITLE
namespace name is not editable functionality and helper text

### DIFF
--- a/frontend/hub/namespaces/HubNamespaceForm.tsx
+++ b/frontend/hub/namespaces/HubNamespaceForm.tsx
@@ -45,7 +45,7 @@ export function CreateHubNamespace() {
         onCancel={() => navigate(-1)}
         defaultValue={{ groups: [] }}
       >
-        <HubNamespaceInputs />
+        <HubNamespaceInputs isDisabled={false} isRequired={true} />
       </HubPageForm>
     </PageLayout>
   );
@@ -109,13 +109,13 @@ export function EditHubNamespace() {
         onCancel={() => navigate(-1)}
         defaultValue={namespace}
       >
-        <HubNamespaceInputs />
+        <HubNamespaceInputs isDisabled={true} />
       </HubPageForm>
     </PageLayout>
   );
 }
 
-function HubNamespaceInputs() {
+function HubNamespaceInputs(props: { isDisabled?: boolean; isRequired?: boolean }) {
   const { t } = useTranslation();
   return (
     <>
@@ -123,7 +123,9 @@ function HubNamespaceInputs() {
         name="name"
         label={t('Name')}
         placeholder={t('Enter name')}
-        isRequired
+        isDisabled={props.isDisabled}
+        isRequired={props.isRequired}
+        helperText={t('Name is not editable.')}
       />
       <PageFormTextInput<HubNamespace>
         name="description"

--- a/frontend/hub/namespaces/HubNamespaceForm.tsx
+++ b/frontend/hub/namespaces/HubNamespaceForm.tsx
@@ -125,7 +125,7 @@ function HubNamespaceInputs(props: { isDisabled?: boolean; isRequired?: boolean 
         placeholder={t('Enter name')}
         isDisabled={props.isDisabled}
         isRequired={props.isRequired}
-        helperText={t('Name is not editable.')}
+        helperText={props.isDisabled ? t('Name is not editable.') : undefined}
       />
       <PageFormTextInput<HubNamespace>
         name="description"


### PR DESCRIPTION
Follow-up  pr to https://github.com/ansible/ansible-ui/pull/1380 and https://github.com/ansible/ansible-ui/pull/1396 to complete the edit namespace functionality. I added some logic to disable the namespace name in the edit form and add a little helper text.

<img width="812" alt="Screenshot 2024-01-03 at 12 24 02 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/baafddee-4fd2-424a-a161-da538e82d264">