### PR TITLE
Fix path to tests in labeler for EDA and HUB

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,11 +4,11 @@ AWX:
 
 EDA:
   - frontend/eda/**/*
-  - cypress/eda/awx/**/*
+  - cypress/e2e/eda/**/*
 
 HUB:
   - frontend/hub/**/*
-  - cypress/hub/awx/**/*
+  - cypress/e2e/hub/**/*
 
 E2E:
   - cypress/e2e/**


### PR DESCRIPTION
Before:
EDA and HUB paths to tests points to nowhere
After:
Points to existing and correct folders 

Note: HUB should copy folder hierarchy from others