### PR TITLE
Approvals only one modal

### DIFF
--- a/cypress/e2e/hub/approvals.cy.ts
+++ b/cypress/e2e/hub/approvals.cy.ts
@@ -40,27 +40,13 @@ describe('Approvals', () => {
   });
 
   it('user can upload a new collection and approve it', () => {
-    approve('Needs review');
+    approve();
   });
 
-  function approve(status: string) {
+  function approve() {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
     clickTableRowPinnedAction(thisCollectionName, 'sign-and-approve');
-
-    //Verify Approve and sign collections modal
-    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-      cy.get('header').contains('Approve and sign collections');
-      cy.get('button')
-        .contains('Approve and sign collections')
-        .should('have.attr', 'aria-disabled', 'true');
-      cy.get('[data-cy="namespace-column-cell"]').should('have.text', namespace);
-      cy.get('[data-cy="collection-column-cell"]').should('have.text', thisCollectionName);
-      cy.get('[data-cy="version-column-cell"]').should('have.text', '1.0.0');
-      cy.get('[data-cy="status-column-cell"]').should('have.text', status);
-      cy.get('input[id="confirm"]').click();
-      cy.get('button').contains('Approve and sign collections').click();
-    });
 
     // handle modal
     const modal = `[aria-label="Select repositories"] `;
@@ -128,13 +114,13 @@ describe('Approvals', () => {
   }
 
   it('user can approve a collection and then reject it', () => {
-    approve('Needs review');
+    approve();
     reject('Signed and Approved');
   });
 
   it('user can reject a collection and then approve it', () => {
     reject('Needs review');
-    approve('Rejected');
+    approve();
   });
 
   it('user can view import logs', () => {

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
@@ -73,7 +73,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
             copyToRepository,
             approveCollectionsFrameworkModal,
             false,
-            t,
+            t
           ),
         isDanger: false,
         isDisabled: (collection) =>
@@ -122,6 +122,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
       require_upload_signatures,
       pageNavigate,
       params,
+      copyToRepository,
     ]
   );
 }
@@ -130,20 +131,24 @@ export function approveCollection(
   collections: CollectionVersionSearch[],
   copyToRepository: ReturnType<typeof useCopyToRepository>,
   approveCollectionsFrameworkModal: ReturnType<typeof useApproveCollectionsFrameworkModal>,
-  bulkAction : boolean,
-  t : TFunction<"translation", undefined>,
+  bulkAction: boolean,
+  t: TFunction<'translation', undefined>
 ) {
-  async function innerAsync() {
-    const repoRes = (await requestGet(
+  void (async () => {
+    const repoRes = await requestGet<PulpItemsResponse<Repository>>(
       pulpAPI`/repositories/ansible/ansible/?pulp_label_select=pipeline=approved`
-    )) as PulpItemsResponse<Repository>;
+    );
 
     if (repoRes.count > 1) {
-        copyToRepository(collections[0], 'approve', bulkAction ? t(`You can only use bulk action when there is only one approved repository available.`) : undefined);
+      copyToRepository(
+        collections[0],
+        'approve',
+        bulkAction
+          ? t(`You can only use bulk action when there is only one approved repository available.`)
+          : undefined
+      );
     } else {
       approveCollectionsFrameworkModal(collections);
     }
-  }
-
-  innerAsync();
+  })();
 }

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
@@ -19,8 +19,8 @@ import { HubRoute } from '../../../main/HubRoutes';
 import { CollectionVersionSearch } from '../Approval';
 import { useApproveCollectionsFrameworkModal } from './useApproveCollections';
 import { useRejectCollections } from './useRejectCollections';
-import { TFunction } from 'i18next';
 import { useCopyToRepository } from '../../../collections/hooks/useCopyToRepository';
