### PR TITLE
Fix warning related to react-router

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -76,10 +76,12 @@ export function CollectionPage() {
   const itemActions = useCollectionActions(() => void collectionRequest.refresh(), true);
 
   function setVersionParams(version: string) {
-    setSearchParams((params) => {
-      params.set('version', version);
-      return params;
-    });
+    setTimeout(() => {
+      setSearchParams((params) => {
+        params.set('version', version);
+        return params;
+      });
+    }, 0);
   }
 
   // load collection versions


### PR DESCRIPTION
Fix warning related to react-router

```
Warning: Cannot update a component (`RouterProvider`) while rendering a different component (`PageAsyncSingleSelect`). To locate the bad setState() call inside `PageAsyncSingleSelect`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
PageAsyncSingleSelect@webpack-internal:///./framework/PageInputs/PageAsyncSingleSelect.tsx:57:68
div
div
```