### PR TITLE
[AAP-8120] Execution Environments List

### DIFF
--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -180,7 +180,7 @@ export function useExecutionEnvironmentsColumns(options?: {
   const organizationColumn = useOrganizationNameColumn(
     AwxRoute.OrganizationDetails,
     options,
-    'Globally available'
+    t('Globally available')
   );
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -22,9 +22,7 @@ import {
   useOrganizationNameColumn,
 } from '../../../common/columns';
 import {
-  useCreatedByToolbarFilter,
-  useDescriptionToolbarFilter,
-  useModifiedByToolbarFilter,
+  useImageToolbarFilter,
   useNameToolbarFilter,
   useOrganizationToolbarFilter,
 } from '../../common/awx-toolbar-filters';
@@ -151,25 +149,11 @@ export function ExecutionEnvironments() {
 
 export function useExecutionEnvironmentsFilters() {
   const nameToolbarFilter = useNameToolbarFilter();
-  const descriptionToolbarFilter = useDescriptionToolbarFilter();
   const organizationToolbarFilter = useOrganizationToolbarFilter();
-  const createdByToolbarFilter = useCreatedByToolbarFilter();
-  const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const imageToolbarFilter = useImageToolbarFilter();
   const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [
-      nameToolbarFilter,
-      descriptionToolbarFilter,
-      organizationToolbarFilter,
-      createdByToolbarFilter,
-      modifiedByToolbarFilter,
-    ],
-    [
-      nameToolbarFilter,
-      descriptionToolbarFilter,
-      organizationToolbarFilter,
-      createdByToolbarFilter,
-      modifiedByToolbarFilter,
-    ]
+    () => [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter],
+    [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter]
   );
   return toolbarFilters;
 }
@@ -208,6 +192,7 @@ export function useExecutionEnvironmentsColumns(options?: {
       {
         header: t('Image'),
         cell: (executionEnvironment) => executionEnvironment.image,
+        sort: 'image',
       },
       organizationColumn,
       createdColumn,

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -193,7 +193,11 @@ export function useExecutionEnvironmentsColumns(options?: {
   });
   const idColumn = useIdColumn<ExecutionEnvironment>();
   const descriptionColumn = useDescriptionColumn();
-  const organizationColumn = useOrganizationNameColumn(AwxRoute.OrganizationDetails, options);
+  const organizationColumn = useOrganizationNameColumn(
+    AwxRoute.OrganizationDetails,
+    options,
+    'Globally available'
+  );
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);
   const tableColumns = useMemo<ITableColumn<ExecutionEnvironment>[]>(

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -161,3 +161,17 @@ export function useGroupTypeToolbarFilter() {
     [t]
   );
 }
+
+export function useImageToolbarFilter() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter>(
+    () => ({
+      key: 'image',
+      label: t('Image'),
+      type: ToolbarFilterType.Text,
+      query: 'image__icontains',
+      comparison: 'contains',
+    }),
+    [t]
+  );
+}

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -168,7 +168,7 @@ export function useImageToolbarFilter() {
     () => ({
       key: 'image',
       label: t('Image'),
-      type: ToolbarFilterType.Text,
+      type: ToolbarFilterType.SingleText,
       query: 'image__icontains',
       comparison: 'contains',
     }),

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -284,7 +284,8 @@ export function useOrganizationNameColumn(
   options?: {
     disableLinks?: boolean;
     disableSort?: boolean;
-  }
+  },
+  defaultValue?: string
 ) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -300,18 +301,20 @@ export function useOrganizationNameColumn(
       header: t('Organization'),
       cell: (item) => (
         <TextCell
-          text={item.summary_fields?.organization?.name}
+          text={item.summary_fields?.organization?.name ?? defaultValue ?? ''}
           to={getPageUrl(orgDetailsRoute, {
             params: { id: item.summary_fields?.organization?.id },
           })}
-          disableLinks={options?.disableLinks}
+          disableLinks={
+            defaultValue && !item.summary_fields?.organization?.name ? true : options?.disableLinks
+          }
         />
       ),
       value: (item) => item.summary_fields?.organization?.name,
       sort: options?.disableSort ? undefined : 'organization',
       dashboard: 'hidden',
     }),
-    [getPageUrl, options?.disableLinks, options?.disableSort, orgDetailsRoute, t]
+    [defaultValue, getPageUrl, options?.disableLinks, options?.disableSort, orgDetailsRoute, t]
   );
   return column;
 }


### PR DESCRIPTION
This PR addresses [AAP-8120](https://issues.redhat.com/browse/AAP-8120), which is about creating an execution environments list. Most of the work surrounding creating the list was already completed beforehand. 
This PR adds... 

- RBAC controlled buttons for the create, edit and delete functionalities in the list. 
- Updates to the useOrganziationColumn hook which now allows passing a default value if the organization is not defined
- Updates to the toolbarfilters (specifically added image toolbar filter and removed unnecessary filter options to match old UI) 