+import { TFunction } from 'i18next';
 
 export function useApprovalActions(callback?: (collections: CollectionVersionSearch[]) => void) {
   const { t } = useTranslation();
@@ -70,10 +70,10 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         onClick: (collection) =>
           approveCollection(
             [collection],
+            copyToRepository,
+            approveCollectionsFrameworkModal,
             false,
             t,
-            copyToRepository,
-            approveCollectionsFrameworkModal
           ),
         isDanger: false,
         isDisabled: (collection) =>
@@ -128,10 +128,10 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
 
 export function approveCollection(
   collections: CollectionVersionSearch[],
-  bulkAction: boolean,
-  t: TFunction<'translation', undefined>,
   copyToRepository: ReturnType<typeof useCopyToRepository>,
-  approveCollectionsFrameworkModal: ReturnType<typeof useApproveCollectionsFrameworkModal>
+  approveCollectionsFrameworkModal: ReturnType<typeof useApproveCollectionsFrameworkModal>,
+  bulkAction : boolean,
+  t : TFunction<"translation", undefined>,
 ) {
   async function innerAsync() {
     const repoRes = (await requestGet(
@@ -139,15 +139,7 @@ export function approveCollection(
     )) as PulpItemsResponse<Repository>;
 
     if (repoRes.count > 1) {
-      if (bulkAction) {
-        throw new Error(
-          t(
-            'You can use bulk action only when there is single approved repo, but you have multiple approved repositories.'
-          )
-        );
-      } else {
-        copyToRepository(collections[0], 'approve');
-      }
+        copyToRepository(collections[0], 'approve', bulkAction ? t(`You can only use bulk action when there is only one approved repository available.`) : undefined);
     } else {
       approveCollectionsFrameworkModal(collections);
     }

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
@@ -12,7 +12,7 @@ import {
 import { useHubContext } from '../../../common/useHubContext';
 import { HubRoute } from '../../../main/HubRoutes';
 import { CollectionVersionSearch } from '../Approval';
-import { useApproveCollections } from './useApproveCollections';
+import { useApproveCollectionsFrameworkModal } from './useApproveCollections';
 import { useRejectCollections } from './useRejectCollections';
 
 export function useApprovalActions(callback?: (collections: CollectionVersionSearch[]) => void) {
@@ -20,7 +20,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
   const pageNavigate = usePageNavigate();
   const params = useParams();
   const rejectCollections = useRejectCollections(callback);
-  const approveCollections = useApproveCollections(callback);
+  const approveCollectionsFrameworkModal = useApproveCollectionsFrameworkModal(callback);
   const { featureFlags } = useHubContext();
   const { collection_auto_sign, require_upload_signatures, can_upload_signatures } = featureFlags;
   const autoSign = collection_auto_sign && !require_upload_signatures;
@@ -58,7 +58,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
         isPinned: true,
         icon: ThumbsUpIcon,
         label: autoSign ? t('Sign and approve') : t('Approve'),
-        onClick: (collection) => approveCollections([collection]),
+        onClick: (collection) => approveCollectionsFrameworkModal([collection]),
         isDanger: false,
         isDisabled: (collection) =>
           collection?.repository?.pulp_labels?.pipeline === 'approved'
@@ -100,7 +100,7 @@ export function useApprovalActions(callback?: (collections: CollectionVersionSea
     [
       t,
       rejectCollections,
-      approveCollections,
+      approveCollectionsFrameworkModal,
       autoSign,
       can_upload_signatures,
       require_upload_signatures,

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
@@ -26,16 +26,6 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
         isDanger: true,
       },
       { type: PageActionType.Seperator },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Multiple,
-        icon: ThumbsUpIcon,
-        label: autoSign
-          ? t('Sign and approve selected collections')
-          : t('Approve selected collections'),
-        onClick: approveCollections,
-        isDanger: false,
-      },
     ],
     [t, rejectCollections, approveCollections, autoSign]
   );

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
@@ -4,13 +4,11 @@ import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
 import { useHubContext } from '../../../common/useHubContext';
 import { CollectionVersionSearch } from '../Approval';
-import { useApproveCollections } from './useApproveCollections';
 import { useRejectCollections } from './useRejectCollections';
 
 export function useApprovalsActions(callback: (collections: CollectionVersionSearch[]) => void) {
   const { t } = useTranslation();
   const rejectCollections = useRejectCollections(callback);
-  const approveCollections = useApproveCollections(callback);
   const { featureFlags } = useHubContext();
   const { collection_auto_sign, require_upload_signatures } = featureFlags;
   const autoSign = collection_auto_sign && !require_upload_signatures;
@@ -27,6 +25,6 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
       },
       { type: PageActionType.Seperator },
     ],
-    [t, rejectCollections, approveCollections, autoSign]
+    [t, rejectCollections, autoSign]
   );
 }

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
@@ -38,7 +38,7 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
           ? t('Sign and approve selected collections')
           : t('Approve selected collections'),
         onClick: (items) =>
-          approveCollection(items, true, t, copyToRepository, approveCollectionsFrameworkModal),
+          approveCollection(items, copyToRepository, approveCollectionsFrameworkModal, true, t),
         isDanger: false,
       },
     ],

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
@@ -5,6 +5,9 @@ import { IPageAction, PageActionSelection, PageActionType } from '../../../../..
 import { useHubContext } from '../../../common/useHubContext';
 import { CollectionVersionSearch } from '../Approval';
 import { useRejectCollections } from './useRejectCollections';
