### PR TITLE
Updates to PageDetailsFromColumns

### DIFF
--- a/framework/PageDetails/PageDetailsFromColumns.tsx
+++ b/framework/PageDetails/PageDetailsFromColumns.tsx
@@ -3,23 +3,15 @@
 import { Fragment } from 'react';
 import { ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
 import { PageDetail } from './PageDetail';
-import { PageDetails } from './PageDetails';
 
 export function PageDetailsFromColumns<T extends object>(props: {
   item: T | undefined;
   columns: ITableColumn<T>[];
-  disablePadding?: boolean;
-  numberOfColumns?: 'multiple' | 'single';
-  labelOrientation?: 'horizontal' | 'vertical';
 }) {
-  const { item, columns, disablePadding, numberOfColumns } = props;
+  const { item, columns } = props;
   if (!item) return <></>;
   return (
-    <PageDetails
-      disablePadding={disablePadding}
-      numberOfColumns={numberOfColumns}
-      labelOrientation={props.labelOrientation}
-    >
+    <>
       {columns.map((column) => {
         if ('value' in column && column.value) {
           const itemValue = column.value(item);
@@ -33,6 +25,6 @@ export function PageDetailsFromColumns<T extends object>(props: {
           </PageDetail>
         );
       })}
-    </PageDetails>
+    </>
   );
 }

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -64,6 +64,7 @@ import {
   useVisibleTableColumns,
 } from './PageTableColumn';
 import { PageTableList } from './PageTableList';
+import { PageDetails } from '../PageDetails/PageDetails';
 
 const ScrollDiv = styled.div`
   height: 100%;
@@ -442,14 +443,9 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
 
     if (expandedRowColumns.length) {
       expandedRowFunctions.push((item) => (
-        <PageDetailsFromColumns
-          key={keyFn(item)}
-          item={item}
-          columns={expandedRowColumns}
-          disablePadding
-          numberOfColumns="multiple"
-          labelOrientation="vertical"
-        />
+        <PageDetails disablePadding numberOfColumns="multiple" labelOrientation="vertical">
+          <PageDetailsFromColumns key={keyFn(item)} item={item} columns={expandedRowColumns} />
+        </PageDetails>
       ));
     }
 

--- a/frontend/awx/access/roles/AwxRoleDetails.tsx
+++ b/frontend/awx/access/roles/AwxRoleDetails.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { PageDetailsFromColumns } from '../../../../framework';
+import { PageDetails, PageDetailsFromColumns } from '../../../../framework';
 import { AwxRole } from './AwxRoles';
 import { useAwxRoleColumns } from './useAwxRoleColumns';
 import { useAwxRoles } from './useAwxRoles';
@@ -16,5 +16,9 @@ export function AwxRoleDetails() {
     resource: awxRoles[params.resourceType!]?.name,
   };
 
-  return <PageDetailsFromColumns<AwxRole> item={role} columns={columns} />;
+  return (
+    <PageDetails>
+      <PageDetailsFromColumns<AwxRole> item={role} columns={columns} />
+    </PageDetails>
+  );
 }

--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { PageDetailsFromColumns } from '../../../../../framework';
+import { PageDetails, PageDetailsFromColumns } from '../../../../../framework';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { WorkflowApproval } from '../../../interfaces/WorkflowApproval';
@@ -13,6 +13,8 @@ export function WorkflowApprovalDetails() {
   );
   const columns = useWorkflowApprovalsColumns();
   return workflowApproval ? (
-    <PageDetailsFromColumns item={workflowApproval} columns={columns} />
+    <PageDetails>
+      <PageDetailsFromColumns item={workflowApproval} columns={columns} />
+    </PageDetails>
   ) : null;
 }

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
-import { PageDetailsFromColumns } from '../../../../framework';
+import { PageDetails, PageDetailsFromColumns } from '../../../../framework';
 import { useJobsColumns } from './hooks/useJobsColumns';
 import { useGetJob } from './JobPage';
 
@@ -11,5 +11,9 @@ export function JobDetails() {
 
   if (!job) return <Skeleton />;
 
-  return <PageDetailsFromColumns columns={columns} item={job} />;
+  return (
+    <PageDetails>
+      <PageDetailsFromColumns columns={columns} item={job} />
+    </PageDetails>
+  );
 }

--- a/frontend/hub/access/roles/RolePage/RoleDetails.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleDetails.tsx
@@ -8,12 +8,9 @@ import {
   LoadingPage,
   PageDetail,
   PageDetails,
-  PageHeader,
   PageLayout,
   Scrollable,
-  useGetPageUrl,
 } from '../../../../../framework';
-import { HubRoute } from '../../../main/HubRoutes';
 import { useLockedRolesWithDescription } from '../hooks/useLockedRolesWithDescription';
 import { RolePermissions } from '../components/RolePermissions';
 import { HubError } from '../../../common/HubError';
@@ -26,7 +23,6 @@ export function RoleDetails() {
     pulpAPI`/roles/?name=${params.id}`
   );
   const role = data?.results?.[0];
-  const getPageUrl = useGetPageUrl();
   const lockedRolesWithDescription = useLockedRolesWithDescription();
 
   if (error) return <HubError error={error} handleRefresh={refresh} />;
@@ -34,10 +30,6 @@ export function RoleDetails() {
 
   return (
     <PageLayout>
-      <PageHeader
-        title={role?.name}
-        breadcrumbs={[{ label: t('Roles'), to: getPageUrl(HubRoute.Roles) }, { label: role?.name }]}
-      />
       <Scrollable>
         <PageDetails>
           <PageDetail label={t('Name')}>{role.name || ''}</PageDetail>

--- a/frontend/hub/collections/CollectionPage/CollectionDetails.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDetails.tsx
@@ -1,5 +1,5 @@
 import { useCollectionColumns } from '../hooks/useCollectionColumns';
-import { PageDetailsFromColumns } from '../../../../framework';
+import { PageDetails, PageDetailsFromColumns } from '../../../../framework';
 import React from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { CollectionVersionSearch } from '../Collection';
@@ -7,5 +7,9 @@ import { CollectionVersionSearch } from '../Collection';
 export function CollectionDetails() {
   const { collection } = useOutletContext<{ collection: CollectionVersionSearch }>();
   const tableColumns = useCollectionColumns();
-  return <PageDetailsFromColumns item={collection} columns={tableColumns} />;
+  return (
+    <PageDetails>
+      <PageDetailsFromColumns item={collection} columns={tableColumns} />
+    </PageDetails>
+  );
 }

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespaceDetails.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespaceDetails.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { LoadingPage } from '../../../../framework';
+import { LoadingPage, PageDetails } from '../../../../framework';
 import { PageDetailsFromColumns } from '../../../../framework/PageDetails/PageDetailsFromColumns';
 import { useGet } from '../../../common/crud/useGet';
 import { HubError } from '../../common/HubError';
@@ -25,5 +25,9 @@ export function HubNamespaceDetails() {
     return <HubError error={error} handleRefresh={refresh} />;
   }
 
-  return <PageDetailsFromColumns item={response.data[0]} columns={tableColumns} />;
+  return (
+    <PageDetails>
+      <PageDetailsFromColumns item={response.data[0]} columns={tableColumns} />
+    </PageDetails>
+  );
 }


### PR DESCRIPTION
This moves the enclosing `PageDetails` component out of `PageDetailsFromColumns` so that we are able to add custom detail sections to `PageDetails` while still utilizing `PageDetailsFromColumns`.

With this change, `PageDetailsFromColumns` can be invoked like this:
```
<PageDetails>
  <PageDetailsFromColumns/>
  <AdditionalCustomPageDetails/>
</PageDetails>
```