### PR TITLE
Fix repo detail

### DIFF
--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -26,12 +26,14 @@ export function RepositoryDetails() {
     results: { name: string; client_url: string }[];
   }>(params.id ? pulpAPI`/distributions/ansible/ansible/?name=${params.id}` : '');
 
-  const { data: remoteData, error: remoteError } = useGet<Task>(
-    params.id ? pulpAPI`/remotes/ansible/collection${parsePulpIDFromURL(repository.remote)}/` : ''
-  );
+  const repoURL = repository.remote
+    ? pulpAPI`/remotes/ansible/collection/${parsePulpIDFromURL(repository.remote)}/`
+    : '';
+  const { data: remoteData, error: remoteError } = useGet<Task>(repoURL);
 
-  if ((!distroData && !distroError) || (!remoteData && !remoteError))
+  if ((!distroData && !distroError) || (!remoteData && !remoteError && repository.remote))
     return <LoadingPage breadcrumbs tabs />;
+
   const distribution: { name: string; client_url: string } | undefined = distroData?.results[0];
 
   return (

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -3,12 +3,12 @@ import { Link, useOutletContext, useParams } from 'react-router-dom';
 import {
   CopyCell,
   LoadingPage,
+  PFColorE,
   PageDetail,
   PageDetails,
   useGetPageUrl,
 } from '../../../../../framework';
 import { useGet } from '../../../../common/crud/useGet';
-import { HubError } from '../../../common/HubError';
 import { pulpAPI } from '../../../common/api/formatPath';
 import { parsePulpIDFromURL } from '../../../common/api/hub-api-utils';
 import { HubRoute } from '../../../main/HubRoutes';
@@ -22,28 +22,30 @@ export function RepositoryDetails() {
   const getPageUrl = useGetPageUrl();
   const { repository } = useOutletContext<{ repository: Repository }>();
 
-  const {
-    data: distroData,
-    error: distroError,
-    refresh,
-  } = useGet<{ results: { name: string; client_url: string }[] }>(
-    params.id ? pulpAPI`/distributions/ansible/ansible/?name=${params.id}` : ''
-  );
+  const { data: distroData, error: distroError } = useGet<{
+    results: { name: string; client_url: string }[];
+  }>(params.id ? pulpAPI`/distributions/ansible/ansible/?name=${params.id}` : '');
+
   const { data: remoteData, error: remoteError } = useGet<Task>(
     params.id ? pulpAPI`/remotes/ansible/collection${parsePulpIDFromURL(repository.remote)}/` : ''
   );
 
-  if (distroError || remoteError)
-    return <HubError error={distroError || remoteError} handleRefresh={refresh} />;
-  if (!distroData || !remoteData) return <LoadingPage breadcrumbs tabs />;
-  const distribution: { name: string; client_url: string } = distroData?.results[0];
+  if ((!distroData && !distroError) || (!remoteData && !remoteError))
+    return <LoadingPage breadcrumbs tabs />;
+  const distribution: { name: string; client_url: string } | undefined = distroData?.results[0];
 
   return (
     <PageDetails>
       <PageDetail label={t('Repository name')}>{params.id}</PageDetail>
       <PageDetail label={t('Description')}>{repository.description || t('None')}</PageDetail>
       <PageDetail label={t('Retained version count')}>{repository.retain_repo_versions}</PageDetail>
-      <PageDetail label={t('Distribution')}>{distribution?.name || t('None')}</PageDetail>
+      <PageDetail label={t('Distribution')}>
+        {distroError ? (
+          <span style={{ color: PFColorE.Red }}>{t('Error loading distribution')}</span>
+        ) : (
+          <>{distribution?.name || t('None')}</>
+        )}
+      </PageDetail>
       <PageDetail label={t('Repository URL')}>
         {distribution?.client_url ? <CopyCell text={distribution.client_url} /> : t('None')}
       </PageDetail>
@@ -52,12 +54,18 @@ export function RepositoryDetails() {
       </PageDetail>
       <PageDetail label={t('Private')}>{repository.private ? t('yes') : t('no')}</PageDetail>
       <PageDetail label={t('Remote')}>
-        {repository.remote ? (
-          <Link to={getPageUrl(HubRoute.RemotePage, { params: { id: remoteData.name } })}>
-            {remoteData.name}
+        {repository.remote && !remoteError ? (
+          <Link to={getPageUrl(HubRoute.RemotePage, { params: { id: remoteData?.name } })}>
+            {remoteData?.name}
           </Link>
         ) : (
-          t('None')
+          <>
+            {remoteError ? (
+              <span style={{ color: PFColorE.Red }}>{t('Error loading remote')}</span>
+            ) : (
+              t('None')
+            )}
+          </>
         )}
       </PageDetail>
     </PageDetails>


### PR DESCRIPTION
Instead of failing the whole detail, when some additional data loading failed (distro and remote), it informs user in the detail, that particular loading failed.

![image](https://github.com/ansible/ansible-ui/assets/23277791/d4717af5-6025-443d-9b53-52c15ee77387)
