### PR TITLE
AWX Fix Instance E2E Test

### DIFF
--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -1,5 +1,6 @@
-import { Instance } from '../../../../frontend/awx/interfaces/Instance';
 import { randomString } from '../../../../framework/utils/random-string';
+import { Instance } from '../../../../frontend/awx/interfaces/Instance';
+import { awxAPI } from '../../../support/formatApiPathForAwx';
 
 describe('Instances', () => {
   let instance: Instance;
@@ -32,21 +33,20 @@ describe('Instances', () => {
     cy.get('[data-cy="enabled"]').click();
     cy.get('[data-cy="managed_by_policy"]').click();
     cy.get('[data-cy="peers_from_control_nodes"]').click();
+
+    cy.intercept('POST', awxAPI`/instances/`).as('newInstance');
     cy.get('[data-cy="Submit"]').click();
-
-    cy.navigateTo('awx', 'instances');
-    cy.clickTableRow(instanceHostname);
-    cy.url().then((currentUrl) => {
-      expect(currentUrl.includes('details')).to.be.true;
-    });
-    cy.get('[data-cy="name"]').should('contain', instanceHostname);
-    cy.get('[data-cy="node-type"]').should('contain', 'Execution');
-    cy.get('[data-cy="status"]').should('contain', 'Installed');
-    cy.get('[data-cy="listener-port"]').should('contain', '9999');
-
-    cy.url().then((currentUrl) => {
-      cy.removeAwxInstance(currentUrl.split('/')[5], { failOnStatusCode: false });
-    });
+    cy.wait('@newInstance')
+      .its('response.body')
+      .then((instance: Instance) => {
+        cy.navigateTo('awx', 'instances');
+        cy.clickTableRow(instanceHostname);
+        cy.get('[data-cy="name"]').should('contain', instanceHostname);
+        cy.get('[data-cy="node-type"]').should('contain', 'Execution');
+        cy.get('[data-cy="status"]').should('contain', 'Installed');
+        cy.get('[data-cy="listener-port"]').should('contain', '9999');
+        cy.removeAwxInstance(instance.instance_type.toString(), { failOnStatusCode: false });
+      });
   });
 
   it.skip('user can edit an instance and navigate to details page', () => {});

--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -45,7 +45,7 @@ describe('Instances', () => {
         cy.get('[data-cy="node-type"]').should('contain', 'Execution');
         cy.get('[data-cy="status"]').should('contain', 'Installed');
         cy.get('[data-cy="listener-port"]').should('contain', '9999');
-        cy.removeAwxInstance(instance.instance_type.toString(), { failOnStatusCode: false });
+        cy.removeAwxInstance(instance.id.toString(), { failOnStatusCode: false });
       });
   });
 


### PR DESCRIPTION
**Test: user can add a new instance and navigate to the details page**
The click on submit was not waiting until the instance was created and navigating away
Our hooks have abort controllers hooked up and on navigate away it aborts the request
This abort canceled the POST randomly based on timing.
Thus the instance was sometimes not created and randomly failed the test