### PR TITLE
Ability to control the order in which columns get displayed in PageDetailsFromColumns

### DIFF
--- a/framework/PageDetails/PageDetailsFromColumns.tsx
+++ b/framework/PageDetails/PageDetailsFromColumns.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Fragment, ReactNode, useMemo } from 'react';
-import { ColumnPriorityOption, ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
+import { ColumnPriority, ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
 import { PageDetail } from './PageDetail';
 
 export function PageDetailsFromColumns<T extends object>(props: {
@@ -12,15 +12,15 @@ export function PageDetailsFromColumns<T extends object>(props: {
 }) {
   const { item, columns, children } = props;
   /**
-   * Columns are displayed based on priority. Columns with ColumnPriorityOption.last appear last.
+   * Columns are displayed based on priority. Columns with ColumnPriority.last appear last.
    * Custom details are received as an optional 'children' prop and placed in the correct position.
    */
   const firstColumns = useMemo(
-    () => columns.filter((column) => column.priority !== ColumnPriorityOption.last).sort(),
+    () => columns.filter((column) => column.priority !== ColumnPriority.last),
     [columns]
   );
   const lastColumns = useMemo(
-    () => columns.filter((column) => column.priority === ColumnPriorityOption.last).sort(),
+    () => columns.filter((column) => column.priority === ColumnPriority.last),
     [columns]
   );
   if (!item) return <></>;

--- a/framework/PageDetails/PageDetailsFromColumns.tsx
+++ b/framework/PageDetails/PageDetailsFromColumns.tsx
@@ -1,18 +1,46 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Fragment } from 'react';
-import { ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
+import { Fragment, ReactNode, useMemo } from 'react';
+import { ColumnPriorityOption, ITableColumn, TableColumnCell } from '../PageTable/PageTableColumn';
 import { PageDetail } from './PageDetail';
 
 export function PageDetailsFromColumns<T extends object>(props: {
   item: T | undefined;
   columns: ITableColumn<T>[];
+  /** Custom page details */
+  children?: ReactNode;
 }) {
-  const { item, columns } = props;
+  const { item, columns, children } = props;
+  /**
+   * Columns are displayed based on priority. Columns with ColumnPriorityOption.last appear last.
+   * Custom details are received as an optional 'children' prop and placed in the correct position.
+   */
+  const firstColumns = useMemo(
+    () => columns.filter((column) => column.priority !== ColumnPriorityOption.last).sort(),
+    [columns]
+  );
+  const lastColumns = useMemo(
+    () => columns.filter((column) => column.priority === ColumnPriorityOption.last).sort(),
+    [columns]
+  );
   if (!item) return <></>;
   return (
     <>
-      {columns.map((column) => {
+      {firstColumns.map((column) => {
+        if ('value' in column && column.value) {
+          const itemValue = column.value(item);
+          if (!itemValue) {
+            return <Fragment key={column.id ?? column.header} />;
+          }
+        }
+        return (
+          <PageDetail key={column.id ?? column.header} label={column.header}>
+            <TableColumnCell column={column} item={item} />
+          </PageDetail>
+        );
+      })}
+      {children ? children : null}
+      {lastColumns.map((column) => {
         if ('value' in column && column.value) {
           const itemValue = column.value(item);
           if (!itemValue) {

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -64,6 +64,13 @@ export enum ColumnDashboardOption {
   hidden = 'hidden',
 }
 
+/** Column options for setting column priority. This is used to determine the order in which
+ * the column is displayed when generating a details page (PageDetailsFromColumns). */
+export enum ColumnPriorityOption {
+  /** Last: The column data will be displayed last in PageDetailsFromColumns */
+  last = 'last',
+}
+
 /** Table column common properties to all columns. */
 interface ITableColumnCommon<T extends object> {
   /** Id of the column. Used to track the column in sorting and user options. */
@@ -112,6 +119,9 @@ interface ITableColumnCommon<T extends object> {
 
   /** Table column options for controlling how the column displays in a dashboard. */
   dashboard?: keyof typeof ColumnDashboardOption;
+
+  /** Table column options for controlling the order in which the column's data is displayed in a details page. */
+  priority?: keyof typeof ColumnPriorityOption;
 }
 
 /** Column that renders using a render function that returns a ReactNode. */

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -66,7 +66,7 @@ export enum ColumnDashboardOption {
 
 /** Column options for setting column priority. This is used to determine the order in which
  * the column is displayed when generating a details page (PageDetailsFromColumns). */
-export enum ColumnPriorityOption {
+export enum ColumnPriority {
   /** Last: The column data will be displayed last in PageDetailsFromColumns */
   last = 'last',
 }
@@ -121,7 +121,7 @@ interface ITableColumnCommon<T extends object> {
   dashboard?: keyof typeof ColumnDashboardOption;
 
   /** Table column options for controlling the order in which the column's data is displayed in a details page. */
-  priority?: keyof typeof ColumnPriorityOption;
+  priority?: keyof typeof ColumnPriority;
 }
 
 /** Column that renders using a render function that returns a ReactNode. */

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   ColumnDashboardOption,
   ColumnModalOption,
-  ColumnPriorityOption,
+  ColumnPriority,
   ColumnTableOption,
   DateTimeCell,
   ITableColumn,
@@ -225,7 +225,7 @@ export function useCreatedColumn(options?: {
       list: 'secondary',
       modal: 'hidden',
       dashboard: 'hidden',
-      priority: ColumnPriorityOption.last,
+      priority: ColumnPriority.last,
     }),
     [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
   );
@@ -275,7 +275,7 @@ export function useModifiedColumn(options?: {
       list: 'secondary',
       modal: 'hidden',
       dashboard: 'hidden',
-      priority: ColumnPriorityOption.last,
+      priority: ColumnPriority.last,
     }),
     [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
   );

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   ColumnDashboardOption,
   ColumnModalOption,
+  ColumnPriorityOption,
   ColumnTableOption,
   DateTimeCell,
   ITableColumn,
@@ -224,6 +225,7 @@ export function useCreatedColumn(options?: {
       list: 'secondary',
       modal: 'hidden',
       dashboard: 'hidden',
+      priority: ColumnPriorityOption.last,
     }),
     [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
   );
@@ -273,6 +275,7 @@ export function useModifiedColumn(options?: {
       list: 'secondary',
       modal: 'hidden',
       dashboard: 'hidden',
+      priority: ColumnPriorityOption.last,
     }),
     [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
   );


### PR DESCRIPTION
- Columns with `ColumnPriority.last` appear last.
- PageDetailsFromColumns accepts additional custom page details as an optional 'children' prop and places in the correct position based on priority.

These changes allow us to customize PageDetailsFromColumns while making sure that certain columns (eg. Created/Modified) still appear last if they are assigned the priority `ColumnPriority.last`. 