### PR TITLE
Hub - check trailing and double slashes when constructing API urls, better page/sort param support

### DIFF
--- a/cypress/e2e/hub/approvals.cy.ts
+++ b/cypress/e2e/hub/approvals.cy.ts
@@ -12,6 +12,7 @@ describe('Approvals', () => {
     cy.hubLogin();
     cy.getNamespace(namespace);
     cy.uploadCollection(thisCollectionName, namespace);
+    cy.galaxykit('task wait all');
 
     cy.navigateTo('hub', Approvals.url);
   });
@@ -24,7 +25,6 @@ describe('Approvals', () => {
   it('user can upload a new collection and approve it', () => {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'approve');
 
     //Verify Approve and sign collections modal
@@ -34,21 +34,21 @@ describe('Approvals', () => {
       cy.get('[data-cy="namespace-column-cell"]').should('have.text', namespace);
       cy.get('[data-cy="collection-column-cell"]').should('have.text', thisCollectionName);
       cy.get('[data-cy="version-column-cell"]').should('have.text', '1.0.0');
-      cy.get('[data-cy="status-column-cell"]').should('have.text', '' || 'Needs review');
+      cy.get('[data-cy="status-column-cell"]').should('have.text', 'Needs review');
       cy.get('input[id="confirm"]').click();
       cy.get('button').contains('Approve collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
 
     repository = 'published';
   });
 
-  it.skip('user can upload a new collection and reject it', () => {
+  it('user can upload a new collection and reject it', () => {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'reject');
 
     //Verify Reject modal
@@ -58,11 +58,12 @@ describe('Approvals', () => {
       cy.get('[data-cy="namespace-column-cell"]').should('have.text', namespace);
       cy.get('[data-cy="collection-column-cell"]').should('have.text', thisCollectionName);
       cy.get('[data-cy="version-column-cell"]').should('have.text', '1.0.0');
-      cy.get('[data-cy="status-column-cell"]').should('have.text', '' || 'Needs review');
+      cy.get('[data-cy="status-column-cell"]').should('have.text', 'Needs review');
       cy.get('input[id="confirm"]').click();
       cy.get('button').contains('Reject collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
 
@@ -72,7 +73,6 @@ describe('Approvals', () => {
   it('user can approve a collection and then reject it', () => {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'approve');
 
     //Verify Approve modal
@@ -87,11 +87,13 @@ describe('Approvals', () => {
       cy.get('button').contains('Approve collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
 
-    cy.navigateTo('hub', Approvals.url);
-    cy.verifyPageTitle(Approvals.title);
+    repository = 'published';
+
+    cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'reject');
 
     //Verify Reject modal
@@ -106,6 +108,7 @@ describe('Approvals', () => {
       cy.get('button').contains('Reject collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
 
@@ -115,7 +118,6 @@ describe('Approvals', () => {
   it('user can reject a collection and then approve it', () => {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'reject');
 
     //Verify Reject modal
@@ -130,8 +132,11 @@ describe('Approvals', () => {
       cy.get('button').contains('Reject collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
+
+    repository = 'rejected';
 
     cy.clickButton(/^Clear all filters$/);
     cy.clickTableRowPinnedAction(thisCollectionName, 'approve');
@@ -148,6 +153,7 @@ describe('Approvals', () => {
       cy.get('button').contains('Approve collections').click();
     });
 
+    cy.galaxykit('task wait all');
     cy.assertModalSuccess();
     cy.clickModalButton('Close');
 

--- a/cypress/support/formatApiPathForHub.ts
+++ b/cypress/support/formatApiPathForHub.ts
@@ -9,7 +9,11 @@
 import { apiTag } from '../../frontend/hub/common/api/formatPath';
 
 function getBaseAPIPath() {
-  return (Cypress.env('HUB_API_PREFIX') as string) || '/api/galaxy';
+  const base = (Cypress.env('HUB_API_PREFIX') as string) || '/api/galaxy';
+  if (base.endsWith('/')) {
+    throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
+  }
+  return base;
 }
 
 export function hubAPI(strings: TemplateStringsArray, ...values: string[]) {

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -287,7 +287,7 @@ Cypress.Commands.add(
     }
   ) => {
     if (role?.name) {
-      cy.requestDelete(pulpAPI`/roles/${parsePulpIDFromURL(role.pulp_href) as string}`, options);
+      cy.requestDelete(pulpAPI`/roles/${parsePulpIDFromURL(role.pulp_href) as string}/`, options);
     }
   }
 );

--- a/frontend/hub/access/roles/RolePage/RoleDetails.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleDetails.cy.tsx
@@ -37,7 +37,7 @@ describe('Hub Role Details', () => {
       featureFlags: mockFeatureFlags,
     }));
     cy.intercept(
-      { method: 'GET', url: pulpAPI`/roles/*` },
+      { method: 'GET', url: pulpAPI`/roles/` + '*' },
       {
         count: 1,
         results: [mockRole],

--- a/frontend/hub/access/roles/RolePage/RoleDetails.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleDetails.tsx
@@ -23,7 +23,7 @@ export function RoleDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data, error, refresh } = useGet<PulpItemsResponse<Role>>(
-    pulpAPI`/roles/?name=${params.id || ''}`
+    pulpAPI`/roles/?name=${params.id}`
   );
   const role = data?.results?.[0];
   const getPageUrl = useGetPageUrl();

--- a/frontend/hub/access/roles/RolePage/RoleForm.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleForm.cy.tsx
@@ -61,7 +61,7 @@ describe('Hub Roles Form', () => {
 
   it('name field should be read-only in edit mode', () => {
     cy.intercept(
-      { method: 'GET', url: pulpAPI`/roles/*` },
+      { method: 'GET', url: pulpAPI`/roles/` + '*' },
       {
         count: 1,
         results: [mockRole],
@@ -73,7 +73,7 @@ describe('Hub Roles Form', () => {
 
   it('should preload the form with current values', () => {
     cy.intercept(
-      { method: 'GET', url: pulpAPI`/roles/*` },
+      { method: 'GET', url: pulpAPI`/roles/` + '*' },
       {
         count: 1,
         results: [mockRole],

--- a/frontend/hub/access/roles/RolePage/RoleForm.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleForm.tsx
@@ -76,7 +76,7 @@ export function EditRole() {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string }>();
   const { data, error, refresh } = useGet<PulpItemsResponse<Role>>(
-    pulpAPI`/roles/?name=${params.id || ''}`
+    pulpAPI`/roles/?name=${params.id}`
   );
   const role = data?.results?.[0];
   const permissionCategories = usePermissionCategories(role?.permissions, false, true);
@@ -88,7 +88,7 @@ export function EditRole() {
   const onSubmit: PageFormSubmitHandler<RoleInput> = async (values) => {
     const { name, description, permissionCategories } = values;
     const permissions = getSelectedPermissions(permissionCategories);
-    await patchRequest(pulpAPI`/roles/${parsePulpIDFromURL(role?.pulp_href ?? '') as string}/`, {
+    await patchRequest(pulpAPI`/roles/${parsePulpIDFromURL(role?.pulp_href ?? '')}/`, {
       name,
       description,
       permissions,

--- a/frontend/hub/access/roles/RolePage/RoleForm.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleForm.tsx
@@ -88,7 +88,7 @@ export function EditRole() {
   const onSubmit: PageFormSubmitHandler<RoleInput> = async (values) => {
     const { name, description, permissionCategories } = values;
     const permissions = getSelectedPermissions(permissionCategories);
-    await patchRequest(pulpAPI`/roles/${parsePulpIDFromURL(role?.pulp_href ?? '')}/`, {
+    await patchRequest(pulpAPI`/roles/${parsePulpIDFromURL(role?.pulp_href)}/`, {
       name,
       description,
       permissions,

--- a/frontend/hub/access/roles/RolePage/RolePage.tsx
+++ b/frontend/hub/access/roles/RolePage/RolePage.tsx
@@ -22,7 +22,7 @@ export function RolePage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data, error, refresh } = useGet<PulpItemsResponse<Role>>(
-    pulpAPI`/roles/?name=${params.id || ''}`
+    pulpAPI`/roles/?name=${params.id}`
   );
   const role = data?.results?.[0];
   const pageNavigate = usePageNavigate();

--- a/frontend/hub/access/roles/Roles.cy.tsx
+++ b/frontend/hub/access/roles/Roles.cy.tsx
@@ -8,7 +8,7 @@ describe('Roles List', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: pulpAPI`/roles/*`,
+        url: pulpAPI`/roles/` + '*',
       },
       {
         fixture: 'hub_roles.json',
@@ -31,7 +31,7 @@ describe('Roles List', () => {
       user: mockUser,
     }));
     cy.mount(<Roles />);
-    cy.intercept(pulpAPI`/roles/*name__icontains=foo*`).as('nameFilterRequest');
+    cy.intercept(pulpAPI`/roles/?*name__icontains=foo*`).as('nameFilterRequest');
     cy.filterTableByText('foo');
     cy.wait('@nameFilterRequest');
     cy.clickButton(/^Clear all filters$/);
@@ -41,7 +41,7 @@ describe('Roles List', () => {
       user: mockUser,
     }));
     cy.mount(<Roles />);
-    cy.intercept(pulpAPI`/roles/*locked=false*`).as('editableFilterRequest');
+    cy.intercept(pulpAPI`/roles/?*locked=false*`).as('editableFilterRequest');
     cy.filterBySingleSelection('Editable', 'Editable');
     cy.wait('@editableFilterRequest');
     cy.clickButton(/^Clear all filters$/);
@@ -51,7 +51,7 @@ describe('Roles List', () => {
       user: mockUser,
     }));
     cy.mount(<Roles />);
-    cy.intercept(pulpAPI`/roles/*name__startswith=&*`).as('allRolesFilterRequest');
+    cy.intercept(pulpAPI`/roles/?*name__startswith=&*`).as('allRolesFilterRequest');
     cy.filterBySingleSelection('Role type', 'All roles');
     cy.wait('@allRolesFilterRequest');
     cy.clickButton(/^Clear all filters$/);
@@ -140,7 +140,7 @@ describe('Roles List', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: pulpAPI`/roles/*`,
+        url: pulpAPI`/roles/` + '*',
       },
       {
         statusCode: 500,

--- a/frontend/hub/access/roles/hooks/useDeleteRoles.tsx
+++ b/frontend/hub/access/roles/hooks/useDeleteRoles.tsx
@@ -87,7 +87,7 @@ export function useDeleteRoles(onComplete: (roles: Role[]) => void) {
       actionColumns,
       onComplete,
       actionFn: (role, signal) =>
-        requestDelete(pulpAPI`/roles/${parsePulpIDFromURL(role.pulp_href) as string}/`, signal),
+        requestDelete(pulpAPI`/roles/${parsePulpIDFromURL(role.pulp_href)}/`, signal),
     });
   };
   return deleteRoles;

--- a/frontend/hub/administration/collection-approvals/hooks/useRejectCollections.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useRejectCollections.tsx
@@ -59,9 +59,9 @@ export function rejectCollection(
     rejectedRepo = repoRes.results[0].pulp_href;
 
     await hubAPIPost(
-      pulpAPI`/repositories/ansible/ansible/${
-        parsePulpIDFromURL(collection.repository?.pulp_href || '') || ''
-      }/move_collection_version/`,
+      pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(
+        collection.repository?.pulp_href
+      )}/move_collection_version/`,
       {
         collection_versions: [`${collection.collection_version?.pulp_href}`],
         destination_repositories: [rejectedRepo],

--- a/frontend/hub/administration/remote-registries/RemoteRegistryDetails.tsx
+++ b/frontend/hub/administration/remote-registries/RemoteRegistryDetails.tsx
@@ -36,7 +36,7 @@ export function RemoteRegistryDetails() {
     error: errorRemoteRegistry,
     refresh: refreshRemoteRegistry,
   } = useGet<HubItemsResponse<RemoteRegistry>>(
-    hubAPI`/_ui/v1/execution-environments/registries/?name=${params.id || ''}`
+    hubAPI`/_ui/v1/execution-environments/registries/?name=${params.id}`
   );
 
   if (errorRemoteRegistry) {

--- a/frontend/hub/administration/remote-registries/RemoteRegistryForm.tsx
+++ b/frontend/hub/administration/remote-registries/RemoteRegistryForm.tsx
@@ -153,7 +153,7 @@ export function EditRemoteRegistry() {
   }
 
   const onSubmit: PageFormSubmitHandler<RemoteRegistryProps> = async (remoteRegistry) => {
-    const remoteRegistryId = parsePulpIDFromURL(remoteRegistry.pulp_href) ?? '';
+    const remoteRegistryId = parsePulpIDFromURL(remoteRegistry.pulp_href) as string;
     await hubAPIPut<RemoteRegistryProps>(
       hubAPI`/_ui/v1/execution-environments/registries/${remoteRegistryId}/`,
       remoteRegistry

--- a/frontend/hub/administration/remote-registries/RemoteRegistryForm.tsx
+++ b/frontend/hub/administration/remote-registries/RemoteRegistryForm.tsx
@@ -124,7 +124,7 @@ export function EditRemoteRegistry() {
   const params = useParams<{ id: string }>();
   const name = params.id;
   const { data, error, refresh } = useGet<HubItemsResponse<RemoteRegistryProps>>(
-    hubAPI`/_ui/v1/execution-environments/registries/?name=${name ?? ''}`
+    hubAPI`/_ui/v1/execution-environments/registries/?name=${name}`
   );
   const getPageUrl = useGetPageUrl();
   if (error) return <HubError error={error} handleRefresh={refresh} />;

--- a/frontend/hub/administration/remote-registries/hooks/useDeleteRemoteRegistries.tsx
+++ b/frontend/hub/administration/remote-registries/hooks/useDeleteRemoteRegistries.tsx
@@ -30,9 +30,9 @@ export function useDeleteRemoteRegistries(onComplete: (remoteRegistry: RemoteReg
       ],
       actionFn: async (remoteRegistry: RemoteRegistry, signal: AbortSignal) =>
         await hubAPIDelete(
-          hubAPI`/_ui/v1/execution-environments/registries/${
-            parsePulpIDFromURL(remoteRegistry.pulp_href) || ''
-          }/`,
+          hubAPI`/_ui/v1/execution-environments/registries/${parsePulpIDFromURL(
+            remoteRegistry.pulp_href
+          )}/`,
           signal
         ),
     });

--- a/frontend/hub/administration/remotes/RemoteDetails.tsx
+++ b/frontend/hub/administration/remotes/RemoteDetails.tsx
@@ -51,9 +51,7 @@ export function RemoteDetails() {
     data: remotesData,
     error: errorRemotes,
     refresh: refreshRemotes,
-  } = useGet<PulpItemsResponse<IRemotes>>(
-    pulpAPI`/remotes/ansible/collection/?name=${params.id || ''}`
-  );
+  } = useGet<PulpItemsResponse<IRemotes>>(pulpAPI`/remotes/ansible/collection/?name=${params.id}`);
   const remote = remotesData?.results?.[0];
   const remoteHref = remote?.pulp_href;
 

--- a/frontend/hub/administration/remotes/RemoteForm.tsx
+++ b/frontend/hub/administration/remotes/RemoteForm.tsx
@@ -224,7 +224,7 @@ export function EditRemote() {
   const name = params.id;
 
   const { data, error, refresh } = useGet<PulpItemsResponse<RemoteFormProps>>(
-    pulpAPI`/remotes/ansible/collection/?name=${name ?? ''}`
+    pulpAPI`/remotes/ansible/collection/?name=${name}`
   );
 
   const getPageUrl = useGetPageUrl();
@@ -247,7 +247,7 @@ export function EditRemote() {
       delete updatedRemote.requirements_file;
     }
     await hubAPIPut<RemoteFormProps>(
-      pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(modifiedRemote.pulp_href) ?? ''}/`,
+      pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(modifiedRemote.pulp_href)}/`,
       updatedRemote
     );
     navigate(-1);

--- a/frontend/hub/administration/remotes/RemoteForm.tsx
+++ b/frontend/hub/administration/remotes/RemoteForm.tsx
@@ -247,7 +247,7 @@ export function EditRemote() {
       delete updatedRemote.requirements_file;
     }
     await hubAPIPut<RemoteFormProps>(
-      pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(modifiedRemote.pulp_href) ?? ''}`,
+      pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(modifiedRemote.pulp_href) ?? ''}/`,
       updatedRemote
     );
     navigate(-1);

--- a/frontend/hub/administration/remotes/hooks/useDeleteRemotes.tsx
+++ b/frontend/hub/administration/remotes/hooks/useDeleteRemotes.tsx
@@ -28,7 +28,7 @@ export function useDeleteRemotes(onComplete: (remotes: IRemotes[]) => void) {
       alertPrompts: [t('This will also delete all associated resources under this remote.')],
       actionFn: async (remote: IRemotes, signal: AbortSignal) =>
         await hubAPIDelete(
-          pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(remote.pulp_href) || ''}/`,
+          pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(remote.pulp_href)}/`,
           signal
         ),
     });

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
@@ -18,7 +18,7 @@ export function RepositoryCollectionVersion() {
   const { repo_id } = useOutletContext<{ id: string; repo_id: string }>();
   const tableColumns = useCollectionColumns();
   const view = useHubView<CollectionVersionSearch>({
-    url: hubAPI`/v3/plugin/ansible/search/collection-versions`,
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
     keyFn: collectionKeyFn,
     defaultSort: 'name',
     queryParams: {

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -30,9 +30,7 @@ export function RepositoryDetails() {
     params.id ? pulpAPI`/distributions/ansible/ansible/?name=${params.id}` : ''
   );
   const { data: remoteData, error: remoteError } = useGet<Task>(
-    params.id
-      ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote || '')}/`
-      : ''
+    params.id ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote)}/` : ''
   );
 
   if (distroError || remoteError)

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -31,7 +31,7 @@ export function RepositoryDetails() {
   );
   const { data: remoteData, error: remoteError } = useGet<Task>(
     params.id
-      ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote || '') || ''}`
+      ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote || '') || ''}/`
       : ''
   );
 

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -31,7 +31,7 @@ export function RepositoryDetails() {
   );
   const { data: remoteData, error: remoteError } = useGet<Task>(
     params.id
-      ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote || '') || ''}/`
+      ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote || '')}/`
       : ''
   );
 

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryPage.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryPage.tsx
@@ -42,7 +42,7 @@ export function RepositoryPage() {
   ];
 
   const repository = data?.results.length > 0 ? data?.results[0] : undefined;
-  const repo_id: string = parsePulpIDFromURL(repository ? repository.pulp_href : '') || '';
+  const repo_id: string = parsePulpIDFromURL(repository?.pulp_href) || '';
   return (
     <>
       <PageLayout>

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
@@ -39,7 +39,7 @@ export function RepositoryVersions() {
   );
 
   const view = useHubView<RepositoryVersion>({
-    url: pulpAPI`/repositories/ansible/ansible/${repo_id}/versions`,
+    url: pulpAPI`/repositories/ansible/ansible/${repo_id}/versions/`,
     keyFn: (repo) => repo.number,
     queryParams: {
       offset: '0',

--- a/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionDetails.tsx
@@ -14,7 +14,7 @@ export function RepositoryVersionDetails() {
   const params = useParams<{ id: string; version: string }>();
   const { data, error, refresh } = useGet<PulpItemsResponse<CollectionVersion>>(
     params.id
-      ? pulpAPI`/repositories/ansible/ansible/${repo_id}/versions/?number=${params.version || ''}`
+      ? pulpAPI`/repositories/ansible/ansible/${repo_id}/versions/?number=${params.version}`
       : ''
   );
   if (error) return <HubError error={error} handleRefresh={refresh} />;

--- a/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionPage.tsx
+++ b/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionPage.tsx
@@ -21,7 +21,7 @@ export function RepositoryVersionPage() {
   if (!data) return <LoadingPage breadcrumbs tabs />;
 
   const repository = data?.results.length > 0 ? data?.results[0] : undefined;
-  const repo_id: string = parsePulpIDFromURL(repository ? repository.pulp_href : '') || '';
+  const repo_id: string = parsePulpIDFromURL(repository?.pulp_href) || '';
   return (
     <>
       <PageLayout>

--- a/frontend/hub/administration/repositories/hooks/useDeleteRepositories.tsx
+++ b/frontend/hub/administration/repositories/hooks/useDeleteRepositories.tsx
@@ -29,7 +29,7 @@ export function useDeleteRepositories(onComplete?: (collections: Repository[]) =
       alertPrompts: [t('This will also delete all associated resources under this repositories.')],
       actionFn: async (repository: Repository, signal: AbortSignal) =>
         await hubAPIDelete(
-          pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(repository.pulp_href) || ''}/`,
+          pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(repository.pulp_href)}/`,
           signal
         ),
     });

--- a/frontend/hub/administration/repositories/hooks/useDeleteRepositories.tsx
+++ b/frontend/hub/administration/repositories/hooks/useDeleteRepositories.tsx
@@ -29,7 +29,7 @@ export function useDeleteRepositories(onComplete?: (collections: Repository[]) =
       alertPrompts: [t('This will also delete all associated resources under this repositories.')],
       actionFn: async (repository: Repository, signal: AbortSignal) =>
         await hubAPIDelete(
-          pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(repository.pulp_href) || ''}`,
+          pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(repository.pulp_href) || ''}/`,
           signal
         ),
     });

--- a/frontend/hub/administration/tasks/Tasks.cy.tsx
+++ b/frontend/hub/administration/tasks/Tasks.cy.tsx
@@ -7,7 +7,7 @@ describe('Tasks List', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: pulpAPI`/tasks/*`,
+        url: pulpAPI`/tasks/` + '*',
       },
       {
         fixture: 'tasks.json',
@@ -32,7 +32,7 @@ describe('Tasks List', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: pulpAPI`/tasks/*`,
+        url: pulpAPI`/tasks/` + '*',
       },
       {
         statusCode: 500,

--- a/frontend/hub/administration/tasks/hooks/useTasksToolbarActions.tsx
+++ b/frontend/hub/administration/tasks/hooks/useTasksToolbarActions.tsx
@@ -75,7 +75,7 @@ export function useStopTasks(onComplete?: (tasks: Task[]) => void) {
 }
 
 function stopRunningTask(task: Task) {
-  return requestPatch(pulpAPI`/tasks/${parsePulpIDFromURL(task.pulp_href) || ''}/`, {
+  return requestPatch(pulpAPI`/tasks/${parsePulpIDFromURL(task.pulp_href)}/`, {
     state: 'canceled',
   });
 }

--- a/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDependencies.tsx
@@ -46,7 +46,7 @@ export function CollectionDependencies() {
         const name = strings[1];
 
         const result = await requestGet<HubItemsResponse<CollectionVersionSearch>>(
-          hubAPI`/v3/plugin/ansible/search/collection-versions?namespace=${namespace}&name=${name}`
+          hubAPI`/v3/plugin/ansible/search/collection-versions/?namespace=${namespace}&name=${name}`
         );
 
         // select the first repo

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -62,9 +62,8 @@ export function CollectionPage() {
   );
 
   const collectionRequest = useGet<HubItemsResponse<CollectionVersionSearch>>(
-    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name || ''}&namespace=${
-      namespace || ''
-    }&repository_name=${repository || ''}` + queryFilter
+    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}` +
+      queryFilter
   );
 
   const collection =
@@ -90,12 +89,9 @@ export function CollectionPage() {
 
       async function load() {
         const data = await requestGet<HubItemsResponse<CollectionVersionSearch>>(
-          hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name || ''}&namespace=${
-            namespace || ''
-          }&repository_name=${repository || ''}&order_by=-version&offset=${(
-            pageSize *
-            (page - 1)
-          ).toString()}&limit=${pageSize.toString()}`
+          hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}&order_by=-version&offset=${
+            pageSize * (page - 1)
+          }&limit=${pageSize}`
         );
 
         return {

--- a/frontend/hub/collections/Collections.tsx
+++ b/frontend/hub/collections/Collections.tsx
@@ -16,7 +16,7 @@ export function Collections() {
   const toolbarFilters = useCollectionFilters();
   const tableColumns = useCollectionColumns();
   const view = useHubView<CollectionVersionSearch>({
-    url: hubAPI`/v3/plugin/ansible/search/collection-versions`,
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
     keyFn: collectionKeyFn,
     queryParams: {
       is_deprecated: 'false',

--- a/frontend/hub/collections/UploadCollection.tsx
+++ b/frontend/hub/collections/UploadCollection.tsx
@@ -172,7 +172,7 @@ export function UploadCollectionByFile() {
 
   async function submitData(data: UploadData) {
     const list = await distroGetRequest(
-      pulpAPI`/distributions/ansible/ansible/?repository=${selectedRepo?.pulp_href || ''}`
+      pulpAPI`/distributions/ansible/ansible/?repository=${selectedRepo?.pulp_href}`
     );
     const base_path = list?.results[0]?.base_path;
 

--- a/frontend/hub/collections/hooks/useCollectionVersionSelector.tsx
+++ b/frontend/hub/collections/hooks/useCollectionVersionSelector.tsx
@@ -29,7 +29,7 @@ function useParameters(
     toolbarFilters,
     useView: useHubView,
     viewParams: {
-      url: hubAPI`/v3/plugin/ansible/search/collection-versions`,
+      url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
       toolbarFilters,
       tableColumns,
       disableQueryString: true,

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -81,9 +81,7 @@ function CopyToRepositoryModal(props: {
   useEffect(() => {
     async function getSelected() {
       const repos = await request(
-        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${
-          collection.collection_version?.name || ''
-        }&version=${collection.collection_version?.version || ''}`
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${collection.collection_version?.name}&version=${collection.collection_version?.version}`
       );
 
       if (repos.data?.length > 0) {
@@ -262,5 +260,5 @@ export async function copyToRepositoryAction(
     copy: 'copy_collection_version',
   }[operation];
 
-  await hubAPIPost(pulpAPI`/repositories/ansible/ansible/${pulpId || ''}/${api_op}/`, params);
+  await hubAPIPost(pulpAPI`/repositories/ansible/ansible/${pulpId}/${api_op}/`, params);
 }

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -81,7 +81,7 @@ function CopyToRepositoryModal(props: {
   useEffect(() => {
     async function getSelected() {
       const repos = await request(
-        hubAPI`/v3/plugin/ansible/search/collection-versions?limit=100&name=${
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${
           collection.collection_version?.name || ''
         }&version=${collection.collection_version?.version || ''}`
       );

--- a/frontend/hub/collections/hooks/useDeleteCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollections.tsx
@@ -80,7 +80,7 @@ async function deleteCollection(
   signal: AbortSignal
 ) {
   const distro: PulpItemsResponse<Distribution> = await requestGet(
-    pulpAPI`/distributions/ansible/ansible/?repository=${collection?.repository?.pulp_href || ''}`
+    pulpAPI`/distributions/ansible/ansible/?repository=${collection?.repository?.pulp_href}`
   );
 
   let versionQuery = '';

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -117,9 +117,9 @@ async function deleteCollectionFromRepository(
   }
 
   const res: { task: string } = await postRequest(
-    pulpAPI`/repositories/ansible/ansible/${
-      parsePulpIDFromURL(collection.repository.pulp_href) || ''
-    }/modify/`,
+    pulpAPI`/repositories/ansible/ansible/${parsePulpIDFromURL(
+      collection.repository.pulp_href
+    )}/modify/`,
     {
       remove_content_units: itemsToDelete,
       base_version: collection.repository.latest_version_href,

--- a/frontend/hub/collections/hooks/useDeprecateCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeprecateCollections.tsx
@@ -44,7 +44,7 @@ export function useDeprecateCollections(
 
 async function deprecateCollection(collection: CollectionVersionSearch) {
   const distro: PulpItemsResponse<Distribution> = await requestGet(
-    pulpAPI`/distributions/ansible/ansible/?repository=${collection.repository?.pulp_href || ''}`
+    pulpAPI`/distributions/ansible/ansible/?repository=${collection.repository?.pulp_href}`
   );
   return requestPatch(
     hubAPI`/v3/plugin/ansible/content/${distro.results[0].base_path}/collections/index/${

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -73,7 +73,7 @@ export function CollectionMultiSelectDialog(props: {
     [t]
   );
   const view = useHubView<CollectionVersionSearch>({
-    url: hubAPI`/v3/plugin/ansible/search/collection-versions`,
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
     keyFn: collectionKeyFn,
     queryParams: {
       is_deprecated: 'false',

--- a/frontend/hub/common/api/README.md
+++ b/frontend/hub/common/api/README.md
@@ -24,7 +24,7 @@ For `GET` actions, it's recommended to utilize the hooks from the framework. The
 ```
 import { useGet } from '@frontend/common/crud/useGet';
 
-const { data, error, isLoading, refresh } = useGet<MyType>(hubAPI`/url`);
+const { data, error, isLoading, refresh } = useGet<MyType>(hubAPI`/url/`);
 ```
 
 When you need to deal with a more complex set of requests, there's also `useGetFn`, which allows firing multiple requests in parallel or depending on each other.
@@ -35,8 +35,8 @@ import { useGetFn } from '@frontend/hub/useGetFn';
 
 const { data, error, isLoading, refresh } = useGetFn<MyType>('unique-identifier-for-caching',
   (signal: AbortSignal) => Promise.all([
-    requestGet(hubAPI`/url1`, signal),
-    requestGet(hubAPI`/url2`, signal),
+    requestGet(hubAPI`/url1/`, signal),
+    requestGet(hubAPI`/url2/`, signal),
   ]).then(([data1, data2]) => Promise.all([
     data1,
     data2,

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -1,5 +1,22 @@
 import { hubQueryString, url2keys } from './query-string';
 
+// used in awx, eda & cypress
+export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
+  if (strings[0]?.[0] !== '/') {
+    throw new Error(`Invalid URL - must start with a slash`);
+  }
+
+  let url = '';
+  strings.forEach((fragment, index) => {
+    url += fragment;
+    if (index !== strings.length - 1) {
+      url += encodeURIComponent(`${values.shift() ?? ''}`);
+    }
+  });
+
+  return url;
+}
+
 function checkParam(url: string, good: string, bad: string) {
   if (url.includes(`?${bad}=`) || url.includes(`&${bad}=`)) {
     throw new Error(`Invalid param - use "${good}", not "${bad}" (url: ${url})`);
@@ -7,7 +24,7 @@ function checkParam(url: string, good: string, bad: string) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function apiTag(strings: TemplateStringsArray, ...values: any[]) {
+function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
   if (strings[0]?.[0] !== '/') {
     throw new Error(`Invalid URL - must start with a slash`);
   }
@@ -82,11 +99,11 @@ if (base.endsWith('/')) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  return base + apiTag(strings, ...values);
+  return base + hubApiTag(strings, ...values);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function pulpAPI(strings: TemplateStringsArray, ...values: any[]) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  return base + '/pulp/api/v3' + apiTag(strings, ...values);
+  return base + '/pulp/api/v3' + hubApiTag(strings, ...values);
 }

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -23,8 +23,10 @@ function checkParam(url: string, good: string, bad: string) {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
+type SimpleValue = string | number | boolean | null | undefined;
+type ParamsValue = SimpleValue | Record<string, SimpleValue>;
+
+function hubApiTag(strings: TemplateStringsArray, ...values: ParamsValue[]) {
   if (strings[0]?.[0] !== '/') {
     throw new Error(`Invalid URL - must start with a slash`);
   }
@@ -33,13 +35,12 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
   strings.forEach((fragment, index) => {
     url += fragment;
     if (index !== strings.length - 1) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const next = values.shift();
       if (next && typeof next === 'object' && (fragment.endsWith('?') || fragment.endsWith('&'))) {
         // ?${obj} or &${obj} will transform a params object to a query string
         url += hubQueryString(url, next as Record<string, string | number | boolean>).slice(1);
       } else {
-        url += encodeURIComponent(`${next ?? ''}`);
+        url += encodeURIComponent(`${(next as SimpleValue) ?? ''}`);
       }
     }
   });
@@ -92,22 +93,18 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
   return url;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
+export function hubAPI(strings: TemplateStringsArray, ...values: ParamsValue[]) {
   const base = process.env.HUB_API_PREFIX;
   if (base && base.endsWith('/')) {
     throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + hubApiTag(strings, ...values);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function pulpAPI(strings: TemplateStringsArray, ...values: any[]) {
+export function pulpAPI(strings: TemplateStringsArray, ...values: ParamsValue[]) {
   const base = process.env.HUB_API_PREFIX;
   if (base && base.endsWith('/')) {
     throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + '/pulp/api/v3' + hubApiTag(strings, ...values);
 }

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -94,7 +94,7 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
   const base = process.env.HUB_API_PREFIX;
-  if (base.endsWith('/')) {
+  if (base && base.endsWith('/')) {
     throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -104,7 +104,7 @@ export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function pulpAPI(strings: TemplateStringsArray, ...values: any[]) {
   const base = process.env.HUB_API_PREFIX;
-  if (base.endsWith('/')) {
+  if (base && base.endsWith('/')) {
     throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -1,3 +1,11 @@
+import { url2keys } from './query-string';
+
+function checkParam(url: string, good: string, bad: string) {
+  if (url.includes(`?${bad}=`) || url.includes(`&${bad}=`)) {
+    throw new Error(`Invalid param - use "${good}", not "${bad}"`);
+  }
+}
+
 export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   if (strings[0]?.[0] !== '/') {
     throw new Error('Invalid URL - must start with a slash');
@@ -25,6 +33,35 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
 
   if (url.indexOf('?') !== url.lastIndexOf('?')) {
     throw new Error('Invalid URL - multiple "?"');
+  }
+
+  if (url.includes('?')) {
+    const { pageKey, sortKey } = url2keys(url);
+
+    if (pageKey === 'page') {
+      checkParam(url, 'page', 'offset');
+      checkParam(url, 'page_size', 'limit');
+    }
+
+    if (pageKey === 'offset') {
+      checkParam(url, 'offset', 'page');
+      checkParam(url, 'limit', 'page_size');
+    }
+
+    if (sortKey === 'sort') {
+      checkParam(url, sortKey, 'ordering');
+      checkParam(url, sortKey, 'order_by');
+    }
+
+    if (sortKey === 'ordering') {
+      checkParam(url, sortKey, 'sort');
+      checkParam(url, sortKey, 'order_by');
+    }
+
+    if (sortKey === 'order_by') {
+      checkParam(url, sortKey, 'sort');
+      checkParam(url, sortKey, 'ordering');
+    }
   }
 
   return url;

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -91,7 +91,6 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
   return url;
 }
 
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
   const base = process.env.HUB_API_PREFIX;

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -1,6 +1,6 @@
 export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   if (strings[0]?.[0] !== '/') {
-    throw new Error('Invalid URL');
+    throw new Error('Invalid URL - must start with a slash');
   }
 
   let url = '';
@@ -11,15 +11,34 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
     }
   });
 
+  if (url.includes('//')) {
+    throw new Error('Invalid URL - must not contain a double slash');
+  }
+
+  if (!url.includes('/?') && !url.endsWith('/')) {
+    throw new Error(
+      url.includes('?')
+        ? 'Invalid URL - missing slash before "?"'
+        : 'Invalid URL - must end with a slash'
+    );
+  }
+
+  if (url.indexOf('?') !== url.lastIndexOf('?')) {
+    throw new Error('Invalid URL - multiple "?"');
+  }
+
   return url;
 }
 
+const base = process.env.HUB_API_PREFIX;
+if (base.endsWith('/')) {
+  throw new Error('Invalid HUB_API_PREFIX - must NOT end with a slash');
+}
+
 export function hubAPI(strings: TemplateStringsArray, ...values: string[]) {
-  const base = process.env.HUB_API_PREFIX;
   return base + apiTag(strings, ...values);
 }
 
 export function pulpAPI(strings: TemplateStringsArray, ...values: string[]) {
-  const base = process.env.HUB_API_PREFIX;
   return base + '/pulp/api/v3' + apiTag(strings, ...values);
 }

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -35,7 +35,8 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
     if (index !== strings.length - 1) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const next = values.shift();
-      if (next && typeof next === 'object' && fragment.endsWith('?')) {
+      if (next && typeof next === 'object' && (fragment.endsWith('?') || fragment.endsWith('&'))) {
+        // ?${obj} or &${obj} will transform a params object to a query string
         url += hubQueryString(url, next as Record<string, string | number | boolean>).slice(1);
       } else {
         url += encodeURIComponent(`${next ?? ''}`);

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -1,4 +1,4 @@
-import { url2keys } from './query-string';
+import { hubQueryString, url2keys } from './query-string';
 
 function checkParam(url: string, good: string, bad: string) {
   if (url.includes(`?${bad}=`) || url.includes(`&${bad}=`)) {
@@ -6,7 +6,8 @@ function checkParam(url: string, good: string, bad: string) {
   }
 }
 
-export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function apiTag(strings: TemplateStringsArray, ...values: any[]) {
   if (strings[0]?.[0] !== '/') {
     throw new Error(`Invalid URL - must start with a slash`);
   }
@@ -15,7 +16,13 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   strings.forEach((fragment, index) => {
     url += fragment;
     if (index !== strings.length - 1) {
-      url += encodeURIComponent(`${values.shift() ?? ''}`);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const next = values.shift();
+      if (next && typeof next === 'object' && fragment.endsWith('?')) {
+        url += hubQueryString(url, next as Record<string, string | number | boolean>).slice(1);
+      } else {
+        url += encodeURIComponent(`${next ?? ''}`);
+      }
     }
   });
 
@@ -72,10 +79,14 @@ if (base.endsWith('/')) {
   throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
 }
 
-export function hubAPI(strings: TemplateStringsArray, ...values: string[]) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + apiTag(strings, ...values);
 }
 
-export function pulpAPI(strings: TemplateStringsArray, ...values: string[]) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function pulpAPI(strings: TemplateStringsArray, ...values: any[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + '/pulp/api/v3' + apiTag(strings, ...values);
 }

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -91,19 +91,23 @@ function hubApiTag(strings: TemplateStringsArray, ...values: any[]) {
   return url;
 }
 
-const base = process.env.HUB_API_PREFIX;
-if (base.endsWith('/')) {
-  throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hubAPI(strings: TemplateStringsArray, ...values: any[]) {
+  const base = process.env.HUB_API_PREFIX;
+  if (base.endsWith('/')) {
+    throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
+  }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + hubApiTag(strings, ...values);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function pulpAPI(strings: TemplateStringsArray, ...values: any[]) {
+  const base = process.env.HUB_API_PREFIX;
+  if (base.endsWith('/')) {
+    throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
+  }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return base + '/pulp/api/v3' + hubApiTag(strings, ...values);
 }

--- a/frontend/hub/common/api/formatPath.tsx
+++ b/frontend/hub/common/api/formatPath.tsx
@@ -2,13 +2,13 @@ import { url2keys } from './query-string';
 
 function checkParam(url: string, good: string, bad: string) {
   if (url.includes(`?${bad}=`) || url.includes(`&${bad}=`)) {
-    throw new Error(`Invalid param - use "${good}", not "${bad}"`);
+    throw new Error(`Invalid param - use "${good}", not "${bad}" (url: ${url})`);
   }
 }
 
 export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   if (strings[0]?.[0] !== '/') {
-    throw new Error('Invalid URL - must start with a slash');
+    throw new Error(`Invalid URL - must start with a slash`);
   }
 
   let url = '';
@@ -20,19 +20,19 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
   });
 
   if (url.includes('//')) {
-    throw new Error('Invalid URL - must not contain a double slash');
+    throw new Error(`Invalid URL - must not contain a double slash (url: ${url})`);
   }
 
   if (!url.includes('/?') && !url.endsWith('/')) {
     throw new Error(
       url.includes('?')
-        ? 'Invalid URL - missing slash before "?"'
-        : 'Invalid URL - must end with a slash'
+        ? `Invalid URL - missing slash before "?" (url: ${url})`
+        : `Invalid URL - must end with a slash (url: ${url})`
     );
   }
 
   if (url.indexOf('?') !== url.lastIndexOf('?')) {
-    throw new Error('Invalid URL - multiple "?"');
+    throw new Error(`Invalid URL - multiple "?" (url: ${url})`);
   }
 
   if (url.includes('?')) {
@@ -69,7 +69,7 @@ export function apiTag(strings: TemplateStringsArray, ...values: string[]) {
 
 const base = process.env.HUB_API_PREFIX;
 if (base.endsWith('/')) {
-  throw new Error('Invalid HUB_API_PREFIX - must NOT end with a slash');
+  throw new Error(`Invalid HUB_API_PREFIX - must NOT end with a slash`);
 }
 
 export function hubAPI(strings: TemplateStringsArray, ...values: string[]) {

--- a/frontend/hub/common/api/hub-api-utils.tsx
+++ b/frontend/hub/common/api/hub-api-utils.tsx
@@ -259,7 +259,7 @@ export async function waitForTask(
   try {
     while (retries > 0) {
       await new Promise((resolve) => setTimeout(resolve, currentDelay));
-      const { response } = await getHubRequest<Task>(pulpAPI`/tasks/${taskHref}`, signal);
+      const { response } = await getHubRequest<Task>(pulpAPI`/tasks/${taskHref}/`, signal);
       const task = response as Task;
 
       if (task && successStatus.includes(task.state)) {

--- a/frontend/hub/common/api/hub-api-utils.tsx
+++ b/frontend/hub/common/api/hub-api-utils.tsx
@@ -103,7 +103,11 @@ export function getQueryString(queryParams: QueryParams) {
 
 const UUIDRegEx = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/i;
 
-export function parsePulpIDFromURL(url: string): string | null {
+export function parsePulpIDFromURL(url: string | undefined | null): string | null {
+  if (!url) {
+    return null;
+  }
+
   for (const section of url.split('/')) {
     if (section.match(UUIDRegEx)) {
       return section;

--- a/frontend/hub/common/api/query-string.ts
+++ b/frontend/hub/common/api/query-string.ts
@@ -1,0 +1,33 @@
+const sortKeys = {
+  '/pulp/api/v3/': 'ordering',
+  '/pulp/api/v3/pulp_container/namespaces/': 'sort',
+  '/v1/imports/': 'order_by',
+  '/v1/roles/': 'order_by',
+  '/_ui/v1/': 'sort',
+  '/v3/plugin/ansible/search/collection-versions/': 'order_by',
+};
+
+const pageKeys = {
+  '/v1/imports/': 'page',
+  '/v1/namespaces/': 'page',
+  '/v1/roles/': 'page',
+  '/_ui/v1/': 'offset',
+};
+
+export function url2keys(url: string): { sortKey: string; pageKey: string } {
+  let sortKey = 'sort';
+  Object.entries(sortKeys).forEach(([k, v]) => {
+    if (url.includes(k)) {
+      sortKey = v;
+    }
+  });
+
+  let pageKey = 'offset';
+  Object.entries(pageKeys).forEach(([k, v]) => {
+    if (url.includes(k)) {
+      pageKey = v;
+    }
+  });
+
+  return { pageKey, sortKey };
+}

--- a/frontend/hub/common/api/query-string.ts
+++ b/frontend/hub/common/api/query-string.ts
@@ -1,3 +1,5 @@
+import { normalizeQueryString } from '../../../common/crud/normalizeQueryString';
+
 const sortKeys = {
   '/pulp/api/v3/': 'ordering',
   '/pulp/api/v3/pulp_container/namespaces/': 'sort',
@@ -30,4 +32,37 @@ export function url2keys(url: string): { sortKey: string; pageKey: string } {
   });
 
   return { pageKey, sortKey };
+}
+
+export function hubQueryString(url: string, params: Record<string, string | number | boolean>) {
+  const { pageKey, sortKey } = url2keys(url);
+  const newParams: Record<string, string> = {};
+  const limitKey = { page: 'page_size', offset: 'limit' }[pageKey] as string;
+  const limit = (params.page_size || params.limit || 10) as number;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Object.entries(params || {}).forEach(([k, v]: [string, any]) => {
+    if (['page', 'offset'].includes(k) && pageKey !== k) {
+      if (k === 'offset' && pageKey === 'page') {
+        v = ~~(v / limit);
+      }
+      if (k === 'page' && pageKey === 'offset') {
+        v *= limit;
+      }
+      k = pageKey;
+    }
+
+    if (['page_size', 'limit'].includes(k) && limitKey !== k) {
+      k = limitKey;
+    }
+
+    if (['sort', 'ordering', 'order_by'].includes(k) && sortKey !== k) {
+      k = sortKey;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    newParams[k] = encodeURIComponent(v);
+  });
+
+  return normalizeQueryString(newParams);
 }

--- a/frontend/hub/common/api/query-string.ts
+++ b/frontend/hub/common/api/query-string.ts
@@ -44,10 +44,10 @@ export function hubQueryString(url: string, params: Record<string, string | numb
   Object.entries(params || {}).forEach(([k, v]: [string, any]) => {
     if (['page', 'offset'].includes(k) && pageKey !== k) {
       if (k === 'offset' && pageKey === 'page') {
-        v = ~~(v / limit);
+        v = 1 + ~~(v / limit);
       }
       if (k === 'page' && pageKey === 'offset') {
-        v *= limit;
+        v = (v - 1) * limit;
       }
       k = pageKey;
     }

--- a/frontend/hub/common/useHubView.tsx
+++ b/frontend/hub/common/useHubView.tsx
@@ -11,6 +11,7 @@ import {
 import { useFetcher } from '../../common/crud/Data';
 import { RequestError } from '../../common/crud/RequestError';
 import { QueryParams, getQueryString, serverlessURL } from './api/hub-api-utils';
+import { url2keys } from './api/query-string';
 
 export interface HubItemsResponse<T extends object> {
   meta: {
@@ -60,40 +61,6 @@ function deconstruct<T extends object>(
       pageItems: data?.results,
     };
   }
-}
-
-const sortKeys = {
-  '/pulp/api/v3/': 'ordering',
-  '/pulp/api/v3/pulp_container/namespaces/': 'sort',
-  '/v1/imports/': 'order_by',
-  '/v1/roles/': 'order_by',
-  '/_ui/v1/': 'sort',
-  '/v3/plugin/ansible/search/collection-versions/': 'order_by',
-};
-
-const pageKeys = {
-  '/v1/imports/': 'page',
-  '/v1/namespaces/': 'page',
-  '/v1/roles/': 'page',
-  '/_ui/v1/': 'offset',
-};
-
-function url2keys(url: string): { sortKey: string; pageKey: string } {
-  let sortKey = 'sort';
-  Object.entries(sortKeys).forEach(([k, v]) => {
-    if (url.includes(k)) {
-      sortKey = v;
-    }
-  });
-
-  let pageKey = 'offset';
-  Object.entries(pageKeys).forEach(([k, v]) => {
-    if (url.includes(k)) {
-      pageKey = v;
-    }
-  });
-
-  return { pageKey, sortKey };
 }
 
 export function useHubView<T extends object>({

--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -50,7 +50,7 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
   const [tagsSet, setTagsSet] = useState<boolean>(false);
 
   const registry = useGet<HubItemsResponse<Registry>>(
-    hubAPI`/_ui/v1/execution-environments/registries/?page_size=${page_size.toString()}`
+    hubAPI`/_ui/v1/execution-environments/registries/?page_size=${page_size}`
   );
 
   const eeUrl =

--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -50,7 +50,7 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
   const [tagsSet, setTagsSet] = useState<boolean>(false);
 
   const registry = useGet<HubItemsResponse<Registry>>(
-    hubAPI`/_ui/v1/execution-environments/registries?page_size=${page_size.toString()}`
+    hubAPI`/_ui/v1/execution-environments/registries/?page_size=${page_size.toString()}`
   );
 
   const eeUrl =

--- a/frontend/hub/execution-environments/hooks/useRegistrySelector.tsx
+++ b/frontend/hub/execution-environments/hooks/useRegistrySelector.tsx
@@ -20,7 +20,7 @@ function useParameters(): AsyncSelectFilterBuilderProps<Registry> {
     toolbarFilters,
     useView: useHubView,
     viewParams: {
-      url: hubAPI`/_ui/v1/execution-environments/registries`,
+      url: hubAPI`/_ui/v1/execution-environments/registries/`,
       toolbarFilters,
       tableColumns,
       disableQueryString: true,

--- a/frontend/hub/namespaces/HubNamespaceForm.tsx
+++ b/frontend/hub/namespaces/HubNamespaceForm.tsx
@@ -61,11 +61,11 @@ export function EditHubNamespace() {
     data: namespace,
     error,
     refresh,
-  } = useGet<HubNamespace>(hubAPI`/_ui/v1/my-namespaces/${name ?? ''}/`);
+  } = useGet<HubNamespace>(hubAPI`/_ui/v1/my-namespaces/${name}/`);
   const putRequest = usePutRequest<HubNamespace, HubNamespace>();
   const onSubmit: PageFormSubmitHandler<HubNamespace> = async (namespace) => {
-    await putRequest(hubAPI`/_ui/v1/my-namespaces/${name ?? ''}/`, namespace);
-    clearCacheByKey(hubAPI`/_ui/v1/my-namespaces/${name ?? ''}/`);
+    await putRequest(hubAPI`/_ui/v1/my-namespaces/${name}/`, namespace);
+    clearCacheByKey(hubAPI`/_ui/v1/my-namespaces/${name}/`);
     navigate(-1);
   };
   const getPageUrl = useGetPageUrl();

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespaceDetails.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespaceDetails.tsx
@@ -14,9 +14,7 @@ export function HubNamespaceDetails() {
     data: response,
     error,
     refresh,
-  } = useGet<HubItemsResponse<HubNamespace>>(
-    hubAPI`/_ui/v1/namespaces/?limit=1&name=${params.id ?? ''}`
-  );
+  } = useGet<HubItemsResponse<HubNamespace>>(hubAPI`/_ui/v1/namespaces/?limit=1&name=${params.id}`);
   const tableColumns = useHubNamespacesColumns();
 
   if (!response || !response.data || (response.data.length === 0 && !error)) {

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespacePage.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespacePage.tsx
@@ -23,7 +23,7 @@ export function HubNamespacePage() {
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
   const { data, error, refresh } = useGet<HubItemsResponse<HubNamespace>>(
-    hubAPI`/_ui/v1/namespaces/?limit=1&name=${params.id ?? ''}`
+    hubAPI`/_ui/v1/namespaces/?limit=1&name=${params.id}`
   );
 
   let namespace: HubNamespace | undefined = undefined;

--- a/frontend/hub/overview/CollectionCategories.tsx
+++ b/frontend/hub/overview/CollectionCategories.tsx
@@ -100,7 +100,7 @@ function getRepoToCollectionPulpHrefsMap(collections: CollectionVersionSearch[])
   const repoToCollectionPulpHrefsMap: { [key: string]: string[] } = {};
 
   collections.forEach((collection) => {
-    const repoPulpId = parsePulpIDFromURL(collection.repository?.pulp_href || '');
+    const repoPulpId = parsePulpIDFromURL(collection.repository?.pulp_href);
     if (repoPulpId) {
       if (!repoToCollectionPulpHrefsMap[repoPulpId]) {
         repoToCollectionPulpHrefsMap[repoPulpId] = [collection.collection_version?.pulp_href || ''];

--- a/frontend/hub/overview/hooks/useCategorizeCollections.tsx
+++ b/frontend/hub/overview/hooks/useCategorizeCollections.tsx
@@ -20,9 +20,7 @@ export function useCategorizeCollections(
     // Maximum of 12 collections displayed per category ordered by time of creation (newest collections appearing first)
     const searchAPIPromises = managedCategories.map((collectionCategory: CollectionCategory) =>
       requestGet<HubItemsResponse<CollectionVersionSearch>>(
-        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=${MAX_NUMBER_OF_COLLECTIONS.toString()}&order_by=-pulp_created&${
-          collectionCategory.searchKey
-        }=${collectionCategory.searchValue}`
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=${MAX_NUMBER_OF_COLLECTIONS}&order_by=-pulp_created&${collectionCategory.searchKey}=${collectionCategory.searchValue}`
       )
     );
     const results = await Promise.allSettled(searchAPIPromises);


### PR DESCRIPTION
Fixes AAH-3007, follows #1408 

`hubAPI` and `pulpAPI` will now throw when any of these happen:
* `HUB_API_PREFIX` ends with a trailing slash
* prefix-relative url doesn't start with a slash (already happening)
* url doesn't end in a slash (end of string or before a ?)
* url contains a double slash
* url contains a double ?
* the wrong param is used based on the url (`page, limit, offset, page_size, sort, ordering, order_by`)

add `hubQueryString` to wrap `normalizeQueryString` and:
* escape values
* convert page/limit/offset/page_size/sort/ordering/sort_by to the right name

allow a `` hubAPI`/foo/?${{ param1: 'abc', param2: 123 }}` `` syntax, calling `hubQueryString`

fixes all instances of `hubAPI` & `pulpAPI` missing a trailing slash

also, this allows us to fix all those `|| ''` and `?? ''` and `as string` in urls

and fix tests

---

In e2e tests, `hubAPI` and `pulpAPI` retain their simpler versions, I'm not sure how to handle the use of `*` wildcards without allowing them in regular code.