### PR TITLE
Fix PageWizard navigation bug when steps are hidden

### DIFF
--- a/framework/PageWizard/PageWizardFooter.cy.tsx
+++ b/framework/PageWizard/PageWizardFooter.cy.tsx
@@ -9,13 +9,15 @@ describe('PageWizardFooter', () => {
 
   const wizardContext = {
     activeStep: step1,
-    steps: [step1, step2, step3],
+    allSteps: [step1, step2, step3],
+    visibleSteps: [step1, step2, step3],
     isToggleExpanded: false,
     setActiveStep: () => {},
     setStepData: () => {},
     setStepError: () => {},
     setToggleExpanded: () => {},
     setWizardData: () => {},
+    setVisibleSteps: () => {},
     stepData: {},
     stepError: {},
     wizardData: {},

--- a/framework/PageWizard/PageWizardFooter.tsx
+++ b/framework/PageWizard/PageWizardFooter.tsx
@@ -8,12 +8,12 @@ export function PageWizardFooter(props: {
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
-  const { activeStep, steps } = usePageWizard();
+  const { activeStep, visibleSteps } = usePageWizard();
 
-  const isLastStep = activeStep?.id === steps[steps.length - 1].id;
+  const isLastStep = activeStep?.id === visibleSteps[visibleSteps.length - 1].id;
   const nextButtonLabel = isLastStep ? t('Finish') : t('Next');
 
-  const isFirstStep = activeStep?.id === steps[0].id;
+  const isFirstStep = activeStep?.id === visibleSteps[0].id;
   const backClassName = isFirstStep
     ? 'pf-v5-c-button pf-m-disabled'
     : 'pf-v5-c-button pf-m-secondary';

--- a/framework/PageWizard/PageWizardNavigation.tsx
+++ b/framework/PageWizard/PageWizardNavigation.tsx
@@ -2,13 +2,13 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { usePageWizard } from './PageWizardProvider';
 
 export function PageWizardNavigation() {
-  const { activeStep, steps, isToggleExpanded, setActiveStep, stepError } = usePageWizard();
+  const { activeStep, isToggleExpanded, setActiveStep, stepError, visibleSteps } = usePageWizard();
   const navClassName = isToggleExpanded
     ? 'pf-v5-c-wizard__nav pf-m-expanded'
     : 'pf-v5-c-wizard__nav bg-lighten';
 
   const goToStepByIndex = (index: number) => {
-    const step = steps[index];
+    const step = visibleSteps[index];
     if (step) {
       setActiveStep(step);
     }
@@ -19,8 +19,8 @@ export function PageWizardNavigation() {
   return (
     <nav className={navClassName} aria-label="Steps" data-cy="wizard-nav">
       <ol className="pf-v5-c-wizard__nav-list">
-        {steps.map((step, index) => {
-          const activeStepIndex = steps.findIndex((step) => step.id === activeStep.id);
+        {visibleSteps.map((step, index) => {
+          const activeStepIndex = visibleSteps.findIndex((step) => step.id === activeStep.id);
           const isDisabled = index > activeStepIndex;
 
           const className =

--- a/framework/PageWizard/types.ts
+++ b/framework/PageWizard/types.ts
@@ -1,4 +1,5 @@
 import { SetStateAction } from 'react';
+import { ErrorAdapter } from '../PageForm/typesErrorAdapter';
 
 export interface PageWizardStep {
   id: string;
@@ -18,6 +19,17 @@ export interface PageWizardState {
   setWizardData: (data: object) => void;
   stepData: Record<string, object>;
   stepError: Record<string, object>;
-  steps: PageWizardStep[];
+  allSteps: PageWizardStep[];
+  visibleSteps: PageWizardStep[];
+  setVisibleSteps: (steps: PageWizardStep[]) => void;
   wizardData: object;
+}
+
+export interface PageWizardBody<T> {
+  onCancel?: () => void;
+  onSubmit: (wizardData: T) => Promise<void>;
+  errorAdapter?: ErrorAdapter;
+  disableGrid?: boolean;
+  isVertical?: boolean;
+  singleColumn?: boolean;
 }


### PR DESCRIPTION
Fix PageWizard TypeError during navigation with dynamic steps.

![Screenshot 2024-02-01 at 10 29 15 AM](https://github.com/ansible/ansible-ui/assets/15881645/53a0985b-ccda-41ad-8b74-f98f74c15984)

Included in PR:
- Fix wizard component tests
- Move PageWizardBody interface to wizard interface file 
- Validate hidden/visible steps and update visible steps when user clicks "Next" 
- Update wizard provider to track the complete step list and visible step list separately 

![wiz](https://github.com/ansible/ansible-ui/assets/15881645/82015aa5-bf71-4799-9a59-2f6ada219d1c)
