### PR TITLE
Webpack: Fix hosting of static assets based on ROUTE_PREFIX.

### DIFF
--- a/.github/workflows/awx-update-server.yml
+++ b/.github/workflows/awx-update-server.yml
@@ -71,7 +71,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":check: AWX E2E Update - <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Success> - <${{ needs.setup.outputs.AWX_SERVER }}/ui_next|Server>"
+                    "text": ":check: AWX E2E Update - <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Success> - <${{ needs.setup.outputs.AWX_SERVER }}|Server>
                   }
                 }
               ]
@@ -98,7 +98,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert: *AWX E2E Update* - *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failure>* - <${{ needs.setup.outputs.AWX_SERVER }}/ui_next|Server> - <https://cloud.cypress.io/projects/77sud6|Cypress> - <!here>"
+                    "text": ":alert: *AWX E2E Update* - *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failure>* - <${{ needs.setup.outputs.AWX_SERVER }}|Server> - <https://cloud.cypress.io/projects/77sud6|Cypress> - <!here>"
                   }
                 }
               ]

--- a/.github/workflows/eda-update-server.yml
+++ b/.github/workflows/eda-update-server.yml
@@ -71,7 +71,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":check: EDA E2E Update - <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Success> - <${{ needs.setup.outputs.EDA_SERVER }}/eda|Server>"
+                    "text": ":check: EDA E2E Update - <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Success> - <${{ needs.setup.outputs.EDA_SERVER }}|Server>"
                   }
                 }
               ]
@@ -98,7 +98,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert: *EDA E2E Update* - *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failure>* - <${{ needs.setup.outputs.EDA_SERVER }}/eda|Server> - <https://cloud.cypress.io/projects/b2zqnv|Cypress> - <!here>"
+                    "text": ":alert: *EDA E2E Update* - *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failure>* - <${{ needs.setup.outputs.EDA_SERVER }}|Server> - <https://cloud.cypress.io/projects/b2zqnv|Cypress> - <!here>"
                   }
                 }
               ]

--- a/cypress/e2e/awx/general-ui/dashboard-checks.cy.ts
+++ b/cypress/e2e/awx/general-ui/dashboard-checks.cy.ts
@@ -18,11 +18,9 @@ describe('Dashboard: General UI tests - resources count and empty state check', 
       )
       .should('be.visible');
     cy.get('[data-cy="tech-preview"] a').should('contain', 'here').click();
