### PR TITLE
Removes bottom border on the Workflow Visualizer toolbar

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
@@ -21,7 +21,7 @@ import {
   withContextMenu,
   withPanZoom,
   withSelection,
-  TopologyView,
+  TopologyView as PFTopologyView,
   ElementModel,
   Edge,
 } from '@patternfly/react-topology';
@@ -43,7 +43,13 @@ import { useCreateEdge } from './hooks';
 import { getNodeLabel } from './wizard/helpers';
 import { GRAPH_ID, NODE_DIAMETER, START_NODE_ID } from './constants';
 import { useCreateNodeComponent } from './hooks/useCreateNodeComponent';
+import { styled } from 'styled-components';
 
+const TopologyView = styled(PFTopologyView)`
+  .pf-v5-c-divider {
+    display: none;
+  }
+`;
 const graphModel: Model = {
   nodes: [],
   edges: [],


### PR DESCRIPTION
Addresses 20539.  Removes bottom border from workflow visualizer toolbar
Before
![Screenshot 2024-02-14 at 11 43 18 AM](https://github.com/ansible/ansible-ui/assets/39280967/b61342ef-babd-4d34-8cd6-44d2e57c3357)



After
![Screenshot 2024-02-14 at 11 43 03 AM](https://github.com/ansible/ansible-ui/assets/39280967/7e893e20-f1cf-4857-aee5-0c28bb92d20f)
