### PR TITLE
Test CRUD Repositories

### DIFF
--- a/cypress/e2e/hub/constants.ts
+++ b/cypress/e2e/hub/constants.ts
@@ -74,6 +74,7 @@ export const SignatureKeys = {
 export const Repositories = {
   title: 'Repository Management',
   url: 'repositories',
+  urlCreate: '/repositories/create',
 };
 
 export const Approvals = {

--- a/cypress/e2e/hub/repositories.cy.ts
+++ b/cypress/e2e/hub/repositories.cy.ts
@@ -37,6 +37,23 @@ describe('Repositories', () => {
     cy.verifyPageTitle(repositoryName);
     cy.get('[data-cy="description"]').should('contain', repositoryDescription);
   });
+  it('should be able to edit a repository', () => {
+    const repositoryName =
+      'repositories_repository_' + randomString(6, undefined, { isLowercase: true });
+    const repositoryDescription = 'Here goes description';
+    cy.navigateTo('hub', Repositories.url);
+    cy.verifyPageTitle(Repositories.title);
+    cy.get('[data-cy="create-repository"]').should('be.visible').click();
+    cy.url().should('include', Repositories.urlCreate);
+    cy.get('[data-cy="name"]').type(repositoryName);
+    cy.get('[data-cy="Submit"]').click();
+    cy.verifyPageTitle(repositoryName);
+    cy.get('[data-cy="edit-repository"]').click();
+    cy.get('[data-cy="description"]').type(repositoryDescription);
+    cy.get('[data-cy="Submit"]').click();
+    cy.verifyPageTitle(repositoryName);
+    cy.get('[data-cy="description"]').should('contain', repositoryDescription);
+  });
 });
 
 describe('Repositories Remove collection', () => {

--- a/cypress/e2e/hub/repositories.cy.ts
+++ b/cypress/e2e/hub/repositories.cy.ts
@@ -5,7 +5,7 @@ describe('Repositories', () => {
   before(() => {
     cy.hubLogin();
   });
-  it('it should render the repositories page', () => {
+  it('should render the repositories page', () => {
     cy.navigateTo('hub', Repositories.url);
     cy.verifyPageTitle(Repositories.title);
   });
@@ -21,6 +21,21 @@ describe('Repositories', () => {
     cy.get('[data-cy="copy-cli-configuration"]').click();
     cy.get('[data-cy="alert-toaster"]').should('be.visible');
     cy.galaxykit('-i repository delete ' + repositoryName);
+  });
+  it('should be able to create a repository', () => {
+    const repositoryName =
+      'repositories_repository_' + randomString(6, undefined, { isLowercase: true });
+    const repositoryDescription = 'Here goes description';
+    cy.navigateTo('hub', Repositories.url);
+    cy.verifyPageTitle(Repositories.title);
+    cy.get('[data-cy="create-repository"]').should('be.visible').click();
+    cy.url().should('include', Repositories.urlCreate);
+    cy.get('[data-cy="name"]').type(repositoryName);
+    cy.get('[data-cy="description"]').type(repositoryDescription);
+    cy.get('[data-cy="Submit"]').click();
+    // new repository should be create and an user redirected to its detail page
+    cy.verifyPageTitle(repositoryName);
+    cy.get('[data-cy="description"]').should('contain', repositoryDescription);
   });
 });
 

--- a/cypress/e2e/hub/repositories.cy.ts
+++ b/cypress/e2e/hub/repositories.cy.ts
@@ -37,6 +37,7 @@ describe('Repositories', () => {
     // new repository should be create and an user redirected to its detail page
     cy.verifyPageTitle(repositoryName);
     cy.get('[data-cy="description"]').should('contain', repositoryDescription);
+    cy.galaxykit('-i repository delete ' + repositoryName);
   });
   it('should be able to edit a repository', () => {
     const repositoryName =
@@ -60,6 +61,7 @@ describe('Repositories', () => {
     cy.wait('@editRepository').then(() => {
       cy.get('[data-cy="description"]').should('contain', repositoryDescription);
     });
+    cy.galaxykit('-i repository delete ' + repositoryName);
   });
   it('should be able to delete a repository', () => {
     const repositoryName =


### PR DESCRIPTION
- [x] create repository

- [x] edit repository

- [x] delete repository

Once `galaxykit` is stable I'll update the tests to create repository with it for edit/delete use case.

Related issues: 
https://issues.redhat.com/browse/AAH-2912
https://issues.redhat.com/browse/AAH-2913
https://issues.redhat.com/browse/AAH-2914
https://issues.redhat.com/browse/AAH-2917