### PR TITLE
Hub E2E approvals fix

### DIFF
--- a/cypress/e2e/hub/approvals.cy.ts
+++ b/cypress/e2e/hub/approvals.cy.ts
@@ -1,5 +1,5 @@
-import { Approvals, Collections, MyImports } from './constants';
 import { randomString } from '../../../framework/utils/random-string';
+import { Approvals, Collections, MyImports } from './constants';
 
 describe('Approvals', () => {
   let thisCollectionName: string;
@@ -46,7 +46,9 @@ describe('Approvals', () => {
   function approve(status: string) {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    clickTableRowPinnedAction(thisCollectionName, 'approve');
+
+    cy.filterTableBySingleText(thisCollectionName);
+    cy.clickTableRowPinnedAction(thisCollectionName, 'view-import-logs', false);
 
     //Verify Approve and sign collections modal
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
@@ -97,7 +99,9 @@ describe('Approvals', () => {
   function reject(status: string) {
     cy.navigateTo('hub', Approvals.url);
     cy.verifyPageTitle(Approvals.title);
-    clickTableRowPinnedAction(thisCollectionName, 'reject');
+
+    cy.filterTableBySingleText(thisCollectionName);
+    cy.clickTableRowPinnedAction(thisCollectionName, 'view-import-logs', false);
 
     //Verify Reject modal
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
@@ -137,7 +141,7 @@ describe('Approvals', () => {
 
   it('user can view import logs', () => {
     cy.filterTableBySingleText(thisCollectionName);
-    clickTableRowPinnedAction(thisCollectionName, 'view-import-logs');
+    cy.clickTableRowPinnedAction(thisCollectionName, 'view-import-logs', false);
 
     cy.url().should('include', MyImports.url);
     cy.url().should('include', namespace);
@@ -151,8 +155,3 @@ describe('Approvals', () => {
     repository = 'staging';
   });
 });
-
-function clickTableRowPinnedAction(text: string, action: string) {
-  cy.filterTableBySingleText(text + '{enter}');
-  cy.get(`[data-cy="actions-column-cell"] [data-cy="${action}"]`).click();
-}

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -347,14 +347,14 @@ Cypress.Commands.add('hasTooltip', (label: string | RegExp) => {
   cy.contains('.pf-v5-c-tooltip__content', label);
 });
 
-Cypress.Commands.add('clickToolbarKebabAction', (dataCyLabel: string | RegExp) => {
+Cypress.Commands.add('clickToolbarKebabAction', (dataCyLabel: string) => {
   cy.get('[data-ouia-component-id="page-toolbar"]').within(() => {
     cy.get('[data-cy*="actions-dropdown"]:not(:disabled):not(:hidden)')
       .should('not.have.attr', 'aria-disabled', 'true')
       .should('be.visible')
       .click()
       .then(() => {
-        cy.get(`[data-cy=${dataCyLabel}]`).click();
+        cy.clickByDataCy(dataCyLabel);
       });
   });
 });
@@ -405,11 +405,8 @@ Cypress.Commands.add(
   'clickTableRowKebabAction',
   (name: string | RegExp, dataCyLabel: string, filter?: boolean) => {
     cy.getTableRowByText(name, filter).within(() => {
-      cy.get('[data-cy*="actions-dropdown"]')
-        .click()
-        .then(() => {
-          cy.clickByDataCy(dataCyLabel);
-        });
+      cy.clickByDataCy('actions-dropdown');
+      cy.clickByDataCy(dataCyLabel);
     });
   }
 );
@@ -432,7 +429,7 @@ Cypress.Commands.add(
   (name: string | RegExp, iconDataCy: string, filter?: boolean) => {
     cy.getTableRowByText(name, filter).within(() => {
       cy.get('[data-cy="actions-column-cell"]').within(() => {
-        cy.get(`[data-cy="${iconDataCy}"]`).click();
+        cy.clickByDataCy(iconDataCy);
       });
     });
   }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -206,7 +206,7 @@ declare global {
       selectDetailsPageKebabAction(dataCy: string): Chainable<void>;
 
       /** Click an action in the table toolbar kebab dropdown actions menu. */
-      clickToolbarKebabAction(dataCyLabel: string | RegExp): Chainable<void>;
+      clickToolbarKebabAction(dataCyLabel: string): Chainable<void>;
 
       /** Get the table row containing the specified text. */
       getTableRowByText(


### PR DESCRIPTION
Switched tests to use
    cy.clickTableRowPinnedAction(thisCollectionName, 'view-import-logs', false);

Updates `clickTableRowPinnedAction` to use
        cy.clickByDataCy(dataCyLabel);

Which waits for the element to be enabled before clicking