### PR TITLE
Hub collection upload test- fix and unskip

### DIFF
--- a/cypress/e2e/hub/collections.cy.ts
+++ b/cypress/e2e/hub/collections.cy.ts
@@ -4,8 +4,7 @@ import { randomString } from '../../../framework/utils/random-string';
 import { hubAPI } from '../../support/formatApiPathForHub';
 import { Collections } from './constants';
 
-// Skipped until collection upload is working in application
-describe.skip('Collections- List View', () => {
+describe('Collections- List View', () => {
   //**Important to know:
   //**In order to upload a collection, a namespace must first exist containing the first word of the collection file name
   //**The only way to get rid of a collection's artifact is to choose the following option:
@@ -30,8 +29,13 @@ describe.skip('Collections- List View', () => {
       cy.getTableRowBySingleText('community').within(() => {
         cy.get('td[data-cy=checkbox-column-cell]').click();
       });
+      cy.intercept(
+        'POST',
+        `/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/`
+      ).as('postedCollection');
       cy.get('[data-cy="Submit"]').click();
-      cy.clickButton(/^Clear all filters$/);
+      cy.url().should('include', 'approvals');
+      cy.reload();
       cy.navigateTo('hub', Collections.url);
       cy.url().should('include', 'collections');
       cy.verifyPageTitle(Collections.title);
@@ -44,7 +48,6 @@ describe.skip('Collections- List View', () => {
       cy.contains(/^Success$/);
       cy.clickButton(/^Close$/);
       cy.clickButton(/^Clear all filters$/);
-
       cy.deleteNamespace(namespace);
     });
   });

--- a/cypress/e2e/hub/collections.cy.ts
+++ b/cypress/e2e/hub/collections.cy.ts
@@ -29,10 +29,6 @@ describe('Collections- List View', () => {
       cy.getTableRowBySingleText('community').within(() => {
         cy.get('td[data-cy=checkbox-column-cell]').click();
       });
-      cy.intercept(
-        'POST',
-        `/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/`
-      ).as('postedCollection');
       cy.get('[data-cy="Submit"]').click();
       cy.url().should('include', 'approvals');
       cy.reload();


### PR DESCRIPTION
I noticed this .skip had been added here:
https://github.com/ansible/ansible-ui/pull/1605/files#:~:text=describe.skip(%27Collections%2D%20List%20View%27%2C%20()%20%3D%3E%20%7B

I fixed the test here.