### PR TITLE
Framework fixes to display of AsyncMultiSelectToolbarFilter

### DIFF
--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -334,6 +334,8 @@ function ToolbarFilterComponent(props: {
               </Button>
             ) : undefined
           }
+          variant="count"
+          disableClearSelection
         />
       );
 

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
@@ -1,8 +1,6 @@
-import { ToolbarFilterType } from '../PageToolbarFilter';
 import { PageAsyncMultiSelectOptionsFn } from '../../PageInputs/PageAsyncMultiSelect';
-
 import { PageAsyncQueryErrorTextType } from '../../PageInputs/PageAsyncSingleSelect';
-
+import { ToolbarFilterType } from '../PageToolbarFilter';
 import { ToolbarFilterCommon } from './ToolbarFilterCommon';
 
 /** A function to open a single selection browse modal for a toolbar filter. */


### PR DESCRIPTION
Sets flag on the toolbar filter dropdown to show the number of selected options as a count chip.
Disables the clear button on the select as the PF toolbar filters always contain a clear filters button.