### PR TITLE
[AAP-7483] Add Execution Env Details

### DIFF
--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
@@ -1,0 +1,76 @@
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { ExecutionEnvironmentDetailInner as ExecutionEnvironmentDetails } from './ExecutionEnvironmentDetails';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { formatDateString } from '../../../../../framework/utils/dateTimeHelpers';
+
+describe('ExecutionEnvironmentDetails', () => {
+  it('Component renders and displays Execution Environment', () => {
+    cy.fixture('execution_environments.json')
+      .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+        const execution_env: ExecutionEnvironment = eeResponse?.results[0];
+        return execution_env;
+      })
+      .then((eeObject) => {
+        cy.mount(<ExecutionEnvironmentDetails execution_env={eeObject} />);
+      });
+  });
+  it('Render only required EE detail fields', () => {
+    cy.fixture('execution_environments.json')
+      .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+        const execution_env: ExecutionEnvironment = eeResponse?.results[0];
+        execution_env['name'] = 'test';
+        execution_env['managed'] = false;
+        execution_env['image'] = 'this.io/is/a/test:latest';
+
+        return execution_env;
+      })
+      .then((eeObject) => {
+        cy.mount(<ExecutionEnvironmentDetails execution_env={eeObject} />);
+        cy.get('[data-cy="name"]').should('have.text', 'test');
+        cy.get('[data-cy="image"]').should('have.text', 'this.io/is/a/test:latest');
+        cy.get('[data-cy="description"]').should('not.exist');
+        cy.get('[data-cy="managed"]').should('have.text', 'false');
+        cy.get('[data-cy="organization"]').should('not.exist');
+        cy.get('[data-cy="pull"]').should('not.exist');
+        cy.get('[date-cy="registry-credential"]').should('not.exist');
+        cy.get('[data-cy="created"]').should('have.text', formatDateString(eeObject.created));
+        cy.get('[data-cy="last-modified"]').should(
+          'have.text',
+          formatDateString(eeObject.modified)
+        );
+      });
+  });
+  it('Render all EE detail fields', () => {
+    cy.fixture('execution_environments.json')
+      .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+        const execution_env: ExecutionEnvironment = eeResponse?.results[0];
+        execution_env['name'] = 'test';
+        execution_env['managed'] = false;
+        execution_env['image'] = 'this.io/is/a/test:latest';
+        execution_env['description'] = 'test';
+        execution_env.summary_fields.organization = { id: 1, name: 'test' };
+        execution_env['pull'] = 'always';
+        execution_env.summary_fields.credential = { id: 1, name: 'test', kind: 'registry' };
+
+        return execution_env;
+      })
+      .then((eeObject) => {
+        cy.mount(<ExecutionEnvironmentDetails execution_env={eeObject} />);
+        cy.get('[data-cy="name"]').should('have.text', 'test');
+        cy.get('[data-cy="image"]').should('have.text', 'this.io/is/a/test:latest');
+        cy.get('[data-cy="description"]').should('have.text', 'test');
+        cy.get('[data-cy="managed"]').should('have.text', 'false');
+        cy.get('[data-cy="organization"]').should('have.text', 'test');
+        cy.get('[data-cy="pull"]').should('have.text', 'always');
+        cy.get('[data-cy="registry-credential"] > .pf-v5-c-description-list__text').should(
+          'have.text',
+          'test'
+        );
+        cy.get('[data-cy="created"]').should('have.text', formatDateString(eeObject.created));
+        cy.get('[data-cy="last-modified"]').should(
+          'have.text',
+          formatDateString(eeObject.modified)
+        );
+      });
+  });
+});

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
@@ -4,7 +4,7 @@ import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { formatDateString } from '../../../../../framework/utils/dateTimeHelpers';
 
 describe('ExecutionEnvironmentDetails', () => {
-  it('Component renders and displays Execution Environment', () => {
+  it('Component renders and displays Execution Environment Details', () => {
     cy.fixture('execution_environments.json')
       .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
         const execution_env: ExecutionEnvironment = eeResponse?.results[0];
@@ -12,6 +12,9 @@ describe('ExecutionEnvironmentDetails', () => {
       })
       .then((eeObject) => {
         cy.mount(<ExecutionEnvironmentDetails execution_env={eeObject} />);
+        cy.get('.pf-v5-c-description-list')
+          .find('.pf-v5-c-description-list__text')
+          .should('have.length', 10);
       });
   });
   it('Render only required EE detail fields', () => {

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -35,11 +35,20 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
 
   return (
     <PageDetails data-cy="execution-environment-page-detail">
-      <PageDetail label={t('Name')}>{execution_env.name}</PageDetail>
-      <PageDetail label={t('Image')}>{execution_env.image}</PageDetail>
-      <PageDetail label={t('Description')}>{execution_env.description}</PageDetail>
-      <PageDetail label={t('Managed')}>{`${execution_env.managed}`}</PageDetail>
-      <PageDetail label={t('Organization')}>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Name')}>
+        {execution_env.name}
+      </PageDetail>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Image')}>
+        {execution_env.image}
+      </PageDetail>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Description')}>
+        {execution_env.description}
+      </PageDetail>
+      <PageDetail
+        data-cy="execution-environment-page-detail"
+        label={t('Managed')}
+      >{`${execution_env.managed}`}</PageDetail>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Organization')}>
         {execution_env.summary_fields?.organization ? (
           <TextCell
             text={execution_env.summary_fields?.organization?.name}
@@ -49,15 +58,17 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
           />
         ) : undefined}
       </PageDetail>
-      <PageDetail label={t('Pull')}>{execution_env.pull}</PageDetail>
-      <PageDetail label={t('Registry Credential')}>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Pull')}>
+        {execution_env.pull}
+      </PageDetail>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Registry Credential')}>
         {execution_env?.summary_fields?.credential?.name ? (
           <Label variant="outline" color="blue">
             {execution_env?.summary_fields?.credential?.name}
           </Label>
         ) : undefined}
       </PageDetail>
-      <PageDetail label={t('Created')}>
+      <PageDetail data-cy="execution-environment-page-detail" label={t('Created')}>
         <DateTimeCell
           format="date-time"
           value={execution_env.created}
@@ -70,6 +81,7 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
         />
       </PageDetail>
       <LastModifiedPageDetail
+        data-cy="execution-environment-page-detail"
         value={execution_env.modified}
         author={execution_env?.summary_fields?.modified_by?.username}
         onClick={() =>

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -34,7 +34,7 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
   const execution_env = props.execution_env;
 
   return (
-    <PageDetails>
+    <PageDetails data-cy="execution-environment-page-detail">
       <PageDetail label={t('Name')}>{execution_env.name}</PageDetail>
       <PageDetail label={t('Image')}>{execution_env.image}</PageDetail>
       <PageDetail label={t('Description')}>{execution_env.description}</PageDetail>

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -40,22 +40,26 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
       <PageDetail label={t('Description')}>{execution_env.description}</PageDetail>
       <PageDetail label={t('Managed')}>{`${execution_env.managed}`}</PageDetail>
       <PageDetail label={t('Organization')}>
-        <TextCell
-          text={execution_env.summary_fields?.organization?.name}
-          to={getPageUrl(AwxRoute.OrganizationPage, {
-            params: { id: execution_env.summary_fields?.organization?.id },
-          })}
-        />
+        {execution_env.summary_fields?.organization ? (
+          <TextCell
+            text={execution_env.summary_fields?.organization?.name}
+            to={getPageUrl(AwxRoute.OrganizationPage, {
+              params: { id: execution_env.summary_fields?.organization?.id },
+            })}
+          />
+        ) : undefined}
       </PageDetail>
       <PageDetail label={t('Pull')}>{execution_env.pull}</PageDetail>
       <PageDetail label={t('Registry Credential')}>
-        <Label variant="outline" color="blue">
-          {execution_env?.summary_fields?.credential?.name}
-        </Label>
+        {execution_env?.summary_fields?.credential?.name ? (
+          <Label variant="outline" color="blue">
+            {execution_env?.summary_fields?.credential?.name}
+          </Label>
+        ) : undefined}
       </PageDetail>
       <PageDetail label={t('Created')}>
         <DateTimeCell
-          format="since"
+          format="date-time"
           value={execution_env.created}
           author={execution_env?.summary_fields?.created_by?.username}
           onClick={() =>

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -35,20 +35,20 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
 
   return (
     <PageDetails data-cy="execution-environment-page-detail">
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Name')}>
+      <PageDetail data-cy="execution-environment-name" label={t('Name')}>
         {execution_env.name}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Image')}>
+      <PageDetail data-cy="execution-environment-image" label={t('Image')}>
         {execution_env.image}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Description')}>
+      <PageDetail data-cy="execution-environment-description" label={t('Description')}>
         {execution_env.description}
       </PageDetail>
       <PageDetail
-        data-cy="execution-environment-page-detail"
+        data-cy="execution-environment-managed"
         label={t('Managed')}
       >{`${execution_env.managed}`}</PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Organization')}>
+      <PageDetail data-cy="execution-environment-org" label={t('Organization')}>
         {execution_env.summary_fields?.organization ? (
           <TextCell
             text={execution_env.summary_fields?.organization?.name}
@@ -58,17 +58,17 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
           />
         ) : undefined}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Pull')}>
+      <PageDetail data-cy="execution-environment-pull" label={t('Pull')}>
         {execution_env.pull}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Registry Credential')}>
+      <PageDetail data-cy="execution-environment-reg-cred" label={t('Registry Credential')}>
         {execution_env?.summary_fields?.credential?.name ? (
           <Label variant="outline" color="blue">
             {execution_env?.summary_fields?.credential?.name}
           </Label>
         ) : undefined}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-page-detail" label={t('Created')}>
+      <PageDetail data-cy="execution-environment-created" label={t('Created')}>
         <DateTimeCell
           format="date-time"
           value={execution_env.created}
@@ -81,7 +81,7 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
         />
       </PageDetail>
       <LastModifiedPageDetail
-        data-cy="execution-environment-page-detail"
+        data-cy="execution-environment-modified"
         value={execution_env.modified}
         author={execution_env?.summary_fields?.modified_by?.username}
         onClick={() =>

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -1,0 +1,79 @@
+import { Label } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  DateTimeCell,
+  PageDetail,
+  PageDetails,
+  TextCell,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../../framework';
+import { useGetItem } from '../../../../common/crud/useGet';
+import { LastModifiedPageDetail } from '../../../../common/LastModifiedPageDetail';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { AwxRoute } from '../../../main/AwxRoutes';
+
+export function ExecutionEnvironmentDetails() {
+  const params = useParams<{ id: string }>();
+  const { data: execution_environment } = useGetItem<ExecutionEnvironment>(
+    awxAPI`/execution_environments/`,
+    params.id
+  );
+  return execution_environment ? (
+    <ExecutionEnvironmentDetailInner execution_env={execution_environment} />
+  ) : null;
+}
+
+export function ExecutionEnvironmentDetailInner(props: { execution_env: ExecutionEnvironment }) {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const pageNavigate = usePageNavigate();
+
+  const execution_env = props.execution_env;
+
+  return (
+    <PageDetails>
+      <PageDetail label={t('Name')}>{execution_env.name}</PageDetail>
+      <PageDetail label={t('Image')}>{execution_env.image}</PageDetail>
+      <PageDetail label={t('Description')}>{execution_env.description}</PageDetail>
+      <PageDetail label={t('Managed')}>{`${execution_env.managed}`}</PageDetail>
+      <PageDetail label={t('Organization')}>
+        <TextCell
+          text={execution_env.summary_fields?.organization?.name}
+          to={getPageUrl(AwxRoute.OrganizationPage, {
+            params: { id: execution_env.summary_fields?.organization?.id },
+          })}
+        />
+      </PageDetail>
+      <PageDetail label={t('Pull')}>{execution_env.pull}</PageDetail>
+      <PageDetail label={t('Registry Credential')}>
+        <Label variant="outline" color="blue">
+          {execution_env?.summary_fields?.credential?.name}
+        </Label>
+      </PageDetail>
+      <PageDetail label={t('Created')}>
+        <DateTimeCell
+          format="since"
+          value={execution_env.created}
+          author={execution_env?.summary_fields?.created_by?.username}
+          onClick={() =>
+            pageNavigate(AwxRoute.UserDetails, {
+              params: { id: execution_env?.summary_fields?.created_by?.id },
+            })
+          }
+        />
+      </PageDetail>
+      <LastModifiedPageDetail
+        value={execution_env.modified}
+        author={execution_env?.summary_fields?.modified_by?.username}
+        onClick={() =>
+          pageNavigate(AwxRoute.UserDetails, {
+            params: { id: execution_env?.summary_fields?.modified_by?.id },
+          })
+        }
+      ></LastModifiedPageDetail>
+    </PageDetails>
+  );
+}

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.tsx
@@ -1,0 +1,83 @@
+import { ButtonVariant } from '@patternfly/react-core';
+import { DropdownPosition } from '@patternfly/react-core/deprecated';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  IPageAction,
+  PageActions,
+  PageActionSelection,
+  PageActionType,
+  PageHeader,
+  PageLayout,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../../framework';
+import { PageRoutedTabs } from '../../../../../framework/PageTabs/PageRoutedTabs';
+import { useGetItem } from '../../../../common/crud/useGet';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { AwxRoute } from '../../../main/AwxRoutes';
+
+export function ExecutionEnvironmentPage() {
+  const params = useParams<{ id: string }>();
+  const { t } = useTranslation();
+
+  const getPageUrl = useGetPageUrl();
+  const pageNavigate = usePageNavigate();
+
+  const { data: executionEnvironment } = useGetItem<ExecutionEnvironment>(
+    awxAPI`/execution_environments/`,
+    params.id
+  );
+
+  const itemActions: IPageAction<ExecutionEnvironment>[] = useMemo(() => {
+    const itemActions: IPageAction<ExecutionEnvironment>[] = [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        isPinned: true,
+        icon: PencilAltIcon,
+        label: t('Edit execution environment'),
+        onClick: (executionEnvironment) =>
+          pageNavigate(AwxRoute.EditExecutionEnvironment, {
+            params: { id: executionEnvironment.id },
+          }),
+      },
+    ];
+    return itemActions;
+  }, [t, pageNavigate]);
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t(`${executionEnvironment?.name}`)}
+        breadcrumbs={[
+          { label: t('Execution Environments'), to: getPageUrl(AwxRoute.ExecutionEnvironments) },
+          { label: executionEnvironment?.name ?? '' },
+        ]}
+        headerActions={
+          <PageActions<ExecutionEnvironment>
+            actions={itemActions}
+            position={DropdownPosition.right}
+            selectedItem={executionEnvironment}
+          />
+        }
+      />
+      <PageRoutedTabs
+        backTab={{
+          label: t('Back to Execution Environments'),
+          page: AwxRoute.ExecutionEnvironments,
+          persistentFilterKey: 'execution_environments',
+        }}
+        tabs={[
+          { label: t('Details'), page: AwxRoute.ExecutionEnvironmentDetails },
+          { label: t('Templates'), page: AwxRoute.ExecutionEnvironmentTemplates },
+        ]}
+        params={{ id: executionEnvironment?.id ?? '' }}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
@@ -218,7 +218,10 @@ describe('Execution Environments List', () => {
         }
       );
       cy.mount(<ExecutionEnvironments />);
-      cy.contains('Error loading execution environments');
+      cy.get('.pf-v5-c-empty-state__title-text').should(
+        'have.text',
+        'Error loading execution environments'
+      );
     });
   });
 

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
@@ -1,0 +1,273 @@
+import * as useOptions from '../../../common/crud/useOptions';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
+import { ExecutionEnvironment } from '../../interfaces/ExecutionEnvironment';
+import { ExecutionEnvironments } from './ExecutionEnvironments';
+
+describe('Execution Environments List', () => {
+  describe('Non-empty list', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/execution_environments/*',
+        },
+        {
+          fixture: 'execution_environments.json',
+        }
+      );
+    });
+
+    it('Execution Environments list renders', () => {
+      cy.mount(<ExecutionEnvironments />);
+      cy.verifyPageTitle('Execution Environments');
+      cy.get('tbody').find('tr').should('have.length', 10);
+    });
+
+    it('Filter execution environments by name', () => {
+      cy.mount(<ExecutionEnvironments />);
+      cy.intercept(
+        'api/v2/execution_environments/?name__icontains=Control%20Plane%20Execution%20Environment*'
+      ).as('nameFilterRequest');
+      cy.filterTableByTypeAndText(/^Name$/, 'Control Plane Execution Environment');
+      cy.wait('@nameFilterRequest');
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Filter execution environments by image', () => {
+      cy.mount(<ExecutionEnvironments />);
+      cy.intercept('api/v2/execution_environments/?image__icontains=quay*').as(
+        'imageFilterRequest'
+      );
+      cy.filterTableByTypeAndText(/^Image$/, 'quay');
+      cy.wait('@imageFilterRequest');
+      cy.clickButton(/^Clear all filters$/);
+    });
+
+    it('Create execution environment button is disabled if the user does not have permission to create execution environment', () => {
+      cy.mount(<ExecutionEnvironments />);
+      cy.contains('button', /^Create execution environment$/).should(
+        'have.attr',
+        'aria-disabled',
+        'true'
+      );
+    });
+
+    it('Delete execution environment row action is disabled if the user does not have permission to delete execution environment', () => {
+      cy.fixture('execution_environments')
+        .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+          for (let i = 0; i < eeResponse.results.length; i++) {
+            eeResponse.results[i].summary_fields.user_capabilities.delete = false;
+          }
+          return eeResponse;
+        })
+        .then((eeBodyNoDeletePerms) => {
+          cy.intercept(
+            {
+              method: 'GET',
+              url: '/api/v2/execution_environments/*',
+            },
+            { body: eeBodyNoDeletePerms }
+          );
+        })
+        .then(() => {
+          cy.mount(<ExecutionEnvironments />);
+        })
+        .then(() => {
+          cy.contains('tr', 'test').within(() => {
+            cy.get('button.toggle-kebab').click();
+            cy.contains('.pf-v5-c-dropdown__menu-item', /^Delete execution environment$/).should(
+              'have.attr',
+              'aria-disabled',
+              'true'
+            );
+          });
+        });
+    });
+
+    it('Edit execution environment row action is disabled if the user does not have permission to edit execution environment', () => {
+      cy.fixture('execution_environments')
+        .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+          for (let i = 0; i < eeResponse.results.length; i++) {
+            eeResponse.results[i].summary_fields.user_capabilities.edit = false;
+          }
+          return eeResponse;
+        })
+        .then((eeBodyNoDeletePerms) => {
+          cy.intercept(
+            {
+              method: 'GET',
+              url: '/api/v2/execution_environments/*',
+            },
+            { body: eeBodyNoDeletePerms }
+          );
+        })
+        .then(() => {
+          cy.mount(<ExecutionEnvironments />);
+        })
+        .then(() => {
+          cy.contains('tr', 'test').within(() => {
+            cy.get('[data-cy="actions-column-cell"]').within(() => {
+              cy.get(`[data-cy="edit-execution-environment"]`).should(
+                'have.attr',
+                'aria-disabled',
+                'true'
+              );
+            });
+          });
+        });
+    });
+
+    it('Create execution environment button is enabled if the user has permission to create execution environment', () => {
+      cy.stub(useOptions, 'useOptions').callsFake(() => ({
+        data: {
+          actions: {
+            POST: {
+              name: {
+                type: 'string',
+                required: true,
+                label: 'Name',
+                max_length: 255,
+                help_text: 'Name of this execution environment.',
+                filterable: true,
+              },
+            },
+          },
+        },
+      }));
+      cy.mount(<ExecutionEnvironments />);
+      cy.contains('button', /^Create execution environment$/).should(
+        'have.attr',
+        'aria-disabled',
+        'false'
+      );
+    });
+
+    it('Delete execution environment row action is enabled if the user has permission to delete execution environment', () => {
+      cy.fixture('execution_environments')
+        .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+          for (let i = 0; i < eeResponse.results.length; i++) {
+            eeResponse.results[i].summary_fields.user_capabilities.delete = true;
+          }
+          return eeResponse;
+        })
+        .then((eeBodyNoDeletePerms) => {
+          cy.intercept(
+            {
+              method: 'GET',
+              url: '/api/v2/execution_environments/*',
+            },
+            { body: eeBodyNoDeletePerms }
+          );
+        })
+        .then(() => {
+          cy.mount(<ExecutionEnvironments />);
+        })
+        .then(() => {
+          cy.contains('tr', 'test').within(() => {
+            cy.get('button.toggle-kebab').click();
+            cy.contains('.pf-v5-c-dropdown__menu-item', /^Delete execution environment$/).should(
+              'have.attr',
+              'aria-disabled',
+              'false'
+            );
+          });
+        });
+    });
+
+    it('Edit execution environment row action is enabled if the user has permission to edit execution environment', () => {
+      cy.fixture('execution_environments')
+        .then((eeResponse: AwxItemsResponse<ExecutionEnvironment>) => {
+          for (let i = 0; i < eeResponse.results.length; i++) {
+            eeResponse.results[i].summary_fields.user_capabilities.edit = true;
+          }
+          return eeResponse;
+        })
+        .then((eeBodyNoDeletePerms) => {
+          cy.intercept(
+            {
+              method: 'GET',
+              url: '/api/v2/execution_environments/*',
+            },
+            { body: eeBodyNoDeletePerms }
+          );
+        })
+        .then(() => {
+          cy.mount(<ExecutionEnvironments />);
+        })
+        .then(() => {
+          cy.contains('tr', 'test').within(() => {
+            cy.get('[data-cy="actions-column-cell"]').within(() => {
+              cy.get(`[data-cy="edit-execution-environment"]`).should(
+                'have.attr',
+                'aria-disabled',
+                'false'
+              );
+            });
+          });
+        });
+    });
+
+    it('Displays error if execution environments are not successfully loaded', () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/execution_environments/*',
+        },
+        {
+          statusCode: 500,
+        }
+      );
+      cy.mount(<ExecutionEnvironments />);
+      cy.contains('Error loading execution environments');
+    });
+  });
+
+  describe('Empty list', () => {
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/execution_environments/*',
+        },
+        {
+          fixture: 'emptyList.json',
+        }
+      ).as('emptyList');
+    });
+    it('Empty state is displayed correctly for user with permission to create execution environments', () => {
+      cy.stub(useOptions, 'useOptions').callsFake(() => ({
+        data: {
+          actions: {
+            POST: {
+              name: {
+                type: 'string',
+                required: true,
+                label: 'Name',
+                max_length: 512,
+                help_text: 'Name of this execution environment.',
+                filterable: true,
+              },
+            },
+          },
+        },
+      }));
+      cy.mount(<ExecutionEnvironments />);
+      cy.contains(/^No execution environments yet$/);
+      cy.contains(/^To get started, create an execution environment.$/);
+      cy.contains('button', /^Create execution environment$/).should('be.visible');
+    });
+    it('Empty state is displayed correctly for user without permission to create execution environments', () => {
+      cy.stub(useOptions, 'useOptions').callsFake(() => ({
+        data: {
+          actions: {},
+        },
+      }));
+      cy.mount(<ExecutionEnvironments />);
+      cy.contains(/^You do not have permission to create an execution environment.$/);
+      cy.contains(
+        /^Please contact your organization administrator if there is an issue with your access.$/
+      );
+      cy.contains('button', /^Create execution environment$/).should('not.exist');
+    });
+  });
+});

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -11,6 +11,8 @@ import { useExecutionEnvRowActions } from './hooks/useExecutionEnvRowActions';
 import { useExecutionEnvToolbarActions } from './hooks/useExecutionEnvToolbarActions';
 import { useExecutionEnvironmentsColumns } from './hooks/useExecutionEnvironmentsColumns';
 import { useExecutionEnvironmentsFilters } from './hooks/useExecutionEnvironmentsFilters';
+import { useOptions } from '../../../common/crud/useOptions';
+import { OptionsResponse, ActionsResponse } from '../../interfaces/OptionsResponse';
 
 export function ExecutionEnvironments() {
   const { t } = useTranslation();
@@ -26,6 +28,9 @@ export function ExecutionEnvironments() {
 
   const rowActions = useExecutionEnvRowActions(view);
   const toolbarActions = useExecutionEnvToolbarActions(view);
+
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/execution_environments/`);
+  const canCreateExecutionEnvironment = Boolean(data && data.actions && data.actions['POST']);
 
   return (
     <PageLayout>
@@ -47,10 +52,26 @@ export function ExecutionEnvironments() {
         tableColumns={tableColumns}
         rowActions={rowActions}
         errorStateTitle={t('Error loading execution environments')}
-        emptyStateTitle={t('No execution environments yet')}
-        emptyStateDescription={t('To get started, create an execution environment.')}
-        emptyStateButtonText={t('Create execution environment')}
-        emptyStateButtonClick={() => pageNavigate(AwxRoute.CreateExecutionEnvironment)}
+        emptyStateTitle={
+          canCreateExecutionEnvironment
+            ? t('No execution environments yet')
+            : t('You do not have permission to create an execution environment.')
+        }
+        emptyStateDescription={
+          canCreateExecutionEnvironment
+            ? t('To get started, create an execution environment.')
+            : t(
+                'Please contact your organization administrator if there is an issue with your access.'
+              )
+        }
+        emptyStateButtonText={
+          canCreateExecutionEnvironment ? t('Create execution environment') : undefined
+        }
+        emptyStateButtonClick={
+          canCreateExecutionEnvironment
+            ? () => pageNavigate(AwxRoute.CreateExecutionEnvironment)
+            : undefined
+        }
         {...view}
         defaultSubtitle={t('Execution environment')}
       />

--- a/frontend/awx/administration/execution-environments/hooks/useDeleteExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useDeleteExecutionEnvironments.tsx
@@ -6,7 +6,7 @@ import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
 import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
-import { useExecutionEnvironmentsColumns } from '../ExecutionEnvironments';
+import { useExecutionEnvironmentsColumns } from './useExecutionEnvironmentsColumns';
 
 export function useDeleteExecutionEnvironments(
   onComplete: (executionEnvironments: ExecutionEnvironment[]) => void

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvRowActions.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvRowActions.tsx
@@ -1,0 +1,48 @@
+import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  usePageNavigate,
+  IPageAction,
+  PageActionType,
+  PageActionSelection,
+} from '../../../../../framework';
+import { cannotEditResource, cannotDeleteResource } from '../../../../common/utils/RBAChelpers';
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { AwxRoute } from '../../../main/AwxRoutes';
+import { useDeleteExecutionEnvironments } from './useDeleteExecutionEnvironments';
+import { IAwxView } from '../../../common/useAwxView';
+
+export function useExecutionEnvRowActions(view: IAwxView<ExecutionEnvironment>) {
+  const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
+  const deleteExecutionEnvironments = useDeleteExecutionEnvironments(view.unselectItemsAndRefresh);
+
+  return useMemo<IPageAction<ExecutionEnvironment>[]>(
+    () => [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: PencilAltIcon,
+        isPinned: true,
+        label: t('Edit execution environment'),
+        isDisabled: (executionEnvironment) => cannotEditResource(executionEnvironment, t),
+        onClick: (executionEnvironment) =>
+          pageNavigate(AwxRoute.EditExecutionEnvironment, {
+            params: { id: executionEnvironment.id },
+          }),
+      },
+      { type: PageActionType.Seperator },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete execution environment'),
+        isDisabled: (executionEnvironment) => cannotDeleteResource(executionEnvironment, t),
+        onClick: (executionEnvironment) => deleteExecutionEnvironments([executionEnvironment]),
+        isDanger: true,
+      },
+    ],
+    [pageNavigate, deleteExecutionEnvironments, t]
+  );
+}

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvToolbarActions.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvToolbarActions.tsx
@@ -1,0 +1,57 @@
+import { ButtonVariant } from '@patternfly/react-core';
+import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  usePageNavigate,
+  IPageAction,
+  PageActionType,
+  PageActionSelection,
+} from '../../../../../framework';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { cannotDeleteResources } from '../../../../common/utils/RBAChelpers';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { IAwxView } from '../../../common/useAwxView';
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { OptionsResponse, ActionsResponse } from '../../../interfaces/OptionsResponse';
+import { AwxRoute } from '../../../main/AwxRoutes';
+import { useDeleteExecutionEnvironments } from './useDeleteExecutionEnvironments';
+
+export function useExecutionEnvToolbarActions(view: IAwxView<ExecutionEnvironment>) {
+  const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
+  const deleteExecutionEnvironments = useDeleteExecutionEnvironments(view.unselectItemsAndRefresh);
+
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/execution_environments/`);
+  const canCreateExecutionEnvironment = Boolean(data && data.actions && data.actions['POST']);
+
+  return useMemo<IPageAction<ExecutionEnvironment>[]>(
+    () => [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.None,
+        variant: ButtonVariant.primary,
+        isPinned: true,
+        icon: PlusIcon,
+        label: t('Create execution environment'),
+        isDisabled: canCreateExecutionEnvironment
+          ? undefined
+          : t(
+              'You do not have permission to create an execution environment. Please contact your organization administrator if there is an issue with your access.'
+            ),
+        onClick: () => pageNavigate(AwxRoute.CreateExecutionEnvironment),
+      },
+      { type: PageActionType.Seperator },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: TrashIcon,
+        label: t('Delete selected execution environments'),
+        isDisabled: (executionEnvironments) => cannotDeleteResources(executionEnvironments, t),
+        onClick: deleteExecutionEnvironments,
+        isDanger: true,
+      },
+    ],
+    [t, canCreateExecutionEnvironment, deleteExecutionEnvironments, pageNavigate]
+  );
+}

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsColumns.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsColumns.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePageNavigate, ITableColumn } from '../../../../../framework';
+import {
+  useNameColumn,
+  useIdColumn,
+  useDescriptionColumn,
+  useOrganizationNameColumn,
+  useCreatedColumn,
+  useModifiedColumn,
+} from '../../../../common/columns';
+import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
+import { AwxRoute } from '../../../main/AwxRoutes';
+
+export function useExecutionEnvironmentsColumns(options?: {
+  disableSort?: boolean;
+  disableLinks?: boolean;
+}) {
+  const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
+  const nameClick = useCallback(
+    (executionEnvironment: ExecutionEnvironment) =>
+      pageNavigate(AwxRoute.ExecutionEnvironmentDetails, {
+        params: { id: executionEnvironment.id },
+      }),
+    [pageNavigate]
+  );
+  const nameColumn = useNameColumn({
+    ...options,
+    onClick: nameClick,
+  });
+  const idColumn = useIdColumn<ExecutionEnvironment>();
+  const descriptionColumn = useDescriptionColumn();
+  const organizationColumn = useOrganizationNameColumn(
+    AwxRoute.OrganizationDetails,
+    options,
+    t('Globally available')
+  );
+  const createdColumn = useCreatedColumn(options);
+  const modifiedColumn = useModifiedColumn(options);
+  const tableColumns = useMemo<ITableColumn<ExecutionEnvironment>[]>(
+    () => [
+      idColumn,
+      nameColumn,
+      descriptionColumn,
+      {
+        header: t('Image'),
+        cell: (executionEnvironment) => executionEnvironment.image,
+        sort: 'image',
+      },
+      organizationColumn,
+      createdColumn,
+      modifiedColumn,
+    ],
+    [idColumn, nameColumn, descriptionColumn, t, organizationColumn, createdColumn, modifiedColumn]
+  );
+  return tableColumns;
+}

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsFilters.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsFilters.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { IToolbarFilter } from '../../../../../framework';
+import {
+  useNameToolbarFilter,
+  useOrganizationToolbarFilter,
+  useImageToolbarFilter,
+} from '../../../common/awx-toolbar-filters';
+
+export function useExecutionEnvironmentsFilters() {
+  const nameToolbarFilter = useNameToolbarFilter();
+  const organizationToolbarFilter = useOrganizationToolbarFilter();
+  const imageToolbarFilter = useImageToolbarFilter();
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter],
+    [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter]
+  );
+  return toolbarFilters;
+}

--- a/frontend/awx/administration/execution-environments/hooks/useSelectExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useSelectExecutionEnvironments.tsx
@@ -3,10 +3,8 @@ import { useSelectDialog } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { ExecutionEnvironment } from '../../../interfaces/ExecutionEnvironment';
-import {
-  useExecutionEnvironmentsColumns,
-  useExecutionEnvironmentsFilters,
-} from '../ExecutionEnvironments';
+import { useExecutionEnvironmentsColumns } from './useExecutionEnvironmentsColumns';
+import { useExecutionEnvironmentsFilters } from './useExecutionEnvironmentsFilters';
 
 export function useSelectExecutionEnvironments(organizationId?: string) {
   const { t } = useTranslation();

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -168,7 +168,7 @@ export function useImageToolbarFilter() {
     () => ({
       key: 'image',
       label: t('Image'),
-      type: ToolbarFilterType.SingleText,
+      type: ToolbarFilterType.MultiText,
       query: 'image__icontains',
       comparison: 'contains',
     }),

--- a/frontend/awx/interfaces/ExecutionEnvironment.ts
+++ b/frontend/awx/interfaces/ExecutionEnvironment.ts
@@ -30,6 +30,11 @@ export interface ExecutionEnvironment {
       first_name: string;
       last_name: string;
     };
+    credential?: {
+      id: number;
+      name: string;
+      kind: string;
+    };
   };
   created: string;
   modified: string;

--- a/frontend/awx/main/AwxRoutes.tsx
+++ b/frontend/awx/main/AwxRoutes.tsx
@@ -210,6 +210,7 @@ export enum AwxRoute {
   ExecutionEnvironments = 'awx-execution-environments',
   ExecutionEnvironmentPage = 'awx-execution-environments-page',
   ExecutionEnvironmentDetails = 'awx-execution-environments-details',
+  ExecutionEnvironmentTemplates = 'awx-execution-environments-templates',
   CreateExecutionEnvironment = 'awx-create-execution-environment',
   EditExecutionEnvironment = 'awx-edit-execution-environment',
 

--- a/frontend/awx/main/routes/useAwxExecutionEnironmentRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxExecutionEnironmentRoutes.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageNavigationItem } from '../../../../framework';
+import { PageNavigationItem, PageNotImplemented } from '../../../../framework';
+import { ExecutionEnvironmentPage } from '../../administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage';
 import { ExecutionEnvironments } from '../../administration/execution-environments/ExecutionEnvironments';
+import { ExecutionEnvironmentDetails } from '../../administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails';
 import { AwxRoute } from '../AwxRoutes';
 
 export function useAwxExecutionEnvironmentRoutes() {
@@ -11,7 +13,29 @@ export function useAwxExecutionEnvironmentRoutes() {
       id: AwxRoute.ExecutionEnvironments,
       label: t('Execution Environments'),
       path: 'execution-environments',
-      element: <ExecutionEnvironments />,
+      children: [
+        {
+          id: AwxRoute.ExecutionEnvironmentPage,
+          path: ':id',
+          element: <ExecutionEnvironmentPage />,
+          children: [
+            {
+              id: AwxRoute.ExecutionEnvironmentDetails,
+              path: 'details',
+              element: <ExecutionEnvironmentDetails />,
+            },
+            {
+              id: AwxRoute.ExecutionEnvironmentTemplates,
+              path: 'templates',
+              element: <PageNotImplemented />,
+            },
+          ],
+        },
+        {
+          path: '',
+          element: <ExecutionEnvironments />,
+        },
+      ],
     }),
     [t]
   );


### PR DESCRIPTION
This PR addresses [AAP-7483](https://issues.redhat.com/browse/AAP-7843) which is about adding the execution env details tab. This PR adds... 

- The details page tab component
- The parent tab page component which contains the details tab and templates tab
- Component tests for the details tab
- Missed component tests for the EE lists page
- Routing to get to the details tab ( `1/infrastructure/execution-environments/:id/details` implemented in this PR) and templates tab ( `1/infrastructure/execution-environments/4/templates` currently set as `<PageNotImplemented>` component) 