### PR TITLE
Execution Environment Details Fix

### DIFF
--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.cy.tsx
@@ -13,8 +13,8 @@ describe('ExecutionEnvironmentDetails', () => {
       .then((eeObject) => {
         cy.mount(<ExecutionEnvironmentDetails execution_env={eeObject} />);
         cy.get('.pf-v5-c-description-list')
-          .find('.pf-v5-c-description-list__text')
-          .should('have.length', 10);
+          .find('.pf-v5-c-description-list__group')
+          .should('have.length', 7);
       });
   });
   it('Render only required EE detail fields', () => {
@@ -24,6 +24,7 @@ describe('ExecutionEnvironmentDetails', () => {
         execution_env['name'] = 'test';
         execution_env['managed'] = false;
         execution_env['image'] = 'this.io/is/a/test:latest';
+        execution_env['pull'] = '';
 
         return execution_env;
       })
@@ -33,8 +34,8 @@ describe('ExecutionEnvironmentDetails', () => {
         cy.get('[data-cy="image"]').should('have.text', 'this.io/is/a/test:latest');
         cy.get('[data-cy="description"]').should('not.exist');
         cy.get('[data-cy="managed"]').should('have.text', 'false');
-        cy.get('[data-cy="organization"]').should('not.exist');
-        cy.get('[data-cy="pull"]').should('not.exist');
+        cy.get('[data-cy="organization"]').should('have.text', 'Globally Available');
+        cy.get('[data-cy="pull"]').should('have.text', 'Missing');
         cy.get('[date-cy="registry-credential"]').should('not.exist');
         cy.get('[data-cy="created"]').should('have.text', formatDateString(eeObject.created));
         cy.get('[data-cy="last-modified"]').should(

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -38,7 +38,32 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
       <PageDetail data-cy="execution-environment-name" label={t('Name')}>
         {execution_env.name}
       </PageDetail>
-      <PageDetail data-cy="execution-environment-image" label={t('Image')}>
+      <PageDetail
+        data-cy="execution-environment-image"
+        label={t('Image')}
+        helpText={
+          <span>
+            {t(
+              'The full image location, including the container registry, image name, and version tag.'
+            )}
+            <br />
+            <br />
+            {t(`Examples`)}
+            <ul>
+              <li>
+                <code>
+                  <b>quay.io/ansible/awx-ee:latest</b>
+                </code>
+              </li>
+              <li>
+                <code>
+                  <b>repo/project/image-name:tag</b>
+                </code>
+              </li>
+            </ul>
+          </span>
+        }
+      >
         {execution_env.image}
       </PageDetail>
       <PageDetail data-cy="execution-environment-description" label={t('Description')}>
@@ -56,10 +81,12 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
               params: { id: execution_env.summary_fields?.organization?.id },
             })}
           />
-        ) : undefined}
+        ) : (
+          t('Globally Available')
+        )}
       </PageDetail>
       <PageDetail data-cy="execution-environment-pull" label={t('Pull')}>
-        {execution_env.pull}
+        {execution_env.pull == '' ? 'Missing' : execution_env.pull}
       </PageDetail>
       <PageDetail data-cy="execution-environment-reg-cred" label={t('Registry Credential')}>
         {execution_env?.summary_fields?.credential?.name ? (

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -86,7 +86,7 @@ export function ExecutionEnvironmentDetailInner(props: { execution_env: Executio
         )}
       </PageDetail>
       <PageDetail data-cy="execution-environment-pull" label={t('Pull')}>
-        {execution_env.pull == '' ? 'Missing' : execution_env.pull}
+        {execution_env.pull === '' ? t('Missing') : execution_env.pull}
       </PageDetail>
       <PageDetail data-cy="execution-environment-reg-cred" label={t('Registry Credential')}>
         {execution_env?.summary_fields?.credential?.name ? (


### PR DESCRIPTION
This PR addresses an issue with the EE details page not showing default values for when an organization and image pull option are `null` and `""` respectively. In addition, a tooltip for the EE image field has been added to match that of the old UI.