### PR TITLE
cy.clickByDataCy

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -310,7 +310,7 @@ Cypress.Commands.add('clickTab', (label: string | RegExp, isLink) => {
 });
 
 Cypress.Commands.add('clickButton', (label: string | RegExp) => {
-  cy.contains('a:not(:disabled):not(:hidden)', label)
+  cy.contains('button:not(:disabled):not(:hidden)', label)
     .should('not.have.attr', 'aria-disabled', 'true')
     .should('be.visible');
   cy.contains('button:not(:disabled):not(:hidden)', label).click();

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -310,7 +310,19 @@ Cypress.Commands.add('clickTab', (label: string | RegExp, isLink) => {
 });
 
 Cypress.Commands.add('clickButton', (label: string | RegExp) => {
-  cy.contains('button', label).click();
+  cy.contains('a:not(:disabled):not(:hidden)', label)
+    .should('not.have.attr', 'aria-disabled', 'true')
+    .should('be.visible');
+  cy.contains('button:not(:disabled):not(:hidden)', label).click();
+});
+
+Cypress.Commands.add('clickByDataCy', (dataCy: string) => {
+  // Having the check before the click is needed for a timing issue which causes:
+  // We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.
+  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`)
+    .should('not.have.attr', 'aria-disabled', 'true')
+    .should('be.visible');
+  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`).click();
 });
 
 Cypress.Commands.add('navigateTo', (component: string, label: string) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -293,6 +293,10 @@ declare global {
 
       clickLink(label: string | RegExp): Chainable<void>;
       clickButton(label: string | RegExp): Chainable<void>;
+
+      /** Clicks an element with a data-cy attribute. Waits for the element to be enabled and visible. */
+      clickByDataCy(dataCy: string): Chainable<void>;
+
       clickPageAction(dataCyLabel: string | RegExp): Chainable<void>;
 
       /**Finds an alert by its label. Does not make an assertion.  */

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -37,8 +37,9 @@ Cypress.Commands.add(
     cy.get('[data-cy="text-input"]').within(() => {
       cy.get('input').clear().type(text, { delay: 0 });
     });
-    if (variant === 'MultiText')
-      cy.get('[data-cy="apply-filter"]:not(:disabled):not(:hidden)').click();
+    if (variant === 'MultiText') {
+      cy.clickByDataCy('apply-filter');
+    }
   }
 );
 


### PR DESCRIPTION
```ts
/** Clicks an element with a data-cy attribute. Waits for the element to be enabled and visible. */
Cypress.Commands.add('clickByDataCy', (dataCy: string) => {
  // Having the check before the click is needed for a timing issue which causes:
  // We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.
  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`)
    .should('not.have.attr', 'aria-disabled', 'true')
    .should('be.visible');
  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`).click();
});
```