### PR TITLE
Hub - update galaxykit to latest

### DIFF
--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -105,7 +105,10 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true' && !inputs.SKIP_JOB
         run: npm ci
       - name: Install galaxykit
-        run: pip3 install galaxykit
+        run: |
+          # pip3 install galaxykit
+          # pending https://github.com/ansible/galaxykit/pull/99
+          pip3 install git+https://github.com/himdel/galaxykit.git@skip-upload
       - name: Cypress
         if: ${{ !inputs.SKIP_JOB }}
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
Update galaxykit to an unreleased version, to get:

https://github.com/ansible/galaxykit/pull/93 - `collection copy`
https://github.com/ansible/galaxykit/pull/94 - `collection upload --path=my_repo_base_path`
https://github.com/ansible/galaxykit/pull/97 - `collection upload --tags=...`
https://github.com/ansible/galaxykit/pull/98 - retry on 504
https://github.com/ansible/galaxykit/pull/99 - `collection upload --skip-upload` and `collection-upload --template=orionutils_template`

cc @akus062381 @acruzgon @ZitaNemeckova @nixocio @MilanPospisil @jerabekjiri @ShaiahWren (I hope I'm not forgetting anyone currently working on tests)

You'll need to `pip3 install --user --upgrade git+https://github.com/himdel/galaxykit.git@skip-upload` to get the same version locally.