### PR TITLE
Display error fetching EDA roles

### DIFF
--- a/frontend/eda/access/roles/EdaRoles.tsx
+++ b/frontend/eda/access/roles/EdaRoles.tsx
@@ -38,7 +38,7 @@ export function EdaRoles() {
 
 export function EdaRolesTable() {
   const { t } = useTranslation();
-  const { data, isLoading } = useGet<EdaItemsResponse<EdaRole>>(edaAPI`/roles/`);
+  const { data, isLoading, error } = useGet<EdaItemsResponse<EdaRole>>(edaAPI`/roles/`);
   const roles = useMemo(() => data?.results ?? [], [data?.results]);
   const getPageUrl = useGetPageUrl();
   const columns = useMemo<ITableColumn<EdaRole>[]>(
@@ -91,6 +91,7 @@ export function EdaRolesTable() {
     items: data?.results ?? [],
     tableColumns: columns,
     toolbarFilters,
+    error,
   });
 
   if (isLoading) return <LoadingPage />;


### PR DESCRIPTION
The EDA roles UI incorrectly shows the empty state UI instead of an error state when there is an error in fetching EDA roles from the backend.