### PR TITLE
Restructure auth options to handle long names

### DIFF
--- a/frontend/common/SocialAuthLogin.tsx
+++ b/frontend/common/SocialAuthLogin.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@patternfly/react-core';
+import { Button as PFButton } from '@patternfly/react-core';
 import { AzureIcon, GithubIcon, GoogleIcon, UserCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -16,8 +16,13 @@ const Heading = styled.h2`
 
 const Grid = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 30px 50px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 30px 0;
+`;
+
+const Button = styled(PFButton)`
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export type AuthOption = {


### PR DESCRIPTION
Removes two-column layout for auth options and handles text overflow on the login screen

<img width="567" alt="Screenshot 2024-01-19 at 12 42 58 PM" src="https://github.com/ansible/ansible-ui/assets/410794/30399b5b-9e79-4189-87f3-2ef2fb930152">
