### PR TITLE
Async select filters, support query for chip label

### DIFF
--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -7,7 +7,10 @@ import { PageMultiSelect } from '../PageInputs/PageMultiSelect';
 import { PageSingleSelect } from '../PageInputs/PageSingleSelect';
 import { useBreakpoint } from '../components/useBreakPoint';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
-import { IToolbarAsyncMultiSelectFilter } from './PageToolbarFilters/ToolbarAsyncMultiSelectFilter';
+import {
+  AsyncQueryChip,
+  IToolbarAsyncMultiSelectFilter,
+} from './PageToolbarFilters/ToolbarAsyncMultiSelectFilter';
 import { IToolbarAsyncSingleSelectFilter } from './PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
 import {
   IToolbarDateRangeFilter,
@@ -175,7 +178,13 @@ export function PageToolbarFilters(props: PageToolbarFiltersProps) {
                 switch (filter.type) {
                   case ToolbarFilterType.SingleSelect:
                   case ToolbarFilterType.MultiSelect:
-                    return filter.options.find((o) => o.value === value)?.label ?? value;
+                    return filter.options?.find((o) => o.value === value)?.label ?? value;
+                  case ToolbarFilterType.AsyncSingleSelect:
+                  case ToolbarFilterType.AsyncMultiSelect:
+                    return {
+                      key: value,
+                      node: <AsyncQueryChip value={value} queryLabel={filter.queryLabel} />,
+                    };
                   default:
                     return value;
                 }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { PageAsyncMultiSelectOptionsFn } from '../../PageInputs/PageAsyncMultiSelect';
 import { PageAsyncQueryErrorTextType } from '../../PageInputs/PageAsyncSingleSelect';
 import { ToolbarFilterType } from '../PageToolbarFilter';
@@ -20,6 +21,9 @@ export interface IToolbarAsyncMultiSelectFilter extends ToolbarFilterCommon {
 
   /** The placeholder to show if the query fails. */
   queryErrorText?: PageAsyncQueryErrorTextType;
+
+  /** The function to query for the label of a value. */
+  queryLabel?: (value: string) => Promise<string | undefined>;
 
   /** The function to open the browse modal. */
   openBrowse?: ToolbarOpenMultiSelectBrowse;
@@ -60,4 +64,18 @@ export function multiSelectBrowseAdapter<T>(
         : []
     );
   };
+}
+
+export function AsyncQueryChip(props: {
+  value: string;
+  queryLabel?: (value: string) => Promise<string | undefined>;
+}) {
+  const { value, queryLabel } = props;
+  const [label, setLabel] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (queryLabel) {
+      void queryLabel(value).then((label) => setLabel(label));
+    }
+  }, [value, queryLabel]);
+  return <>{label || value}</>;
 }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -26,6 +26,9 @@ export interface IToolbarAsyncSingleSelectFilter extends ToolbarFilterCommon {
   /** The function to open the browse modal. */
   openBrowse?: ToolbarOpenSingleSelectBrowse;
 
+  /** The function to query for the label of a value. */
+  queryLabel?: (value: string) => Promise<string | undefined>;
+
   /**
    * Whether the select required an option to be selected.
    *


### PR DESCRIPTION
This allows async filter which have values like "1" or "2" to have a callback to query the label for the value and show that label in the filter chips.

![Screenshot 2024-01-16 at 12 28 01 PM](https://github.com/ansible/ansible-ui/assets/6277895/b99ed419-1880-4502-aa4d-c7d9fe4019e7)
