### PR TITLE
DataEditor Responsive Layout Support

### DIFF
--- a/cypress/fixtures/extra_vars.yaml
+++ b/cypress/fixtures/extra_vars.yaml
@@ -1,3 +1,2 @@
----
 ansible_ssh_user: root
 ansible_connection: ssh

--- a/framework/PageForm/Inputs/PageFormDataEditor.cy.tsx
+++ b/framework/PageForm/Inputs/PageFormDataEditor.cy.tsx
@@ -52,9 +52,9 @@ describe('PageFormDataEditor', () => {
         />
       </PageForm>
     );
-    expect(cy.get('div#copy-button').should('be.visible'));
-    expect(cy.get('div#upload-button').should('be.visible'));
-    expect(cy.get('div#download-button').should('be.visible'));
+    expect(cy.get('button#copy-button').should('be.visible'));
+    expect(cy.get('button#upload-button').should('be.visible'));
+    expect(cy.get('button#download-button').should('be.visible'));
     expect(cy.get('div#toggle-json').should('be.visible'));
     expect(cy.get('div#toggle-yaml').should('be.visible'));
     expect(cy.get('div#data-editor-extra_vars').should('be.visible'));

--- a/framework/PageForm/Inputs/PageFormDataEditor.tsx
+++ b/framework/PageForm/Inputs/PageFormDataEditor.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { AngleRightIcon, CopyIcon, DownloadIcon, UploadIcon } from '@patternfly/react-icons';
+import jsyaml from 'js-yaml';
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import {
@@ -79,7 +80,7 @@ function ActionsRow(props: {
           onClick={() => handleCopy()}
           variant="plain"
           size="sm"
-          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
+          style={{ minWidth: 0, padding: 0, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -98,7 +99,7 @@ function ActionsRow(props: {
           onClick={() => handleUpload()}
           variant="plain"
           size="sm"
-          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
+          style={{ minWidth: 0, padding: 0, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -117,7 +118,7 @@ function ActionsRow(props: {
           onClick={() => handleDownload()}
           variant="plain"
           size="sm"
-          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
+          style={{ minWidth: 0, padding: 0, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -182,6 +183,7 @@ export type PageFormDataEditorInputProps<
   labelHelpTitle?: string;
 
   disableLineNumbers?: boolean;
+  isObject?: boolean;
 };
 
 export function PageFormDataEditor<
@@ -233,7 +235,6 @@ export function PageFormDataEditor<
   const handleLanguageChange = useCallback(
     (language: string) => {
       const value = getValues(name);
-
       if ((language !== 'json' && language !== 'yaml') || !value) return;
 
       if (isJsonString(value)) {
@@ -341,6 +342,23 @@ export function PageFormDataEditor<
       render={({ field: { name, onChange, value }, fieldState: { error } }) => {
         const errorSet = [...new Set(error?.message?.split('\n'))];
         const disabled = value !== undefined && value !== null && value !== '';
+
+        function handleChange(value: string) {
+          if (props.isObject) {
+            try {
+              onChange(JSON.parse(value));
+            } catch (e) {
+              try {
+                onChange(jsyaml.load(value));
+              } catch (e) {
+                onChange(value);
+              }
+            }
+          } else {
+            onChange(value);
+          }
+        }
+
         return (
           <PageFormGroup
             fieldId={id}
@@ -404,7 +422,7 @@ export function PageFormDataEditor<
                       name={name}
                       language={selectedLanguage}
                       value={value}
-                      onChange={onChange}
+                      onChange={handleChange}
                       isReadOnly={isReadOnly || isSubmitting}
                       invalid={!(validate && isValidating) && error?.message !== undefined}
                     />
@@ -418,7 +436,7 @@ export function PageFormDataEditor<
                     name={name}
                     language={selectedLanguage}
                     value={value}
-                    onChange={onChange}
+                    onChange={handleChange}
                     isReadOnly={isReadOnly || isSubmitting}
                     invalid={!(validate && isValidating) && error?.message !== undefined}
                     disableLineNumbers={disableLineNumbers}

--- a/framework/PageForm/Inputs/PageFormDataEditor.tsx
+++ b/framework/PageForm/Inputs/PageFormDataEditor.tsx
@@ -69,7 +69,7 @@ function ActionsRow(props: {
   if (allowCopy) {
     actionItems.push(
       <Tooltip key="copy-file" content={t('Copy')}>
-        <IconButton
+        <Button
           key="copy-button"
           id="copy-button"
           data-cy="copy-button"
@@ -79,6 +79,7 @@ function ActionsRow(props: {
           onClick={() => handleCopy()}
           variant="plain"
           size="sm"
+          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -87,7 +88,7 @@ function ActionsRow(props: {
   if (allowUpload) {
     actionItems.push(
       <Tooltip key="upload-file" content={t('Upload')}>
-        <IconButton
+        <Button
           key="upload-button"
           id="upload-button"
           data-cy="upload-button"
@@ -97,6 +98,7 @@ function ActionsRow(props: {
           onClick={() => handleUpload()}
           variant="plain"
           size="sm"
+          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -105,7 +107,7 @@ function ActionsRow(props: {
   if (allowDownload) {
     actionItems.push(
       <Tooltip key="download-file" content={t('Download')}>
-        <IconButton
+        <Button
           key="download-button"
           id="download-button"
           data-cy="download-button"
@@ -115,6 +117,7 @@ function ActionsRow(props: {
           onClick={() => handleDownload()}
           variant="plain"
           size="sm"
+          style={{ minWidth: 0, padding: 6, paddingLeft: 8, paddingRight: 8 }}
         />
       </Tooltip>
     );
@@ -439,10 +442,3 @@ export function PageFormDataEditor<
     />
   );
 }
-
-const IconButton = styled(Button)`
-  minwidth: 0;
-  padding: 0;
-  paddingleft: 8;
-  paddingright: 8;
-`;

--- a/framework/PageForm/Inputs/PageFormDataEditor.tsx
+++ b/framework/PageForm/Inputs/PageFormDataEditor.tsx
@@ -1,5 +1,6 @@
 import {
   AlertProps,
+  Button,
   Flex,
   FlexItem,
   ToggleGroupItem as PFToggleGroupItem,
@@ -46,6 +47,7 @@ function ActionsRow(props: {
   selectedLanguage: string;
   errors: FieldErrors<FieldValues>;
   name: string;
+  children?: ReactNode;
 }) {
   const { t } = useTranslation();
   const {
@@ -67,7 +69,7 @@ function ActionsRow(props: {
   if (allowCopy) {
     actionItems.push(
       <Tooltip key="copy-file" content={t('Copy')}>
-        <ToggleGroupItem
+        <IconButton
           key="copy-button"
           id="copy-button"
           data-cy="copy-button"
@@ -75,6 +77,8 @@ function ActionsRow(props: {
           icon={<CopyIcon />}
           type="button"
           onClick={() => handleCopy()}
+          variant="plain"
+          size="sm"
         />
       </Tooltip>
     );
@@ -83,7 +87,7 @@ function ActionsRow(props: {
   if (allowUpload) {
     actionItems.push(
       <Tooltip key="upload-file" content={t('Upload')}>
-        <ToggleGroupItem
+        <IconButton
           key="upload-button"
           id="upload-button"
           data-cy="upload-button"
@@ -91,6 +95,8 @@ function ActionsRow(props: {
           icon={<UploadIcon />}
           type="button"
           onClick={() => handleUpload()}
+          variant="plain"
+          size="sm"
         />
       </Tooltip>
     );
@@ -99,7 +105,7 @@ function ActionsRow(props: {
   if (allowDownload) {
     actionItems.push(
       <Tooltip key="download-file" content={t('Download')}>
-        <ToggleGroupItem
+        <IconButton
           key="download-button"
           id="download-button"
           data-cy="download-button"
@@ -107,6 +113,8 @@ function ActionsRow(props: {
           icon={<DownloadIcon />}
           type="button"
           onClick={() => handleDownload()}
+          variant="plain"
+          size="sm"
         />
       </Tooltip>
     );
@@ -128,10 +136,15 @@ function ActionsRow(props: {
     )) || [];
 
   return (
-    <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-      <FlexItem>
-        <ToggleGroup isCompact>{actionItems}</ToggleGroup>
-      </FlexItem>
+    <Flex
+      grow={{ default: 'grow' }}
+      columnGap={{ default: 'columnGapSm' }}
+      rowGap={{ default: 'rowGapNone' }}
+      justifyContent={{ default: 'justifyContentFlexEnd' }}
+      // style={{ marginTop: -8, marginBottom: -8 }}
+    >
+      <FlexItem>{props.children}</FlexItem>
+      <FlexItem>{actionItems}</FlexItem>
       <FlexItem align={{ default: 'alignRight' }}>
         <ToggleGroup isCompact>{languageActions}</ToggleGroup>
       </FlexItem>
@@ -148,6 +161,7 @@ export type PageFormDataEditorInputProps<
 > = {
   name: TFieldName;
   validate?: Validate<string, TFieldValues> | Record<string, Validate<string, TFieldValues>>;
+  language?: string;
   toggleLanguages?: string[];
   isExpandable?: boolean;
   allowUpload?: boolean;
@@ -163,6 +177,8 @@ export type PageFormDataEditorInputProps<
   additionalControls?: ReactNode;
   labelHelp?: string | string[] | ReactNode;
   labelHelpTitle?: string;
+
+  disableLineNumbers?: boolean;
 };
 
 export function PageFormDataEditor<
@@ -183,8 +199,10 @@ export function PageFormDataEditor<
     isRequired,
     label,
     name,
+    language,
     toggleLanguages,
     validate,
+    disableLineNumbers,
     ...formGroupInputProps
   } = props;
   const {
@@ -196,7 +214,7 @@ export function PageFormDataEditor<
     setValue,
   } = useFormContext<TFieldValues>();
 
-  const [selectedLanguage, setSelectedLanguage] = useState('yaml');
+  const [selectedLanguage, setSelectedLanguage] = useState(props.language ?? 'yaml');
   const [isCollapsed, setCollapsed] = useState(!defaultExpanded);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const alertToaster = usePageAlertToaster();
@@ -339,9 +357,10 @@ export function PageFormDataEditor<
             }
             label={props.label}
             helperTextInvalid={!(validate && isValidating) && errorSet}
-          >
-            {(!isExpandable || !isCollapsed) && (
-              <>
+            additionalControls={
+              isExpandable && isCollapsed ? (
+                props.additionalControls
+              ) : (
                 <ActionsRow
                   key="actions-row"
                   allowCopy={allowCopy}
@@ -355,7 +374,14 @@ export function PageFormDataEditor<
                   selectedLanguage={selectedLanguage}
                   setLanguage={setLanguage}
                   toggleLanguages={toggleLanguages}
-                />
+                >
+                  {props.additionalControls}
+                </ActionsRow>
+              )
+            }
+          >
+            {(!isExpandable || !isCollapsed) && (
+              <>
                 {props.allowUpload ? (
                   <div
                     id="code-editor-dropzone"
@@ -392,6 +418,7 @@ export function PageFormDataEditor<
                     onChange={onChange}
                     isReadOnly={isReadOnly || isSubmitting}
                     invalid={!(validate && isValidating) && error?.message !== undefined}
+                    disableLineNumbers={disableLineNumbers}
                   />
                 )}
               </>
@@ -412,3 +439,10 @@ export function PageFormDataEditor<
     />
   );
 }
+
+const IconButton = styled(Button)`
+  minwidth: 0;
+  padding: 0;
+  paddingleft: 8;
+  paddingright: 8;
+`;

--- a/framework/PageFramework.css
+++ b/framework/PageFramework.css
@@ -86,3 +86,19 @@ tr.selected:hover {
 }
 
 */
+
+/* PF labels do not wrap the addition controls cleanly, so we need to override the default behavior */
+.pf-v5-c-form__group-label {
+  flex-wrap: wrap;
+  align-items: center;
+}
+.pf-v5-c-form__group-label.pf-m-info {
+  align-items: center !important;
+  justify-content: end;
+}
+.pf-v5-c-form__group-label-main {
+  flex-grow: 1;
+}
+.pf-v5-c-form__group-label-info {
+  margin-inline-start: 0 !important;
+}

--- a/frontend/awx/resources/inventories/inventoryGroup/InventoryGroupForm.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryGroup/InventoryGroupForm.cy.tsx
@@ -57,7 +57,7 @@ describe('EditGroup', () => {
     cy.fixture('groupDetails.json').then((group: InventoryGroup) => {
       cy.get('[data-cy="name"]').should('have.value', group.name);
       cy.get('[data-cy="description"]').should('have.value', group.description);
-      cy.get('.view-lines').contains(/^---$/);
+      cy.get('.view-lines').contains('test: true');
     });
   });
 });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
@@ -5,7 +5,7 @@ import { CreateHost, EditHost } from './InventoryHostForm';
 describe('Create Edit Inventory Host Form', () => {
   const payload = {
     name: 'test',
-    variables: '---\nhello: world',
+    variables: 'hello: world',
     description: 'mock host description',
     inventory: 1,
   };


### PR DESCRIPTION
These changes will be needed for the AWX Settings Pages.

Handles responsive layout much better in all cases.
Makes editor webworkers single instanced  (settings load a lot of editors on same page)
Add support for data editor to edit and save object vs just string

Puts all the data editor actions on a single line.
![Screenshot 2024-02-19 at 12 49 57 PM](https://github.com/ansible/ansible-ui/assets/6277895/3b087064-e879-41eb-ac0f-7a8af69305eb)

Support horizontal labels
![Screenshot 2024-02-19 at 12 51 03 PM](https://github.com/ansible/ansible-ui/assets/6277895/efa46fe2-121a-44dd-a71a-839b8565162e)


VS the previous

![Screenshot 2024-02-19 at 12 51 56 PM](https://github.com/ansible/ansible-ui/assets/6277895/1c0febf4-5d39-4bea-b6c3-01a0278cf081)


NEW:
![Screenshot 2024-02-19 at 12 55 50 PM](https://github.com/ansible/ansible-ui/assets/6277895/2398231c-30f9-4506-8653-cf85e2ffacd8)

OLD:
![Screenshot 2024-02-19 at 12 56 07 PM](https://github.com/ansible/ansible-ui/assets/6277895/d9367789-b54c-4254-8bfb-386be4f2f20e)

