### PR TITLE
Repository detail add collection

### DIFF
--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -33,7 +33,7 @@ export type MultiSelectDialogProps<T extends object> = {
   defaultSort?: string;
   maxSelections?: number;
   allowZeroSelections?: boolean;
-  onClose? : () => void;
+  onClose?: () => void;
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
@@ -52,8 +52,7 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
   } = props;
   const [_, setDialog] = usePageDialog();
   let onClose = useCallback(() => setDialog(undefined), [setDialog]);
-  if (props.onClose)
-  {
+  if (props.onClose) {
     onClose = props.onClose;
   }
   const [translations] = useFrameworkTranslations();

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -33,6 +33,7 @@ export type MultiSelectDialogProps<T extends object> = {
   defaultSort?: string;
   maxSelections?: number;
   allowZeroSelections?: boolean;
+  onClose? : () => void;
 };
 
 export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProps<T>) {
@@ -50,7 +51,11 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     allowZeroSelections,
   } = props;
   const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  let onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  if (props.onClose)
+  {
+    onClose = props.onClose;
+  }
   const [translations] = useFrameworkTranslations();
   return (
     <Modal

--- a/framework/PageDialogs/SelectSingleDialog.tsx
+++ b/framework/PageDialogs/SelectSingleDialog.tsx
@@ -18,18 +18,17 @@ export type SelectSingleDialogProps<T extends object> = {
   cancelText?: string;
   emptyStateTitle?: string;
   errorStateTitle?: string;
-  onClose? : () => void;
+  onClose?: () => void;
 };
 
 export function SelectSingleDialog<T extends object>(props: SelectSingleDialogProps<T>) {
   const { title, view, tableColumns, toolbarFilters, confirmText, cancelText, onSelect } = props;
   const [_, setDialog] = usePageDialog();
   let onClose = useCallback(() => setDialog(undefined), [setDialog]);
-  if (props.onClose)
-  {
+  if (props.onClose) {
     onClose = props.onClose;
   }
-  
+
   const [translations] = useFrameworkTranslations();
   return (
     <Modal

--- a/framework/PageDialogs/SelectSingleDialog.tsx
+++ b/framework/PageDialogs/SelectSingleDialog.tsx
@@ -18,12 +18,18 @@ export type SelectSingleDialogProps<T extends object> = {
   cancelText?: string;
   emptyStateTitle?: string;
   errorStateTitle?: string;
+  onClose? : () => void;
 };
 
 export function SelectSingleDialog<T extends object>(props: SelectSingleDialogProps<T>) {
   const { title, view, tableColumns, toolbarFilters, confirmText, cancelText, onSelect } = props;
   const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  let onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  if (props.onClose)
+  {
+    onClose = props.onClose;
+  }
+  
   const [translations] = useFrameworkTranslations();
   return (
     <Modal

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
@@ -55,11 +55,13 @@ export function multiSelectBrowseAdapter<T>(
   keyFn: (item: T) => string,
   /** The function to create an object from the key. Used for default selection in the dialog. */
   objectFn: (name: string) => object,
-  customOnSelect?: (items : T[]) => void,
+  customOnSelect?: (items: T[]) => void
 ): ToolbarOpenMultiSelectBrowse {
   return (onSelect: (value: string[]) => void, defaultSelections?: string[]) => {
     selectFn(
-      (items: T[]) => {customOnSelect ? customOnSelect(items) : onSelect(items.map((item) => keyFn(item)))},
+      (items: T[]) => {
+        customOnSelect ? customOnSelect(items) : onSelect(items.map((item) => keyFn(item)));
+      },
       defaultSelections
         ? defaultSelections.map((defaultSelection) => objectFn(defaultSelection) as T)
         : []

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
@@ -54,11 +54,12 @@ export function multiSelectBrowseAdapter<T>(
   /** The function to get a unique key from the object. Used as the string value in the toolbar filter values and query string. */
   keyFn: (item: T) => string,
   /** The function to create an object from the key. Used for default selection in the dialog. */
-  objectFn: (name: string) => object
+  objectFn: (name: string) => object,
+  customOnSelect?: (items : T[]) => void,
 ): ToolbarOpenMultiSelectBrowse {
   return (onSelect: (value: string[]) => void, defaultSelections?: string[]) => {
     selectFn(
-      (items: T[]) => onSelect(items.map((item) => keyFn(item))),
+      (items: T[]) => {customOnSelect ? customOnSelect(items) : onSelect(items.map((item) => keyFn(item)))},
       defaultSelections
         ? defaultSelections.map((defaultSelection) => objectFn(defaultSelection) as T)
         : []

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
@@ -24,7 +24,11 @@ export type AsyncSelectFilterBuilderProps<T extends object> = {
 export function useAsyncSingleSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  const [_, setDialog] = usePageDialog();
+  let [_, setDialog] = usePageDialog();
+  if (props.multiDialogs?.pushDialog)
+  {
+    setDialog = props.multiDialogs.pushDialog;
+  }
 
   return {
     openBrowse: useCallback(
@@ -46,7 +50,11 @@ export function useAsyncSingleSelectFilterBuilder<T extends object>(
 export function useAsyncMultiSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  const [_, setDialog] = usePageDialog();
+  let [_, setDialog] = usePageDialog();
+  if (props.multiDialogs?.pushDialog)
+  {
+    setDialog = props.multiDialogs.pushDialog;
+  }
 
   return {
     openBrowse: useCallback(
@@ -88,6 +96,7 @@ function SelectFilter<T extends object>(
         toolbarFilters={toolbarFilters ? toolbarFilters : []}
         tableColumns={tableColumns}
         view={view}
+        onClose={props.multiDialogs ? () => props.multiDialogs?.popDialog() : undefined}
       />
     );
   } else {
@@ -98,6 +107,7 @@ function SelectFilter<T extends object>(
         toolbarFilters={toolbarFilters ? toolbarFilters : []}
         tableColumns={tableColumns}
         view={view}
+        onClose={props.multiDialogs ? () => props.multiDialogs?.popDialog() : undefined}
       />
     );
   }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
@@ -24,7 +24,7 @@ export type AsyncSelectFilterBuilderProps<T extends object> = {
 export function useAsyncSingleSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  let [_, setDialog] = usePageDialog();
+  let [, setDialog] = usePageDialog();
   if (props.multiDialogs?.pushDialog) {
     setDialog = props.multiDialogs.pushDialog;
   }
@@ -49,7 +49,7 @@ export function useAsyncSingleSelectFilterBuilder<T extends object>(
 export function useAsyncMultiSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  let [_, setDialog] = usePageDialog();
+  let [, setDialog] = usePageDialog();
   if (props.multiDialogs?.pushDialog) {
     setDialog = props.multiDialogs.pushDialog;
   }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
@@ -3,6 +3,7 @@ import { ITableColumn, IToolbarFilter, usePageDialog, ISelected } from '../../..
 import { MultiSelectDialog } from '../../../framework/PageDialogs/MultiSelectDialog';
 import { SelectSingleDialog } from '../../../framework/PageDialogs/SelectSingleDialog';
 import { IView, ViewExtendedOptions } from '../../useView';
+import { MultiDialogs } from '../../../frontend/hub/administration/repositories/hooks/useAddCollections';
 
 type BaseView<T extends object> = IView &
   ISelected<T> & {
@@ -17,6 +18,7 @@ export type AsyncSelectFilterBuilderProps<T extends object> = {
   toolbarFilters?: IToolbarFilter[];
   viewParams: ViewExtendedOptions<T>;
   useView: (viewParams: ViewExtendedOptions<T>) => BaseView<T>;
+  multiDialogs? : MultiDialogs;
 };
 
 export function useAsyncSingleSelectFilterBuilder<T extends object>(

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder.tsx
@@ -18,15 +18,14 @@ export type AsyncSelectFilterBuilderProps<T extends object> = {
   toolbarFilters?: IToolbarFilter[];
   viewParams: ViewExtendedOptions<T>;
   useView: (viewParams: ViewExtendedOptions<T>) => BaseView<T>;
-  multiDialogs? : MultiDialogs;
+  multiDialogs?: MultiDialogs;
 };
 
 export function useAsyncSingleSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
   let [_, setDialog] = usePageDialog();
-  if (props.multiDialogs?.pushDialog)
-  {
+  if (props.multiDialogs?.pushDialog) {
     setDialog = props.multiDialogs.pushDialog;
   }
 
@@ -51,8 +50,7 @@ export function useAsyncMultiSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
   let [_, setDialog] = usePageDialog();
-  if (props.multiDialogs?.pushDialog)
-  {
+  if (props.multiDialogs?.pushDialog) {
     setDialog = props.multiDialogs.pushDialog;
   }
 

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -56,11 +56,13 @@ export function singleSelectBrowseAdapter<T>(
   keyFn: (item: T) => string,
   /** The function to create an object from the key. Used for default selection in the dialog. */
   objectFn: (name: string) => object,
-  customOnSelect?: (item : T) => void,
+  customOnSelect?: (item: T) => void
 ): ToolbarOpenSingleSelectBrowse {
   return (onSelect: (value: string) => void, defaultSelection?: string) => {
     selectFn(
-      (item: T) => {customOnSelect ? customOnSelect(item) : onSelect(keyFn(item))},
+      (item: T) => {
+        customOnSelect ? customOnSelect(item) : onSelect(keyFn(item));
+      },
       defaultSelection ? (objectFn(defaultSelection) as T) : undefined
     );
   };

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -55,11 +55,12 @@ export function singleSelectBrowseAdapter<T>(
   /** The function to get a unique key from the object. Used as the string value in the toolbar filter values and query string. */
   keyFn: (item: T) => string,
   /** The function to create an object from the key. Used for default selection in the dialog. */
-  objectFn: (name: string) => object
+  objectFn: (name: string) => object,
+  customOnSelect?: (item : T) => void,
 ): ToolbarOpenSingleSelectBrowse {
   return (onSelect: (value: string) => void, defaultSelection?: string) => {
     selectFn(
-      (item: T) => onSelect(keyFn(item)),
+      (item: T) => {customOnSelect ? customOnSelect(item) : onSelect(keyFn(item))},
       defaultSelection ? (objectFn(defaultSelection) as T) : undefined
     );
   };

--- a/frontend/hub/administration/repositories/AddCollectionsModal.tsx
+++ b/frontend/hub/administration/repositories/AddCollectionsModal.tsx
@@ -1,0 +1,8 @@
+import { usePageDialogs } from "../../../../framework";
+import { Repository } from "./Repository";
+
+function AddCollectionsToRepository(repository : Repository)
+{
+    
+    return <></>;
+}

--- a/frontend/hub/administration/repositories/AddCollectionsModal.tsx
+++ b/frontend/hub/administration/repositories/AddCollectionsModal.tsx
@@ -1,8 +1,0 @@
-import { usePageDialogs } from "../../../../framework";
-import { Repository } from "./Repository";
-
-function AddCollectionsToRepository(repository : Repository)
-{
-    
-    return <></>;
-}

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
@@ -16,6 +16,7 @@ import { useMemo } from 'react';
 import { useHubBulkConfirmation } from '../../../common/useHubBulkConfirmation';
 import { useCallback } from 'react';
 import { ITableColumn } from '../../../../../framework';
+import { useAddCollections } from '../hooks/useAddCollections';
 
 export function RepositoryCollectionVersion() {
   const { t } = useTranslation();
@@ -46,22 +47,28 @@ export function RepositoryCollectionVersion() {
     setSelectedCollections([]);
   }, 'remove');
 
+  const runAddModal = useAddCollections(repository);
+
   return (
     <PageTable<CollectionVersionSearch>
       id="hub-collection-versions-search-table"
       tableColumns={tableColumns}
       toolbarFilters={toolbarFilters}
       toolbarContent={
-        <Button
-          onClick={() =>
-            dialog([selectedCollections], () =>
-              deleteCollectionFromRepository(repository, selectedCollections, true)
-            )
-          }
-          isDisabled={selectedCollections.length === 0}
-        >
-          {t('Remove collections')}
-        </Button>
+        <>
+          <Button
+            onClick={() =>
+              dialog([selectedCollections], () =>
+                deleteCollectionFromRepository(repository, selectedCollections, true)
+              )
+            }
+            isDisabled={selectedCollections.length === 0}
+          >
+            {t('Remove collections')}
+          </Button>
+          &nbsp;&nbsp;
+          <Button onClick={() => runAddModal()}>{t('Add collections')}</Button>
+        </>
       }
       rowActions={rowActions}
       errorStateTitle={t('Error loading collection versions')}

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
@@ -47,7 +47,10 @@ export function RepositoryCollectionVersion() {
     setSelectedCollections([]);
   }, 'remove');
 
-  const runAddModal = useAddCollections(repository);
+  const runAddModal = useAddCollections(repository, () => {
+    view.unselectItemsAndRefresh([]);
+    setSelectedCollections([]);
+  });
 
   return (
     <PageTable<CollectionVersionSearch>

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
@@ -76,6 +76,8 @@ export function RepositoryCollectionVersion() {
       rowActions={rowActions}
       errorStateTitle={t('Error loading collection versions')}
       emptyStateTitle={t('No collection versions yet')}
+      emptyStateButtonText={t('Add collections')}
+      emptyStateButtonClick={() => runAddModal()}
       emptyStateDescription={t('Collection versions will appear once the repository is modified.')}
       {...view}
       defaultTableView="list"

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -28,7 +28,6 @@ import { TextCell } from '../../../../../framework';
 import { HubRoute } from '../../../main/HubRoutes';
 import { useSearchParams } from '../../../../../framework/components/useSearchParams';
 
-
 export function useAddCollections(repository: Repository) {
   const { pushDialog, popDialog } = usePageDialogs();
 
@@ -36,7 +35,7 @@ export function useAddCollections(repository: Repository) {
     pushDialog(
       <AddCollectionToRepositoryModal
         repository={repository}
-        multiDialogs={ {pushDialog, popDialog} }
+        multiDialogs={{ pushDialog, popDialog }}
       />
     );
   };
@@ -44,8 +43,7 @@ export function useAddCollections(repository: Repository) {
 
 function AddCollectionToRepositoryModal(props: {
   repository: Repository;
-  multiDialogs : MultiDialogs;
-  
+  multiDialogs: MultiDialogs;
 }): ReactNode {
   const { t } = useTranslation();
   const toolbarFilters = useRepositoryCollectionVersionFiltersAdd(props.multiDialogs);
@@ -111,13 +109,13 @@ function AddCollectionToRepositoryModal(props: {
   );
 }
 
-function useRepositoryCollectionVersionFiltersAdd(multiDialogs : MultiDialogs) {
+function useRepositoryCollectionVersionFiltersAdd(multiDialogs: MultiDialogs) {
   const { t } = useTranslation();
 
   const repoQueryOptions = useRepoQueryOptions();
   const selectRepositorySingle = useSelectRepositorySingle(multiDialogs);
 
-  const [ ,setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
   const params = new URLSearchParams();
 
   const repoSelector = singleSelectBrowseAdapter<AnsibleRepository>(
@@ -126,7 +124,10 @@ function useRepositoryCollectionVersionFiltersAdd(multiDialogs : MultiDialogs) {
     (name) => {
       return { name };
     },
-    (item) => {params.set('repository', item.name);  setSearchParams(params);},
+    (item) => {
+      params.set('repository', item.name);
+      setSearchParams(params);
+    }
   );
 
   return useMemo<IToolbarFilter[]>(
@@ -250,8 +251,7 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
   );
 }
 
-export type MultiDialogs =
-{
-    pushDialog: (_dialog: ReactNode) => void;
-    popDialog: () => void;
-}
+export type MultiDialogs = {
+  pushDialog: (_dialog: ReactNode) => void;
+  popDialog: () => void;
+};

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -74,7 +74,6 @@ function AddCollectionToRepositoryModal(props: {
   const [error, setError] = useState<string>('');
 
   async function addCollectionsToRepository(collections: CollectionVersionSearch[]) {
-
     let operationOk = true;
 
     try {
@@ -96,7 +95,7 @@ function AddCollectionToRepositoryModal(props: {
       // get unique items
       itemsToDAdd = [...new Set(itemsToDAdd)];
 
-      const res: { task: string } = (await postRequest(
+      const res: { task: string } = await postRequest(
         pulpAPI`/repositories/ansible/ansible/${
           parsePulpIDFromURL(actualRepository.pulp_href) || ''
         }/modify/`,
@@ -104,7 +103,7 @@ function AddCollectionToRepositoryModal(props: {
           add_content_units: itemsToDAdd,
           base_version: actualRepository.latest_version_href,
         }
-      ));
+      );
 
       if (res?.task) {
         await waitForTask(parsePulpIDFromURL(res.task));
@@ -112,8 +111,8 @@ function AddCollectionToRepositoryModal(props: {
       setIsLoading(false);
     } catch (err) {
       setIsLoading(false);
-      if (err)
-      {
+      if (err) {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         setError(err.toString());
       }
       operationOk = false;
@@ -136,8 +135,7 @@ function AddCollectionToRepositoryModal(props: {
           onClick={() => {
             void (async () => {
               const ok = await addCollectionsToRepository(selectedCollections);
-              if (ok)
-              {
+              if (ok) {
                 props.multiDialogs.popDialog();
                 props.refresh();
               }
@@ -197,7 +195,13 @@ function AddCollectionToRepositoryModal(props: {
           setSelectedCollections([]);
         }}
       />
-      {error ? <HubError error={{  name: '', message: t('Can not add collections to repository. ') + error }} /> : <></>}
+      {error ? (
+        <HubError
+          error={{ name: '', message: t('Can not add collections to repository. ') + error }}
+        />
+      ) : (
+        <></>
+      )}
     </Modal>
   );
 }

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -1,0 +1,246 @@
+import { AnsibleAnsibleRepositoryResponse as AnsibleRepository } from '../../../interfaces/generated/AnsibleAnsibleRepositoryResponse';
+import { Repository } from '../Repository';
+import { Modal } from '@patternfly/react-core';
+import { usePageDialogs } from '../../../../../framework';
+import { useHubView } from '../../../common/useHubView';
+import { CollectionVersionSearch } from '../../../collections/Collection';
+import { hubAPI } from '../../../common/api/formatPath';
+import { collectionKeyFn } from '../../../common/api/hub-api-utils';
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IToolbarFilter, ToolbarFilterType } from '../../../../../framework';
+import { useState } from 'react';
+import { useSelectRepositorySingle } from './useRepositorySelector';
+
+import { useRepoQueryOptions } from './useRepoQueryOptions';
+import { singleSelectBrowseAdapter } from '../../../../../framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
+import { PageTable } from '../../../../../framework';
+import { collectionId } from '../RepositoryPage/RepositoryCollectionVersion';
+import { ReactNode } from 'react';
+import { useGetPageUrl } from '../../../../../framework';
+import { ITableColumn } from '../../../../../framework';
+
+import { AnsibleTowerIcon } from '@patternfly/react-icons';
+
+import { TextCell } from '../../../../../framework';
+
+import { HubRoute } from '../../../main/HubRoutes';
+
+export function useAddCollections(repository: Repository) {
+  const { pushDialog, popDialog } = usePageDialogs();
+
+  return () => {
+    pushDialog(
+      <AddCollectionToRepositoryModal
+        repository={repository}
+        pushDialog={pushDialog}
+        popDialog={popDialog}
+      />
+    );
+  };
+}
+
+function AddCollectionToRepositoryModal(props: {
+  repository: Repository;
+  pushDialog: (_dialog: ReactNode) => void;
+  popDialog: () => void;
+}): ReactNode {
+  const { t } = useTranslation();
+  const toolbarFilters = useRepositoryCollectionVersionFiltersAdd();
+  const view = useHubView<CollectionVersionSearch>({
+    url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
+    keyFn: collectionKeyFn,
+    defaultSort: 'name',
+    queryParams: {
+      is_deprecated: 'false',
+    },
+    toolbarFilters,
+  });
+
+  const [selectedCollections, setSelectedCollections] = useState<CollectionVersionSearch[]>([]);
+  const tableColumns = useCollectionColumns();
+
+  return (
+    <Modal
+      onClose={props.popDialog}
+      isOpen
+      variant={'large'}
+      title={t('Add collections version to repository')}
+    >
+      <PageTable<CollectionVersionSearch>
+        disableListView={true}
+        disableCardView={true}
+        id="hub-collection-versions-search-table"
+        tableColumns={tableColumns}
+        toolbarFilters={toolbarFilters}
+        errorStateTitle={t('Error loading collection versions')}
+        emptyStateTitle={t('No collection versions yet')}
+        emptyStateDescription={t(
+          'Collection versions will appear once the repository is modified.'
+        )}
+        {...view}
+        defaultTableView="table"
+        defaultSubtitle={t('Collection')}
+        compact={true}
+        showSelect={true}
+        selectedItems={selectedCollections}
+        isSelectMultiple={true}
+        isSelected={(item) =>
+          selectedCollections.find((i) => collectionId(i) === collectionId(item)) ? true : false
+        }
+        selectItem={(item) => {
+          const newItems = [...selectedCollections, item];
+          setSelectedCollections(newItems);
+        }}
+        selectItems={(items) => {
+          const newItems = [...selectedCollections, ...items];
+          setSelectedCollections(newItems);
+        }}
+        unselectItem={(item) => {
+          setSelectedCollections(
+            selectedCollections.filter((item2) => collectionId(item2) !== collectionId(item))
+          );
+        }}
+        unselectAll={() => {
+          setSelectedCollections([]);
+        }}
+      />
+    </Modal>
+  );
+}
+
+function useRepositoryCollectionVersionFiltersAdd() {
+  const { t } = useTranslation();
+
+  const repoQueryOptions = useRepoQueryOptions();
+  const selectRepositorySingle = useSelectRepositorySingle();
+
+  const repoSelector = singleSelectBrowseAdapter<AnsibleRepository>(
+    selectRepositorySingle.openBrowse,
+    (item) => item.name,
+    (name) => {
+      return { name };
+    }
+  );
+
+  return useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'keywords',
+        label: t('Keywords'),
+        type: ToolbarFilterType.SingleText,
+        query: 'keywords',
+        comparison: 'equals',
+      },
+      {
+        key: 'namespace',
+        label: t('Namespace'),
+        type: ToolbarFilterType.SingleText,
+        query: 'namespace',
+        comparison: 'equals',
+      },
+      {
+        key: 'repository',
+        label: t('Repository'),
+        type: ToolbarFilterType.AsyncSingleSelect,
+        query: 'repository_name',
+        queryOptions: repoQueryOptions,
+        openBrowse: repoSelector,
+      },
+    ],
+    [t, repoSelector, repoQueryOptions]
+  );
+}
+
+export function useCollectionColumns(_options?: { disableSort?: boolean; disableLinks?: boolean }) {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+
+  return useMemo<ITableColumn<CollectionVersionSearch>[]>(
+    () => [
+      {
+        header: t('Name'),
+        value: (collection) => collection.collection_version?.name,
+        cell: (collection) => (
+          <TextCell
+            text={collection.collection_version?.name}
+            to={getPageUrl(HubRoute.CollectionPage, {
+              params: {
+                name: collection.collection_version?.name,
+                namespace: collection.collection_version?.namespace,
+                repository: collection.repository?.name,
+              },
+            })}
+          />
+        ),
+        card: 'name',
+        list: 'name',
+        icon: () => <AnsibleTowerIcon />,
+        sort: 'name',
+      },
+      {
+        header: t('Provided by'),
+        type: 'text',
+        value: (collection) =>
+          t(`Provided by {{namespace}}`, { namespace: collection.collection_version?.namespace }),
+        card: 'subtitle',
+        list: 'subtitle',
+        table: 'hidden',
+      },
+      {
+        header: t('Repository'),
+        value: (collection) => collection.repository?.name,
+        cell: (collection) => (
+          <TextCell
+            text={collection.repository?.name}
+            to={getPageUrl(HubRoute.RepositoryDetails, {
+              params: {
+                id: collection.repository?.name,
+              },
+            })}
+          />
+        ),
+      },
+      {
+        header: t('Namespace'),
+        value: (collection) => collection.collection_version?.namespace,
+        sort: 'namespace',
+        cell: (collection) => (
+          <TextCell
+            text={collection.collection_version?.namespace}
+            to={getPageUrl(HubRoute.NamespaceDetails, {
+              params: {
+                id: collection.collection_version?.namespace,
+              },
+            })}
+          />
+        ),
+      },
+      {
+        header: t('Description'),
+        type: 'description',
+        value: (collection) => collection.collection_version?.description,
+        card: 'description',
+        list: 'description',
+      },
+
+      {
+        header: t('Updated'),
+        type: 'datetime',
+        value: (collection) => collection.collection_version?.pulp_created,
+        card: 'hidden',
+        list: 'secondary',
+      },
+      {
+        header: t('Version'),
+        type: 'text',
+        value: (collection) => collection.collection_version?.version,
+        card: 'hidden',
+        list: 'secondary',
+        sort: 'version',
+      },
+    ],
+    [getPageUrl, t]
+  );
+}

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -26,6 +26,8 @@ import { AnsibleTowerIcon } from '@patternfly/react-icons';
 import { TextCell } from '../../../../../framework';
 
 import { HubRoute } from '../../../main/HubRoutes';
+import { useSearchParams } from '../../../../../framework/components/useSearchParams';
+
 
 export function useAddCollections(repository: Repository) {
   const { pushDialog, popDialog } = usePageDialogs();
@@ -115,9 +117,12 @@ function useRepositoryCollectionVersionFiltersAdd(multiDialogs : MultiDialogs) {
   const repoQueryOptions = useRepoQueryOptions();
   const selectRepositorySingle = useSelectRepositorySingle(multiDialogs);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const params = new URLSearchParams();
+
   const repoSelector = singleSelectBrowseAdapter<AnsibleRepository>(
     selectRepositorySingle.openBrowse,
-    (item) => item.name,
+    (item) => { params.set('repository', item.name);  setSearchParams(params); return item.name},
     (name) => {
       return { name };
     }

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -117,15 +117,16 @@ function useRepositoryCollectionVersionFiltersAdd(multiDialogs : MultiDialogs) {
   const repoQueryOptions = useRepoQueryOptions();
   const selectRepositorySingle = useSelectRepositorySingle(multiDialogs);
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [ ,setSearchParams] = useSearchParams();
   const params = new URLSearchParams();
 
   const repoSelector = singleSelectBrowseAdapter<AnsibleRepository>(
     selectRepositorySingle.openBrowse,
-    (item) => { params.set('repository', item.name);  setSearchParams(params); return item.name},
+    (item) => item.name,
     (name) => {
       return { name };
-    }
+    },
+    (item) => {params.set('repository', item.name);  setSearchParams(params);},
   );
 
   return useMemo<IToolbarFilter[]>(

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -46,7 +46,7 @@ function AddCollectionToRepositoryModal(props: {
   
 }): ReactNode {
   const { t } = useTranslation();
-  const toolbarFilters = useRepositoryCollectionVersionFiltersAdd();
+  const toolbarFilters = useRepositoryCollectionVersionFiltersAdd(props.multiDialogs);
   const view = useHubView<CollectionVersionSearch>({
     url: hubAPI`/v3/plugin/ansible/search/collection-versions/`,
     keyFn: collectionKeyFn,
@@ -109,11 +109,11 @@ function AddCollectionToRepositoryModal(props: {
   );
 }
 
-function useRepositoryCollectionVersionFiltersAdd() {
+function useRepositoryCollectionVersionFiltersAdd(multiDialogs : MultiDialogs) {
   const { t } = useTranslation();
 
   const repoQueryOptions = useRepoQueryOptions();
-  const selectRepositorySingle = useSelectRepositorySingle();
+  const selectRepositorySingle = useSelectRepositorySingle(multiDialogs);
 
   const repoSelector = singleSelectBrowseAdapter<AnsibleRepository>(
     selectRepositorySingle.openBrowse,

--- a/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
+++ b/frontend/hub/administration/repositories/hooks/useAddCollections.tsx
@@ -34,8 +34,7 @@ export function useAddCollections(repository: Repository) {
     pushDialog(
       <AddCollectionToRepositoryModal
         repository={repository}
-        pushDialog={pushDialog}
-        popDialog={popDialog}
+        multiDialogs={ {pushDialog, popDialog} }
       />
     );
   };
@@ -43,8 +42,8 @@ export function useAddCollections(repository: Repository) {
 
 function AddCollectionToRepositoryModal(props: {
   repository: Repository;
-  pushDialog: (_dialog: ReactNode) => void;
-  popDialog: () => void;
+  multiDialogs : MultiDialogs;
+  
 }): ReactNode {
   const { t } = useTranslation();
   const toolbarFilters = useRepositoryCollectionVersionFiltersAdd();
@@ -63,7 +62,7 @@ function AddCollectionToRepositoryModal(props: {
 
   return (
     <Modal
-      onClose={props.popDialog}
+      onClose={props.multiDialogs.popDialog}
       isOpen
       variant={'large'}
       title={t('Add collections version to repository')}
@@ -243,4 +242,10 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
     ],
     [getPageUrl, t]
   );
+}
+
+export type MultiDialogs =
+{
+    pushDialog: (_dialog: ReactNode) => void;
+    popDialog: () => void;
 }

--- a/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
@@ -14,8 +14,9 @@ import {
 import { pulpAPI } from '../../../common/api/formatPath';
 import { useHubView } from '../../../common/useHubView';
 import { AnsibleAnsibleRepositoryResponse as Repository } from '../../../interfaces/generated/AnsibleAnsibleRepositoryResponse';
+import { MultiDialogs } from './useAddCollections';
 
-function useParameters(): AsyncSelectFilterBuilderProps<Repository> {
+function useParameters(multiDialogs? : MultiDialogs): AsyncSelectFilterBuilderProps<Repository> {
   const tableColumns = useRepositoryColumns();
   const toolbarFilters = useRepositoryFilters();
   const { t } = useTranslation();
@@ -32,17 +33,18 @@ function useParameters(): AsyncSelectFilterBuilderProps<Repository> {
       disableQueryString: true,
       keyFn: (item) => item?.name,
     },
+    multiDialogs, 
   };
 }
 
-export function useSelectRepositoryMulti() {
-  const params = useParameters();
+export function useSelectRepositoryMulti(multiDialogs? : MultiDialogs) {
+  const params = useParameters(multiDialogs);
 
   return useAsyncMultiSelectFilterBuilder<Repository>(params);
 }
 
-export function useSelectRepositorySingle() {
-  const params = useParameters();
+export function useSelectRepositorySingle(multiDialogs? : MultiDialogs) {
+  const params = useParameters(multiDialogs);
 
   return useAsyncSingleSelectFilterBuilder<Repository>(params);
 }

--- a/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
@@ -16,7 +16,7 @@ import { useHubView } from '../../../common/useHubView';
 import { AnsibleAnsibleRepositoryResponse as Repository } from '../../../interfaces/generated/AnsibleAnsibleRepositoryResponse';
 import { MultiDialogs } from './useAddCollections';
 
-function useParameters(multiDialogs? : MultiDialogs): AsyncSelectFilterBuilderProps<Repository> {
+function useParameters(multiDialogs?: MultiDialogs): AsyncSelectFilterBuilderProps<Repository> {
   const tableColumns = useRepositoryColumns();
   const toolbarFilters = useRepositoryFilters();
   const { t } = useTranslation();
@@ -33,17 +33,17 @@ function useParameters(multiDialogs? : MultiDialogs): AsyncSelectFilterBuilderPr
       disableQueryString: true,
       keyFn: (item) => item?.name,
     },
-    multiDialogs, 
+    multiDialogs,
   };
 }
 
-export function useSelectRepositoryMulti(multiDialogs? : MultiDialogs) {
+export function useSelectRepositoryMulti(multiDialogs?: MultiDialogs) {
   const params = useParameters(multiDialogs);
 
   return useAsyncMultiSelectFilterBuilder<Repository>(params);
 }
 
-export function useSelectRepositorySingle(multiDialogs? : MultiDialogs) {
+export function useSelectRepositorySingle(multiDialogs?: MultiDialogs) {
   const params = useParameters(multiDialogs);
 
   return useAsyncSingleSelectFilterBuilder<Repository>(params);

--- a/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositorySelector.tsx
@@ -93,17 +93,6 @@ export function useRepositoryFilters() {
           { label: t('Rejected'), value: `pipeline=rejected` },
         ],
       },
-      {
-        key: 'remote',
-        label: t('Remote'),
-        type: ToolbarFilterType.SingleSelect,
-        placeholder: t('Remote'),
-        query: 'remote',
-        options: [
-          { label: t('None'), value: 'null' },
-          // TODO get all remotes
-        ],
-      },
     ],
     [t]
   );


### PR DESCRIPTION
Adds ability to add collection to particular repository at repositories -> detail -> tab collection versions.

 Button Add Collections in toolbar or empty state opens a modal that allows selection of collections. After clicking Confirm button, collections are added as one request to server (endpoint modify).
 
 What is hard in this PR is multiple modals - that required changes in the framework, because collections has repository selector filter, that has browse button, that opens another modal. So ToolbarAsyncBuilder (single and multi) has to be enhanced to not uses setDialog function, but pushDialog and popDialog props that can handle multiple modals.
 
 
![image](https://github.com/ansible/ansible-ui/assets/23277791/8c483a4c-c2e9-422e-9584-cb16020ff6ef)
