### PR TITLE
[AAP-17161] Modify BulkActionDialog to use errorAdapter

### DIFF
--- a/framework/PageDialogs/BulkActionDialog.tsx
+++ b/framework/PageDialogs/BulkActionDialog.tsx
@@ -12,6 +12,8 @@ import pLimit from 'p-limit';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAbortController } from '../../frontend/common/crud/useAbortController';
+import { genericErrorAdapter } from '../PageForm/genericErrorAdapter';
+import { ErrorAdapter } from '../PageForm/typesErrorAdapter';
 import { PageTable } from '../PageTable/PageTable';
 import { ITableColumn, useVisibleModalColumns } from '../PageTable/PageTableColumn';
 import { usePaged } from '../PageTable/useTableItems';
@@ -50,6 +52,9 @@ export interface BulkActionDialogProps<T extends object> {
 
   /** Indicates if this is a destructive operation */
   isDanger?: boolean;
+
+  /** Error adapter used to parse the error message */
+  errorAdapter?: ErrorAdapter;
 }
 
 /**
@@ -67,6 +72,7 @@ export interface BulkActionDialogProps<T extends object> {
  * @param {function=} onClose - Callback called when the dialog closes.
  * @param {string=} processingText - The text to show for each item when the action is happening.
  * @param {boolean=} isDanger - Indicates if this is a destructive operation.
+ * @param {ErrorAdapter} [errorAdapter] - Optional adapter for error handling.
  */
 export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<T>) {
   const {
@@ -79,6 +85,7 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
     onClose,
     processingText,
     isDanger,
+    errorAdapter = genericErrorAdapter,
   } = props;
   const { t } = useTranslation();
   const [translations] = useFrameworkTranslations();
@@ -128,9 +135,14 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
               }
               successfulItems.push(item);
             } catch (err) {
+              const { genericErrors, fieldErrors } = errorAdapter(err);
+              const parsedErrors = [...genericErrors, ...fieldErrors.filter((e) => e.message)];
               if (!abortController.signal.aborted) {
                 if (err instanceof Error) {
-                  const message = err.message;
+                  const message =
+                    typeof parsedErrors[0].message === 'string' && parsedErrors.length === 1
+                      ? parsedErrors[0].message
+                      : t(`Unknown error`);
                   setStatuses((statuses) => ({
                     ...(statuses ?? {}),
                     [key]: message,
@@ -157,7 +169,16 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
       onComplete?.(successfulItems);
     }
     void process();
-  }, [abortController, actionFn, items, keyFn, onComplete, translations.errorText, t]);
+  }, [
+    abortController,
+    actionFn,
+    items,
+    keyFn,
+    onComplete,
+    translations.errorText,
+    t,
+    errorAdapter,
+  ]);
 
   const pagination = usePaged(items);
 
@@ -274,11 +295,16 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
 /**
  * useBulkActionDialog - react hook to open a BulkActionDialog
  *
+ * @template T - The type of the items on which the bulk action will be performed.
+ * @param {ErrorAdapter} [defaultErrorAdapter = genericErrorAdapter] - Optional default adapter for error handling.
+ * @returns {(props: BulkActionDialogProps<T>) => void} - A function to set the properties of the BulkActionDialog.
  * @example
  * const openBulkActionDialog = useBulkActionDialog()
  * openBulkActionDialog(...) // Pass BulkActionDialogProps
  */
-export function useBulkActionDialog<T extends object>() {
+export function useBulkActionDialog<T extends object>(
+  defaultErrorAdapter: ErrorAdapter = genericErrorAdapter
+) {
   const [_, setDialog] = usePageDialog();
   const [props, setProps] = useState<BulkActionDialogProps<T>>();
   useEffect(() => {
@@ -287,10 +313,16 @@ export function useBulkActionDialog<T extends object>() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<BulkActionDialog<T> {...props} onClose={onCloseHandler} />);
+      setDialog(
+        <BulkActionDialog<T>
+          {...props}
+          errorAdapter={props.errorAdapter ?? defaultErrorAdapter}
+          onClose={onCloseHandler}
+        />
+      );
     } else {
       setDialog(undefined);
     }
-  }, [props, setDialog]);
+  }, [props, setDialog, defaultErrorAdapter]);
   return setProps;
 }

--- a/frontend/awx/access/common/useRemoveUserFromResource.tsx
+++ b/frontend/awx/access/common/useRemoveUserFromResource.tsx
@@ -1,18 +1,19 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { awxAPI } from '../../api/awx-utils';
 import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 import { User } from '../../interfaces/User';
 import { useUsersColumns } from '../users/hooks/useUsersColumns';
 import { ResourceType } from './ResourceAccessList';
