### PR TITLE
Hub E2E Filter registry table before row click 

### DIFF
--- a/cypress/e2e/hub/remote-registries.cy.ts
+++ b/cypress/e2e/hub/remote-registries.cy.ts
@@ -130,7 +130,12 @@ describe('Remote Registry', () => {
       cy.get('[data-cy="url"]').clear().type(RemoteRegistry.remoteURL);
       cy.clickButton(/^Edit remote registry$/);
       cy.clickButton(/^Clear all filters$/);
-      cy.contains(remoteRegistryName).click();
+      cy.filterTableBySingleText(remoteRegistryName);
+      cy.contains('tr', remoteRegistryName).within(() => {
+        cy.contains('td', remoteRegistryName).within(() => {
+          cy.get('a').click();
+        });
+      });
       cy.url().should('include', `remote-registries/details/${remoteRegistryName}`);
       cy.get('[data-cy="name"]').should('contain', remoteRegistryName);
       cy.get('[data-cy="url"]').should('contain', RemoteRegistry.remoteURL);


### PR DESCRIPTION
Fixing failing Hub remote registries test

### Bug: 
"edit a remote registry" fails when the remote registry table has more than one page. 
It assumed the edited row would be visible on page 1, but if there is more than one page, the edited row could be hidden.

### Fix: 
Filter the remote registry table to only show the edited remote registry, then click on the row. 