+import { approveCollection } from './useApprovalActions';
+import { useCopyToRepository } from '../../../collections/hooks/useCopyToRepository';
+import { useApproveCollectionsFrameworkModal } from './useApproveCollections';
 
 export function useApprovalsActions(callback: (collections: CollectionVersionSearch[]) => void) {
   const { t } = useTranslation();
@@ -12,6 +15,9 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
   const { featureFlags } = useHubContext();
   const { collection_auto_sign, require_upload_signatures } = featureFlags;
   const autoSign = collection_auto_sign && !require_upload_signatures;
+
+  const copyToRepository = useCopyToRepository();
+  const approveCollectionsFrameworkModal = useApproveCollectionsFrameworkModal(callback);
 
   return useMemo<IPageAction<CollectionVersionSearch>[]>(
     () => [
@@ -24,7 +30,18 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
         isDanger: true,
       },
       { type: PageActionType.Seperator },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: ThumbsUpIcon,
+        label: autoSign
+          ? t('Sign and approve selected collections')
+          : t('Approve selected collections'),
+        onClick: (items) =>
+          approveCollection(items, true, t, copyToRepository, approveCollectionsFrameworkModal),
+        isDanger: false,
+      },
     ],
-    [t, rejectCollections, autoSign]
+    [t, rejectCollections, approveCollection, autoSign]
   );
 }

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalsActions.tsx
@@ -42,6 +42,6 @@ export function useApprovalsActions(callback: (collections: CollectionVersionSea
         isDanger: false,
       },
     ],
-    [t, rejectCollections, approveCollection, autoSign]
+    [t, rejectCollections, autoSign, approveCollectionsFrameworkModal, copyToRepository]
   );
 }

