### PR TITLE
Prevents circular dependencies on workflows

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
@@ -172,6 +172,7 @@ export const Visualizer = ({ data: { workflowNodes = [], template } }: TopologyP
         data: {
           resource: n,
         },
+        state: { isInvalidLinkTarget: false },
       };
 
       return node;

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomEdge.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomEdge.tsx
@@ -53,7 +53,6 @@ const CustomEdgeInner: FC<
   const [tagHover, tagHoverRef] = useHover(0);
   const startPoint = edgeElement.getStartPoint();
   const endPoint = edgeElement.getEndPoint();
-
   const edgePath = integralShapePath(startPoint, endPoint, 0, 20);
   const { centerPoint, pathRef } = useCenterPoint(edgePath);
   const isSourceRootNode = edgeElement.getSource().getId() === START_NODE_ID;

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
@@ -12,6 +12,7 @@ import {
 import {
   DefaultNode,
   LabelPosition,
+  NodeStatus,
   WithContextMenuProps,
   WithCreateConnectorProps,
   WithDragNodeProps,
@@ -44,14 +45,19 @@ export const CustomNode: FC<
 
   const { element, contextMenuOpen, onContextMenu, onSelect, selected, ...rest } = props;
   const data = element.getData();
+  const isInvalidLinkTarget = element.getState<{ isInvalidLinkTarget: boolean }>()
+    .isInvalidLinkTarget;
+
   const id = element.getId();
   const jobType = data && data.resource.summary_fields?.unified_job_template?.unified_job_type;
 
   if (!data && id !== START_NODE_ID) return null;
-
   const Icon = jobType ? NodeIcon[jobType] : TrashIcon;
   return id !== START_NODE_ID ? (
     <DefaultNode
+      nodeStatus={isInvalidLinkTarget ? NodeStatus.danger : NodeStatus.default}
+      showStatusDecorator
+      canDrop={!isInvalidLinkTarget}
       element={element}
       labelClassName={`${id}-node-label`}
       contextMenuOpen={contextMenuOpen}
@@ -63,7 +69,6 @@ export const CustomNode: FC<
         onSelect && onSelect(e);
       }}
       selected={selected}
-      showStatusDecorator
       truncateLength={20}
       {...rest}
     >

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useCreateEdge.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useCreateEdge.tsx
@@ -22,6 +22,7 @@ export function useCreateEdge() {
         type: 'edge',
         source,
         target,
+        visible: true,
         data: {
           originalStatus,
           source,

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useHandleCollectNodeProps.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useHandleCollectNodeProps.tsx
@@ -1,0 +1,41 @@
+import {
+  DropTargetMonitor,
+  GraphElementProps,
+  Node,
+  NodeModel,
+  NodeShape,
+  action,
+} from '@patternfly/react-topology';
+import { useCallback } from 'react';
+import { useTargetNodeAncestors } from './useTargetNodeAncestors';
+import { GraphNodeData } from '../types';
+
+export function useHandleCollectNodeProps() {
+  const targetNodeAncestors = useTargetNodeAncestors();
+  return useCallback(
+    (monitor: DropTargetMonitor, props: GraphElementProps) => {
+      const isDragging = monitor.isDragging();
+
+      const target = monitor.getDropResult() as Node;
+      const isInvalidLinkTarget: boolean =
+        target?.getState<{ isInvalidLinkTarget: boolean }>()?.isInvalidLinkTarget ?? false;
+
+      const sourceNode = monitor.getItem() as Node;
+
+      if (!isDragging) {
+        const iteratedNode = props.element as Node<NodeModel, GraphNodeData>;
+        iteratedNode.setState({ ...props.element.getState(), isInvalidLinkTarget: false });
+        action(() => iteratedNode.setNodeShape(NodeShape.circle))();
+      }
+      if (isDragging) {
+        targetNodeAncestors(sourceNode);
+      }
+      return {
+        ...props,
+        canDrop: isInvalidLinkTarget,
+        edgeDragging: isDragging,
+      };
+    },
+    [targetNodeAncestors]
+  );
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useRemoveGraphElements.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useRemoveGraphElements.tsx
@@ -123,7 +123,12 @@ export function useRemoveGraphElements() {
 
   const handleRemoveLink = action((element: Edge) => {
     element.setVisible(false);
-    element.getSource().setState({ modified: true });
+    element.getSource().setState({ modified: true, isInvalidLinkTarget: false });
+
+    const model = element.getController().toModel();
+    const edges = model?.edges?.filter((edge) => edge.id !== element.getId());
+    model.edges = edges;
+    element.getController().fromModel(model);
   });
   const removeLink = useCallback(
     (element: Edge) => {

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useTargetNodeAncestors.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useTargetNodeAncestors.tsx
@@ -1,0 +1,56 @@
+import { ElementModel, GraphElement, NodeShape, action } from '@patternfly/react-topology';
+import { useCallback } from 'react';
+import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
+
+export function useTargetNodeAncestors() {
+  return useCallback((source: GraphElement<ElementModel, { resource: WorkflowNode }>) => {
+    if (!source?.getGraph?.()) return;
+    const nodes = source.getGraph().getNodes();
+    const links = source.getGraph().getEdges();
+    const newNodes = [...nodes];
+    const parentMap: Record<string, { parents: string[]; traversed: boolean }> = {};
+    const invalidLinkTargetIds: string[] = [];
+    // Find and mark any ancestors as disabled to prevent cycles
+    links.forEach((link) => {
+      // id=1 is our artificial root node so we don't care about that
+      if (link.getSource().getId() === 'startNode') {
+        return;
+      }
+      if (link.getSource().getId() === source.getId()) {
+        // Disables direct children from the add link process
+        invalidLinkTargetIds.push(link.getTarget().getId());
+      }
+      if (!parentMap[link.getTarget().getId()]) {
+        parentMap[link.getTarget().getId()] = {
+          parents: [],
+          traversed: false,
+        };
+      }
+      parentMap[link.getTarget().getId()].parents.push(link.getSource().getId());
+    });
+
+    const getAncestors = (id: string) => {
+      if (parentMap[id] && !parentMap[id].traversed) {
+        parentMap[id].parents.forEach((parentId) => {
+          invalidLinkTargetIds.push(parentId);
+          getAncestors(parentId);
+        });
+        parentMap[id].traversed = true;
+      }
+    };
+
+    getAncestors(source.getId());
+
+    // Filter out the duplicates
+    invalidLinkTargetIds
+      .filter((element, index, array) => index === array.indexOf(element))
+      .forEach((ancestorId) => {
+        newNodes.forEach((node) => {
+          if (node.getId() === ancestorId) {
+            node.setState({ ...node.getState(), isInvalidLinkTarget: true });
+            action(() => node.setNodeShape(NodeShape.hexagon))();
+          }
+        });
+      });
+  }, []);
+}


### PR DESCRIPTION
This addresses #20243. It prevents circular dependencies by disabling nodes that are in the family tree of the source node.  

A disabled node is indicated, while dragging to edge connector, by making the outline of the node red, and changing the shape of the node to a hexagon.  When the user drops the connector the nodes return to the default state.
![ancestors](https://github.com/ansible/ansible-ui/assets/39280967/797c13eb-b9db-49bb-9bf1-02433a2b7d2a)
