### PR TITLE
[AAP-19237] Hide post 2.4 nav items

### DIFF
--- a/frontend/awx/analytics/Reports/AutomationCalculator.tsx
+++ b/frontend/awx/analytics/Reports/AutomationCalculator.tsx
@@ -365,7 +365,7 @@ export function AutomationCalculatorInternal(props: {
       awxAPI`/analytics/roi_templates/?limit=${perPage.toString()}&offset=${(
         (page - 1) *
         perPage
-      ).toString()}&sort_by=${sortOption?.value}${encodeURIComponent(`:${sortOrder}`)}`,
+      ).toString()}&sort_by=${sortOption?.value}:${encodeURIComponent(sortOrder)}`,
       requestBody,
       abortController.signal
     )
@@ -409,7 +409,7 @@ export function AutomationCalculatorInternal(props: {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     const tooltip = `${sortOption.label} for ${datum.name || ''}: ${
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      formattedValue('successful_hosts_savings', datum.y) || ''
+      formattedValue(sortOption.value, datum.y) || ''
     }`;
     return tooltip;
   };

--- a/frontend/awx/analytics/Reports/ErrorStates.tsx
+++ b/frontend/awx/analytics/Reports/ErrorStates.tsx
@@ -4,6 +4,7 @@ import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EmptyStateCustom } from '../../../../framework/components/EmptyStateCustom';
 import { useAwxActiveUser } from '../../common/useAwxActiveUser';
+import { EmptyStateError } from '../../../../framework/components/EmptyStateError';
 
 export function AnalyticsErrorState(props: { error?: string }) {
   const { t } = useTranslation();
@@ -71,13 +72,7 @@ export function AnalyticsErrorState(props: { error?: string }) {
         />
       );
     }
-    return (
-      <EmptyStateCustom
-        title={t('ERROR')}
-        description={t('WHO KNOWS WHAT HAPPENED')}
-        icon={KeyIcon}
-      />
-    );
+    return <EmptyStateError />;
   }
   function DisabledState() {
     return (

--- a/frontend/awx/main/useAwxNavigation.tsx
+++ b/frontend/awx/main/useAwxNavigation.tsx
@@ -6,9 +6,9 @@ import { AwxRolePage } from '../access/roles/AwxRolePage';
 import { AwxRoles } from '../access/roles/AwxRoles';
 import { AwxSettings } from '../administration/settings/AwxSettings';
 import { Topology } from '../administration/topology/Topology';
-import { Test } from '../analytics/AnalyticsReportBuilder/Test';
+// import { Test } from '../analytics/AnalyticsReportBuilder/Test';
 import { Reports } from '../analytics/Reports/Reports';
-import { ReportsList } from '../analytics/Reports/ReportsList/ReportsList';
+// import { ReportsList } from '../analytics/Reports/ReportsList/ReportsList';
 import { SubscriptionUsage } from '../analytics/subscription-usage/SubscriptionUsage';
 import { AwxOverview } from '../overview/AwxOverview';
 import { HostMetrics } from '../views/jobs/HostMetrics';
@@ -87,24 +87,24 @@ export function useAwxNavigation() {
       label: t('Analytics'),
       path: 'analytics',
       children: [
-        {
-          id: AwxRoute.Reports,
-          label: t('Reports'),
-          path: 'reports',
-          element: <ReportsList />,
-        },
+        // {
+        //   id: AwxRoute.Reports,
+        //   label: t('Reports'),
+        //   path: 'reports',
+        //   element: <ReportsList />,
+        // },
         {
           id: AwxRoute.AutomationCalculator,
           label: t('Automation Calculator'),
           path: 'automation-calculator',
           element: <Reports />,
         },
-        {
-          id: AwxRoute.AnalyticsBuilder,
-          label: t('Analytics builder'),
-          path: 'builder',
-          element: <Test />,
-        },
+        // {
+        //   id: AwxRoute.AnalyticsBuilder,
+        //   label: t('Analytics builder'),
+        //   path: 'builder',
+        //   element: <Test />,
+        // },
         {
           id: AwxRoute.HostMetrics,
           label: t('Host Metrics'),


### PR DESCRIPTION
Removed reports and analytics builder nav items because they are not yet ready to be released in 2.5. Changes were also made to fix the broken automation calculator page, better handle error states, and make tooltip text dynamic.

Jira issue: https://issues.redhat.com/browse/AAP-19237

**Nav bar before:**
![Screenshot 2024-01-19 at 12 20 47 PM](https://github.com/ansible/ansible-ui/assets/89094075/1cb41d28-79dd-4932-b6ae-9a2c6eb4926d)

**Nav bar after:** 
![Screenshot 2024-01-19 at 12 20 08 PM](https://github.com/ansible/ansible-ui/assets/89094075/42078261-ae68-4fde-bd59-dd4ecf193be4)

**Automation calculator before:**
![Screenshot 2024-01-19 at 12 47 58 PM](https://github.com/ansible/ansible-ui/assets/89094075/d5a56769-6f4a-4a33-b76a-bd08684df820)

**Automation calculator after:**
![Screenshot 2024-01-19 at 12 48 27 PM](https://github.com/ansible/ansible-ui/assets/89094075/3533a314-f12e-4a89-afaf-b04afa60312e)