-    cy.url().should('not.include', '/ui_next');
   });
 
   it('clicking on Cog icon opens the Manage Dashboard modal', () => {
-    cy.visit('/ui_next/overview');
     cy.navigateTo('awx', 'overview');
     cy.clickButton('Manage view');
     cy.get('.pf-v5-c-modal-box__title-text').should('contain', 'Manage Dashboard');

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -34,7 +34,7 @@ describe('Inventory source page', () => {
 
   it('deletes an inventory source from the details page', () => {
     cy.visit(
-      `/ui_next/infrastructure/inventories/inventory/${inventorySource.inventory}/sources/${inventorySource.id}/details`
+      `/infrastructure/inventories/inventory/${inventorySource.inventory}/sources/${inventorySource.id}/details`
     );
 
     cy.verifyPageTitle(inventorySource.name);

--- a/cypress/e2e/awx/resources/workflowApproval.cy.ts
+++ b/cypress/e2e/awx/resources/workflowApproval.cy.ts
@@ -43,7 +43,7 @@ describe('Workflow Approvals List View', () => {
   it('admin can create a WF approval and assign user with access to approve and then delete the WF from the list toolbar', () => {
     //Post an approval node to the WFJT that was created in the beforeEach block
     //Post to the launch endpoint to trigger the job to launch
-    cy.visit('/ui_next/views/workflow-approvals?page=1&perPage=100&sort=name');
+    cy.visit('/views/workflow-approvals?page=1&perPage=100&sort=name');
     //filter by the name of the node to display it in the list
     // cy.searchAndDisplayResource(approvalNode.name);
   });

--- a/cypress/e2e/awx/resources/workflowVisualizerNodes.cy.ts
+++ b/cypress/e2e/awx/resources/workflowVisualizerNodes.cy.ts
@@ -1,7 +1,7 @@
-import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
-import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { InventorySource } from '../../../../frontend/awx/interfaces/InventorySource';
+import { Organization } from '../../../../frontend/awx/interfaces/Organization';
+import { Project } from '../../../../frontend/awx/interfaces/Project';
 
 describe('Workflow Visualizer Nodes', function () {
   let organization: Organization;
@@ -39,7 +39,7 @@ describe('Workflow Visualizer Nodes', function () {
           cy.createWorkflowJTSuccessNodeLink(projectNode, approvalNode);
         });
       });
-      cy.visit(`/ui_next/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+      cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
       cy.contains('Workflow Visualizer').should('be.visible');
       cy.contains(`${workflowJobTemplate.name}`);
       cy.contains('button', 'Save').click();
@@ -103,7 +103,7 @@ describe('Workflow Visualizer Nodes', function () {
             }
           );
         });
-        cy.visit(`/ui_next/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+        cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
         cy.contains('Workflow Visualizer').should('be.visible');
         cy.contains(`${jobTemplate.name}`);
         cy.contains('button', 'Save').click();

--- a/cypress/support/auth.ts
+++ b/cypress/support/auth.ts
@@ -23,7 +23,7 @@ Cypress.Commands.add('awxLogin', () => {
       window.localStorage.setItem('theme', 'light');
       window.localStorage.setItem('disclaimer', 'true');
       window.localStorage.setItem('hide-welcome-message', 'true');
-      cy.visit(`/ui_next/login`, {
+      cy.visit(`/login`, {
         retryOnStatusCodeFailure: true,
         retryOnNetworkFailure: true,
       });
@@ -45,7 +45,7 @@ Cypress.Commands.add('awxLogin', () => {
       cacheAcrossSpecs: true,
     }
   );
-  cy.visit(`/ui_next`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
+  cy.visit(`/`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
 });
 
 Cypress.Commands.add('edaLogin', () => {
@@ -54,7 +54,7 @@ Cypress.Commands.add('edaLogin', () => {
     'EDA',
     () => {
       window.localStorage.setItem('default-nav-expanded', 'true');
-      cy.visit(`/eda/login`, {
+      cy.visit(`/login`, {
         retryOnStatusCodeFailure: true,
         retryOnNetworkFailure: true,
       });
@@ -76,7 +76,7 @@ Cypress.Commands.add('edaLogin', () => {
       },
     }
   );
-  cy.visit(`/eda`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
+  cy.visit(`/`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
 });
 
 Cypress.Commands.add('edaLogout', () => {
@@ -94,7 +94,7 @@ Cypress.Commands.add('hubLogin', () => {
     'HUB',
     () => {
       window.localStorage.setItem('default-nav-expanded', 'true');
-      cy.visit(`/hub/login`, {
+      cy.visit(`/login`, {
         retryOnStatusCodeFailure: true,
         retryOnNetworkFailure: true,
       });
@@ -116,5 +116,5 @@ Cypress.Commands.add('hubLogin', () => {
       },
     }
   );
-  cy.visit(`/hub`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
+  cy.visit(`/`, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true });
 });

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -911,7 +911,7 @@ Cypress.Commands.add(
         )
           .as('newVisualizerView')
           .then(() => {
-            cy.visit(`/ui_next/templates/workflow_job_template/${results.id}/visualizer`);
+            cy.visit(`/templates/workflow_job_template/${results.id}/visualizer`);
           });
       });
   }

--- a/framework/README.md
+++ b/framework/README.md
@@ -2,4 +2,4 @@
 
 A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers.
 
-[Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework).
+[Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework)

--- a/frontend/awx/analytics/Reports/ReportsList/useReportCardColumns.tsx
+++ b/frontend/awx/analytics/Reports/ReportsList/useReportCardColumns.tsx
@@ -10,10 +10,7 @@ export function useReportCardColumns() {
       {
         header: t('Name'),
         cell: (report) => (
-          <TextCell
-            text={report.name}
-            to={`/ui_next/analytics/builder?reportName=${report.slug}`}
-          />
+          <TextCell text={report.name} to={`/analytics/builder?reportName=${report.slug}`} />
         ),
         sort: 'name',
         card: 'name',

--- a/frontend/eda/access/users/UserPage/UserPage.tsx
+++ b/frontend/eda/access/users/UserPage/UserPage.tsx
@@ -49,7 +49,7 @@ export function UserPage() {
     activeUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
 
   const isActionTab =
-    location.pathname === `/eda${getPageUrl(EdaRoute.UserDetails, { params: { id: user?.id } })}`;
+    location.pathname === getPageUrl(EdaRoute.UserDetails, { params: { id: user?.id } });
 
   const itemActions = useMemo<IPageAction<EdaUser>[]>(() => {
     const actions: IPageAction<EdaUser>[] = isActionTab
@@ -61,7 +61,7 @@ export function UserPage() {
             icon: PencilAltIcon,
             isPinned: true,
             label: t('Edit user'),
-            isHidden: (_user: EdaUser) => !canEditUser,
+            // isHidden: (_user: EdaUser) => !canEditUser,
             onClick: (user: EdaUser) =>
               pageNavigate(EdaRoute.EditUser, { params: { id: user.id } }),
           },

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "homepage": "https://github.com/ansible/ansible-ui#readme",
   "scripts": {
     "start": "echo Usage: npm start:[awx:hub:eda]",
-    "awx": "UI_MODE=AWX webpack serve --mode development --config ./webpack/webpack.awx.cjs --port 4101 --open https://localhost:4101/ui_next",
-    "hub": "UI_MODE=HUB webpack serve --mode development --config ./webpack/webpack.hub.cjs --port 4102 --open https://localhost:4102/hub",
-    "eda": "UI_MODE=EDA webpack serve --mode development --config ./webpack/webpack.eda.cjs --port 4103 --open https://localhost:4103/eda",
+    "awx": "UI_MODE=AWX webpack serve --mode development --config ./webpack/webpack.awx.cjs --port 4101 --open https://localhost:4101",
+    "hub": "UI_MODE=HUB webpack serve --mode development --config ./webpack/webpack.hub.cjs --port 4102 --open https://localhost:4102",
+    "eda": "UI_MODE=EDA webpack serve --mode development --config ./webpack/webpack.eda.cjs --port 4103 --open https://localhost:4103",
     "build": "concurrently npm:build:awx npm:build:hub npm:build:eda -c cyan,green,blue",
     "build:awx": "rm -rf build/awx && UI_MODE=AWX webpack --mode production --config ./webpack/webpack.awx.cjs --output-path build/awx",
     "build:hub": "rm -rf build/hub && UI_MODE=HUB webpack --mode production --config ./webpack/webpack.hub.cjs --output-path build/hub",

--- a/webpack/environment.cjs
+++ b/webpack/environment.cjs
@@ -5,7 +5,7 @@ const AWX_SERVER =
 const AWX_USERNAME = process.env.AWX_USERNAME || process.env.CYPRESS_AWX_USERNAME || 'admin';
 const AWX_PASSWORD = process.env.AWX_PASSWORD || process.env.CYPRESS_AWX_PASSWORD || 'password';
 const AWX_API_PREFIX = process.env.AWX_API_PREFIX || '/api/v2';
-const AWX_ROUTE_PREFIX = process.env.AWX_ROUTE_PREFIX || '/ui_next';
+const AWX_ROUTE_PREFIX = process.env.AWX_ROUTE_PREFIX || '/';
 
 const EDA_PROTOCOL = process.env.EDA_PROTOCOL || 'http';
 const EDA_HOST = process.env.EDA_HOST || 'localhost:8000';
@@ -14,7 +14,7 @@ const EDA_SERVER =
 const EDA_USERNAME = process.env.EDA_USERNAME || process.env.CYPRESS_EDA_USERNAME || 'admin';
 const EDA_PASSWORD = process.env.EDA_PASSWORD || process.env.CYPRESS_EDA_PASSWORD || 'testpass';
 const EDA_API_PREFIX = process.env.EDA_API_PREFIX || '/api/eda/v1';
-const EDA_ROUTE_PREFIX = process.env.EDA_ROUTE_PREFIX || '/eda';
+const EDA_ROUTE_PREFIX = process.env.EDA_ROUTE_PREFIX || '/';
 
 const HUB_PROTOCOL = process.env.HUB_PROTOCOL || 'http';
 const HUB_HOST = process.env.HUB_HOST || 'localhost:5001';
@@ -24,7 +24,7 @@ const HUB_USERNAME = process.env.HUB_USERNAME || process.env.CYPRESS_HUB_USERNAM
 const HUB_PASSWORD = process.env.HUB_PASSWORD || process.env.CYPRESS_HUB_PASSWORD || 'password';
 const HUB_API_PREFIX =
   process.env.HUB_API_PREFIX || process.env.HUB_API_BASE_PATH || '/api/automation-hub';
-const HUB_ROUTE_PREFIX = process.env.HUB_ROUTE_PREFIX || '/hub';
+const HUB_ROUTE_PREFIX = process.env.HUB_ROUTE_PREFIX || '/';
 
 module.exports = {
   AWX_API_PREFIX,

--- a/webpack/webpack.awx.cjs
+++ b/webpack/webpack.awx.cjs
@@ -4,8 +4,12 @@ const { AWX_SERVER } = env;
 const proxyUrl = new URL(AWX_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
-
   config.entry = './frontend/awx/Awx.tsx';
+
+  // publicPath is the path where the bundle is served from
+  // https://webpack.js.org/guides/public-path/
+  // it nees to match the route prefix of the app
+  config.output.publicPath = process.env.PUBLIC_PATH || process.env.AWX_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {
     '/api': {

--- a/webpack/webpack.awx.cjs
+++ b/webpack/webpack.awx.cjs
@@ -8,7 +8,6 @@ module.exports = function (env, argv) {
 
   // publicPath is the path where the bundle is served from
   // https://webpack.js.org/guides/public-path/
-  // it nees to match the route prefix of the app
   config.output.publicPath = process.env.PUBLIC_PATH || process.env.AWX_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {

--- a/webpack/webpack.eda.cjs
+++ b/webpack/webpack.eda.cjs
@@ -8,7 +8,6 @@ module.exports = function (env, argv) {
 
   // publicPath is the path where the bundle is served from
   // https://webpack.js.org/guides/public-path/
-  // it nees to match the route prefix of the app
   config.output.publicPath = process.env.PUBLIC_PATH || process.env.EDA_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {

--- a/webpack/webpack.eda.cjs
+++ b/webpack/webpack.eda.cjs
@@ -4,8 +4,12 @@ const { EDA_SERVER } = env;
 const proxyUrl = new URL(EDA_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
-
   config.entry = './frontend/eda/main/Eda.tsx';
+
+  // publicPath is the path where the bundle is served from
+  // https://webpack.js.org/guides/public-path/
+  // it nees to match the route prefix of the app
+  config.output.publicPath = process.env.PUBLIC_PATH || process.env.EDA_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {
     '/api': {

--- a/webpack/webpack.hub.cjs
+++ b/webpack/webpack.hub.cjs
@@ -4,8 +4,12 @@ const { HUB_SERVER } = env;
 const proxyUrl = new URL(HUB_SERVER);
 module.exports = function (env, argv) {
   const config = webpackConfig(env, argv);
-
   config.entry = './frontend/hub/Hub.tsx';
+
+  // publicPath is the path where the bundle is served from
+  // https://webpack.js.org/guides/public-path/
+  // it nees to match the route prefix of the app
+  config.output.publicPath = process.env.PUBLIC_PATH || process.env.HUB_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {
     '/api': {

--- a/webpack/webpack.hub.cjs
+++ b/webpack/webpack.hub.cjs
@@ -8,7 +8,6 @@ module.exports = function (env, argv) {
 
   // publicPath is the path where the bundle is served from
   // https://webpack.js.org/guides/public-path/
-  // it nees to match the route prefix of the app
   config.output.publicPath = process.env.PUBLIC_PATH || process.env.HUB_ROUTE_PREFIX || '/';
 
   config.devServer.proxy = {


### PR DESCRIPTION
This fixes the case where the EDA_ROUTE_PREFIX was being set to '/eda' but static assets were deployed from '/'.
The default routes are all now '/' but they can still be overridden if needed.

Example for AWX hosting the UI
```
PUBLIC_PATH=/static/awx/ AWX_ROUTE_PREFIX='/ui_next' npm run build:awx
```
That is because AWX is setup to serve the files from '/static/awx/' but wants the route of the UI to be on 'ui_next'
