### PR TITLE
Collections tab ns page

### DIFF
--- a/frontend/hub/HubRoutes.tsx
+++ b/frontend/hub/HubRoutes.tsx
@@ -8,6 +8,7 @@ export enum HubRoute {
   CreateNamespace = 'hub-create-namespace',
   EditNamespace = 'hub-edit-namespace',
   NamespacePage = 'hub-namespace-page',
+  NamespaceCollections = 'hub-namespace-collections',
   NamespaceDetails = 'hub-namespace-details',
   NamespaceCLI = 'hub-namespace-cli',
 

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCollections.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCollections.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { PageLayout, PageTable, usePageNavigate } from '../../../../framework';
+import { HubRoute } from '../../HubRoutes';
+import { collectionKeyFn } from '../../api/utils';
+import { hubAPI } from '../../api/formatPath';
+import { useHubView } from '../../useHubView';
+import { useCollectionColumns } from '../../collections/hooks/useCollectionColumns';
+import { useCollectionFilters } from '../../collections/hooks/useCollectionFilters';
+import { CollectionVersionSearch } from '../../collections/Collection';
+import { useCollectionActions } from '../../collections/hooks/useCollectionActions';
+import { useCollectionsActions } from '../../collections/hooks/useCollectionsActions';
+import { useParams } from 'react-router-dom';
+
+export function HubNamespaceCollections() {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const pageNavigate = usePageNavigate();
+  const toolbarFilters = useCollectionFilters();
+  const tableColumns = useCollectionColumns();
+  const view = useHubView<CollectionVersionSearch>({
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
+    keyFn: collectionKeyFn,
+    sortKey: 'order_by',
+    queryParams: {
+      is_deprecated: 'false',
+      repository_label: '!hide_from_search',
+      is_highest: 'true',
+      namespace: params?.id || '',
+    },
+    toolbarFilters,
+  });
+
+  const toolbarActions = useCollectionsActions(view.unselectItemsAndRefresh);
+  const rowActions = useCollectionActions(view.unselectItemsAndRefresh);
+
+  return (
+    <PageLayout>
+      <PageTable<CollectionVersionSearch>
+        id="hub-collection-version-search-table"
+        toolbarFilters={toolbarFilters}
+        toolbarActions={toolbarActions}
+        tableColumns={tableColumns}
+        rowActions={rowActions}
+        errorStateTitle={t('Error loading collections')}
+        emptyStateTitle={t('No collections yet')}
+        emptyStateDescription={t('To get started, upload a collection.')}
+        emptyStateButtonText={t('Upload collection')}
+        emptyStateButtonClick={() => pageNavigate(HubRoute.UploadCollection)}
+        {...view}
+        defaultTableView="list"
+        defaultSubtitle={t('Collection')}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespacePage.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespacePage.tsx
@@ -57,6 +57,10 @@ export function HubNamespacePage() {
             page: HubRoute.NamespaceDetails,
           },
           {
+            label: t('Collections'),
+            page: HubRoute.NamespaceCollections,
+          },
+          {
             label: t('CLI Configuration'),
             page: HubRoute.NamespaceCLI,
           },

--- a/frontend/hub/useHubNavigation.tsx
+++ b/frontend/hub/useHubNavigation.tsx
@@ -23,6 +23,7 @@ import {
 } from './execution-environments/ExecutionEnvironmentForm';
 import { ExecutionEnvironments } from './execution-environments/ExecutionEnvironments';
 import { CreateHubNamespace, EditHubNamespace } from './namespaces/HubNamespaceForm';
+import { HubNamespaceCollections } from './namespaces/HubNamespacePage/HubNamespaceCollections';
 import { HubNamespaceDetails } from './namespaces/HubNamespacePage/HubNamespaceDetails';
 import { HubNamespaceCLI } from './namespaces/HubNamespacePage/HubNamespaceCLI';
 import { HubNamespacePage } from './namespaces/HubNamespacePage/HubNamespacePage';
@@ -76,6 +77,11 @@ export function useHubNavigation() {
           path: ':id',
           element: <HubNamespacePage />,
           children: [
+            {
+              id: HubRoute.NamespaceCollections,
+              path: 'collections',
+              element: <HubNamespaceCollections />,
+            },
             {
               id: HubRoute.NamespaceDetails,
               path: 'details',


### PR DESCRIPTION
This pr ads the collections tab to the namespace page alongside "details" and "CLI config". It uses the same logic from the collections list view and adds `params.id` as a namespace query so collections stay relevant to the given namespace.
See https://issues.redhat.com/browse/AAH-2476

<img width="1016" alt="Screenshot 2024-01-04 at 11 58 12 AM" src="https://github.com/ansible/ansible-ui/assets/64337863/d139427c-58a6-4d28-98f0-adaff535a737">
