### PR TITLE
[AAP-12403] Update team details from modified to last modified

### DIFF
--- a/frontend/awx/access/teams/TeamPage/AwxTeamDetails.cy.tsx
+++ b/frontend/awx/access/teams/TeamPage/AwxTeamDetails.cy.tsx
@@ -15,8 +15,8 @@ describe('TeamDetails', () => {
       'contain',
       mockAwxTeam.summary_fields?.created_by?.username
     );
-    cy.get('[data-cy="modified"]').should('contain', formatDateString(mockAwxTeam.modified));
-    cy.get('[data-cy="modified"]').should(
+    cy.get('[data-cy="last-modified"]').should('contain', formatDateString(mockAwxTeam.modified));
+    cy.get('[data-cy="last-modified"]').should(
       'contain',
       mockAwxTeam.summary_fields?.modified_by?.username
     );

--- a/frontend/common/access/TeamDetails.tsx
+++ b/frontend/common/access/TeamDetails.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { DateTimeCell, LabelsCell, PageDetail, PageDetails } from '../../../framework';
 import { useNavigate } from 'react-router-dom';
+import { LastModifiedPageDetail } from '../LastModifiedPageDetail';
 
 export type TeamDetailsType = {
   name: string;
@@ -83,20 +84,18 @@ export function TeamDetails<T extends TeamDetailsType>(props: {
           </PageDetail>
         )}
         {(team.modified || team.modified_on || team.modified_at) && (
-          <PageDetail label={t('Modified')}>
-            <DateTimeCell
-              format="date-time"
-              author={team.summary_fields?.modified_by?.username}
-              value={team.modified ?? team.modified_on ?? team.modified_at}
-              onClick={
-                modifiedByUserDetailsUrl
-                  ? () => {
-                      navigate(modifiedByUserDetailsUrl);
-                    }
-                  : undefined
-              }
-            />
-          </PageDetail>
+          <LastModifiedPageDetail
+            format="date-time"
+            author={team.summary_fields?.modified_by?.username}
+            value={team.modified ?? team.modified_on ?? team.modified_at}
+            onClick={
+              modifiedByUserDetailsUrl
+                ? () => {
+                    navigate(modifiedByUserDetailsUrl);
+                  }
+                : undefined
+            }
+          />
         )}
       </PageDetails>
     </>


### PR DESCRIPTION
This PR is addressing a comment on [AAP-12403](https://issues.redhat.com/browse/AAP-12403) which found a `modified` label instead of `last modified` on the team details page.