### PR TITLE
Recreates parse vars field

### DIFF
--- a/framework/utils/codeEditorUtils.ts
+++ b/framework/utils/codeEditorUtils.ts
@@ -10,3 +10,36 @@ export function jsonToYaml(jsonString: string) {
   }
   return jsyaml.dump(value);
 }
+export function isJsonString(jsonString: unknown) {
+  if (typeof jsonString !== 'string') {
+    return false;
+  }
+  let value;
+  try {
+    value = JSON.parse(jsonString) as object;
+  } catch (e) {
+    return false;
+  }
+
+  return typeof value === 'object' && value !== null;
+}
+export function yamlToJson(yamlString: string) {
+  const value: object = jsyaml.load(yamlString) as object;
+  if (!value) {
+    return '{}';
+  }
+  if (typeof value !== 'object') {
+    throw new Error('yaml is not in object format');
+  }
+  return JSON.stringify(value, null, 2);
+}
+export function parseVariableField(variableField: string) {
+  if (variableField === '---' || variableField === '{}') {
+    return {};
+  }
+  if (!isJsonString(variableField)) {
+    variableField = yamlToJson(variableField);
+  }
+
+  return JSON.parse(variableField) as object;
+}


### PR DESCRIPTION
These function were removed in this [PR](https://github.com/ansible/ansible-ui/commit/06dc9ba13d0fc7d66224455e9a73645255178c1f#diff-0cccc60a97885dfd5686a894f794950d699421f18521a9886f7c2010c0b8013aL43).   Workflow Vis needs these functions so this pr brings them back.