### PR TITLE
Activity Stream column alignment

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -670,6 +670,7 @@ function TableHead<T extends object>(props: {
                       ? column.minWidth
                       : undefined,
                 maxWidth: column.maxWidth !== undefined ? column.maxWidth : undefined,
+                width: column.fullWidth ? '100%' : undefined,
               }}
               data-cy={getID(column.header + '-column-header')}
               className="bg-lighten"

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -78,6 +78,9 @@ interface ITableColumnCommon<T extends object> {
   /** MaxWidth for the column. */
   maxWidth?: number;
 
+  /** Makes the column take up the full width */
+  fullWidth?: boolean;
+
   /** Indicates the key for the sorting. This key is usually handled by the view to so the sorting. */
   sort?: string;
 

--- a/frontend/awx/administration/activity-stream/hooks/useActivityStreamColumns.tsx
+++ b/frontend/awx/administration/activity-stream/hooks/useActivityStreamColumns.tsx
@@ -37,6 +37,7 @@ export function useActivityStreamColumns(options?: {
         ),
         sort: undefined,
         list: 'secondary',
+        fullWidth: true,
       },
     ],
     [options, t]


### PR DESCRIPTION
Allows marking a column as full width for tables that have a main column.

![Screenshot 2024-02-19 at 10 48 21 AM](https://github.com/ansible/ansible-ui/assets/6277895/48eb1669-c7d7-4690-bdc5-f110f1721d7d)

Vs

![Screenshot 2024-02-19 at 10 48 47 AM](https://github.com/ansible/ansible-ui/assets/6277895/3037e699-2fb8-4db5-b70f-eea5c7941290)
