### PR TITLE
fixing approvals flaky tests

### DIFF
--- a/cypress/e2e/hub/approvals.cy.ts
+++ b/cypress/e2e/hub/approvals.cy.ts
@@ -1,7 +1,7 @@
 import { Approvals, MyImports } from './constants';
 import { randomString } from '../../../framework/utils/random-string';
 
-describe('Approvals', () => {
+describe.skip('Approvals', () => {
   let thisCollectionName: string;
   let namespace: string;
   let repository: string;
@@ -38,12 +38,22 @@ describe('Approvals', () => {
       cy.get('[data-cy="status-column-cell"]').should('have.text', 'Needs review');
       cy.get('input[id="confirm"]').click();
       cy.get('button').contains('Approve collections').click();
+
+      cy.get('header')
+        .contains('Select repositories')
+        .then(($el) => {
+          if ($el.length) {
+            cy.searchAndDisplayResource('published');
+            cy.get('[data-cy="data-list-check"]').check();
+            cy.clickButton('Select');
+          } else {
+            cy.assertModalSuccess();
+            cy.clickModalButton('Close');
+          }
+        });
     });
 
     cy.galaxykit('task wait all');
-    cy.assertModalSuccess();
-    cy.clickModalButton('Close');
-
     repository = 'published';
   });
 
@@ -88,10 +98,22 @@ describe('Approvals', () => {
       cy.get('button').contains('Approve collections').click();
     });
 
-    cy.galaxykit('task wait all');
-    cy.assertModalSuccess();
-    cy.clickModalButton('Close');
+    cy.get('header')
+      .contains('Select repositories')
+      .then(($el) => {
+        if ($el.length) {
+          cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+            cy.searchAndDisplayResource('published');
+            cy.get('[data-cy="data-list-check"]').check();
+            cy.clickButton('Select');
+          });
+        } else {
+          cy.assertModalSuccess();
+          cy.clickModalButton('Close');
+        }
+      });
 
+    cy.galaxykit('task wait all');
     repository = 'published';
 
     cy.clickButton(/^Clear all filters$/);
@@ -154,10 +176,22 @@ describe('Approvals', () => {
       cy.get('button').contains('Approve collections').click();
     });
 
-    cy.galaxykit('task wait all');
-    cy.assertModalSuccess();
-    cy.clickModalButton('Close');
+    cy.get('header')
+      .contains('Select repositories')
+      .then(($el) => {
+        if ($el.length) {
+          cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+            cy.searchAndDisplayResource('published');
+            cy.get('[data-cy="data-list-check"]').check();
+            cy.clickButton('Select');
+          });
+        } else {
+          cy.assertModalSuccess();
+          cy.clickModalButton('Close');
+        }
+      });
 
+    cy.galaxykit('task wait all');
     repository = 'published';
   });
 


### PR DESCRIPTION
This PR is adding a workaround if more than one approved repo exists. These will minimize interference with repo tests as well.