### PR TITLE
Simplified breadcrumb handling

### DIFF
--- a/framework/PageFramework.tsx
+++ b/framework/PageFramework.tsx
@@ -7,6 +7,7 @@ import { PageNavSideBarProvider } from './PageNavigation/PageNavSidebar';
 import { PageNotificationsProvider } from './PageNotifications/PageNotificationsProvider';
 import { SettingsProvider } from './Settings';
 import { FrameworkTranslationsProvider } from './useFrameworkTranslations';
+import { PageBreadcrumbsProvider } from './PageTabs/PageBreadcrumbs';
 
 /**
  * The `PageFramework` component bundles up all the context providers in the Ansible UI framework in a convienent component for framework consumers. Examples of internal context providers are translations, navigation, settings, alerts, and dialogs.
@@ -21,7 +22,9 @@ export function PageFramework(props: { children: ReactNode }) {
         <PageDialogProvider>
           <PageAlertToasterProvider>
             <PageNavSideBarProvider>
-              <PageNotificationsProvider>{props.children}</PageNotificationsProvider>
+              <PageNotificationsProvider>
+                <PageBreadcrumbsProvider>{props.children}</PageBreadcrumbsProvider>
+              </PageNotificationsProvider>
             </PageNavSideBarProvider>
           </PageAlertToasterProvider>
         </PageDialogProvider>

--- a/framework/PageHeader.tsx
+++ b/framework/PageHeader.tsx
@@ -14,11 +14,12 @@ import {
   Truncate,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { CSSProperties, Fragment, ReactNode } from 'react';
+import { CSSProperties, Fragment, ReactNode, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './PageFramework.css';
 import { useBreakpoint } from './components/useBreakPoint';
 import { useFrameworkTranslations } from './useFrameworkTranslations';
+import { usePageBreadcrumbs } from './PageTabs/PageBreadcrumbs';
 
 export interface ICatalogBreadcrumb {
   id?: string;
@@ -26,9 +27,10 @@ export interface ICatalogBreadcrumb {
   to?: string;
   target?: string;
   component?: React.ElementType;
+  isLoading?: boolean;
 }
 
-function Breadcrumbs(props: { breadcrumbs: ICatalogBreadcrumb[]; style?: CSSProperties }) {
+function Breadcrumbs(props: { breadcrumbs?: ICatalogBreadcrumb[]; style?: CSSProperties }) {
   const navigate = useNavigate();
   if (!props.breadcrumbs) return <Fragment />;
   return (
@@ -102,25 +104,38 @@ export interface PageHeaderProps {
  * </PageLayout>
  */
 export function PageHeader(props: PageHeaderProps) {
-  const { breadcrumbs, title, description, controls, headerActions, footer } = props;
+  const { title, description, controls, headerActions, footer } = props;
   const isLg = useBreakpoint('lg');
   const isXl = useBreakpoint('xl');
   const isMdOrLarger = useBreakpoint('md');
   const [translations] = useFrameworkTranslations();
+
+  const { tabBreadcrumb } = usePageBreadcrumbs();
+
+  const pageBreadcrumbs = useMemo(() => {
+    const pageBreadcrumbs = [];
+    if (props.breadcrumbs) pageBreadcrumbs.push(...props.breadcrumbs);
+    if (tabBreadcrumb) pageBreadcrumbs.push(tabBreadcrumb);
+    return pageBreadcrumbs;
+  }, [props.breadcrumbs, tabBreadcrumb]);
+
   return (
     <PageSection
       variant={PageSectionVariants.light}
       className="bg-lighten border-bottom"
       style={{
-        paddingTop: breadcrumbs ? (isXl ? 16 : 12) : isXl ? 16 : 12,
+        paddingTop: pageBreadcrumbs?.length ? (isXl ? 16 : 12) : isXl ? 16 : 12,
         paddingBottom: isXl ? 16 : 12,
       }}
     >
       <Stack hasGutter>
         <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsStretch' }}>
           <FlexItem grow={{ default: 'grow' }}>
-            {breadcrumbs && (
-              <Breadcrumbs breadcrumbs={breadcrumbs} style={{ paddingBottom: isLg ? 6 : 4 }} />
+            {pageBreadcrumbs && (
+              <Breadcrumbs
+                breadcrumbs={pageBreadcrumbs?.length ? pageBreadcrumbs : undefined}
+                style={{ paddingBottom: isLg ? 6 : 4 }}
+              />
             )}
             {title ? (
               props.titleHelp ? (

--- a/framework/PageTabs/PageBreadcrumbs.tsx
+++ b/framework/PageTabs/PageBreadcrumbs.tsx
@@ -1,0 +1,25 @@
+import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
+import { ICatalogBreadcrumb } from '../PageHeader';
+
+export type PageBreadcrumbsContext = {
+  /** The tab breadcrumb is used to display the current active tab
+   * in the page breadcrumbs (displayed by the PageHeader component) */
+  tabBreadcrumb?: ICatalogBreadcrumb;
+  setTabBreadcrumb: Dispatch<SetStateAction<ICatalogBreadcrumb | undefined>>;
+};
+
+export const PageBreadcrumbsContext = createContext<PageBreadcrumbsContext>({
+  tabBreadcrumb: {},
+  setTabBreadcrumb: () => {},
+});
+
+export function PageBreadcrumbsProvider(props: { children: ReactNode }) {
+  const [tabBreadcrumb, setTabBreadcrumb] = useState<ICatalogBreadcrumb | undefined>({});
+  return (
+    <PageBreadcrumbsContext.Provider value={{ tabBreadcrumb, setTabBreadcrumb }}>
+      {props.children}
+    </PageBreadcrumbsContext.Provider>
+  );
+}
+
+export const usePageBreadcrumbs = (): PageBreadcrumbsContext => useContext(PageBreadcrumbsContext);

--- a/framework/PageTabs/PageRoutedTabs.tsx
+++ b/framework/PageTabs/PageRoutedTabs.tsx
@@ -4,6 +4,8 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { PageLayout, useGetPageUrl, usePageNavigate } from '..';
 import { getPersistentFilters } from '../../frontend/common/PersistentFilters';
 import { useSearchParams } from 'react-router-dom';
+import { usePageBreadcrumbs } from './PageBreadcrumbs';
+import { useEffect } from 'react';
 
 export function PageRoutedTabs(props: {
   backTab?: { label: string; page: string; persistentFilterKey: string };
@@ -19,9 +21,21 @@ export function PageRoutedTabs(props: {
   const navigate = useNavigate();
   const getPageUrl = useGetPageUrl();
   const location = useLocation();
+  const { setTabBreadcrumb } = usePageBreadcrumbs();
+
   const activeTab = props.tabs.find(
     (tab) => tab && getPageUrl(tab.page, { params: props.params }) === location.pathname
   );
+
+  // Set current active tab to tabBreadcrumb in the PageBreadcrumbContext
+  useEffect(() => {
+    if (activeTab) {
+      setTabBreadcrumb({ label: activeTab.label });
+      return () => setTabBreadcrumb(undefined);
+    } else {
+      setTabBreadcrumb(undefined);
+    }
+  }, [activeTab, setTabBreadcrumb]);
 
   const [searchParams] = useSearchParams();
 

--- a/framework/components/LoadingPage.tsx
+++ b/framework/components/LoadingPage.tsx
@@ -9,7 +9,7 @@ export function LoadingPage(props: { breadcrumbs?: boolean; tabs?: boolean }) {
       <PageHeader
         breadcrumbs={
           props.breadcrumbs
-            ? [{ label: (<Skeleton width="150px" />) as unknown as string }]
+            ? [{ label: (<Skeleton width="150px" />) as unknown as string, isLoading: true }]
             : undefined
         }
         title={(<Skeleton width="200px" />) as unknown as string}


### PR DESCRIPTION
https://github.com/ansible/ansible-ui/pull/1498 introduced some updates to the framework for handling page breadcrumbs - so that breadcrumbs reflect the current active tab in pages that utilize `PageRoutedTabs`. There are some backend data model / API discussions ongoing related to Access Management on Hub. As a result https://github.com/ansible/ansible-ui/pull/1498 is currently blocked.

This PR pulls out some framework relevant changes around handling page breadcrumbs so we can merge this separately. 

<img width="1050" alt="Screenshot 2024-02-05 at 11 20 38 AM" src="https://github.com/ansible/ansible-ui/assets/43621546/ddbf4ebf-f4d9-4887-a7d3-be4492f45b80">
