### PR TITLE
Topology view expandable sidebar + single column layout.

### DIFF
--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -120,6 +120,7 @@ export function InstanceDetailsTab(props: {
   instanceForks: number;
   handleToggleInstance: (instance: Instance, isEnabled: boolean) => Promise<void>;
   handleInstanceForksSlider: (instance: Instance, value: number) => Promise<void>;
+  numberOfColumns?: 'multiple' | 'single' | undefined;
 }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
@@ -135,7 +136,7 @@ export function InstanceDetailsTab(props: {
   const toolTipMap: { [item: string]: string } = useNodeTypeTooltip();
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
   return (
-    <PageDetails>
+    <PageDetails numberOfColumns={props.numberOfColumns}>
       <PageDetail label={t('Name')} data-cy="name">
         <Button
           variant="link"

--- a/frontend/awx/administration/topology/Sidebar.tsx
+++ b/frontend/awx/administration/topology/Sidebar.tsx
@@ -20,6 +20,7 @@ export function InstanceDetailInner(props: {
   } = props;
   return (
     <InstanceDetailsTab
+      numberOfColumns="single"
       instance={instance}
       instanceGroups={instanceGroups}
       handleToggleInstance={handleToggleInstance}

--- a/frontend/awx/administration/topology/Visualizer.tsx
+++ b/frontend/awx/administration/topology/Visualizer.tsx
@@ -224,15 +224,20 @@ export const TopologyViewLayer = (props: { mesh: MeshVisualizer }) => {
   return (
     <TopologyView
       id="mesh-topology"
+      sideBarResizable
+      sideBarOpen={selectedIds.length > 0}
       sideBar={
-        <TopologySideBar
-          data-cy="mesh-viz-sidebar"
-          className="mesh-viz-sidebar"
-          show={selectedIds.length > 0}
-          onClose={() => setSelectedIds([])}
-        >
-          <InstanceDetailSidebar selectedId={selectedIds[0]}></InstanceDetailSidebar>
-        </TopologySideBar>
+        selectedIds.length > 0 && (
+          <TopologySideBar
+            data-cy="mesh-viz-sidebar"
+            className="mesh-viz-sidebar"
+            show={selectedIds.length > 0}
+            onClose={() => setSelectedIds([])}
+            resizable
+          >
+            <InstanceDetailSidebar selectedId={selectedIds[0]}></InstanceDetailSidebar>
+          </TopologySideBar>
+        )
       }
       controlBar={
         !isLoading && (


### PR DESCRIPTION
Per UXD's request, the following changes have been added to Topology view to use an expandable sidebar + single column detail view.

Before:
![Screenshot 2024-01-16 at 9 39 18 AM](https://github.com/ansible/ansible-ui/assets/2293210/b00daa86-c21d-4981-a435-339fa814edac)

After:
![Screenshot 2024-01-16 at 9 38 15 AM](https://github.com/ansible/ansible-ui/assets/2293210/54b4253b-383d-4efc-a739-a4176fc338f1)
