### PR TITLE
Make roles UI in EDA/AWX consistent with Hub

### DIFF
--- a/frontend/awx/AwxRoutes.tsx
+++ b/frontend/awx/AwxRoutes.tsx
@@ -152,6 +152,7 @@ export enum AwxRoute {
 
   Roles = 'awx-roles',
   Role = 'awx-role',
+  RoleDetails = 'awx-role-details',
 
   // Administration
 

--- a/frontend/awx/access/roles/AwxRoleDetails.tsx
+++ b/frontend/awx/access/roles/AwxRoleDetails.tsx
@@ -1,0 +1,20 @@
+import { useParams } from 'react-router-dom';
+import { PageDetailsFromColumns } from '../../../../framework';
+import { AwxRole } from './AwxRoles';
+import { useAwxRoleColumns } from './useAwxRoleColumns';
+import { useAwxRoles } from './useAwxRoles';
+
+export function AwxRoleDetails() {
+  const columns = useAwxRoleColumns();
+  const params = useParams<{ id: string; resourceType: string }>();
+  const awxRoles = useAwxRoles();
+  const role: AwxRole = {
+    ...awxRoles[params.resourceType!]?.roles[params.id!],
+    name: awxRoles[params.resourceType!]?.roles[params.id!].label,
+    roleId: params.id!,
+    resourceId: params.resourceType!,
+    resource: awxRoles[params.resourceType!]?.name,
+  };
+
+  return <PageDetailsFromColumns<AwxRole> item={role} columns={columns} />;
+}

--- a/frontend/awx/access/roles/AwxRolePage.tsx
+++ b/frontend/awx/access/roles/AwxRolePage.tsx
@@ -1,16 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import {
-  PageDetailsFromColumns,
-  PageHeader,
-  PageLayout,
-  useGetPageUrl,
-} from '../../../../framework';
+import { PageHeader, PageLayout, useGetPageUrl } from '../../../../framework';
 import { AwxRoute } from '../../AwxRoutes';
 import { AwxRole } from './AwxRoles';
-import { useAwxRoleColumns } from './useAwxRoleColumns';
 import { useAwxRoles } from './useAwxRoles';
+import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
 
 export function AwxRolePage() {
   const params = useParams<{ id: string; resourceType: string }>();
@@ -23,15 +18,23 @@ export function AwxRolePage() {
     resource: awxRoles[params.resourceType!]?.name,
   };
   const getPageUrl = useGetPageUrl();
-  const columns = useAwxRoleColumns();
   const { t } = useTranslation();
+
   return (
     <PageLayout>
       <PageHeader
         title={role?.name}
         breadcrumbs={[{ label: t('Roles'), to: getPageUrl(AwxRoute.Roles) }, { label: role?.name }]}
       />
-      <PageDetailsFromColumns<AwxRole> item={role} columns={columns} />
+      <PageRoutedTabs
+        backTab={{
+          label: t('Back to Roles'),
+          page: AwxRoute.Roles,
+          persistentFilterKey: 'awx-roles',
+        }}
+        tabs={[{ label: t('Details'), page: AwxRoute.RoleDetails }]}
+        params={{ id: params.id ?? '', resourceType: params.resourceType ?? '' }}
+      />
     </PageLayout>
   );
 }

--- a/frontend/awx/useAwxNavigation.tsx
+++ b/frontend/awx/useAwxNavigation.tsx
@@ -31,6 +31,7 @@ import { useAwxUsersRoutes } from './routes/useAwxUsersRoutes';
 import { useAwxWorkflowApprovalRoutes } from './routes/useAwxWorkflowApprovalRoutes';
 import Settings from './settings/Settings';
 import HostMetrics from './views/jobs/HostMetrics';
+import { AwxRoleDetails } from './access/roles/AwxRoleDetails';
 
 export function useAwxNavigation() {
   const { t } = useTranslation();
@@ -152,6 +153,17 @@ export function useAwxNavigation() {
               id: AwxRoute.Role,
               path: ':resourceType/:id',
               element: <AwxRolePage />,
+              children: [
+                {
+                  id: AwxRoute.RoleDetails,
+                  path: 'details',
+                  element: <AwxRoleDetails />,
+                },
+                {
+                  path: '',
+                  element: <Navigate to="details" />,
+                },
+              ],
             },
             {
               path: '',

--- a/frontend/eda/access/roles/EdaRoleDetails.tsx
+++ b/frontend/eda/access/roles/EdaRoleDetails.tsx
@@ -16,7 +16,7 @@ import { EdaRole } from '../../interfaces/EdaRole';
 import { EdaRoute } from '../../main/EdaRoutes';
 import { EdaRolePermissions } from './components/EdaRolePermissions';
 
-export function RoleDetails() {
+export function EdaRoleDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data: role } = useGet<EdaRole>(edaAPI`/roles/${params.id ?? ''}/`, undefined, {

--- a/frontend/eda/access/roles/EdaRolePage.tsx
+++ b/frontend/eda/access/roles/EdaRolePage.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { PageHeader, PageLayout, useGetPageUrl } from '../../../../framework';
+import { useGet } from '../../../common/crud/useGet';
+import { SWR_REFRESH_INTERVAL } from '../../common/eda-constants';
+import { edaAPI } from '../../common/eda-utils';
+import { EdaRole } from '../../interfaces/EdaRole';
+import { EdaRoute } from '../../main/EdaRoutes';
+import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
+
+export function EdaRolePage() {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const { data: role } = useGet<EdaRole>(edaAPI`/roles/${params.id ?? ''}/`, undefined, {
+    refreshInterval: SWR_REFRESH_INTERVAL,
+  });
+
+  const getPageUrl = useGetPageUrl();
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={role?.name}
+        breadcrumbs={[{ label: t('Roles'), to: getPageUrl(EdaRoute.Roles) }, { label: role?.name }]}
+      />
+      <PageRoutedTabs
+        backTab={{
+          label: t('Back to Roles'),
+          page: EdaRoute.Roles,
+          persistentFilterKey: 'eda-roles',
+        }}
+        tabs={[{ label: t('Details'), page: EdaRoute.RoleDetails }]}
+        params={{ id: role?.id ?? '' }}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/eda/access/roles/EdaRoles.tsx
+++ b/frontend/eda/access/roles/EdaRoles.tsx
@@ -19,6 +19,7 @@ import { EdaItemsResponse } from '../../common/EdaItemsResponse';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRole } from '../../interfaces/EdaRole';
 import { EdaRoute } from '../../main/EdaRoutes';
+import { EdaRoleExpandedRow } from './components/EdaRoleExpandedRow';
 
 export function EdaRoles() {
   const { t } = useTranslation();
@@ -99,6 +100,7 @@ export function EdaRolesTable() {
       id="eda-roles-table"
       tableColumns={columns}
       toolbarFilters={toolbarFilters}
+      expandedRow={(role) => <EdaRoleExpandedRow role={role} />}
       errorStateTitle={t('Error loading roles')}
       emptyStateTitle={t('There are currently no roles added for your organization.')}
       {...view}

--- a/frontend/eda/access/roles/RoleDetails.tsx
+++ b/frontend/eda/access/roles/RoleDetails.tsx
@@ -1,11 +1,3 @@
-import {
-  DescriptionList,
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
-  Label,
-  LabelGroup,
-} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -22,6 +14,7 @@ import { SWR_REFRESH_INTERVAL } from '../../common/eda-constants';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRole } from '../../interfaces/EdaRole';
 import { EdaRoute } from '../../main/EdaRoutes';
+import { EdaRolePermissions } from './components/EdaRolePermissions';
 
 export function RoleDetails() {
   const { t } = useTranslation();
@@ -29,22 +22,6 @@ export function RoleDetails() {
   const { data: role } = useGet<EdaRole>(edaAPI`/roles/${params.id ?? ''}/`, undefined, {
     refreshInterval: SWR_REFRESH_INTERVAL,
   });
-  const ResourceTypes = {
-    activation: t('Activation'),
-    activation_instance: t('Activation Instance'),
-    audit_rule: t('Audit Rule'),
-    audit_event: t('Audit Event'),
-    task: t('Task'),
-    user: t('User'),
-    project: t('Project'),
-    inventory: t('Inventory'),
-    extra_var: t('Extra Vars'),
-    playbook: t('Playbook'),
-    rulebook: t('Rulebook'),
-    role: t('Role'),
-    decision_environment: t('Decision environment'),
-    credential: t('Credential'),
-  };
 
   const getPageUrl = useGetPageUrl();
 
@@ -64,32 +41,7 @@ export function RoleDetails() {
         </PageDetails>
         <PageDetails numberOfColumns={'single'}>
           <PageDetail label={t('Permissions')}>
-            <DescriptionList
-              isCompact
-              isHorizontal
-              horizontalTermWidthModifier={{
-                default: '16ch',
-              }}
-            >
-              {role?.permissions.map((permission) => (
-                <DescriptionListGroup key={permission?.resource_type}>
-                  <DescriptionListTerm
-                    data-cy={'permissions'}
-                    style={{ fontWeight: 'normal' }}
-                    key={permission?.resource_type}
-                  >
-                    {ResourceTypes[permission?.resource_type] || permission?.resource_type}
-                  </DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {!!permission?.action.length && (
-                      <LabelGroup numLabels={5}>
-                        {permission?.action.map((action) => <Label key={action}>{action}</Label>)}
-                      </LabelGroup>
-                    )}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              ))}
-            </DescriptionList>
+            <EdaRolePermissions role={role} />
           </PageDetail>
         </PageDetails>
       </Scrollable>

--- a/frontend/eda/access/roles/components/EdaRoleExpandedRow.tsx
+++ b/frontend/eda/access/roles/components/EdaRoleExpandedRow.tsx
@@ -1,0 +1,20 @@
+import { ExpandableRowContent } from '@patternfly/react-table';
+import { EdaRole } from '../../../interfaces/EdaRole';
+import { EdaRolePermissions } from './EdaRolePermissions';
+import { useGet } from '../../../../common/crud/useGet';
+import { SWR_REFRESH_INTERVAL } from '../../../common/eda-constants';
+import { edaAPI } from '../../../common/eda-utils';
+
+export function EdaRoleExpandedRow(props: { role: EdaRole }) {
+  const { role } = props;
+
+  const { data: roleDetails } = useGet<EdaRole>(edaAPI`/roles/${role.id ?? ''}/`, undefined, {
+    refreshInterval: SWR_REFRESH_INTERVAL,
+  });
+
+  return (
+    <ExpandableRowContent>
+      <EdaRolePermissions role={roleDetails} />
+    </ExpandableRowContent>
+  );
+}

--- a/frontend/eda/access/roles/components/EdaRolePermissions.tsx
+++ b/frontend/eda/access/roles/components/EdaRolePermissions.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import { EdaRole } from '../../../interfaces/EdaRole';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Label,
+  LabelGroup,
+} from '@patternfly/react-core';
+
+export function EdaRolePermissions(props: { role?: EdaRole }) {
+  const { t } = useTranslation();
+  const { role } = props;
+
+  const ResourceTypes = {
+    activation: t('Activation'),
+    activation_instance: t('Activation Instance'),
+    audit_rule: t('Audit Rule'),
+    audit_event: t('Audit Event'),
+    task: t('Task'),
+    user: t('User'),
+    project: t('Project'),
+    inventory: t('Inventory'),
+    extra_var: t('Extra Vars'),
+    playbook: t('Playbook'),
+    rulebook: t('Rulebook'),
+    role: t('Role'),
+    decision_environment: t('Decision environment'),
+    credential: t('Credential'),
+  };
+
+  return (
+    <DescriptionList
+      isHorizontal
+      horizontalTermWidthModifier={{
+        default: '12ch',
+        sm: '15ch',
+        md: '20ch',
+        lg: '28ch',
+        xl: '30ch',
+        '2xl': '35ch',
+      }}
+    >
+      {!role && (
+        <DescriptionListGroup data-cy={'permission-categories-no-permissions'}>
+          <DescriptionListTerm>{t('No permissions')}</DescriptionListTerm>
+        </DescriptionListGroup>
+      )}
+      {role?.permissions.map((permission) => (
+        <DescriptionListGroup key={permission?.resource_type}>
+          <DescriptionListTerm
+            data-cy={'permissions'}
+            style={{ fontWeight: 'normal' }}
+            key={permission?.resource_type}
+          >
+            {ResourceTypes[permission?.resource_type] || permission?.resource_type}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            {!!permission?.action.length && (
+              <LabelGroup numLabels={5}>
+                {permission?.action.map((action) => <Label key={action}>{action}</Label>)}
+              </LabelGroup>
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      ))}
+    </DescriptionList>
+  );
+}

--- a/frontend/eda/access/roles/hooks/useRoleColumns.tsx
+++ b/frontend/eda/access/roles/hooks/useRoleColumns.tsx
@@ -15,7 +15,7 @@ export function useRoleColumns(withLinks: boolean) {
           withLinks ? (
             <TextCell
               text={role.name}
-              to={getPageUrl(EdaRoute.RolePage, { params: { id: role.id } })}
+              to={getPageUrl(EdaRoute.RoleDetails, { params: { id: role.id } })}
             />
           ) : (
             <TextCell text={role.name} />

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -51,6 +51,7 @@ export enum EdaRoute {
   CreateRole = 'eda-create-role',
   EditRole = 'eda-edit-role',
   RolePage = 'eda-role-page',
+  RoleDetails = 'eda-role-details',
 
   CreateControllerToken = 'eda-create-controller-token',
 

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -41,6 +41,7 @@ import { RulebookActivationHistory } from '../rulebook-activations/RulebookActiv
 import { RulebookActivationPage } from '../rulebook-activations/RulebookActivationPage/RulebookActivationPage';
 import { RulebookActivations } from '../rulebook-activations/RulebookActivations';
 import { EdaRoute } from './EdaRoutes';
+import { EdaRolePage } from '../access/roles/EdaRolePage';
 
 export function useEdaNavigation() {
   const { t } = useTranslation();
@@ -315,8 +316,19 @@ export function useEdaNavigation() {
             },
             {
               id: EdaRoute.RolePage,
-              path: ':id',
-              element: <RoleDetails />,
+              path: ':id/',
+              element: <EdaRolePage />,
+              children: [
+                {
+                  id: EdaRoute.RoleDetails,
+                  path: 'details',
+                  element: <RoleDetails />,
+                },
+                {
+                  path: '',
+                  element: <Navigate to="details" />,
+                },
+              ],
             },
             {
               path: '',

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -7,7 +7,7 @@ import { Credentials } from '../access/credentials/Credentials';
 import { CreateCredential, EditCredential } from '../access/credentials/EditCredential';
 import { EdaRoles } from '../access/roles/EdaRoles';
 import { EditRole } from '../access/roles/EditRole';
-import { RoleDetails } from '../access/roles/RoleDetails';
+import { EdaRoleDetails } from '../access/roles/EdaRoleDetails';
 import { CreateControllerToken } from '../access/users/CreateControllerToken';
 import { CreateUser, EditCurrentUser, EditUser } from '../access/users/EditUser';
 import { ControllerTokens } from '../access/users/UserPage/ControllerTokens';
@@ -322,7 +322,7 @@ export function useEdaNavigation() {
                 {
                   id: EdaRoute.RoleDetails,
                   path: 'details',
-                  element: <RoleDetails />,
+                  element: <EdaRoleDetails />,
                 },
                 {
                   path: '',


### PR DESCRIPTION
- Add an explicit "Details" tab to the role details UI for AWX and EDA
- Make the rows in the EDA roles list expandable to view the role's permissions

<img width="916" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/61f8b042-f358-4947-8cd3-a3240c7746ef">

<img width="1097" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/9498d938-86f8-48c1-880f-9953084f48ba">

<img width="1137" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/f64c1f61-681a-45ec-bfdf-40e476911d40">

