### PR TITLE
Repositories tab versions action revert

### DIFF
--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
@@ -80,7 +80,6 @@ export function useRepositoryVersionColumns() {
   );
 }
 
-
 export function useRevertToVersion(onComplete?: (items: RepositoryVersion[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useRepositoryVersionColumns();

--- a/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../../../framework';
 import { CollectionVersionSearch } from '../../../collections/Collection';
 import { PROTECTED_REPOSITORIES } from '../../../common/constants';
-import { Repository, RepositoryVersion } from '../Repository';
+import { Repository } from '../Repository';
 import { useDeleteRepositories } from './useDeleteRepositories';
 import { getRepositoryBasePath } from '../../../common/api/hub-api-utils';
 import { getRepoURL } from '../../../common/api/hub-api-utils';
@@ -119,23 +119,6 @@ export function useCollectionVersionsActions() {
         selection: PageActionSelection.Multiple,
         type: PageActionType.Button,
         isDanger: true,
-      },
-    ],
-    [t]
-  );
-
-  return actions;
-}
-
-export function useVersionsActions() {
-  const { t } = useTranslation();
-  const actions = useMemo<IPageAction<RepositoryVersion>[]>(
-    () => [
-      {
-        label: t('Revert to this version'),
-        onClick: () => {},
-        selection: PageActionSelection.Multiple,
-        type: PageActionType.Button,
       },
     ],
     [t]


### PR DESCRIPTION
Repository detail, tab versions and action revert. It reverts repository to actual version.

How to test it - you need repository with max retain versions for example 100. Default is 1, so there is only 1 version and you cant test it.

Then you can add some collection to the repository (for example using old UI - add collection to repository). Then new repo version will appear and we can revert repo to original one. Then the collections should dissapear from repo again.

We cant revert to latest version of repo.