### PR TITLE
HUB: Fix create namespace button text

### DIFF
--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -77,7 +77,7 @@ export function CommonNamespaces({ url }: { url: string }) {
       errorStateTitle={t('Error loading namespaces')}
       emptyStateTitle={t('No namespaces yet')}
       emptyStateDescription={t('To get started, create an namespace.')}
-      emptyStateButtonText={t('Add namespace')}
+      emptyStateButtonText={t('Create namespace')}
       emptyStateButtonClick={() => pageNavigate(HubRoute.CreateNamespace)}
       {...view}
       defaultSubtitle={t('Namespace')}


### PR DESCRIPTION
This was breaking E2E testing because f there were no namespaces it could not find a button with "Create namespace".