--- a/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
@@ -61,15 +61,7 @@ export function useApproveCollectionsFrameworkModal(
         actionColumns,
         onComplete,
         actionFn: (collection: CollectionVersionSearch) =>
-          approveCollection(
-            collection,
-            getRequest,
-            collections.length > 1,
-            t,
-            copyToRepository,
-            context,
-            pulpRequest
-          ),
+          approveCollection(collection, getRequest, t, context, pulpRequest),
       });
     },
     [
@@ -90,9 +82,7 @@ export function useApproveCollectionsFrameworkModal(
 export function approveCollection(
   collection: CollectionVersionSearch,
   getRequest: ReturnType<typeof useGetRequest>,
-  bulkAction: boolean,
   t: TFunction<'translation', undefined>,
-  copyToRepository: ReturnType<typeof useCopyToRepository>,
   context: HubContext,
   pulpRequest: ReturnType<typeof useGetRequest<PulpItemsResponse<SigningServiceResponse>>>
 ) {
@@ -104,30 +94,14 @@ export function approveCollection(
     )) as PulpItemsResponse<Repository>;
     approvedRepo = repoRes.results[0].pulp_href;
 
-    const pipeline = collection.repository?.pulp_labels?.pipeline;
-    if (pipeline === 'approved') {
-      throw new Error(t('You can only approve collections in rejected or staging repositories'));
-    }
-
-    if (repoRes.count > 1) {
-      if (bulkAction) {
-        throw new Error(
-          t(
-            'You can use bulk action only when there is single approved repo, but you have multiple approved repositories.'
-          )
-        );
-      } else {
-        copyToRepository(collection, 'approve');
-      }
-    } else {
-      await copyToRepositoryAction(
-        collection,
-        'approve',
-        [{ pulp_href: approvedRepo } as Repository],
-        context,
-        pulpRequest
-      );
-    }
+    await copyToRepositoryAction(
+      collection,
+      'approve',
+      [{ pulp_href: approvedRepo } as Repository],
+      context,
+      pulpRequest,
+      t
+    );
   }
 
   return innerAsync();

--- a/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
@@ -3,10 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { compareStrings } from '../../../../../framework';
 import { useGetRequest } from '../../../../common/crud/useGet';
-import {
-  copyToRepositoryAction,
-  useCopyToRepository,
-} from '../../../collections/hooks/useCopyToRepository';
+import { copyToRepositoryAction } from '../../../collections/hooks/useCopyToRepository';
 import { pulpAPI } from '../../../common/api/formatPath';
 import { collectionKeyFn } from '../../../common/api/hub-api-utils';
 import { useHubBulkConfirmation } from '../../../common/useHubBulkConfirmation';
@@ -31,7 +28,6 @@ export function useApproveCollectionsFrameworkModal(
   const { collection_auto_sign, require_upload_signatures } = context.featureFlags;
   const autoSign = collection_auto_sign && !require_upload_signatures;
 
-  const copyToRepository = useCopyToRepository();
   const pulpRequest = useGetRequest<PulpItemsResponse<SigningServiceResponse>>();
 
   return useCallback(
@@ -72,7 +68,6 @@ export function useApproveCollectionsFrameworkModal(
       t,
       getRequest,
       autoSign,
-      copyToRepository,
       pulpRequest,
       context,
     ]

--- a/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApproveCollections.tsx
@@ -16,7 +16,7 @@ import { SigningServiceResponse } from '../../../interfaces/generated/SigningSer
 import { CollectionVersionSearch } from '../Approval';
 import { useApprovalsColumns } from './useApprovalsColumns';
 
-export function useApproveCollections(
+export function useApproveCollectionsFrameworkModal(
   onComplete?: (collections: CollectionVersionSearch[]) => void
 ) {
   const { t } = useTranslation();

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -23,13 +23,14 @@ export function useCopyToRepository() {
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
   const context = useHubContext();
 
-  return (collection: CollectionVersionSearch, operation: 'approve' | 'copy') => {
+  return (collection: CollectionVersionSearch, operation: 'approve' | 'copy', displayDefaultError? : string) => {
     setDialog(
       <CopyToRepositoryModal
         collection={collection}
         onClose={onClose}
         context={context}
         operation={operation}
+        displayDefaultError={displayDefaultError}
       />
     );
   };
@@ -40,6 +41,7 @@ function CopyToRepositoryModal(props: {
   onClose: () => void;
   context: HubContext;
   operation: 'approve' | 'copy';
+  displayDefaultError? : string;
 }) {
   const toolbarFilters = useRepositoryFilters();
   const tableColumns = useRepositoryColumns();
@@ -138,7 +140,7 @@ function CopyToRepositoryModal(props: {
           onClick={() => {
             void copyToRepositories();
           }}
-          isDisabled={selectedRepositories.length === 0}
+          isDisabled={selectedRepositories.length === 0 || props.displayDefaultError !== undefined}
           isLoading={isLoading}
         >
           {t('Select')}
@@ -201,6 +203,7 @@ function CopyToRepositoryModal(props: {
         }}
       />
       {error && <HubError error={{ name: t('Error'), message: error }}></HubError>}
+      {props.displayDefaultError && <HubError error={{ name: t('Error'), message: props.displayDefaultError }}></HubError>}
     </Modal>
   );
 }
@@ -216,7 +219,7 @@ export async function copyToRepositoryAction(
   selectedRepositories: Repository[],
   context: HubContext,
   pulpRequest: ReturnType<typeof useGetRequest<PulpItemsResponse<SigningServiceResponse>>>,
-  t: TFunction<'translation', undefined>
+  t: TFunction<'translation', undefined>,
 ) {
   debugger;
   const { repository } = collection;

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -16,6 +16,7 @@ import { CollectionVersionSearch } from '../Collection';
 import { usePageDialog } from './../../../../framework';
 import { PageTable } from './../../../../framework/PageTable/PageTable';
 import { useGetRequest } from './../../../common/crud/useGet';
+import { TFunction } from 'i18next';
 
 export function useCopyToRepository() {
   const [_, setDialog] = usePageDialog();
@@ -65,7 +66,8 @@ function CopyToRepositoryModal(props: {
         operation,
         selectedRepositories,
         props.context,
-        pulpRequest
+        pulpRequest,
+        t
       );
 
       setIsLoading(false);
@@ -213,13 +215,19 @@ export async function copyToRepositoryAction(
   operation: 'approve' | 'copy',
   selectedRepositories: Repository[],
   context: HubContext,
-  pulpRequest: ReturnType<typeof useGetRequest<PulpItemsResponse<SigningServiceResponse>>>
+  pulpRequest: ReturnType<typeof useGetRequest<PulpItemsResponse<SigningServiceResponse>>>,
+  t: TFunction<'translation', undefined>
 ) {
+  debugger;
   const { repository } = collection;
   if (!repository) {
     return;
   }
 
+  const pipeline = collection.repository?.pulp_labels?.pipeline;
+  if (!(pipeline === 'staging' || pipeline === 'rejected')) {
+    throw new Error(t('You can only approve collections in rejected or staging repositories'));
+  }
   const pulpId = parsePulpIDFromURL(repository?.pulp_href);
 
   const { collection_auto_sign, require_upload_signatures } = context.featureFlags;

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -23,7 +23,11 @@ export function useCopyToRepository() {
   const onClose = useCallback(() => setDialog(undefined), [setDialog]);
   const context = useHubContext();
 
-  return (collection: CollectionVersionSearch, operation: 'approve' | 'copy', displayDefaultError? : string) => {
+  return (
+    collection: CollectionVersionSearch,
+    operation: 'approve' | 'copy',
+    displayDefaultError?: string
+  ) => {
     setDialog(
       <CopyToRepositoryModal
         collection={collection}
@@ -41,7 +45,7 @@ function CopyToRepositoryModal(props: {
   onClose: () => void;
   context: HubContext;
   operation: 'approve' | 'copy';
-  displayDefaultError? : string;
+  displayDefaultError?: string;
 }) {
   const toolbarFilters = useRepositoryFilters();
   const tableColumns = useRepositoryColumns();
@@ -203,7 +207,9 @@ function CopyToRepositoryModal(props: {
         }}
       />
       {error && <HubError error={{ name: t('Error'), message: error }}></HubError>}
-      {props.displayDefaultError && <HubError error={{ name: t('Error'), message: props.displayDefaultError }}></HubError>}
+      {props.displayDefaultError && (
+        <HubError error={{ name: t('Error'), message: props.displayDefaultError }}></HubError>
+      )}
     </Modal>
   );
 }
@@ -219,9 +225,8 @@ export async function copyToRepositoryAction(
   selectedRepositories: Repository[],
   context: HubContext,
   pulpRequest: ReturnType<typeof useGetRequest<PulpItemsResponse<SigningServiceResponse>>>,
-  t: TFunction<'translation', undefined>,
+  t: TFunction<'translation', undefined>
 ) {
-  debugger;
   const { repository } = collection;
   if (!repository) {
     return;


### PR DESCRIPTION
Approvals now show standard modal for approvals to single repo, or approve modal for selection of multiple repos.

Previously, standard framework modal was always shown, force user to click checkbox and then confirm and then approve modal opened and user had to select repositories for multiple repos, which was time consuming and user unfriendly.