+import { useAwxBulkConfirmation } from '../../common/useAwxBulkConfirmation';
 
 export function useRemoveUsersFromResource() {
   const { t } = useTranslation();
   const activeUser = useAwxActiveUser();
   const confirmationColumns = useUsersColumns();
-  const removeUserConfirmationDialog = useBulkConfirmation<User>();
+  const removeUserConfirmationDialog = useAwxBulkConfirmation<User>();
 
   const postRequest = usePostRequest();
 

--- a/frontend/awx/access/organizations/hooks/useAddOrganizationsToUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useAddOrganizationsToUsers.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../api/awx-utils';
 import { Organization } from '../../../interfaces/Organization';
 import { User } from '../../../interfaces/User';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useAddOrganizationsToUsers() {
   const { t } = useTranslation();
-  const organizationProgressDialog = useBulkActionDialog<Organization>();
+  const organizationProgressDialog = useAwxBulkActionDialog<Organization>();
   const postRequest = usePostRequest<{ id: number }, Organization>();
 
   const addUserToOrganizations = useCallback(

--- a/frontend/awx/access/organizations/hooks/useDeleteOrganizations.tsx
+++ b/frontend/awx/access/organizations/hooks/useDeleteOrganizations.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Organization } from '../../../interfaces/Organization';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useOrganizationsColumns } from '../Organizations';
 
 export function useDeleteOrganizations(onComplete: (organizations: Organization[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteOrganizations(onComplete: (organizations: Organization[
   const confirmationColumns = useOrganizationsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Organization>();
+  const bulkAction = useAwxBulkConfirmation<Organization>();
   const deleteOrganizations = (organizations: Organization[]) => {
     bulkAction({
       title: t('Permanently delete organizations', { count: organizations.length }),

--- a/frontend/awx/access/organizations/hooks/useRemoveOrganizationsFromUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useRemoveOrganizationsFromUsers.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { awxAPI } from '../../../api/awx-utils';
 import { Organization } from '../../../interfaces/Organization';
 import { User } from '../../../interfaces/User';
-import { awxAPI } from '../../../api/awx-utils';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useRemoveOrganizationsFromUsers() {
   const { t } = useTranslation();
-  const organizationProgressDialog = useBulkActionDialog<Organization>();
+  const organizationProgressDialog = useAwxBulkActionDialog<Organization>();
   const postRequest = usePostRequest<{ id: number; disassociate: boolean }, Organization>();
   const removeUserToOrganizations = useCallback(
     (

--- a/frontend/awx/access/roles/AddRolesForm.tsx
+++ b/frontend/awx/access/roles/AddRolesForm.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { PageFormSelect, useBulkActionDialog } from '../../../../framework';
+import { PageFormSelect } from '../../../../framework';
 import { PageFormCheckbox } from '../../../../framework/PageForm/Inputs/PageFormCheckbox';
 import { PageFormHidden } from '../../../../framework/PageForm/Utils/PageFormHidden';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
@@ -15,6 +15,7 @@ import { PageFormInventorySelect } from '../../resources/inventories/components/
 import { PageFormProjectSelect } from '../../resources/projects/components/PageFormProjectSelect';
 import { PageFormJobTemplateSelect } from '../../resources/templates/components/PageFormJobTemplateSelect';
 import { PageFormWorkflowJobTemplateSelect } from '../../resources/templates/components/PageFormWorkflowJobTemplateSelect';
+import { useAwxBulkActionDialog } from '../../common/useAwxBulkActionDialog';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
 import { AwxResourceTypeRoles, useAwxRoles } from './useAwxRoles';
 
@@ -39,7 +40,7 @@ type AddRole = UserRole | TeamRole;
 export function AddRolesForm(props: { users?: User[]; teams?: Team[]; onClose?: () => void }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const openBulkActionDialog = useBulkActionDialog<AddRole>();
+  const openBulkActionDialog = useAwxBulkActionDialog<AddRole>();
   const postRequest = usePostRequest();
   return (
     <AwxPageForm

--- a/frontend/awx/access/teams/hooks/useAddTeamsToUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useAddTeamsToUsers.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { awxAPI } from '../../../api/awx-utils';
 import { Team } from '../../../interfaces/Team';
 import { User } from '../../../interfaces/User';
-import { awxAPI } from '../../../api/awx-utils';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useAddTeamsToUsers() {
   const { t } = useTranslation();
-  const teamProgressDialog = useBulkActionDialog<Team>();
+  const teamProgressDialog = useAwxBulkActionDialog<Team>();
   const postRequest = usePostRequest();
   const addTeamsToUser = useCallback(
     (teams: Team[], users: User[], onComplete?: (teams: Team[]) => void) => {

--- a/frontend/awx/access/teams/hooks/useDeleteTeams.tsx
+++ b/frontend/awx/access/teams/hooks/useDeleteTeams.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn, useOrganizationNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { AwxRoute } from '../../../AwxRoutes';
 import { awxAPI } from '../../../api/awx-utils';
 import { Team } from '../../../interfaces/Team';
 import { useTeamsColumns } from './useTeamsColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteTeams(onComplete: (teams: Team[]) => void) {
   const { t } = useTranslation();
@@ -27,7 +28,7 @@ export function useDeleteTeams(onComplete: (teams: Team[]) => void) {
       : t('The team cannot be deleted due to insufficient permissions.');
   };
 
-  const bulkAction = useBulkConfirmation<Team>();
+  const bulkAction = useAwxBulkConfirmation<Team>();
 
   const deleteTeams = (teams: Team[]) => {
     const undeletableTeams = teams.filter(cannotDeleteTeam);

--- a/frontend/awx/access/teams/hooks/useRemoveTeamsFromUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useRemoveTeamsFromUsers.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../api/awx-utils';
 import { Team } from '../../../interfaces/Team';
 import { User } from '../../../interfaces/User';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useRemoveTeamsFromUsers(onComplete?: (team: Team[]) => void) {
   const { t } = useTranslation();
-  const bulkProgressDialog = useBulkActionDialog<Team>();
+  const bulkProgressDialog = useAwxBulkActionDialog<Team>();
   const postRequest = usePostRequest();
   const removeUserToTeams = useCallback(
     (users: User[], teams: Team[]) => {

--- a/frontend/awx/access/users/hooks/useAddUsersToResources.tsx
+++ b/frontend/awx/access/users/hooks/useAddUsersToResources.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../api/awx-utils';
 import { User } from '../../../interfaces/User';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { ResourceType } from '../../common/ResourceAccessList';
 
 export function useAddUsersToResources() {
   const { t } = useTranslation();
-  const userProgressDialog = useBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<User>();
   const postRequest = usePostRequest();
   const addUserToTeams = useCallback(
     (users: User[], resources: ResourceType[], onComplete?: (users: User[]) => void) => {

--- a/frontend/awx/access/users/hooks/useDeleteUsers.tsx
+++ b/frontend/awx/access/users/hooks/useDeleteUsers.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, TextCell, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings, TextCell } from '../../../../../framework';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { User } from '../../../interfaces/User';
 import { useUsersColumns } from './useUsersColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteUsers(onComplete: (users: User[]) => void) {
   const { t } = useTranslation();
@@ -24,7 +25,7 @@ export function useDeleteUsers(onComplete: (users: User[]) => void) {
       ? undefined
       : t('The user cannot be deleted due to insufficient permissions.');
   };
-  const bulkAction = useBulkConfirmation<User>();
+  const bulkAction = useAwxBulkConfirmation<User>();
   const deleteUsers = (users: User[]) => {
     const undeletableUsers = users.filter(cannotDeleteUser);
 

--- a/frontend/awx/access/users/hooks/useRemoveUsersFromOrganizations.tsx
+++ b/frontend/awx/access/users/hooks/useRemoveUsersFromOrganizations.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { awxAPI } from '../../../api/awx-utils';
 import { Organization } from '../../../interfaces/Organization';
 import { User } from '../../../interfaces/User';
-import { awxAPI } from '../../../api/awx-utils';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useRemoveUsersFromOrganizations(onComplete?: (users: User[]) => void) {
   const { t } = useTranslation();
-  const userProgressDialog = useBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<User>();
   const postRequest = usePostRequest();
   const removeUserToOrganizations = useCallback(
     (users: User[], organizations: Organization[]) => {

--- a/frontend/awx/access/users/hooks/useRemoveUsersFromTeams.tsx
+++ b/frontend/awx/access/users/hooks/useRemoveUsersFromTeams.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBulkActionDialog } from '../../../../../framework';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { awxAPI } from '../../../api/awx-utils';
 import { Team } from '../../../interfaces/Team';
 import { User } from '../../../interfaces/User';
-import { awxAPI } from '../../../api/awx-utils';
+import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 
 export function useRemoveUsersFromTeams() {
   const { t } = useTranslation();
-  const userProgressDialog = useBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<User>();
   const postRequest = usePostRequest();
   const removeUserToTeams = useCallback(
     (users: User[], teams: Team[], onComplete?: (users: User[]) => void) => {

--- a/frontend/awx/administration/applications/hooks/useDeleteApplications.tsx
+++ b/frontend/awx/administration/applications/hooks/useDeleteApplications.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Application } from '../../../interfaces/Application';
 import { useApplicationsColumns } from './useApplicationsColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteApplications(onComplete: (applications: Application[]) => void) {
   const { t } = useTranslation();
@@ -15,7 +16,7 @@ export function useDeleteApplications(onComplete: (applications: Application[]) 
   });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Application>();
+  const bulkAction = useAwxBulkConfirmation<Application>();
   const deleteApplications = (applications: Application[]) => {
     bulkAction({
       title: t('Permanently delete applications', { count: applications.length }),

--- a/frontend/awx/administration/applications/hooks/useDeleteTokens.tsx
+++ b/frontend/awx/administration/applications/hooks/useDeleteTokens.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Token } from '../../../interfaces/Token';
 import { useTokensColumns } from './useTokensColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteTokens(onComplete: (applications: Token[]) => void) {
   const { t } = useTranslation();
@@ -15,7 +16,7 @@ export function useDeleteTokens(onComplete: (applications: Token[]) => void) {
   });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Token>();
+  const bulkAction = useAwxBulkConfirmation<Token>();
   const deleteTokens = (tokens: Token[]) => {
     bulkAction({
       title: tokens.length === 1 ? t('Permanently delete token') : t('Permanently delete tokens'),

--- a/frontend/awx/administration/credential-types/hooks/useDeleteCredentialTypes.tsx
+++ b/frontend/awx/administration/credential-types/hooks/useDeleteCredentialTypes.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TextCell, compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { TextCell, compareStrings } from '../../../../../framework';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { CredentialType } from '../../../interfaces/CredentialType';
 import { useCredentialTypesColumns } from './useCredentialTypesColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteCredentialTypes(onComplete: (users: CredentialType[]) => void) {
   const { t } = useTranslation();
@@ -29,7 +30,7 @@ export function useDeleteCredentialTypes(onComplete: (users: CredentialType[]) =
       ? t(`The credential type is provided by the system and is read-only.`)
       : '';
 
-  const bulkAction = useBulkConfirmation<CredentialType>();
+  const bulkAction = useAwxBulkConfirmation<CredentialType>();
   const deleteCredentialTypes = (credentialTypes: CredentialType[]) => {
     const undeletableManagedCredentialTypes: CredentialType[] = credentialTypes.filter(
       (credentialType) => credentialType.managed

--- a/frontend/awx/administration/execution-environments/hooks/useDeleteExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useDeleteExecutionEnvironments.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
 import { useExecutionEnvironmentsColumns } from '../ExecutionEnvironments';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteExecutionEnvironments(
   onComplete: (executionEnvironments: ExecutionEnvironment[]) => void
@@ -17,7 +18,7 @@ export function useDeleteExecutionEnvironments(
   });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<ExecutionEnvironment>();
+  const bulkAction = useAwxBulkConfirmation<ExecutionEnvironment>();
   const deleteExecutionEnvironments = (executionEnvironments: ExecutionEnvironment[]) => {
     bulkAction({
       title: t('Permanently delete execution environments', {

--- a/frontend/awx/administration/instance-groups/hooks/useDeleteInstanceGroups.tsx
+++ b/frontend/awx/administration/instance-groups/hooks/useDeleteInstanceGroups.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete, requestGet } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
@@ -11,6 +11,7 @@ import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { Inventory } from '../../../interfaces/Inventory';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 async function checkIfInstanceGroupIsBeingUsed(instanceGroup: InstanceGroup) {
   const relatedOrganizationsData = await requestGet<AwxItemsResponse<Organization>>(
@@ -37,7 +38,7 @@ export function useDeleteInstanceGroups(onComplete: (instanceGroups: InstanceGro
   const confirmationColumns = useInstanceGroupsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<InstanceGroup>();
+  const bulkAction = useAwxBulkConfirmation<InstanceGroup>();
   const cannotDeleteInstanceGroup = (instanceGroup: InstanceGroup) => {
     return instanceGroup?.summary_fields?.user_capabilities?.delete
       ? undefined

--- a/frontend/awx/administration/instances/hooks/useRunHealthCheck.tsx
+++ b/frontend/awx/administration/instances/hooks/useRunHealthCheck.tsx
@@ -1,18 +1,19 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, postRequest } from '../../../../common/crud/Data';
-import { Instance } from '../../../interfaces/Instance';
-import { useInstancesColumns } from './useInstancesColumns';
 import { awxAPI } from '../../../api/awx-utils';
+import { Instance } from '../../../interfaces/Instance';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
+import { useInstancesColumns } from './useInstancesColumns';
 
 export function useRunHealthCheck(onComplete: (instances: Instance[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useInstancesColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Instance>();
+  const bulkAction = useAwxBulkConfirmation<Instance>();
   const cannotRunHealthCheckDueToNodeType = (instance: Instance) => {
     if (instance.node_type !== 'execution')
       return t(`Health checks can only be run on execution instances.`);

--- a/frontend/awx/common/useAwxBulkActionDialog.tsx
+++ b/frontend/awx/common/useAwxBulkActionDialog.tsx
@@ -1,0 +1,5 @@
+import { awxErrorAdapter } from '../adapters/awxErrorAdapter';
+import { useBulkActionDialog } from '../../../framework/PageDialogs/BulkActionDialog';
+
+export const useAwxBulkActionDialog = <T extends object>() =>
+  useBulkActionDialog<T>(awxErrorAdapter);

--- a/frontend/awx/common/useAwxBulkConfirmation.tsx
+++ b/frontend/awx/common/useAwxBulkConfirmation.tsx
@@ -1,0 +1,5 @@
+import { awxErrorAdapter } from '../adapters/awxErrorAdapter';
+import { useBulkConfirmation } from '../../../framework/PageDialogs/BulkConfirmationDialog';
+
+export const useAwxBulkConfirmation = <T extends object>() =>
+  useBulkConfirmation<T>(awxErrorAdapter);

--- a/frontend/awx/resources/credentials/hooks/useDeleteCredentials.tsx
+++ b/frontend/awx/resources/credentials/hooks/useDeleteCredentials.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Credential } from '../../../interfaces/Credential';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useCredentialsColumns } from './useCredentialsColumns';
 
 export function useDeleteCredentials(onComplete?: (credentials: Credential[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteCredentials(onComplete?: (credentials: Credential[]) =>
   const confirmationColumns = useCredentialsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Credential>();
+  const bulkAction = useAwxBulkConfirmation<Credential>();
   const deleteCredentials = (credentials: Credential[]) => {
     bulkAction({
       title: t('Permanently delete credentials', { count: credentials.length }),

--- a/frontend/awx/resources/hosts/useDeleteHosts.tsx
+++ b/frontend/awx/resources/hosts/useDeleteHosts.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { useNameColumn } from '../../../common/columns';
 import { getItemKey, requestDelete } from '../../../common/crud/Data';
 import { awxAPI } from '../../api/awx-utils';
 import { AwxHost } from '../../interfaces/AwxHost';
+import { useAwxBulkConfirmation } from '../../common/useAwxBulkConfirmation';
 import { useHostsColumns } from './Hosts';
 
 export function useDeleteHosts(onComplete: (hosts: AwxHost[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteHosts(onComplete: (hosts: AwxHost[]) => void) {
   const confirmationColumns = useHostsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<AwxHost>();
+  const bulkAction = useAwxBulkConfirmation<AwxHost>();
   const deleteHosts = (hosts: AwxHost[]) => {
     bulkAction({
       title: t('Permanently delete hosts', { count: hosts.length }),

--- a/frontend/awx/resources/inventories/hooks/useDeleteInventories.tsx
+++ b/frontend/awx/resources/inventories/hooks/useDeleteInventories.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Inventory } from '../../../interfaces/Inventory';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useInventoriesColumns } from './useInventoriesColumns';
 
 export function useDeleteInventories(onComplete: (inventories: Inventory[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteInventories(onComplete: (inventories: Inventory[]) => v
   const confirmationColumns = useInventoriesColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Inventory>();
+  const bulkAction = useAwxBulkConfirmation<Inventory>();
 
   const cannotDeleteInventory = (inventory: Inventory) => {
     return inventory?.summary_fields?.user_capabilities?.delete

--- a/frontend/awx/resources/inventories/hooks/useDeleteInventorySources.tsx
+++ b/frontend/awx/resources/inventories/hooks/useDeleteInventorySources.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { InventorySource } from '../../../interfaces/InventorySource';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useInventorySourceColumns } from './useInventorySourceColumns';
 
 export function useDeleteInventorySources(
@@ -14,7 +15,7 @@ export function useDeleteInventorySources(
   const confirmationColumns = useInventorySourceColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<InventorySource>();
+  const bulkAction = useAwxBulkConfirmation<InventorySource>();
 
   const cannotDeleteInventorySources = (inventorySource: InventorySource) => {
     return inventorySource?.summary_fields?.user_capabilities?.delete

--- a/frontend/awx/resources/projects/hooks/useCancelProjects.tsx
+++ b/frontend/awx/resources/projects/hooks/useCancelProjects.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey } from '../../../../common/crud/Data';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../api/awx-utils';
 import { Project } from '../../../interfaces/Project';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useProjectsColumns } from './useProjectsColumns';
 
 export function useCancelProjects(onComplete?: (projects: Project[]) => void) {
@@ -13,7 +14,7 @@ export function useCancelProjects(onComplete?: (projects: Project[]) => void) {
   const confirmationColumns = useProjectsColumns({ disableLinks: true, disableSort: true });
   const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Project>();
+  const bulkAction = useAwxBulkConfirmation<Project>();
   const postRequest = usePostRequest();
 
   function isProjectRunning(status: string) {

--- a/frontend/awx/resources/projects/hooks/useDeleteProjects.tsx
+++ b/frontend/awx/resources/projects/hooks/useDeleteProjects.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Project } from '../../../interfaces/Project';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useProjectsColumns } from './useProjectsColumns';
 
 export function useDeleteProjects(onComplete: (projects: Project[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteProjects(onComplete: (projects: Project[]) => void) {
   const confirmationColumns = useProjectsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<Project>();
+  const bulkAction = useAwxBulkConfirmation<Project>();
   const deleteProjects = (projects: Project[]) => {
     bulkAction({
       title: t('Permanently delete projects', { count: projects.length }),

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useWorkflowVisualizerToolbarActions.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useWorkflowVisualizerToolbarActions.tsx
@@ -25,7 +25,7 @@ import {
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { useBulkConfirmation, usePageNavigate } from '../../../../../../framework';
+import { usePageNavigate } from '../../../../../../framework';
 import { getItemKey, postRequest } from '../../../../../common/crud/Data';
 import { AwxRoute } from '../../../../AwxRoutes';
 import { awxAPI } from '../../../../api/awx-utils';
@@ -34,6 +34,7 @@ import getDocsBaseUrl from '../../../../common/util/getDocsBaseUrl';
 import { stringIsUUID } from '../../../../common/util/strings';
 import { WorkflowJobTemplate } from '../../../../interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
+import { useAwxBulkConfirmation } from '../../../../common/useAwxBulkConfirmation';
 import { AddNodeButton } from '../components/AddNodeButton';
 
 export function useWorkflowVisualizerToolbarActions(
@@ -47,7 +48,7 @@ export function useWorkflowVisualizerToolbarActions(
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
   const pageNavigate = usePageNavigate();
   const config = useAwxConfig();
-  const bulkAction = useBulkConfirmation<WorkflowNode>();
+  const bulkAction = useAwxBulkConfirmation<WorkflowNode>();
   const handleLaunchWorkflow = useCallback(async () => {
     await postRequest(awxAPI`/workflow_job_templates/${Number(params.id).toString()}/launch/`, {});
   }, [params.id]);

--- a/frontend/awx/resources/templates/hooks/useDeleteTemplates.tsx
+++ b/frontend/awx/resources/templates/hooks/useDeleteTemplates.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useTemplateColumns } from './useTemplateColumns';
 
 export function useDeleteTemplates(
@@ -15,7 +16,7 @@ export function useDeleteTemplates(
   const confirmationColumns = useTemplateColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<JobTemplate | WorkflowJobTemplate>();
+  const bulkAction = useAwxBulkConfirmation<JobTemplate | WorkflowJobTemplate>();
   const getSingularDeleteTitle = (type: string) =>
     type === 'job_template'
       ? t('Permanently delete job template')

--- a/frontend/awx/views/jobs/hooks/useCancelJobs.tsx
+++ b/frontend/awx/views/jobs/hooks/useCancelJobs.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey } from '../../../../common/crud/Data';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { getJobsAPIUrl, isJobRunning } from '../jobUtils';
 import { useJobsColumns } from './useJobsColumns';
 
@@ -13,7 +14,7 @@ export function useCancelJobs(onComplete: (jobs: UnifiedJob[]) => void) {
   const confirmationColumns = useJobsColumns({ disableLinks: true, disableSort: true });
   const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
-  const bulkAction = useBulkConfirmation<UnifiedJob>();
+  const bulkAction = useAwxBulkConfirmation<UnifiedJob>();
   const postRequest = usePostRequest();
   const cannotCancelJobDueToPermissions = (job: UnifiedJob) => {
     if (!job.summary_fields?.user_capabilities?.start && isJobRunning(job.status))

--- a/frontend/awx/views/jobs/hooks/useDeleteHostMetrics.tsx
+++ b/frontend/awx/views/jobs/hooks/useDeleteHostMetrics.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { HostMetric } from '../../../interfaces/HostMetric';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { useHostMetricsColumns } from './useHostMetricsColumns';
 
 export function useDeleteHostMetrics(onComplete: (host: HostMetric[]) => void) {
@@ -12,7 +13,7 @@ export function useDeleteHostMetrics(onComplete: (host: HostMetric[]) => void) {
   const confirmationColumns = useHostMetricsColumns();
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<HostMetric>();
+  const bulkAction = useAwxBulkConfirmation<HostMetric>();
   const deleteHostMetrics = (host: HostMetric[]) => {
     bulkAction({
       title: t('Soft delete hostnames', { count: host.length }),

--- a/frontend/awx/views/jobs/hooks/useDeleteJobs.tsx
+++ b/frontend/awx/views/jobs/hooks/useDeleteJobs.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { getJobsAPIUrl, isJobRunning } from '../jobUtils';
 import { useJobsColumns } from './useJobsColumns';
 
@@ -12,7 +13,7 @@ export function useDeleteJobs(onComplete: (jobs: UnifiedJob[]) => void) {
   const confirmationColumns = useJobsColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<UnifiedJob>();
+  const bulkAction = useAwxBulkConfirmation<UnifiedJob>();
   const cannotDeleteJobDueToPermissions = (job: UnifiedJob) => {
     if (!job.summary_fields.user_capabilities.delete && !isJobRunning(job.status))
       return t(`The job cannot be deleted due to insufficient permission`);

--- a/frontend/awx/views/schedules/hooks/useDeleteSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useDeleteSchedules.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../api/awx-utils';
 import { Schedule } from '../../../interfaces/Schedule';
 import { useSchedulesColumns } from './useSchedulesColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDeleteSchedules(onComplete?: (schedules: Schedule[]) => void) {
   const { t } = useTranslation();
@@ -13,7 +14,7 @@ export function useDeleteSchedules(onComplete?: (schedules: Schedule[]) => void)
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
 
-  const bulkAction = useBulkConfirmation<Schedule>();
+  const bulkAction = useAwxBulkConfirmation<Schedule>();
   const deleteSchedules = (schedules: Schedule[]) => {
     bulkAction({
       title: t('Permanently delete schedule', { count: schedules.length }),

--- a/frontend/awx/views/workflow-approvals/hooks/useApproveWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useApproveWorkflowApprovals.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey } from '../../../../common/crud/Data';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
 import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
 import { awxAPI } from '../../../api/awx-utils';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useApproveWorkflowApprovals(
   onComplete: (workflow_approvals: WorkflowApproval[]) => void
@@ -18,7 +19,7 @@ export function useApproveWorkflowApprovals(
   });
   const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
-  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const bulkAction = useAwxBulkConfirmation<WorkflowApproval>();
   const postRequest = usePostRequest();
   const cannotApprove = (workflow_approval: WorkflowApproval) => {
     if (workflow_approval.timed_out)

--- a/frontend/awx/views/workflow-approvals/hooks/useDeleteWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useDeleteWorkflowApprovals.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
-import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
-import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
 import { awxAPI } from '../../../api/awx-utils';
+import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
+import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
 
 export function useDeleteWorkflowApprovals(
   onComplete: (workflow_approvals: WorkflowApproval[]) => void
@@ -17,7 +18,7 @@ export function useDeleteWorkflowApprovals(
   });
   const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
-  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const bulkAction = useAwxBulkConfirmation<WorkflowApproval>();
   const cannotDeleteDueToPermissions = (workflow_approval: WorkflowApproval) => {
     if (!workflow_approval.summary_fields.user_capabilities.delete)
       return t(`The workflow approval cannot be deleted due to insufficient permission`);

--- a/frontend/awx/views/workflow-approvals/hooks/useDenyWorkflowApprovals.tsx
+++ b/frontend/awx/views/workflow-approvals/hooks/useDenyWorkflowApprovals.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { getItemKey } from '../../../../common/crud/Data';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../api/awx-utils';
 import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
 import { useWorkflowApprovalsColumns } from './useWorkflowApprovalsColumns';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 
 export function useDenyWorkflowApprovals(
   onComplete: (workflow_approvals: WorkflowApproval[]) => void
@@ -18,7 +19,7 @@ export function useDenyWorkflowApprovals(
   });
   const cancelActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [cancelActionNameColumn], [cancelActionNameColumn]);
-  const bulkAction = useBulkConfirmation<WorkflowApproval>();
+  const bulkAction = useAwxBulkConfirmation<WorkflowApproval>();
   const postRequest = usePostRequest();
   const cannotDeny = (workflow_approval: WorkflowApproval) => {
     if (workflow_approval.timed_out)

--- a/frontend/eda/access/credentials/hooks/useDeleteCredentials.tsx
+++ b/frontend/eda/access/credentials/hooks/useDeleteCredentials.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { useNameColumn } from '../../../../common/columns';
 import { requestDelete } from '../../../../common/crud/Data';
 import { idKeyFn } from '../../../../common/utils/nameKeyFn';
@@ -8,13 +8,14 @@ import { InUseResources } from '../../../common/EdaResourcesComon';
 import { edaAPI } from '../../../common/eda-utils';
 import { EdaCredential } from '../../../interfaces/EdaCredential';
 import { useCredentialColumns } from './useCredentialColumns';
+import { useEdaBulkConfirmation } from '../../../common/useEdaBulkConfirmation';
 
 export function useDeleteCredentials(onComplete?: (credentials: EdaCredential[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useCredentialColumns();
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const bulkAction = useBulkConfirmation<EdaCredential>();
+  const bulkAction = useEdaBulkConfirmation<EdaCredential>();
   return useCallback(
     async (credentials: EdaCredential[]) => {
       const inUseDes = await InUseResources(credentials, edaAPI`/activations/?credential_id=`);

--- a/frontend/eda/access/users/hooks/useDeleteControllerTokens.tsx
+++ b/frontend/eda/access/users/hooks/useDeleteControllerTokens.tsx
@@ -1,17 +1,18 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { requestDelete } from '../../../../common/crud/Data';
 import { idKeyFn } from '../../../../common/utils/nameKeyFn';
 import { edaAPI } from '../../../common/eda-utils';
 import { EdaControllerToken } from '../../../interfaces/EdaControllerToken';
+import { useEdaBulkConfirmation } from '../../../common/useEdaBulkConfirmation';
 import { useControllerTokensColumns } from './useControllerTokensColumns';
 
 export function useDeleteControllerTokens(onComplete: (credentials: EdaControllerToken[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useControllerTokensColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaControllerToken>();
+  const bulkAction = useEdaBulkConfirmation<EdaControllerToken>();
   return useCallback(
     (controllerTokens: EdaControllerToken[]) => {
       bulkAction({

--- a/frontend/eda/access/users/hooks/useDeleteUser.tsx
+++ b/frontend/eda/access/users/hooks/useDeleteUser.tsx
@@ -1,17 +1,18 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../../framework';
+import { compareStrings } from '../../../../../framework';
 import { requestDelete } from '../../../../common/crud/Data';
 import { idKeyFn } from '../../../../common/utils/nameKeyFn';
 import { edaAPI } from '../../../common/eda-utils';
 import { EdaUser } from '../../../interfaces/EdaUser';
+import { useEdaBulkConfirmation } from '../../../common/useEdaBulkConfirmation';
 import { useUserColumns } from './useUserColumns';
 
 export function useDeleteUsers(onComplete: (users: EdaUser[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useUserColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaUser>();
+  const bulkAction = useEdaBulkConfirmation<EdaUser>();
   return useCallback(
     (users: EdaUser[]) => {
       bulkAction({

--- a/frontend/eda/common/useEdaBulkActionDialog.tsx
+++ b/frontend/eda/common/useEdaBulkActionDialog.tsx
@@ -1,0 +1,5 @@
+import { useBulkActionDialog } from '../../../framework/PageDialogs/BulkActionDialog';
+import { edaErrorAdapter } from './edaErrorAdapter';
+
+export const useEdaBulkActionDialog = <T extends object>() =>
+  useBulkActionDialog<T>(edaErrorAdapter);

--- a/frontend/eda/common/useEdaBulkConfirmation.tsx
+++ b/frontend/eda/common/useEdaBulkConfirmation.tsx
@@ -1,0 +1,5 @@
+import { useBulkConfirmation } from '../../../framework/PageDialogs/BulkConfirmationDialog';
+import { edaErrorAdapter } from './edaErrorAdapter';
+
+export const useEdaBulkConfirmation = <T extends object>() =>
+  useBulkConfirmation<T>(edaErrorAdapter);

--- a/frontend/eda/decision-environments/hooks/useDeleteDecisionEnvironments.tsx
+++ b/frontend/eda/decision-environments/hooks/useDeleteDecisionEnvironments.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { requestDelete } from '../../../common/crud/Data';
 import { idKeyFn } from '../../../common/utils/nameKeyFn';
 import { InUseResources } from '../../common/EdaResourcesComon';
 import { edaAPI } from '../../common/eda-utils';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
 import {
   EdaDecisionEnvironment,
   EdaDecisionEnvironmentRead,
@@ -20,7 +21,7 @@ export function useDeleteDecisionEnvironments(
   const { t } = useTranslation();
   const confirmationColumns = useDecisionEnvironmentsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaDecisionEnvironment>();
+  const bulkAction = useEdaBulkConfirmation<EdaDecisionEnvironment>();
   return useCallback(
     async (decisionEnvironments: EdaDecisionEnvironment[]) => {
       const inUseDes = await InUseResources(
@@ -67,7 +68,7 @@ export function useDeleteDecisionEnvironment(
   const { t } = useTranslation();
   const confirmationColumns = useDecisionEnvironmentColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaDecisionEnvironmentRead>();
+  const bulkAction = useEdaBulkConfirmation<EdaDecisionEnvironmentRead>();
   return useCallback(
     async (decisionEnvironments: EdaDecisionEnvironmentRead[]) => {
       const inUseDes = await InUseResources(

--- a/frontend/eda/projects/hooks/useDeleteProjects.tsx
+++ b/frontend/eda/projects/hooks/useDeleteProjects.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { requestDelete } from '../../../common/crud/Data';
 import { idKeyFn } from '../../../common/utils/nameKeyFn';
 import { edaAPI } from '../../common/eda-utils';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
 import { EdaProject } from '../../interfaces/EdaProject';
 import { useProjectColumns } from './useProjectColumns';
 
@@ -11,7 +12,7 @@ export function useDeleteProjects(onComplete: (projects: EdaProject[]) => void) 
   const { t } = useTranslation();
   const confirmationColumns = useProjectColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaProject>();
+  const bulkAction = useEdaBulkConfirmation<EdaProject>();
   return useCallback(
     (projects: EdaProject[]) => {
       bulkAction({

--- a/frontend/eda/rulebook-activations/hooks/useControlRulebookActivations.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useControlRulebookActivations.tsx
@@ -1,11 +1,12 @@
 import { AlertProps } from '@patternfly/react-core';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation, usePageAlertToaster } from '../../../../framework';
+import { compareStrings, usePageAlertToaster } from '../../../../framework';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { useRulebookActivationColumns } from './useRulebookActivationColumns';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
 
 export function useEnableRulebookActivations(
   onComplete: (rulebookActivations: EdaRulebookActivation[]) => void
@@ -48,7 +49,7 @@ export function useDisableRulebookActivations(
   const { t } = useTranslation();
   const confirmationColumns = useRulebookActivationColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaRulebookActivation>();
+  const bulkAction = useEdaBulkConfirmation<EdaRulebookActivation>();
   const postRequest = usePostRequest<undefined, undefined>();
   return useCallback(
     (rulebookActivations: EdaRulebookActivation[]) => {
@@ -81,7 +82,7 @@ export function useRestartRulebookActivations(
   const { t } = useTranslation();
   const confirmationColumns = useRulebookActivationColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaRulebookActivation>();
+  const bulkAction = useEdaBulkConfirmation<EdaRulebookActivation>();
   const postRequest = usePostRequest<undefined, undefined>();
   return useCallback(
     (rulebookActivations: EdaRulebookActivation[]) => {

--- a/frontend/eda/rulebook-activations/hooks/useDeleteRulebookActivations.tsx
+++ b/frontend/eda/rulebook-activations/hooks/useDeleteRulebookActivations.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { requestDelete } from '../../../common/crud/Data';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
 import { useRulebookActivationColumns } from './useRulebookActivationColumns';
 
 export function useDeleteRulebookActivations(
@@ -12,7 +13,7 @@ export function useDeleteRulebookActivations(
   const { t } = useTranslation();
   const confirmationColumns = useRulebookActivationColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<EdaRulebookActivation>();
+  const bulkAction = useEdaBulkConfirmation<EdaRulebookActivation>();
   return useCallback(
     (rulebookActivations: EdaRulebookActivation[]) => {
       bulkAction({

--- a/frontend/hub/access/roles/hooks/useDeleteRoles.tsx
+++ b/frontend/hub/access/roles/hooks/useDeleteRoles.tsx
@@ -1,17 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { Role } from '../Role';
 import { useRoleColumns } from './useRoleColumns';
-import {
-  ITableColumn,
-  TextCell,
-  compareStrings,
-  useBulkConfirmation,
-} from '../../../../../framework';
+import { ITableColumn, TextCell, compareStrings } from '../../../../../framework';
 import { useMemo } from 'react';
 import { useHubContext } from '../../../useHubContext';
 import { parsePulpIDFromURL } from '../../../api/utils';
 import { requestDelete } from '../../../../common/crud/Data';
 import { pulpAPI } from '../../../api/formatPath';
+import { useHubBulkConfirmation } from '../../../common/useHubBulkConfirmation';
 
 export function useDeleteRoles(onComplete: (roles: Role[]) => void) {
   const { t } = useTranslation();
@@ -28,7 +24,7 @@ export function useDeleteRoles(onComplete: (roles: Role[]) => void) {
     [t]
   );
   const { user } = useHubContext();
-  const bulkAction = useBulkConfirmation<Role>();
+  const bulkAction = useHubBulkConfirmation<Role>();
   const cannotDeleteBuiltInRole = (role: Role) =>
     role.locked ? t('Built-in roles cannot be deleted.') : '';
   const cannotDeleteRoleDueToPermissions = () =>

--- a/frontend/hub/approvals/hooks/useApproveCollections.tsx
+++ b/frontend/hub/approvals/hooks/useApproveCollections.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { useGetRequest } from '../../../common/crud/useGet';
 import { collectionKeyFn } from '../../api/utils';
 import { pulpAPI } from '../../api/formatPath';
@@ -12,6 +12,7 @@ import { HubContext, useHubContext } from './../../useHubContext';
 import { useCopyToRepository } from '../../collections/hooks/useCopyToRepository';
 import { copyToRepositoryAction } from '../../collections/hooks/useCopyToRepository';
 import { SigningServiceResponse } from '../../api-schemas/generated/SigningServiceResponse';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useApproveCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void
@@ -20,7 +21,7 @@ export function useApproveCollections(
   const confirmationColumns = useApprovalsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
 
-  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+  const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
 
   const getRequest = useGetRequest();
 

--- a/frontend/hub/approvals/hooks/useRejectCollections.tsx
+++ b/frontend/hub/approvals/hooks/useRejectCollections.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { useGetRequest } from '../../../common/crud/useGet';
 import { collectionKeyFn, parsePulpIDFromURL, hubAPIPost } from '../../api/utils';
 import { pulpAPI } from '../../api/formatPath';
 import { PulpItemsResponse } from '../../usePulpView';
 import { CollectionVersionSearch } from '../Approval';
 import { useApprovalsColumns } from './useApprovalsColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useRejectCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void
@@ -15,7 +16,7 @@ export function useRejectCollections(
   const confirmationColumns = useApprovalsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
 
-  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+  const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
 
   const getRequest = useGetRequest();
 

--- a/frontend/hub/collections/hooks/useDeleteCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollections.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation, usePageNavigate } from '../../../../framework';
+import { compareStrings, usePageNavigate } from '../../../../framework';
 import { requestGet } from '../../../common/crud/Data';
 import { collectionKeyFn, hubAPIDelete } from '../../api/utils';
 import { hubAPI, pulpAPI } from '../../api/formatPath';
@@ -8,6 +8,7 @@ import { PulpItemsResponse } from '../../usePulpView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionColumns } from './useCollectionColumns';
 import { navigateAfterDelete } from './useDeleteCollectionsFromRepository';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeleteCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void,
@@ -17,7 +18,7 @@ export function useDeleteCollections(
   const { t } = useTranslation();
   const confirmationColumns = useCollectionColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+  const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
   const navigate = usePageNavigate();
 
   return useCallback(

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { collectionKeyFn, parsePulpIDFromURL, waitForTask } from '../../api/utils';
 import { hubAPI, pulpAPI } from '../../api/formatPath';
 import { CollectionVersionSearch } from '../Collection';
@@ -11,6 +11,7 @@ import { usePageNavigate } from '../../../../framework';
 import { HubRoute } from '../../HubRoutes';
 import { postRequest } from '../../../common/crud/Data';
 import { getHubAllItems } from '../../api/request';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeleteCollectionsFromRepository(
   onComplete?: (collections: CollectionVersionSearch[]) => void,
@@ -20,7 +21,7 @@ export function useDeleteCollectionsFromRepository(
   const { t } = useTranslation();
   const confirmationColumns = useCollectionColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+  const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
   const navigate = usePageNavigate();
 
   return useCallback(

--- a/frontend/hub/collections/hooks/useDeprecateCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeprecateCollections.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { requestGet, requestPatch } from '../../../common/crud/Data';
 import { collectionKeyFn } from '../../api/utils';
 import { hubAPI, pulpAPI } from '../../api/formatPath';
 import { PulpItemsResponse } from '../../usePulpView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionColumns } from './useCollectionColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeprecateCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void
@@ -14,7 +15,7 @@ export function useDeprecateCollections(
   const { t } = useTranslation();
   const confirmationColumns = useCollectionColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<CollectionVersionSearch>();
+  const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
   return useCallback(
     (collections: CollectionVersionSearch[]) => {
       bulkAction({

--- a/frontend/hub/common/useHubBulkActionDialog.tsx
+++ b/frontend/hub/common/useHubBulkActionDialog.tsx
@@ -1,0 +1,5 @@
+import { hubErrorAdapter } from '../adapters/hubErrorAdapter';
+import { useBulkActionDialog } from '../../../framework/PageDialogs/BulkActionDialog';
+
+export const useHubBulkActionDialog = <T extends object>() =>
+  useBulkActionDialog<T>(hubErrorAdapter);

--- a/frontend/hub/common/useHubBulkConfirmation.tsx
+++ b/frontend/hub/common/useHubBulkConfirmation.tsx
@@ -1,0 +1,5 @@
+import { hubErrorAdapter } from '../adapters/hubErrorAdapter';
+import { useBulkConfirmation } from '../../../framework/PageDialogs/BulkConfirmationDialog';
+
+export const useHubBulkConfirmation = <T extends object>() =>
+  useBulkConfirmation<T>(hubErrorAdapter);

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
@@ -8,7 +8,6 @@ import {
   PageActionSelection,
   PageActionType,
   compareStrings,
-  useBulkConfirmation,
   usePageNavigate,
 } from '../../../../framework';
 import { postRequest, requestGet } from '../../../common/crud/Data';
@@ -20,6 +19,7 @@ import { HubContext, useHubContext } from '../../useHubContext';
 import { PulpItemsResponse } from '../../usePulpView';
 import { ExecutionEnvironment } from '../ExecutionEnvironment';
 import { useExecutionEnvironmentsColumns } from './useExecutionEnvironmentsColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnvironment[]) => void) {
   const { t } = useTranslation();
@@ -91,7 +91,7 @@ export function useDeleteExecutionEnvironments(onComplete?: (ees: ExecutionEnvir
   const { t } = useTranslation();
   const confirmationColumns = useExecutionEnvironmentsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<ExecutionEnvironment>();
+  const bulkAction = useHubBulkConfirmation<ExecutionEnvironment>();
   return useCallback(
     (ees: ExecutionEnvironment[]) => {
       bulkAction({
@@ -127,7 +127,7 @@ export function useSyncExecutionEnvironments(onComplete?: (ees: ExecutionEnviron
   const { t } = useTranslation();
   const confirmationColumns = useExecutionEnvironmentsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<ExecutionEnvironment>();
+  const bulkAction = useHubBulkConfirmation<ExecutionEnvironment>();
   return useCallback(
     (ees: ExecutionEnvironment[]) => {
       bulkAction({
@@ -162,7 +162,7 @@ export function useSignExecutionEnvironments(onComplete?: (ees: ExecutionEnviron
   const { t } = useTranslation();
   const confirmationColumns = useExecutionEnvironmentsColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<ExecutionEnvironment>();
+  const bulkAction = useHubBulkConfirmation<ExecutionEnvironment>();
   const context = useHubContext();
 
   return useCallback(

--- a/frontend/hub/namespaces/hooks/useDeleteHubNamespaces.tsx
+++ b/frontend/hub/namespaces/hooks/useDeleteHubNamespaces.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { nameKeyFn } from '../../../common/utils/nameKeyFn';
 import { hubAPI } from '../../api/formatPath';
 import { hubAPIDelete } from '../../api/utils';
 import { HubNamespace } from '../HubNamespace';
 import { useHubNamespacesColumns } from './useHubNamespacesColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeleteHubNamespaces(onComplete: (namespaces: HubNamespace[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useHubNamespacesColumns({ disableLinks: true, disableSort: true });
-  const bulkAction = useBulkConfirmation<HubNamespace>();
+  const bulkAction = useHubBulkConfirmation<HubNamespace>();
 
   const deleteHubNamespaces = (namespaces: HubNamespace[]) => {
     bulkAction({

--- a/frontend/hub/namespaces/hooks/useHubNamespacesColumns.tsx
+++ b/frontend/hub/namespaces/hooks/useHubNamespacesColumns.tsx
@@ -1,7 +1,7 @@
 import { RedhatIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, TextCell, useGetPageUrl } from '../../../../framework';
+import { ColumnModalOption, ITableColumn, TextCell, useGetPageUrl } from '../../../../framework';
 import { HubRoute } from '../../HubRoutes';
 import { HubNamespace } from '../HubNamespace';
 
@@ -33,6 +33,7 @@ export function useHubNamespacesColumns(_options?: {
         value: (namespace) => namespace.description ?? undefined,
         card: 'description',
         list: 'description',
+        modal: ColumnModalOption.Hidden,
       },
       {
         header: t('Company'),

--- a/frontend/hub/remote-registries/hooks/useDeleteRemoteRegistries.tsx
+++ b/frontend/hub/remote-registries/hooks/useDeleteRemoteRegistries.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { nameKeyFn } from '../../../common/utils/nameKeyFn';
 import { hubAPI } from '../../api/formatPath';
 import { hubAPIDelete, parsePulpIDFromURL } from '../../api/utils';
 import { RemoteRegistry } from '../RemoteRegistry';
 import { useRemoteRegistriesColumns } from './useRemoteRegistriesColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeleteRemoteRegistries(onComplete: (remoteRegistry: RemoteRegistry[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useRemoteRegistriesColumns();
-  const bulkAction = useBulkConfirmation<RemoteRegistry>();
+  const bulkAction = useHubBulkConfirmation<RemoteRegistry>();
 
   const deleteRemoteRegistry = (remoteRegistry: RemoteRegistry[]) => {
     bulkAction({

--- a/frontend/hub/remotes/hooks/useDeleteRemotes.tsx
+++ b/frontend/hub/remotes/hooks/useDeleteRemotes.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { nameKeyFn } from '../../../common/utils/nameKeyFn';
 import { hubAPIDelete, parsePulpIDFromURL } from '../../api/utils';
 import { pulpAPI } from '../../api/formatPath';
 import { IRemotes } from '../Remotes';
 import { useRemoteColumns } from './useRemoteColumns';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useDeleteRemotes(onComplete: (remotes: IRemotes[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useRemoteColumns();
-  const bulkAction = useBulkConfirmation<IRemotes>();
+  const bulkAction = useHubBulkConfirmation<IRemotes>();
 
   const deleteRemotes = (remotes: IRemotes[]) => {
     bulkAction({

--- a/frontend/hub/tasks/hooks/useTasksActions.tsx
+++ b/frontend/hub/tasks/hooks/useTasksActions.tsx
@@ -4,11 +4,12 @@ import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../framework';
 import { Task } from '../Task';
 import { useHubContext } from '../../useHubContext';
-import { compareStrings, useBulkConfirmation } from '../../../../framework';
+import { compareStrings } from '../../../../framework';
 import { requestPatch } from '../../../common/crud/Data';
 import { useTasksColumns } from '../Tasks';
 import { pulpAPI } from '../../api/formatPath';
 import { parsePulpIDFromURL } from '../../api/utils';
+import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 
 export function useTasksActions(onComplete?: (tasks: Task[]) => void) {
   const { t } = useTranslation();
@@ -37,7 +38,7 @@ export function useStopTasks(onComplete?: (tasks: Task[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useTasksColumns();
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
-  const bulkAction = useBulkConfirmation<Task>();
+  const bulkAction = useHubBulkConfirmation<Task>();
   return useCallback(
     (tasks: Task[]) => {
       bulkAction({


### PR DESCRIPTION
Modify BulkActionDialog to use errorAdapter

Add dedicated hooks to create specific bulk actions per projects

Update AWX to use useAwxBulkActionDialog

Update useBulkConfirmation to use errorAdapter and create dedicate versions of this hook for each project

Update AWX project to use useAwxBulkConfirmation

Update EDA project to use useEdaBulkConfirmation

Update Hub project to use useHubBulkConfirmation

Move files related to specific projects to their directories and update imports


After change


![image](https://github.com/ansible/ansible-ui/assets/9053044/b3b03fa7-5502-45d6-a787-bb532ee783e2)

Before change

![image](https://github.com/ansible/ansible-ui/assets/9053044/656868a5-4b3c-4c53-a24f-34a13333ff04)

