### PR TITLE
HUB galaxykit E2E user per Cypress parallel test run

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,8 +6,8 @@ import '@cypress/code-coverage/support';
 import 'cypress-file-upload';
 import { SetOptional, SetRequired } from 'type-fest';
 import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
-import { AwxToken } from '../../frontend/awx/interfaces/AwxToken';
 import { Application } from '../../frontend/awx/interfaces/Application';
+import { AwxToken } from '../../frontend/awx/interfaces/AwxToken';
 import { Credential } from '../../frontend/awx/interfaces/Credential';
 import { CredentialType } from '../../frontend/awx/interfaces/CredentialType';
 import { ExecutionEnvironment } from '../../frontend/awx/interfaces/ExecutionEnvironment';
@@ -41,6 +41,7 @@ import {
 import { EdaUser, EdaUserCreateUpdate } from '../../frontend/eda/interfaces/EdaUser';
 import { Role as HubRole } from '../../frontend/hub/access/roles/Role';
 import { RemoteRegistry } from '../../frontend/hub/administration/remote-registries/RemoteRegistry';
+import { CollectionVersionSearch } from '../../frontend/hub/collections/Collection';
 import './auth';
 import './awx-commands';
 import { IAwxResources } from './awx-commands';
@@ -50,7 +51,6 @@ import './e2e';
 import './eda-commands';
 import './hub-commands';
 import './rest-commands';
-import { CollectionVersionSearch } from '../../frontend/hub/collections/Collection';
 
 declare global {
   namespace Cypress {
@@ -305,6 +305,16 @@ declare global {
 
       /** Sends a request to the API to create a particular resource. */
       requestPost<ResponseT, RequestT = ResponseT>(
+        url: string,
+        data: Partial<RequestT>
+      ): Chainable<ResponseT>;
+
+      requestPut<ResponseT, RequestT = ResponseT>(
+        url: string,
+        data: Partial<RequestT>
+      ): Chainable<ResponseT>;
+
+      requestPatch<ResponseT, RequestT = ResponseT>(
         url: string,
         data: Partial<RequestT>
       ): Chainable<ResponseT>;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,6 +18,7 @@ before(function () {
       cy.createGlobalProject();
       break;
     case '4102': // HUB
+      cy.hubLogin();
       cy.requestPost<{ id: number }, HubUser>(hubAPI`/_ui/v1/users/`, {
         username: galaxykitUsername,
         first_name: '',

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -6,6 +6,7 @@ import { parsePulpIDFromURL } from '../../frontend/hub/common/api/hub-api-utils'
 import { HubItemsResponse } from '../../frontend/hub/common/useHubView';
 import { HubNamespace } from '../../frontend/hub/namespaces/HubNamespace';
 import './commands';
+import { galaxykitPassword, galaxykitUsername } from './e2e';
 import { hubAPI, pulpAPI } from './formatApiPathForHub';
 import './rest-commands';
 import { escapeForShellCommand } from './utils';
@@ -14,15 +15,13 @@ const apiPrefix = Cypress.env('HUB_API_PREFIX') as string;
 
 // GalaxyKit Integration: To invoke `galaxykit` commands for generating resources
 Cypress.Commands.add('galaxykit', (operation: string, ...args: string[]) => {
-  const adminUsername = Cypress.env('HUB_USERNAME') as string;
-  const adminPassword = Cypress.env('HUB_PASSWORD') as string;
   const galaxykitCommand = (Cypress.env('HUB_GALAXYKIT_COMMAND') as string) ?? 'galaxykit';
   const server = (Cypress.env('HUB_SERVER') as string) + apiPrefix + '/';
   const options = { failOnNonZeroExit: false };
 
   cy.log(`${galaxykitCommand} ${operation} ${args.join(' ')}`);
 
-  const cmd = `${galaxykitCommand} -c -s '${server}' -u '${adminUsername}' -p '${adminPassword}' ${operation} ${escapeForShellCommand(
+  const cmd = `${galaxykitCommand} -c -s '${server}' -u '${galaxykitUsername}' -p '${galaxykitPassword}' ${operation} ${escapeForShellCommand(
     args
   )}`;
 

--- a/cypress/support/rest-commands.ts
+++ b/cypress/support/rest-commands.ts
@@ -20,6 +20,44 @@ Cypress.Commands.add('requestPost', function requestPost<
   );
 });
 
+Cypress.Commands.add('requestPut', function requestPost<
+  ResponseT,
+  RequestT = ResponseT,
+>(url: string, body: Partial<RequestT>) {
+  cy.getCookie('csrftoken').then((cookie) =>
+    cy
+      .request<ResponseT>({
+        method: 'PUT',
+        url,
+        body,
+        headers: {
+          'X-CSRFToken': cookie?.value,
+          Referer: Cypress.config().baseUrl,
+        },
+      })
+      .then((response) => response.body)
+  );
+});
+
+Cypress.Commands.add('requestPatch', function requestPost<
+  ResponseT,
+  RequestT = ResponseT,
+>(url: string, body: Partial<RequestT>) {
+  cy.getCookie('csrftoken').then((cookie) =>
+    cy
+      .request<ResponseT>({
+        method: 'PATCH',
+        url,
+        body,
+        headers: {
+          'X-CSRFToken': cookie?.value,
+          Referer: Cypress.config().baseUrl,
+        },
+      })
+      .then((response) => response.body)
+  );
+});
+
 Cypress.Commands.add('requestGet', function requestGet<T>(url: string) {
   return cy.request<T>({ method: 'GET', url }).then((response) => response.body);
 });

--- a/frontend/hub/interfaces/expanded/HubUser.ts
+++ b/frontend/hub/interfaces/expanded/HubUser.ts
@@ -1,0 +1,6 @@
+import { User } from '../generated/User';
+
+export interface HubUser extends User {
+  id: number;
+  groups: string[];
+}


### PR DESCRIPTION
galaxykit takes in username and password and seems to be underneath getting a token for the user. galaxy can only have one token for a user, so it invalidates the previous token. if two test runs are running with the same user, they invalidate the token the other one is using, resulting in random failures. the fix is to have an e2e user per run, but with cypress we can also turn on parallelization of tests, meaning one run could have multiple parallel tests, causing the same issue. The fix then is to have an e2e user per parallel run. To do that we create the user in a before() and clean the user up in an after().