### PR TITLE
Disable card and list view for Repositories

### DIFF
--- a/frontend/hub/administration/repositories/Repositories.tsx
+++ b/frontend/hub/administration/repositories/Repositories.tsx
@@ -45,6 +45,8 @@ export function Repositories() {
         tableColumns={tableColumns}
         toolbarActions={toolbarActions}
         toolbarFilters={toolbarFilters}
+        disableCardView
+        disableListView
         {...view}
       />
     </PageLayout>


### PR DESCRIPTION
Disable card and list view because they look bad(see below) and aren't part of feature parity.
<img width="1430" alt="Screenshot 2024-02-05 at 16 30 47" src="https://github.com/ansible/ansible-ui/assets/9210860/81a48c9c-00a9-4684-a7a0-a02f0013eade">
<img width="1430" alt="Screenshot 2024-02-05 at 16 30 55" src="https://github.com/ansible/ansible-ui/assets/9210860/1e3961c5-3237-49b7-914c-ff5adc2e573f">
