### PR TITLE
[AAP-17959] Fix Double Header

### DIFF
--- a/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.cy.tsx
+++ b/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.cy.tsx
@@ -6,7 +6,7 @@ describe('Application Tokens', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/api/v2/applications/1/tokens*',
+          url: '/api/v2/applications/1/tokens/*',
         },
         {
           fixture: 'applicationPageTokens.json',
@@ -16,13 +16,12 @@ describe('Application Tokens', () => {
 
     it('Tokens list renders', () => {
       cy.mount(<ApplicationTokens />);
-      cy.verifyPageTitle('Application Tokens');
       cy.get('tbody').find('tr').should('have.length', 10);
     });
 
     it('Filter tokens by name', () => {
       cy.mount(<ApplicationTokens />);
-      cy.intercept('api/v2/applications/1/tokens?user__username__icontains=test*').as(
+      cy.intercept('api/v2/applications/1/tokens/?user__username__icontains=test*').as(
         'nameFilterRequest'
       );
       cy.filterTableByText('test');
@@ -32,12 +31,12 @@ describe('Application Tokens', () => {
 
     it('Clicking name table header sorts application tokens by name', () => {
       cy.mount(<ApplicationTokens />);
-      cy.intercept('/api/v2/applications/1/tokens?order_by=-user__username*').as(
+      cy.intercept('/api/v2/applications/1/tokens/?order_by=-user__username*').as(
         'nameDescSortRequest'
       );
       cy.clickTableHeader(/^Name$/);
       cy.wait('@nameDescSortRequest');
-      cy.intercept('/api/v2/applications/1/tokens?order_by=user__username*').as(
+      cy.intercept('/api/v2/applications/1/tokens/?order_by=user__username*').as(
         'nameAscSortRequest'
       );
       cy.clickTableHeader(/^Name$/);
@@ -46,20 +45,20 @@ describe('Application Tokens', () => {
 
     it('Clicking name table header sorts application tokens by scope', () => {
       cy.mount(<ApplicationTokens />);
-      cy.intercept('api/v2/applications/1/tokens?order_by=scope*').as('nameAscSortRequest');
+      cy.intercept('api/v2/applications/1/tokens/?order_by=scope*').as('nameAscSortRequest');
       cy.clickTableHeader(/^Scope$/);
       cy.wait('@nameAscSortRequest');
-      cy.intercept('api/v2/applications/1/tokens?order_by=-scope*').as('nameDescSortRequest');
+      cy.intercept('api/v2/applications/1/tokens/?order_by=-scope*').as('nameDescSortRequest');
       cy.clickTableHeader(/^Scope$/);
       cy.wait('@nameDescSortRequest');
     });
 
     it('Clicking name table header sorts application tokens by expires', () => {
       cy.mount(<ApplicationTokens />);
-      cy.intercept('api/v2/applications/1/tokens?order_by=expires*').as('nameAscSortRequest');
+      cy.intercept('api/v2/applications/1/tokens/?order_by=expires*').as('nameAscSortRequest');
       cy.clickTableHeader(/^Expires$/);
       cy.wait('@nameAscSortRequest');
-      cy.intercept('api/v2/applications/1/tokens?order_by=-expires*').as('nameDescSortRequest');
+      cy.intercept('api/v2/applications/1/tokens/?order_by=-expires*').as('nameDescSortRequest');
       cy.clickTableHeader(/^Expires$/);
       cy.wait('@nameDescSortRequest');
     });
@@ -68,7 +67,7 @@ describe('Application Tokens', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/api/v2/applications/1/tokens*',
+          url: '/api/v2/applications/1/tokens/*',
         },
         {
           statusCode: 500,
@@ -84,7 +83,7 @@ describe('Application Tokens', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/api/v2/applications/1/tokens*',
+          url: '/api/v2/applications/1/tokens/*',
         },
         {
           fixture: 'emptyList.json',

--- a/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.tsx
+++ b/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.tsx
@@ -6,14 +6,11 @@ import {
   IPageAction,
   PageActionSelection,
   PageActionType,
-  PageHeader,
   PageLayout,
   PageTable,
 } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { useAwxConfig } from '../../../common/useAwxConfig';
 import { useAwxView } from '../../../common/useAwxView';
-import { getDocsBaseUrl } from '../../../common/util/getDocsBaseUrl';
 import { Token } from '../../../interfaces/Token';
 import { useDeleteTokens } from '../hooks/useDeleteTokens';
 import { useTokensColumns } from '../hooks/useTokensColumns';
@@ -21,7 +18,6 @@ import { useTokensFilters } from '../hooks/useTokensFilters';
 
 export function ApplicationTokens() {
   const { t } = useTranslation();
-  const config = useAwxConfig();
   const tableColumns = useTokensColumns();
   const toolbarFilters = useTokensFilters();
   const params = useParams<{ id: string }>();

--- a/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.tsx
+++ b/frontend/awx/administration/applications/ApplicationPage/ApplicationPageTokens.tsx
@@ -26,7 +26,7 @@ export function ApplicationTokens() {
   const toolbarFilters = useTokensFilters();
   const params = useParams<{ id: string }>();
   const view = useAwxView<Token>({
-    url: awxAPI`/applications/${params.id ?? ''}/tokens`,
+    url: awxAPI`/applications/${params.id ?? ''}/tokens/`,
     tableColumns,
     toolbarFilters,
   });
@@ -62,13 +62,6 @@ export function ApplicationTokens() {
 
   return (
     <PageLayout>
-      <PageHeader
-        title={t('Application Tokens')}
-        description={t('List of access tokens associated with this application.')}
-        titleHelpTitle={t('Application Tokens')}
-        titleHelp={t('List of access tokens associated with this application.')}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/applications_auth.html`}
-      />
       <PageTable<Token>
         id="awx-applications-token-table"
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -108,7 +108,7 @@ export function useAwxInventoryRoutes() {
             {
               id: AwxRoute.InventorySourceSchedules,
               path: 'schedules',
-              element: <Schedules sublistEndpoint={awxAPI`/inventory_sources`} />,
+              element: <Schedules sublistEndpoint={awxAPI`/inventory_sources`} noHeader />,
             },
           ],
         },

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -13,7 +13,6 @@ import { CreateSchedule } from '../../views/schedules/ScheduleForm';
 import { ScheduleDetails } from '../../views/schedules/SchedulePage/ScheduleDetails';
 import { SchedulePage } from '../../views/schedules/SchedulePage/SchedulePage';
 import { ScheduleRules } from '../../views/schedules/SchedulePage/ScheduleRules';
-import { Schedules } from '../../views/schedules/Schedules';
 import { AwxRoute } from '../AwxRoutes';
 import { InventoryJobTemplates } from '../../resources/inventories/InventoryPage/InventoryJobTemplates';
 import { InventoryHosts } from '../../resources/inventories/InventoryPage/InventoryHosts';
@@ -36,6 +35,7 @@ import { GroupDetails } from '../../resources/groups/GroupDetails';
 import { InventoryHostJobs } from '../../resources/inventories/inventoryHostsPage/InventoryHostJobs';
 import { InventoryHostFacts } from '../../resources/inventories/inventoryHostsPage/InventoryHostFacts';
 import { ResourceNotifications } from '../../resources/notifications/ResourceNotifications';
+import { SchedulesList } from '../../views/schedules/SchedulesList';
 
 export function useAwxInventoryRoutes() {
   const { t } = useTranslation();
@@ -108,7 +108,7 @@ export function useAwxInventoryRoutes() {
             {
               id: AwxRoute.InventorySourceSchedules,
               path: 'schedules',
-              element: <Schedules sublistEndpoint={awxAPI`/inventory_sources`} noHeader />,
+              element: <SchedulesList sublistEndpoint={awxAPI`/inventory_sources`} />,
             },
           ],
         },

--- a/frontend/awx/main/routes/useAwxProjectRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxProjectRoutes.tsx
@@ -13,9 +13,9 @@ import { CreateSchedule } from '../../views/schedules/ScheduleForm';
 import { ScheduleDetails } from '../../views/schedules/SchedulePage/ScheduleDetails';
 import { SchedulePage } from '../../views/schedules/SchedulePage/SchedulePage';
 import { ScheduleRules } from '../../views/schedules/SchedulePage/ScheduleRules';
-import { Schedules } from '../../views/schedules/Schedules';
 import { AwxRoute } from '../AwxRoutes';
 import { ResourceNotifications } from '../../resources/notifications/ResourceNotifications';
+import { SchedulesList } from '../../views/schedules/SchedulesList';
 
 export function useAwxProjectRoutes() {
   const { t } = useTranslation();
@@ -105,7 +105,7 @@ export function useAwxProjectRoutes() {
             {
               id: AwxRoute.ProjectSchedules,
               path: 'schedules',
-              element: <Schedules sublistEndpoint={awxAPI`/projects`} noHeader />,
+              element: <SchedulesList sublistEndpoint={awxAPI`/projects`} />,
             },
             {
               path: '',

--- a/frontend/awx/main/routes/useAwxProjectRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxProjectRoutes.tsx
@@ -105,7 +105,7 @@ export function useAwxProjectRoutes() {
             {
               id: AwxRoute.ProjectSchedules,
               path: 'schedules',
-              element: <Schedules sublistEndpoint={awxAPI`/projects`} />,
+              element: <Schedules sublistEndpoint={awxAPI`/projects`} noHeader />,
             },
             {
               path: '',

--- a/frontend/awx/views/schedules/Schedules.tsx
+++ b/frontend/awx/views/schedules/Schedules.tsx
@@ -15,7 +15,7 @@ import { useSchedulesFilter } from './hooks/useSchedulesFilter';
 import { useScheduleToolbarActions } from './hooks/useSchedulesToolbarActions';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 
-export function Schedules(props: { sublistEndpoint?: string }) {
+export function Schedules(props: { sublistEndpoint?: string; noHeader?: boolean }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const params = useParams<{ id: string; source_id?: string }>();
@@ -48,18 +48,20 @@ export function Schedules(props: { sublistEndpoint?: string }) {
   });
   return (
     <PageLayout>
-      <PageHeader
-        title={t('Schedules')}
-        titleHelpTitle={t('Schedule')}
-        titleHelp={t(
-          'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
-        )}
-        titleDocLink="https://docs.ansible.com/automation-controller/latest/html/userguide/scheduling.html"
-        description={t(
-          'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
-        )}
-        headerActions={<ActivityStreamIcon type={'schedule'} />}
-      />
+      {!props.noHeader && (
+        <PageHeader
+          title={t('Schedules')}
+          titleHelpTitle={t('Schedule')}
+          titleHelp={t(
+            'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
+          )}
+          titleDocLink="https://docs.ansible.com/automation-controller/latest/html/userguide/scheduling.html"
+          description={t(
+            'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
+          )}
+          headerActions={<ActivityStreamIcon type={'schedule'} />}
+        />
+      )}
       <PageTable<Schedule>
         id="awx-schedules-table"
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/views/schedules/Schedules.tsx
+++ b/frontend/awx/views/schedules/Schedules.tsx
@@ -1,91 +1,25 @@
-import { CubesIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { PageHeader, PageLayout, PageTable } from '../../../../framework';
-import { usePersistentFilters } from '../../../common/PersistentFilters';
-import { useOptions } from '../../../common/crud/useOptions';
-import { awxAPI } from '../../common/api/awx-utils';
-import { useAwxView } from '../../common/useAwxView';
-import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
-import { Schedule } from '../../interfaces/Schedule';
-import { scheduleResourceTypeOptions, useGetSchedulCreateUrl } from './hooks/scheduleHelpers';
-import { useSchedulesActions } from './hooks/useSchedulesActions';
-import { useSchedulesColumns } from './hooks/useSchedulesColumns';
-import { useSchedulesFilter } from './hooks/useSchedulesFilter';
-import { useScheduleToolbarActions } from './hooks/useSchedulesToolbarActions';
+import { PageHeader, PageLayout } from '../../../../framework';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
+import { SchedulesList } from './SchedulesList';
 
-export function Schedules(props: { sublistEndpoint?: string; noHeader?: boolean }) {
+export function Schedules(props: { sublistEndpoint?: string }) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const params = useParams<{ id: string; source_id?: string }>();
-  const location = useLocation();
-  const toolbarFilters = useSchedulesFilter();
-  const tableColumns = useSchedulesColumns();
-  const resourceId = params.source_id ?? params.id;
-  const apiEndPoint: string | undefined = props.sublistEndpoint
-    ? `${props.sublistEndpoint}/${resourceId}/schedules/`
-    : undefined;
-
-  const view = useAwxView<Schedule>({
-    url: apiEndPoint ?? awxAPI`/schedules/`,
-    toolbarFilters,
-    tableColumns,
-  });
-
-  const resource_type = scheduleResourceTypeOptions.find((route) =>
-    location.pathname.split('/').includes(route)
-  );
-  usePersistentFilters(resource_type ? `${resource_type}-schedules` : 'schedules');
-
-  const { data } = useOptions<OptionsResponse<ActionsResponse>>(apiEndPoint ?? awxAPI`/schedules/`);
-  const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
-  const createUrl = useGetSchedulCreateUrl(apiEndPoint);
-  const toolbarActions = useScheduleToolbarActions(view.unselectItemsAndRefresh, apiEndPoint);
-  const rowActions = useSchedulesActions({
-    onScheduleToggleorDeleteCompleted: () => void view.refresh(),
-    sublistEndpoint: apiEndPoint,
-  });
   return (
     <PageLayout>
-      {!props.noHeader && (
-        <PageHeader
-          title={t('Schedules')}
-          titleHelpTitle={t('Schedule')}
-          titleHelp={t(
-            'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
-          )}
-          titleDocLink="https://docs.ansible.com/automation-controller/latest/html/userguide/scheduling.html"
-          description={t(
-            'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
-          )}
-          headerActions={<ActivityStreamIcon type={'schedule'} />}
-        />
-      )}
-      <PageTable<Schedule>
-        id="awx-schedules-table"
-        toolbarFilters={toolbarFilters}
-        toolbarActions={toolbarActions}
-        tableColumns={tableColumns}
-        rowActions={rowActions}
-        errorStateTitle={t('Error loading schedules')}
-        emptyStateTitle={
-          canCreateSchedule
-            ? t('No schedules yet')
-            : t('You do not have permission to create a schedule')
-        }
-        emptyStateDescription={
-          canCreateSchedule
-            ? t('Please create a schedule by using the button below.')
-            : t(
-                'Please contact your organization administrator if there is an issue with your access.'
-              )
-        }
-        emptyStateIcon={canCreateSchedule ? undefined : CubesIcon}
-        emptyStateButtonText={canCreateSchedule ? t('Create schedule') : undefined}
-        emptyStateButtonClick={canCreateSchedule ? () => navigate(createUrl) : undefined}
-        {...view}
+      <PageHeader
+        title={t('Schedules')}
+        titleHelpTitle={t('Schedule')}
+        titleHelp={t(
+          'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
+        )}
+        titleDocLink="https://docs.ansible.com/automation-controller/latest/html/userguide/scheduling.html"
+        description={t(
+          'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
+        )}
+        headerActions={<ActivityStreamIcon type={'schedule'} />}
       />
+      <SchedulesList sublistEndpoint={props.sublistEndpoint} />
     </PageLayout>
   );
 }

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -1,0 +1,74 @@
+import { CubesIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { PageTable } from '../../../../framework';
+import { usePersistentFilters } from '../../../common/PersistentFilters';
+import { useOptions } from '../../../common/crud/useOptions';
+import { awxAPI } from '../../common/api/awx-utils';
+import { useAwxView } from '../../common/useAwxView';
+import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
+import { Schedule } from '../../interfaces/Schedule';
+import { scheduleResourceTypeOptions, useGetSchedulCreateUrl } from './hooks/scheduleHelpers';
+import { useSchedulesActions } from './hooks/useSchedulesActions';
+import { useSchedulesColumns } from './hooks/useSchedulesColumns';
+import { useSchedulesFilter } from './hooks/useSchedulesFilter';
+import { useScheduleToolbarActions } from './hooks/useSchedulesToolbarActions';
+
+export function SchedulesList(props: { sublistEndpoint?: string }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const params = useParams<{ id: string; source_id?: string }>();
+  const location = useLocation();
+  const toolbarFilters = useSchedulesFilter();
+  const tableColumns = useSchedulesColumns();
+  const resourceId = params.source_id ?? params.id;
+  const apiEndPoint: string | undefined = props.sublistEndpoint
+    ? `${props.sublistEndpoint}/${resourceId}/schedules/`
+    : undefined;
+
+  const view = useAwxView<Schedule>({
+    url: apiEndPoint ?? awxAPI`/schedules/`,
+    toolbarFilters,
+    tableColumns,
+  });
+
+  const resource_type = scheduleResourceTypeOptions.find((route) =>
+    location.pathname.split('/').includes(route)
+  );
+  usePersistentFilters(resource_type ? `${resource_type}-schedules` : 'schedules');
+
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(apiEndPoint ?? awxAPI`/schedules/`);
+  const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
+  const createUrl = useGetSchedulCreateUrl(apiEndPoint);
+  const toolbarActions = useScheduleToolbarActions(view.unselectItemsAndRefresh, apiEndPoint);
+  const rowActions = useSchedulesActions({
+    onScheduleToggleorDeleteCompleted: () => void view.refresh(),
+    sublistEndpoint: apiEndPoint,
+  });
+  return (
+    <PageTable<Schedule>
+      id="awx-schedules-table"
+      toolbarFilters={toolbarFilters}
+      toolbarActions={toolbarActions}
+      tableColumns={tableColumns}
+      rowActions={rowActions}
+      errorStateTitle={t('Error loading schedules')}
+      emptyStateTitle={
+        canCreateSchedule
+          ? t('No schedules yet')
+          : t('You do not have permission to create a schedule')
+      }
+      emptyStateDescription={
+        canCreateSchedule
+          ? t('Please create a schedule by using the button below.')
+          : t(
+              'Please contact your organization administrator if there is an issue with your access.'
+            )
+      }
+      emptyStateIcon={canCreateSchedule ? undefined : CubesIcon}
+      emptyStateButtonText={canCreateSchedule ? t('Create schedule') : undefined}
+      emptyStateButtonClick={canCreateSchedule ? () => navigate(createUrl) : undefined}
+      {...view}
+    />
+  );
+}


### PR DESCRIPTION
This PR adds a flag to display or hide the header on the schedules component. The projects section and inventories section, both of which use this component in their tabbed views no use this component without the header to follow UI designs more closely.

Small changes have also been made to the application tokens page to remove the header and fix the trailing slash redirect endpoint issue.