### PR TITLE
Fix isRequired behavior for PageFormCreatableSelect

### DIFF
--- a/framework/PageForm/Inputs/FormGroupTypeAheadMultiSelect.tsx
+++ b/framework/PageForm/Inputs/FormGroupTypeAheadMultiSelect.tsx
@@ -31,6 +31,7 @@ export type FormGroupTypeAheadMultiSelectProps = {
   isSubmitting: boolean;
   value: Partial<{ name: string }>[];
   onHandleClear: (chip?: string) => void;
+  isRequired?: boolean;
 };
 
 /** A PatternFly FormGroup with a PatternFly Select */
@@ -46,6 +47,8 @@ export function FormGroupTypeAheadMultiSelect(props: FormGroupTypeAheadMultiSele
     placeholderText,
     isSubmitting,
     isReadOnly,
+    isRequired,
+    helperTextInvalid,
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -74,7 +77,14 @@ export function FormGroupTypeAheadMultiSelect(props: FormGroupTypeAheadMultiSele
   const id = useID(props);
 
   return (
-    <PageFormGroup fieldId={id} label={label} labelHelp={labelHelp} labelHelpTitle={labelHelpTitle}>
+    <PageFormGroup
+      fieldId={id}
+      label={label}
+      labelHelp={labelHelp}
+      labelHelpTitle={labelHelpTitle}
+      helperTextInvalid={helperTextInvalid}
+      isRequired={isRequired}
+    >
       <Select
         chipGroupComponent={chipGroupComponent()}
         variant={SelectVariant.typeaheadMulti}

--- a/framework/PageForm/Inputs/PageFormCreatableSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormCreatableSelect.tsx
@@ -50,6 +50,7 @@ export function PageFormCreatableSelect<
           helperTextInvalid={error?.message}
           value={value}
           isSubmitting={isSubmitting}
+          isRequired={isRequired}
           onHandleClear={(chip?: string) => {
             const values: { name: string }[] = getValues(props.name);
             onChange(!chip ? [] : values.filter((v: { name: string }) => v.name !== chip));


### PR DESCRIPTION
Pass through necessary props so required `*` indicator is shown and error message displays upon form validation

![Screenshot 2024-02-15 at 2 28 00 PM](https://github.com/ansible/ansible-ui/assets/410794/961fe4f0-68a6-4ab3-9108-709f25c6705b)
