### PR TITLE
Display inventory sources in inventory source select dialog

### DIFF
--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -48,7 +48,7 @@ describe('Inventory source page', () => {
     cy.clickTableRow(inventory.name);
     cy.verifyPageTitle(inventory.name);
     cy.clickLink(/^Sources$/);
-    cy.get('#add-source').click();
+    cy.clickButton(/^Add source/);
     cy.verifyPageTitle('Add new source');
     cy.get('[data-cy="name"]').type('source 1');
     cy.selectDropdownOptionByResourceName('source_control_type', 'Sourced from a Project');
@@ -69,7 +69,7 @@ describe('Inventory source page', () => {
     cy.get('[data-cy="update_on_launch"]').check();
     cy.get('[data-cy="update-cache-timeout"]').type('1');
     cy.get('.view-lines').type('test: "output"');
-    cy.get('[data-cy="Submit"]').click();
+    cy.clickButton(/^Save$/);
     cy.verifyPageTitle('source 1');
   });
 });

--- a/frontend/awx/resources/inventories/components/PageFormInventorySourceSelect.tsx
+++ b/frontend/awx/resources/inventories/components/PageFormInventorySourceSelect.tsx
@@ -11,24 +11,26 @@ import { useSelectInventorySource } from '../hooks/useSelectInventorySource';
 export function PageFormInventorySourceSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
->(props: { name: TFieldName; isRequired?: boolean; inventoryId: number }) {
+>(props: { name: TFieldName; isRequired?: boolean; inventoryId?: number }) {
+  const { name, inventoryId, isRequired = false } = props;
   const { t } = useTranslation();
-  const openSelectDialog = useSelectInventorySource();
+  const openSelectDialog = useSelectInventorySource(inventoryId);
+
   const query = useCallback(async () => {
     const response = await requestGet<AwxItemsResponse<InventorySource>>(
-      awxAPI`/inventories/${props.inventoryId.toString()}/inventory_sources/`.concat(
-        `?page_size=200`
-      )
+      inventoryId === null || inventoryId === undefined
+        ? awxAPI`/inventory_sources/?page_size=200`
+        : awxAPI`/inventories/${inventoryId.toString()}/inventory_sources/?page_size=200`
     );
     return Promise.resolve({
       total: response.count,
       values: response.results as FieldPathValue<TFieldValues, Path<TFieldValues>>[],
     });
-  }, [props.inventoryId]);
+  }, [inventoryId]);
 
   return (
     <PageFormAsyncSelect<TFieldValues>
-      name={props.name}
+      name={name}
       id="inventory-source-select"
       label={t('Inventory source')}
       query={query}
@@ -38,7 +40,7 @@ export function PageFormInventorySourceSelect<
       placeholder={t('Select inventory source')}
       loadingPlaceholder={t('Loading inventory sources...')}
       loadingErrorText={t('Error loading inventory sources')}
-      isRequired={props.isRequired}
+      isRequired={isRequired}
       limit={200}
       openSelectDialog={openSelectDialog}
     />

--- a/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
+++ b/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
@@ -11,18 +11,24 @@ import { useInventorySourceFilters } from './useInventorySourceFilters';
 function SelectInventorySource(props: {
   title: string;
   onSelect: (inventorySource: InventorySource) => void;
+  inventoryId?: number;
 }) {
+  const { title, inventoryId, onSelect } = props;
   const toolbarFilters = useInventorySourceFilters();
   const tableColumns = useInventorySourceColumns({ disableLinks: true });
+  const url = inventoryId
+    ? awxAPI`/inventories/${inventoryId.toString()}/inventory_sources/`
+    : awxAPI`/inventory_sources/`;
   const view = useAwxView<InventorySource>({
-    url: awxAPI`/inventories/`,
+    url,
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
   return (
     <SingleSelectDialog<InventorySource>
-      {...props}
+      title={title}
+      onSelect={onSelect}
       toolbarFilters={toolbarFilters}
       tableColumns={tableColumns}
       view={view}
@@ -30,14 +36,20 @@ function SelectInventorySource(props: {
   );
 }
 
-export function useSelectInventorySource() {
+export function useSelectInventorySource(inventoryId?: number) {
   const [_, setDialog] = usePageDialog();
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (inventory: InventorySource) => void) => {
-      setDialog(<SelectInventorySource title={t('Select inventory source')} onSelect={onSelect} />);
+      setDialog(
+        <SelectInventorySource
+          title={t('Select inventory source')}
+          inventoryId={inventoryId}
+          onSelect={onSelect}
+        />
+      );
     },
-    [setDialog, t]
+    [setDialog, inventoryId, t]
   );
   return openSelectInventory;
 }


### PR DESCRIPTION
Issue:
Resolved a bug where the inventory source select dialog displayed a list of inventories instead of the intended inventory sources.

Changes:
* By default, show list of all inventory sources in the select dropdown and browse dialog 
* Maintain ability to fetch list of inventory sources based on inventory 

_Screenshot of bug:_ 
<img width="770" alt="Screenshot 2024-02-13 at 1 29 22 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/a715bb40-e0c9-4a97-b6c6-8b31f756d3d4">

_Screenshot of fix:_ 
<img width="776" alt="Screenshot 2024-02-13 at 1 26 52 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/a9787921-b8c3-412a-b56d-7edb4387c7e9">

