### PR TITLE
Fix show signature

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
@@ -215,9 +215,9 @@ function ShowSignature(props: { collection: CollectionVersionSearch }) {
   const name = collection.collection_version?.name || '';
   const version = collection.collection_version?.version || '';
 
-  let url = hubAPI`/v3/plugin/ansible/content/${basePath}/collections/index/${namespace}/${name}/versions/${version}/`;
-  if (!basePath) {
-    url = '';
+  let url = '';
+  if (basePath) {
+    url = hubAPI`/v3/plugin/ansible/content/${basePath}/collections/index/${namespace}/${name}/versions/${version}/`;
   }
 
   const { data: signData, error: signError } = useGet<SignatureType>(url);


### PR DESCRIPTION
![image](https://github.com/ansible/ansible-ui/assets/23277791/d209a679-0eea-4d3c-8701-43f2c85b6d80)

Fixing failing show signature. With introduction with hubAPI and pulpAPI failing with incorrect URL, this condition has to be reversed and initialy url should be set to '', then to correct value if base path is valid.