### PR TITLE
Fixes failing credential type e2e test

### DIFF
--- a/cypress/e2e/awx/administration/credentials-types.cy.ts
+++ b/cypress/e2e/awx/administration/credentials-types.cy.ts
@@ -35,7 +35,7 @@ describe('Credential Types', () => {
     cy.navigateTo('awx', 'credential-types');
     cy.verifyPageTitle('Credential Types');
     cy.setTablePageSize('50');
-    cy.get('span.pf-v5-c-label__text').should('contain', 'Read-only').and('have.length', 28);
+    cy.get('span.pf-v5-c-label__text').should('contain', 'Read-only').and('not.have.length', 0);
   });
 
   it('navigate to the details page for a credential type', () => {


### PR DESCRIPTION
In this test we were relying on a hard coded number to ensure we were getting 28 read-only credential types back from the api.  IMO this type of test is more of an API test than a UI test.  The api is the source of truth and determines how many read-only credential types there are, and we don't want our tests to fail if that number changes.  

This fix ensure that we get more than 0 read-only credential types.