### PR TITLE
Update cypress core commands to be more resilient

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -329,10 +329,10 @@ Cypress.Commands.add('hasTooltip', (label: string | RegExp) => {
   cy.contains('.pf-v5-c-tooltip__content', label);
 });
 
-Cypress.Commands.add('clickToolbarKebabAction', (dataCyLabel: string | RegExp) => {
+Cypress.Commands.add('clickToolbarKebabAction', (dataCy: string) => {
   cy.getBy('[data-ouia-component-id="page-toolbar"]').within(() => {
-    cy.getBy('[data-cy*="actions-dropdown"]').click();
-    cy.getBy(`[data-cy=${dataCyLabel}]`).click();
+    cy.getByDataCy('actions-dropdown').click();
+    cy.getByDataCy(dataCy).click();
   });
 });
 

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -23,10 +23,7 @@ import { Team } from '../../frontend/awx/interfaces/Team';
 import { User } from '../../frontend/awx/interfaces/User';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../frontend/awx/interfaces/WorkflowNode';
-import './auth';
-import './commands';
 import { awxAPI } from './formatApiPathForAwx';
-import './rest-commands';
 
 //  AWX related custom command implementation
 
@@ -292,10 +289,7 @@ Cypress.Commands.add('setTablePageSize', (text: '10' | '20' | '50' | '100') => {
 });
 
 Cypress.Commands.add('clickLink', (label: string | RegExp) => {
-  cy.contains('a:not(:disabled):not(:hidden)', label)
-    .should('not.have.attr', 'aria-disabled', 'true')
-    .should('be.visible');
-  cy.contains('a:not(:disabled):not(:hidden)', label).click();
+  cy.containsBy('a', label).click();
 });
 
 Cypress.Commands.add('clickTab', (label: string | RegExp, isLink) => {
@@ -307,19 +301,7 @@ Cypress.Commands.add('clickTab', (label: string | RegExp, isLink) => {
 });
 
 Cypress.Commands.add('clickButton', (label: string | RegExp) => {
-  cy.contains('button:not(:disabled):not(:hidden)', label)
-    .should('not.have.attr', 'aria-disabled', 'true')
-    .should('be.visible');
-  cy.contains('button:not(:disabled):not(:hidden)', label).click();
-});
-
-Cypress.Commands.add('clickByDataCy', (dataCy: string) => {
-  // Having the check before the click is needed for a timing issue which causes:
-  // We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page.
-  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`)
-    .should('not.have.attr', 'aria-disabled', 'true')
-    .should('be.visible');
-  cy.get(`[data-cy="${dataCy}"]:not(:disabled):not(:hidden)`).click();
+  cy.containsBy('button', label).click();
 });
 
 Cypress.Commands.add('navigateTo', (component: string, label: string) => {
@@ -348,23 +330,17 @@ Cypress.Commands.add('hasTooltip', (label: string | RegExp) => {
 });
 
 Cypress.Commands.add('clickToolbarKebabAction', (dataCyLabel: string | RegExp) => {
-  cy.get('[data-ouia-component-id="page-toolbar"]').within(() => {
-    cy.get('[data-cy*="actions-dropdown"]:not(:disabled):not(:hidden)')
-      .should('not.have.attr', 'aria-disabled', 'true')
-      .should('be.visible')
-      .click()
-      .then(() => {
-        cy.get(`[data-cy=${dataCyLabel}]`).click();
-      });
+  cy.getBy('[data-ouia-component-id="page-toolbar"]').within(() => {
+    cy.getBy('[data-cy*="actions-dropdown"]').click();
+    cy.getBy(`[data-cy=${dataCyLabel}]`).click();
   });
 });
 
 Cypress.Commands.add('clickTableRow', (name: string | RegExp, filter?: boolean) => {
-  if (filter !== false && typeof name === 'string') {
-    cy.filterTableByText(name);
-  }
-  cy.contains('td', name).within(() => {
-    cy.get('a').click();
+  cy.getTableRowByText(name, filter).within(() => {
+    cy.contains('td', name).within(() => {
+      cy.getBy('a').click();
+    });
   });
 });
 
@@ -431,8 +407,8 @@ Cypress.Commands.add(
   'clickTableRowPinnedAction',
   (name: string | RegExp, iconDataCy: string, filter?: boolean) => {
     cy.getTableRowByText(name, filter).within(() => {
-      cy.get('[data-cy="actions-column-cell"]').within(() => {
-        cy.get(`[data-cy="${iconDataCy}"]`).click();
+      cy.getByDataCy('actions-column-cell').within(() => {
+        cy.getByDataCy(iconDataCy).click();
       });
     });
   }
@@ -487,12 +463,9 @@ Cypress.Commands.add('assertModalSuccess', () => {
   });
 });
 
-Cypress.Commands.add('clickPageAction', (dataCyLabel: string | RegExp) => {
-  cy.get('[data-cy="actions-dropdown"]')
-    .click()
-    .then(() => {
-      cy.get(`[data-cy="${dataCyLabel}"]`).click();
-    });
+Cypress.Commands.add('clickPageAction', (dataCy: string) => {
+  cy.getByDataCy('actions-dropdown').click();
+  cy.getByDataCy(dataCy).click();
 });
 
 // Resources for testing AWX

--- a/cypress/support/awx-user-access-commands.ts
+++ b/cypress/support/awx-user-access-commands.ts
@@ -1,15 +1,12 @@
 import '@cypress/code-coverage/support';
 import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
 import { Credential } from '../../frontend/awx/interfaces/Credential';
-import { Role } from '../../frontend/awx/interfaces/Role';
-import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
-import './auth';
-import './commands';
-import './rest-commands';
-import { Project } from '../../frontend/awx/interfaces/Project';
 import { Inventory } from '../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../frontend/awx/interfaces/Organization';
+import { Project } from '../../frontend/awx/interfaces/Project';
+import { Role } from '../../frontend/awx/interfaces/Role';
 import { Team } from '../../frontend/awx/interfaces/Team';
+import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 
 Cypress.Commands.add('giveUserWfjtAccess', (wfjtName: string, userId: number, roleName: string) => {
   cy.awxRequestGet<AwxItemsResponse<WorkflowJobTemplate>>(

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -43,16 +43,7 @@ import { EdaUser, EdaUserCreateUpdate } from '../../frontend/eda/interfaces/EdaU
 import { Role as HubRole } from '../../frontend/hub/access/roles/Role';
 import { RemoteRegistry } from '../../frontend/hub/administration/remote-registries/RemoteRegistry';
 import { CollectionVersionSearch } from '../../frontend/hub/collections/Collection';
-import './auth';
-import './awx-commands';
 import { IAwxResources } from './awx-commands';
-import './awx-user-access-commands';
-import './common-commands';
-import './core-commands';
-import './e2e';
-import './eda-commands';
-import './hub-commands';
-import './rest-commands';
 
 declare global {
   namespace Cypress {
@@ -61,15 +52,8 @@ declare global {
       awxLogin(): Chainable<void>;
       edaLogin(): Chainable<void>;
       hubLogin(): Chainable<void>;
+      platformLogin(): Chainable<void>;
       requiredVariablesAreSet(requiredVariables: string[]): Chainable<void>;
-
-      // --- NAVIGATION COMMANDS ---
-      // createGlobalProject(): Chainable<Project>;
-      /**Navigates to a page of the UI using using the links on the page sidebar. Intended as an alternative to cy.visit(). */
-      navigateTo(component: 'awx' | 'eda' | 'hub', label: string): Chainable<void>;
-
-      /**Locates a title using its label. No assertion is made. */
-      verifyPageTitle(label: string): Chainable<void>;
 
       // ---------------------------------------------------------------------
       // Core Commands
@@ -84,8 +68,11 @@ declare global {
       /** Get by data-cy attribute, making sure it is not disabled or hidden */
       getByDataCy(dataCy: string): Chainable<JQuery<HTMLElement>>;
 
+      /** Contains by selector, making sure it is not disabled or hidden */
+      containsBy(selector: string, text?: string | number | RegExp): Chainable<JQuery<HTMLElement>>;
+
       /** Click by selector, making sure it is not disabled or hidden */
-      clickBy(selector: string): Chainable<void>;
+      clickBy(selector: string, text?: string | number | RegExp): Chainable<void>;
 
       /** Click by data-cy attribute, making sure it is not disabled or hidden */
       clickByDataCy(dataCy: string): Chainable<void>;
@@ -107,6 +94,18 @@ declare global {
 
       /** Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden */
       multiSelectByDataCy(dataCy: string, value: string): Chainable<void>;
+
+      // --- NAVIGATION COMMANDS ---
+      // createGlobalProject(): Chainable<Project>;
+      /**Navigates to a page of the UI using using the links on the page sidebar. Intended as an alternative to cy.visit(). */
+      navigateTo(component: 'platform' | 'awx' | 'eda' | 'hub', label: string): Chainable<void>;
+
+      /**Locates a title using its label. No assertion is made. */
+      verifyPageTitle(label: string): Chainable<void>;
+
+      // ---- UI COMMANDS ---
+
+      setTableView(viewType: string): Chainable<void>;
 
       // ---------------------------------------------------------------------
       // Input Commands
@@ -293,10 +292,7 @@ declare global {
       clickLink(label: string | RegExp): Chainable<void>;
       clickButton(label: string | RegExp): Chainable<void>;
 
-      /** Clicks an element with a data-cy attribute. Waits for the element to be enabled and visible. */
-      clickByDataCy(dataCy: string): Chainable<void>;
-
-      clickPageAction(dataCyLabel: string | RegExp): Chainable<void>;
+      clickPageAction(dataCy: string): Chainable<void>;
 
       /**Finds an alert by its label. Does not make an assertion.  */
       hasAlert(label: string | RegExp): Chainable<void>;
@@ -1040,8 +1036,10 @@ declare global {
       ): Cypress.Chainable<void>;
       collectionCopyVersionToRepositories(collection: string): Cypress.Chainable<void>;
       addAndApproveMultiCollections(thisRange: number): Cypress.Chainable<void>;
+
       createRepository(repositoryName: string, remoteName?: string): Cypress.Chainable<void>;
       deleteRepository(repositoryName: string): Cypress.Chainable<void>;
+
       undeprecateCollection(
         collectionName: string,
         namespaceName: string,

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -69,10 +69,7 @@ declare global {
       getByDataCy(dataCy: string): Chainable<JQuery<HTMLElement>>;
 
       /** Contains by selector, making sure it is not disabled or hidden */
-      containsBy(selector: string, text?: string | number | RegExp): Chainable<JQuery<HTMLElement>>;
-
-      /** Click by selector, making sure it is not disabled or hidden */
-      clickBy(selector: string, text?: string | number | RegExp): Chainable<void>;
+      containsBy(selector: string, text: string | number | RegExp): Chainable<JQuery<HTMLElement>>;
 
       /** Click by data-cy attribute, making sure it is not disabled or hidden */
       clickByDataCy(dataCy: string): Chainable<void>;

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -1,9 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
-import '@4tw/cypress-drag-drop';
-import '@cypress/code-coverage/support';
-import 'cypress-file-upload';
 import { SetOptional, SetRequired } from 'type-fest';
 import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
 import { Application } from '../../frontend/awx/interfaces/Application';

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -202,7 +202,7 @@ declare global {
       selectDetailsPageKebabAction(dataCy: string): Chainable<void>;
 
       /** Click an action in the table toolbar kebab dropdown actions menu. */
-      clickToolbarKebabAction(dataCyLabel: string | RegExp): Chainable<void>;
+      clickToolbarKebabAction(dataCy: string): Chainable<void>;
 
       /** Get the table row containing the specified text. */
       getTableRowByText(

--- a/cypress/support/component.tsx
+++ b/cypress/support/component.tsx
@@ -27,10 +27,17 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PageFramework } from '../../framework';
 import { AwxActiveUserProvider } from '../../frontend/awx/common/useAwxActiveUser';
 import { User } from '../../frontend/awx/interfaces/User';
-import './commands';
-
 import '../../frontend/common/i18n';
+import './auth';
+import './awx-commands';
+import './awx-user-access-commands';
+import './common-commands';
+import './core-commands';
+import './e2e';
+import './eda-commands';
 import { awxAPI } from './formatApiPathForAwx';
+import './hub-commands';
+import './rest-commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/component.tsx
+++ b/cypress/support/component.tsx
@@ -19,7 +19,10 @@ import '@patternfly/patternfly/patternfly-charts.css';
 
 import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 
+import '@4tw/cypress-drag-drop';
+import '@cypress/code-coverage/support';
 import { Page } from '@patternfly/react-core';
+import 'cypress-file-upload';
 import 'cypress-react-selector';
 import type { MountReturn } from 'cypress/react';
 import { mount } from 'cypress/react18';

--- a/cypress/support/core-commands.ts
+++ b/cypress/support/core-commands.ts
@@ -7,10 +7,7 @@
 
 /** Get by selector, making sure it is not disabled or hidden */
 Cypress.Commands.add('getBy', (selector: string) => {
-  cy.get(`${selector}:not(:disabled):not(:hidden)`)
-    .should('not.have.attr', 'aria-disabled', 'true')
-    .should('be.visible');
-  cy.get(`${selector}:not(:disabled):not(:hidden)`);
+  cy.get(`${selector}:not(:disabled):not(:hidden):visible:not([aria-disabled="true"])`);
 });
 
 /** Get by data-cy attribute, making sure it is not disabled or hidden */
@@ -18,14 +15,19 @@ Cypress.Commands.add('getByDataCy', (dataCy: string) => {
   cy.getBy(`[data-cy="${dataCy}"]`);
 });
 
+/** Contains by selector, making sure it is not disabled or hidden */
+Cypress.Commands.add('containsBy', (selector: string, text?: string | number | RegExp) => {
+  cy.contains(`${selector}:not(:disabled):not(:hidden):visible:not([aria-disabled="true"])`, text);
+});
+
 /** Click by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('clickBy', (selector: string) => {
-  cy.getBy(selector).click();
+Cypress.Commands.add('clickBy', (selector: string, text?: string | number | RegExp) => {
+  cy.containsBy(selector, text).click();
 });
 
 /** Click by data-cy attribute, making sure it is not disabled or hidden */
 Cypress.Commands.add('clickByDataCy', (dataCy: string) => {
-  cy.clickBy(`[data-cy="${dataCy}"]`);
+  cy.getBy(`[data-cy="${dataCy}"]`).click();
 });
 
 /** Type input by selector, making sure it is not disabled or hidden */

--- a/cypress/support/core-commands.ts
+++ b/cypress/support/core-commands.ts
@@ -16,13 +16,8 @@ Cypress.Commands.add('getByDataCy', (dataCy: string) => {
 });
 
 /** Contains by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('containsBy', (selector: string, text?: string | number | RegExp) => {
+Cypress.Commands.add('containsBy', (selector: string, text: string | number | RegExp) => {
   cy.contains(`${selector}:not(:disabled):not(:hidden):visible:not([aria-disabled="true"])`, text);
-});
-
-/** Click by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('clickBy', (selector: string, text?: string | number | RegExp) => {
-  cy.containsBy(selector, text).click();
 });
 
 /** Click by data-cy attribute, making sure it is not disabled or hidden */

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 // import 'cypress-axe';
+import '@4tw/cypress-drag-drop';
 import '@cypress/code-coverage/support';
+import 'cypress-file-upload';
 import { randomString } from '../../framework/utils/random-string';
 import { HubUser } from '../../frontend/hub/interfaces/expanded/HubUser';
 import './auth';

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -3,8 +3,16 @@
 import '@cypress/code-coverage/support';
 import { randomString } from '../../framework/utils/random-string';
 import { HubUser } from '../../frontend/hub/interfaces/expanded/HubUser';
-import './commands';
+import './auth';
+import './awx-commands';
+import './awx-user-access-commands';
+import './common-commands';
+import './core-commands';
+import './e2e';
+import './eda-commands';
 import { hubAPI } from './formatApiPathForHub';
+import './hub-commands';
+import './rest-commands';
 
 export const galaxykitUsername: string = `e2e-${randomString(4)}`;
 export const galaxykitPassword: string = randomString(9);

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -21,8 +21,6 @@ import {
   RestartPolicyEnum,
   Status906Enum,
 } from '../../frontend/eda/interfaces/generated/eda-api';
-import './auth';
-import './commands';
 import { edaAPI } from './formatApiPathForEDA';
 
 /*  EDA related custom command implementation  */

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -5,10 +5,8 @@ import { Task } from '../../frontend/hub/administration/tasks/Task';
 import { CollectionVersionSearch } from '../../frontend/hub/collections/Collection';
 import { parsePulpIDFromURL } from '../../frontend/hub/common/api/hub-api-utils';
 import { HubItemsResponse } from '../../frontend/hub/common/useHubView';
-import './commands';
 import { galaxykitPassword, galaxykitUsername } from './e2e';
 import { hubAPI, pulpAPI } from './formatApiPathForHub';
-import './rest-commands';
 import { escapeForShellCommand } from './utils';
 
 const apiPrefix = Cypress.env('HUB_API_PREFIX') as string;


### PR DESCRIPTION
Leverages commands that make sure elements are not disabled or hidden.
Used to interact with the UI in a way that is consistent and reliable.

```ts
/** Get by selector, making sure it is not disabled or hidden */
Cypress.Commands.add('getBy', (selector: string) => {
  cy.get(`${selector}:not(:disabled):not(:hidden):visible:not([aria-disabled="true"])`);
});

/** Contains by selector, making sure it is not disabled or hidden */
Cypress.Commands.add('containsBy', (selector: string, text: string | number | RegExp) => {
  cy.contains(`${selector}:not(:disabled):not(:hidden):visible:not([aria-disabled="true"])`, text);
});
```