### PR TITLE
Hub roles UI: optional chaining for is_superuser

### DIFF
--- a/frontend/hub/access/roles/hooks/useRoleActions.tsx
+++ b/frontend/hub/access/roles/hooks/useRoleActions.tsx
@@ -64,7 +64,7 @@ export function useRoleRowActions(onComplete: (roles: Role[]) => void) {
         isDisabled: (role) =>
           role.locked
             ? t('Built-in roles cannot be edited.')
-            : user.is_superuser
+            : user?.is_superuser
               ? undefined
               : t(
                   'You do not have permission to edit this role. Please contact your organization administrator if there is an issue with your access.'
@@ -94,6 +94,6 @@ export function useRoleRowActions(onComplete: (roles: Role[]) => void) {
         isDanger: true,
       },
     ],
-    [deleteRoles, getPageUrl, t, user.is_superuser]
+    [deleteRoles, getPageUrl, t, user?.is_superuser]
   );
 }


### PR DESCRIPTION
This is to prevent the following error if we're unable to access the Hub server and the hub user context is empty:

![Screenshot 2024-02-02 at 9 54 19 AM](https://github.com/ansible/ansible-ui/assets/43621546/d2f87128-538e-4d18-b6e0-a6b9d331d1a6)
