### PR TITLE
Fix scrolling of details pages by making PageDetails scroll by default

### DIFF
--- a/framework/PageDetails/PageDetails.tsx
+++ b/framework/PageDetails/PageDetails.tsx
@@ -11,55 +11,59 @@ export function PageDetails(props: {
   labelOrientation?: 'horizontal' | 'vertical';
   alertPrompts?: string[];
   isCompact?: boolean;
+  disableScroll?: boolean;
 }) {
   const { disablePadding, alertPrompts } = props;
   const settings = useSettings();
   const orientation = props.labelOrientation ?? settings.formLayout;
   const numberOfColumns = props.numberOfColumns ? props.numberOfColumns : settings.formColumns;
   const isCompact = props.isCompact;
-  return (
-    <Scrollable>
-      <PageSectionStyled variant="light" padding={{ default: 'noPadding' }}>
-        {alertPrompts &&
-          alertPrompts.length > 0 &&
-          alertPrompts.map((alertPrompt, i) => (
-            <Alert
-              style={{ margin: 12 }}
-              isInline
-              title={alertPrompt}
-              variant="warning"
-              key={i}
-              data-cy={alertPrompt}
-            ></Alert>
-          ))}
-        <DescriptionList
-          orientation={{
-            sm: orientation,
-            md: orientation,
-            lg: orientation,
-            xl: orientation,
-            '2xl': orientation,
-          }}
-          columnModifier={
-            numberOfColumns === 'multiple'
-              ? {
-                  default: '1Col',
-                  sm: '1Col',
-                  md: '2Col',
-                  lg: '2Col',
-                  xl: '3Col',
-                  '2xl': '3Col',
-                }
-              : undefined
-          }
-          style={{ maxWidth: 1200, padding: disablePadding ? undefined : 24 }}
-          isCompact={isCompact}
-        >
-          {props.children}
-        </DescriptionList>
-      </PageSectionStyled>
-    </Scrollable>
+
+  let component = (
+    <PageSectionStyled variant="light" padding={{ default: 'noPadding' }}>
+      {alertPrompts &&
+        alertPrompts.length > 0 &&
+        alertPrompts.map((alertPrompt, i) => (
+          <Alert
+            style={{ margin: 12 }}
+            isInline
+            title={alertPrompt}
+            variant="warning"
+            key={i}
+            data-cy={alertPrompt}
+          ></Alert>
+        ))}
+      <DescriptionList
+        orientation={{
+          sm: orientation,
+          md: orientation,
+          lg: orientation,
+          xl: orientation,
+          '2xl': orientation,
+        }}
+        columnModifier={
+          numberOfColumns === 'multiple'
+            ? {
+                default: '1Col',
+                sm: '1Col',
+                md: '2Col',
+                lg: '2Col',
+                xl: '3Col',
+                '2xl': '3Col',
+              }
+            : undefined
+        }
+        style={{ maxWidth: 1200, padding: disablePadding ? undefined : 24 }}
+        isCompact={isCompact}
+      >
+        {props.children}
+      </DescriptionList>
+    </PageSectionStyled>
   );
+  if (!props.disableScroll) {
+    component = <Scrollable>{component}</Scrollable>;
+  }
+  return component;
 }
 
 const PageSectionStyled = styled(PageSection)`

--- a/framework/PageDetails/PageDetails.tsx
+++ b/framework/PageDetails/PageDetails.tsx
@@ -2,6 +2,7 @@ import { Alert, DescriptionList, PageSection } from '@patternfly/react-core';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { useSettings } from '../Settings';
+import { Scrollable } from '../components/Scrollable';
 
 export function PageDetails(props: {
   children?: ReactNode;
@@ -17,45 +18,47 @@ export function PageDetails(props: {
   const numberOfColumns = props.numberOfColumns ? props.numberOfColumns : settings.formColumns;
   const isCompact = props.isCompact;
   return (
-    <PageSectionStyled variant="light" padding={{ default: 'noPadding' }}>
-      {alertPrompts &&
-        alertPrompts.length > 0 &&
-        alertPrompts.map((alertPrompt, i) => (
-          <Alert
-            style={{ margin: 12 }}
-            isInline
-            title={alertPrompt}
-            variant="warning"
-            key={i}
-            data-cy={alertPrompt}
-          ></Alert>
-        ))}
-      <DescriptionList
-        orientation={{
-          sm: orientation,
-          md: orientation,
-          lg: orientation,
-          xl: orientation,
-          '2xl': orientation,
-        }}
-        columnModifier={
-          numberOfColumns === 'multiple'
-            ? {
-                default: '1Col',
-                sm: '1Col',
-                md: '2Col',
-                lg: '2Col',
-                xl: '3Col',
-                '2xl': '3Col',
-              }
-            : undefined
-        }
-        style={{ maxWidth: 1200, padding: disablePadding ? undefined : 24 }}
-        isCompact={isCompact}
-      >
-        {props.children}
-      </DescriptionList>
-    </PageSectionStyled>
+    <Scrollable>
+      <PageSectionStyled variant="light" padding={{ default: 'noPadding' }}>
+        {alertPrompts &&
+          alertPrompts.length > 0 &&
+          alertPrompts.map((alertPrompt, i) => (
+            <Alert
+              style={{ margin: 12 }}
+              isInline
+              title={alertPrompt}
+              variant="warning"
+              key={i}
+              data-cy={alertPrompt}
+            ></Alert>
+          ))}
+        <DescriptionList
+          orientation={{
+            sm: orientation,
+            md: orientation,
+            lg: orientation,
+            xl: orientation,
+            '2xl': orientation,
+          }}
+          columnModifier={
+            numberOfColumns === 'multiple'
+              ? {
+                  default: '1Col',
+                  sm: '1Col',
+                  md: '2Col',
+                  lg: '2Col',
+                  xl: '3Col',
+                  '2xl': '3Col',
+                }
+              : undefined
+          }
+          style={{ maxWidth: 1200, padding: disablePadding ? undefined : 24 }}
+          isCompact={isCompact}
+        >
+          {props.children}
+        </DescriptionList>
+      </PageSectionStyled>
+    </Scrollable>
   );
 }
 

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -453,6 +453,7 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
             numberOfColumns="multiple"
             labelOrientation="vertical"
             isCompact
+            disableScroll
           >
             <PageDetailsFromColumns key={keyFn(item)} item={item} columns={expandedRowColumns} />
           </PageDetails>

--- a/framework/components/Scrollable.css
+++ b/framework/components/Scrollable.css
@@ -4,6 +4,7 @@
   flex-grow: 1;
   overflow-y: hidden;
   position: relative;
+  pointer-events: none;
 }
 
 .scrollable-inner {
@@ -11,6 +12,7 @@
   flex-direction: column;
   flex-grow: 1;
   overflow-y: auto;
+  pointer-events: none;
 }
 
 .scrollable-shadow-top {

--- a/framework/components/Scrollable.css
+++ b/framework/components/Scrollable.css
@@ -4,7 +4,6 @@
   flex-grow: 1;
   overflow-y: hidden;
   position: relative;
-  pointer-events: none;
 }
 
 .scrollable-inner {
@@ -12,7 +11,6 @@
   flex-direction: column;
   flex-grow: 1;
   overflow-y: auto;
-  pointer-events: none;
 }
 
 .scrollable-shadow-top {

--- a/frontend/awx/access/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
+++ b/frontend/awx/access/credential-types/CredentialTypePage/CredentialTypeDetails.tsx
@@ -1,13 +1,7 @@
 import { Label } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  DateTimeCell,
-  PageDetail,
-  PageDetails,
-  Scrollable,
-  useGetPageUrl,
-} from '../../../../../framework';
+import { DateTimeCell, PageDetail, PageDetails, useGetPageUrl } from '../../../../../framework';
 import { PageDetailCodeEditor } from '../../../../../framework/PageDetails/PageDetailCodeEditor';
 import { jsonToYaml } from '../../../../../framework/utils/codeEditorUtils';
 import { LastModifiedPageDetail } from '../../../../common/LastModifiedPageDetail';
@@ -43,51 +37,49 @@ export function CredentialTypeDetailInner(props: { credentialType: CredentialTyp
   }
 
   return (
-    <Scrollable>
-      <PageDetails>
-        <PageDetail label={t('Name')}>{renderCredentialTypeName(props.credentialType)}</PageDetail>
-        <PageDetail label={t('Description')}>{props.credentialType.description}</PageDetail>
-        <PageDetailCodeEditor
-          helpText={t('Input schema which defines a set of ordered fields for that type.')}
-          label={t('Input configuration')}
-          value={jsonToYaml(JSON.stringify(props.credentialType.inputs))}
-        />
-        <PageDetailCodeEditor
-          helpText={t(
-            'Environment variables or extra variables that specify the values a credential type can inject.'
-          )}
-          label={t('Injector configuration')}
-          value={jsonToYaml(JSON.stringify(props.credentialType.injectors))}
-        />
-        <PageDetail label={t('Created')}>
-          <DateTimeCell
-            value={props.credentialType.created}
-            author={props.credentialType.summary_fields?.created_by?.username}
-            onClick={() =>
-              history(
-                getPageUrl(AwxRoute.UserDetails, {
-                  params: {
-                    id: (props.credentialType.summary_fields?.created_by?.id ?? 0).toString(),
-                  },
-                })
-              )
-            }
-          />
-        </PageDetail>
-        <LastModifiedPageDetail
-          value={props.credentialType.modified}
-          author={props.credentialType.summary_fields?.modified_by?.username}
+    <PageDetails>
+      <PageDetail label={t('Name')}>{renderCredentialTypeName(props.credentialType)}</PageDetail>
+      <PageDetail label={t('Description')}>{props.credentialType.description}</PageDetail>
+      <PageDetailCodeEditor
+        helpText={t('Input schema which defines a set of ordered fields for that type.')}
+        label={t('Input configuration')}
+        value={jsonToYaml(JSON.stringify(props.credentialType.inputs))}
+      />
+      <PageDetailCodeEditor
+        helpText={t(
+          'Environment variables or extra variables that specify the values a credential type can inject.'
+        )}
+        label={t('Injector configuration')}
+        value={jsonToYaml(JSON.stringify(props.credentialType.injectors))}
+      />
+      <PageDetail label={t('Created')}>
+        <DateTimeCell
+          value={props.credentialType.created}
+          author={props.credentialType.summary_fields?.created_by?.username}
           onClick={() =>
             history(
               getPageUrl(AwxRoute.UserDetails, {
                 params: {
-                  id: (props.credentialType.summary_fields?.modified_by?.id ?? 0).toString(),
+                  id: (props.credentialType.summary_fields?.created_by?.id ?? 0).toString(),
                 },
               })
             )
           }
         />
-      </PageDetails>
-    </Scrollable>
+      </PageDetail>
+      <LastModifiedPageDetail
+        value={props.credentialType.modified}
+        author={props.credentialType.summary_fields?.modified_by?.username}
+        onClick={() =>
+          history(
+            getPageUrl(AwxRoute.UserDetails, {
+              params: {
+                id: (props.credentialType.summary_fields?.modified_by?.id ?? 0).toString(),
+              },
+            })
+          )
+        }
+      />
+    </PageDetails>
   );
 }

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -37,9 +37,8 @@ import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 import { Instance } from '../../interfaces/Instance';
 import { InstanceGroup } from '../../interfaces/InstanceGroup';
 import { AwxRoute } from '../../main/AwxRoutes';
-import { useInstanceActions } from './hooks/useInstanceActions';
+import { useInstanceActions, useInstanceDetailsActions } from './hooks/useInstanceActions';
 import { useNodeTypeTooltip } from './hooks/useNodeTypeTooltip';
-import { useInstanceDetailsActions } from './hooks/useInstanceActions';
 
 export function InstanceDetails() {
   const { t } = useTranslation();
@@ -112,7 +111,7 @@ export function InstanceDetailsTab(props: {
   const toolTipMap: { [item: string]: string } = useNodeTypeTooltip();
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
   return (
-    <PageDetails numberOfColumns={props.numberOfColumns}>
+    <PageDetails numberOfColumns={props.numberOfColumns} disableScroll>
       <PageDetail label={t('Name')} data-cy="name">
         <Button
           variant="link"

--- a/frontend/awx/administration/settings/AwxSettings.tsx
+++ b/frontend/awx/administration/settings/AwxSettings.tsx
@@ -10,7 +10,13 @@ import {
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { LoadingPage, PageHeader, PageLayout, useGetPageUrl } from '../../../../framework';
+import {
+  LoadingPage,
+  PageHeader,
+  PageLayout,
+  Scrollable,
+  useGetPageUrl,
+} from '../../../../framework';
 import { Masonry } from '../../../../framework/PageMasonry';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 import { AwxError } from '../../common/AwxError';
@@ -26,35 +32,37 @@ export function AwxSettings() {
   return (
     <PageLayout>
       <PageHeader title={t('Settings')} headerActions={<ActivityStreamIcon type={'setting'} />} />
-      <PageSection>
-        <Masonry minSize={500}>
-          {groups.map((group) => (
-            <Card isRounded isFlat key={group.name}>
-              <CardHeader>
-                <CardTitle>
-                  <Title headingLevel="h3">{group.name}</Title>
-                </CardTitle>
-                {group.description && <p>{group.description}</p>}
-              </CardHeader>
-              <CardBody>
-                <List isPlain>
-                  {group.categories.map((category) => (
-                    <ListItem key={category.name}>
-                      <Link
-                        to={getPageUrl(AwxRoute.SettingsCategory, {
-                          params: { category: category.id },
-                        })}
-                      >
-                        {category.name}
-                      </Link>
-                    </ListItem>
-                  ))}
-                </List>
-              </CardBody>
-            </Card>
-          ))}
-        </Masonry>
-      </PageSection>
+      <Scrollable>
+        <PageSection>
+          <Masonry minSize={500}>
+            {groups.map((group) => (
+              <Card isRounded isFlat key={group.name}>
+                <CardHeader>
+                  <CardTitle>
+                    <Title headingLevel="h3">{group.name}</Title>
+                  </CardTitle>
+                  {group.description && <p>{group.description}</p>}
+                </CardHeader>
+                <CardBody>
+                  <List isPlain>
+                    {group.categories.map((category) => (
+                      <ListItem key={category.name}>
+                        <Link
+                          to={getPageUrl(AwxRoute.SettingsCategory, {
+                            params: { category: category.id },
+                          })}
+                        >
+                          {category.name}
+                        </Link>
+                      </ListItem>
+                    ))}
+                  </List>
+                </CardBody>
+              </Card>
+            ))}
+          </Masonry>
+        </PageSection>
+      </Scrollable>
     </PageLayout>
   );
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
@@ -96,7 +96,7 @@ describe('Create Edit Inventory Host Form', () => {
       cy.get('[data-cy="name"]').type('Edited Host');
       cy.get('[data-cy="description"]').clear();
       cy.get('[data-cy="description"]').type('Edited Description');
-      cy.get('[data-cy="variables"]').type('s');
+      cy.getBy('[data-cy="variables"]').type('s');
       cy.clickButton(/^Save host$/);
       cy.wait('@editHost')
         .its('request.body')

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
@@ -38,7 +38,10 @@ export type WebsocketInventorySource = {
   status: string;
 } & InventorySource;
 
-export function InventorySourceDetails(props: { inventorySourceId?: string }) {
+export function InventorySourceDetails(props: {
+  inventorySourceId?: string;
+  disableScroll?: boolean;
+}) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const params = useParams<{ source_id: string; id: string }>();
@@ -196,7 +199,7 @@ export function InventorySourceDetails(props: { inventorySourceId?: string }) {
     summary_fields.current_job || summary_fields.last_job;
 
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t`Name`}>
         {props.inventorySourceId ? (
           <Link

--- a/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
@@ -34,7 +34,7 @@ import { getDocsBaseUrl } from '../../../common/util/getDocsBaseUrl';
 import { Project } from '../../../interfaces/Project';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
-export function ProjectDetails(props: { projectId?: string }) {
+export function ProjectDetails(props: { projectId?: string; disableScroll?: boolean }) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const urlId = props?.projectId ? props.projectId : params.id;
@@ -209,7 +209,7 @@ export function ProjectDetails(props: { projectId?: string }) {
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!project) return <LoadingPage breadcrumbs tabs />;
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t('Name')}>
         {props.projectId ? (
           <Link to={getPageUrl(AwxRoute.ProjectDetails, { params: { id: props.projectId } })}>

--- a/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
@@ -28,7 +28,7 @@ function useInstanceGroups(templateId: string) {
   return data?.results ?? [];
 }
 
-export function TemplateDetails(props: { templateId?: string }) {
+export function TemplateDetails(props: { templateId?: string; disableScroll?: boolean }) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
@@ -58,7 +58,7 @@ export function TemplateDetails(props: { templateId?: string }) {
   };
 
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t('Name')}>
         {props.templateId ? (
           <Link to={getPageUrl(AwxRoute.JobTemplateDetails, { params: { id: props.templateId } })}>

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.tsx
@@ -19,7 +19,10 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
-export function WorkflowJobTemplateDetails(props: { templateId?: string }) {
+export function WorkflowJobTemplateDetails(props: {
+  templateId?: string;
+  disableScroll?: boolean;
+}) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const urlId = props?.templateId ? props.templateId : params.id;
@@ -44,7 +47,7 @@ export function WorkflowJobTemplateDetails(props: { templateId?: string }) {
   };
 
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t('Name')}>
         {props.templateId ? (
           <Link

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/SystemJobNodeDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/SystemJobNodeDetails.tsx
@@ -3,11 +3,14 @@ import { DateTimeCell, PageDetail, PageDetails } from '../../../../../../framewo
 import { PageDetailCodeEditor } from '../../../../../../framework/PageDetails/PageDetailCodeEditor';
 import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
 
-export function SystemJobNodeDetails(props: { selectedNode: WorkflowNode }) {
+export function SystemJobNodeDetails(props: {
+  selectedNode: WorkflowNode;
+  disableScroll?: boolean;
+}) {
   const { t } = useTranslation();
   const { selectedNode } = props;
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t('Name')}>
         {selectedNode.identifier ?? selectedNode.summary_fields.unified_job_template.name}
       </PageDetail>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/SystemJobNodeDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/SystemJobNodeDetails.tsx
@@ -7,34 +7,32 @@ export function SystemJobNodeDetails(props: { selectedNode: WorkflowNode }) {
   const { t } = useTranslation();
   const { selectedNode } = props;
   return (
-    <>
-      <PageDetails>
-        <PageDetail label={t('Name')}>
-          {selectedNode.identifier ?? selectedNode.summary_fields.unified_job_template.name}
-        </PageDetail>
-        <PageDetail
-          isEmpty={!selectedNode.summary_fields.unified_job_template.description}
-          label={t('Description')}
-        >
-          {selectedNode.summary_fields.unified_job_template.description}
-        </PageDetail>
-        <PageDetail label={t('Type')}>{t('System job template')}</PageDetail>
-        <PageDetail label={t('Convergence')}>
-          {selectedNode.all_parents_must_converge ? t('All') : t('Any')}
-        </PageDetail>
-        <PageDetail label={t('Created')}>
-          <DateTimeCell value={selectedNode.created} />
-        </PageDetail>
-        <PageDetail label={t('Modified')}>
-          <DateTimeCell value={selectedNode.modified} />
-        </PageDetail>
-        <PageDetailCodeEditor
-          label={t('Variables')}
-          showCopyToClipboard
-          data-cy="workflow-node-detail-variables"
-          value={JSON.stringify(selectedNode.extra_data) || '---'}
-        />
-      </PageDetails>
-    </>
+    <PageDetails>
+      <PageDetail label={t('Name')}>
+        {selectedNode.identifier ?? selectedNode.summary_fields.unified_job_template.name}
+      </PageDetail>
+      <PageDetail
+        isEmpty={!selectedNode.summary_fields.unified_job_template.description}
+        label={t('Description')}
+      >
+        {selectedNode.summary_fields.unified_job_template.description}
+      </PageDetail>
+      <PageDetail label={t('Type')}>{t('System job template')}</PageDetail>
+      <PageDetail label={t('Convergence')}>
+        {selectedNode.all_parents_must_converge ? t('All') : t('Any')}
+      </PageDetail>
+      <PageDetail label={t('Created')}>
+        <DateTimeCell value={selectedNode.created} />
+      </PageDetail>
+      <PageDetail label={t('Modified')}>
+        <DateTimeCell value={selectedNode.modified} />
+      </PageDetail>
+      <PageDetailCodeEditor
+        label={t('Variables')}
+        showCopyToClipboard
+        data-cy="workflow-node-detail-variables"
+        value={JSON.stringify(selectedNode.extra_data) || '---'}
+      />
+    </PageDetails>
   );
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowApprovalNodeDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowApprovalNodeDetails.tsx
@@ -14,11 +14,14 @@ function formatTimeout(
     seconds: seconds.toString(),
   });
 }
-export function WorkflowApprovalNodeDetails(props: { selectedNode: WorkflowNode }) {
+export function WorkflowApprovalNodeDetails(props: {
+  selectedNode: WorkflowNode;
+  disableScroll?: boolean;
+}) {
   const { t } = useTranslation();
   const { selectedNode } = props;
   return (
-    <PageDetails>
+    <PageDetails disableScroll={props.disableScroll}>
       <PageDetail label={t('Name')}>
         {selectedNode.identifier ?? selectedNode.summary_fields.unified_job_template.name}
       </PageDetail>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetDetailComponent.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetDetailComponent.tsx
@@ -15,6 +15,7 @@ export function useGetDetailComponent(selectedNode: WorkflowNode) {
         component = (
           <ProjectDetails
             projectId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            disableScroll
           />
         );
         break;
@@ -22,6 +23,7 @@ export function useGetDetailComponent(selectedNode: WorkflowNode) {
         component = (
           <TemplateDetails
             templateId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            disableScroll
           />
         );
 
@@ -30,6 +32,7 @@ export function useGetDetailComponent(selectedNode: WorkflowNode) {
         component = (
           <WorkflowJobTemplateDetails
             templateId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            disableScroll
           />
         );
 
@@ -38,14 +41,15 @@ export function useGetDetailComponent(selectedNode: WorkflowNode) {
         component = (
           <InventorySourceDetails
             inventorySourceId={selectedNode?.summary_fields.unified_job_template.id.toString()}
+            disableScroll
           />
         );
         break;
       case UnifiedJobType.system_job:
-        component = <SystemJobNodeDetails selectedNode={selectedNode} />;
+        component = <SystemJobNodeDetails selectedNode={selectedNode} disableScroll />;
         break;
       case UnifiedJobType.workflow_approval:
-        component = <WorkflowApprovalNodeDetails selectedNode={selectedNode} />;
+        component = <WorkflowApprovalNodeDetails selectedNode={selectedNode} disableScroll />;
         break;
 
       default:

--- a/frontend/common/access/TeamDetails.tsx
+++ b/frontend/common/access/TeamDetails.tsx
@@ -50,52 +50,50 @@ export function TeamDetails<T extends TeamDetailsType>(props: {
   const { team, organizationDetailsUrl, createdByUserDetailsUrl, modifiedByUserDetailsUrl } = props;
 
   return (
-    <>
-      <PageDetails>
-        <PageDetail label={t('Name')}>{team.name}</PageDetail>
-        {team.description && <PageDetail label={t('Description')}>{team.description}</PageDetail>}
-        {team.summary_fields?.organization && (
-          <PageDetail label={t('Organization')}>
-            {organizationDetailsUrl ? (
-              <LabelsCell
-                labelsWithLinks={[
-                  { name: team.summary_fields?.organization?.name, link: organizationDetailsUrl },
-                ]}
-              />
-            ) : (
-              <LabelsCell labels={[team.summary_fields?.organization?.name]} />
-            )}
-          </PageDetail>
-        )}
-        {(team.created || team.created_on || team.created_at) && (
-          <PageDetail label={t('Created')}>
-            <DateTimeCell
-              author={team.summary_fields?.created_by?.username}
-              value={team.created ?? team.created_on ?? team.created_at}
-              onClick={
-                createdByUserDetailsUrl
-                  ? () => {
-                      navigate(createdByUserDetailsUrl);
-                    }
-                  : undefined
-              }
+    <PageDetails>
+      <PageDetail label={t('Name')}>{team.name}</PageDetail>
+      {team.description && <PageDetail label={t('Description')}>{team.description}</PageDetail>}
+      {team.summary_fields?.organization && (
+        <PageDetail label={t('Organization')}>
+          {organizationDetailsUrl ? (
+            <LabelsCell
+              labelsWithLinks={[
+                { name: team.summary_fields?.organization?.name, link: organizationDetailsUrl },
+              ]}
             />
-          </PageDetail>
-        )}
-        {(team.modified || team.modified_on || team.modified_at) && (
-          <LastModifiedPageDetail
-            author={team.summary_fields?.modified_by?.username}
-            value={team.modified ?? team.modified_on ?? team.modified_at}
+          ) : (
+            <LabelsCell labels={[team.summary_fields?.organization?.name]} />
+          )}
+        </PageDetail>
+      )}
+      {(team.created || team.created_on || team.created_at) && (
+        <PageDetail label={t('Created')}>
+          <DateTimeCell
+            author={team.summary_fields?.created_by?.username}
+            value={team.created ?? team.created_on ?? team.created_at}
             onClick={
-              modifiedByUserDetailsUrl
+              createdByUserDetailsUrl
                 ? () => {
-                    navigate(modifiedByUserDetailsUrl);
+                    navigate(createdByUserDetailsUrl);
                   }
                 : undefined
             }
           />
-        )}
-      </PageDetails>
-    </>
+        </PageDetail>
+      )}
+      {(team.modified || team.modified_on || team.modified_at) && (
+        <LastModifiedPageDetail
+          author={team.summary_fields?.modified_by?.username}
+          value={team.modified ?? team.modified_on ?? team.modified_at}
+          onClick={
+            modifiedByUserDetailsUrl
+              ? () => {
+                  navigate(modifiedByUserDetailsUrl);
+                }
+              : undefined
+          }
+        />
+      )}
+    </PageDetails>
   );
 }

--- a/frontend/common/access/UserDetails.tsx
+++ b/frontend/common/access/UserDetails.tsx
@@ -46,53 +46,51 @@ export function UserDetails<T extends UserDetailsType>(props: {
   const { user, organizations, options } = props;
 
   return (
-    <>
-      <PageDetails>
-        <PageDetail label={t('First name')}>{user.first_name}</PageDetail>
-        <PageDetail label={t('Last name')}>{user.last_name}</PageDetail>
-        <PageDetail label={t('Email')}>{user.email}</PageDetail>
-        <PageDetail label={t('Username')}>{user.username}</PageDetail>
-        {organizations && organizations.length > 0 && (
-          <PageDetail label={t('Organization', { count: organizations.length })}>
-            <LabelsCell labelsWithLinks={organizations} />
-          </PageDetail>
-        )}
-        {user.last_login && (
-          <PageDetail label={t('Last login')}>
-            <DateTimeCell value={user.last_login} />
-          </PageDetail>
-        )}
-        {options?.showAuthType && (
-          <PageDetail label={t('Authentication type')}>
-            <AuthenticationType user={user} />
-          </PageDetail>
-        )}{' '}
-        {options?.showUserType && (
-          <PageDetail label={t('User type')}>
-            <UserType user={user} />
-          </PageDetail>
-        )}
-        <PageDetail label={t('Created')}>
-          <DateTimeCell
-            value={user.created ?? user.created_at ?? user.date_joined ?? user.created_on}
-          />
+    <PageDetails>
+      <PageDetail label={t('First name')}>{user.first_name}</PageDetail>
+      <PageDetail label={t('Last name')}>{user.last_name}</PageDetail>
+      <PageDetail label={t('Email')}>{user.email}</PageDetail>
+      <PageDetail label={t('Username')}>{user.username}</PageDetail>
+      {organizations && organizations.length > 0 && (
+        <PageDetail label={t('Organization', { count: organizations.length })}>
+          <LabelsCell labelsWithLinks={organizations} />
         </PageDetail>
-        {(user.modified || user.modified_at || user.modified_on) && (
-          <LastModifiedPageDetail
-            data-cy="modified"
-            value={user.modified ?? user.modified_at ?? user.modified_on}
-          />
-        )}
-        {user.roles && user.roles.length > 0 && (
-          <PageDetail label={t('Role(s)')}>
-            <LabelGroup>
-              {user.roles.map((role) => (
-                <Label key={role?.id}>{role?.name}</Label>
-              ))}
-            </LabelGroup>
-          </PageDetail>
-        )}
-      </PageDetails>
-    </>
+      )}
+      {user.last_login && (
+        <PageDetail label={t('Last login')}>
+          <DateTimeCell value={user.last_login} />
+        </PageDetail>
+      )}
+      {options?.showAuthType && (
+        <PageDetail label={t('Authentication type')}>
+          <AuthenticationType user={user} />
+        </PageDetail>
+      )}{' '}
+      {options?.showUserType && (
+        <PageDetail label={t('User type')}>
+          <UserType user={user} />
+        </PageDetail>
+      )}
+      <PageDetail label={t('Created')}>
+        <DateTimeCell
+          value={user.created ?? user.created_at ?? user.date_joined ?? user.created_on}
+        />
+      </PageDetail>
+      {(user.modified || user.modified_at || user.modified_on) && (
+        <LastModifiedPageDetail
+          data-cy="modified"
+          value={user.modified ?? user.modified_at ?? user.modified_on}
+        />
+      )}
+      {user.roles && user.roles.length > 0 && (
+        <PageDetail label={t('Role(s)')}>
+          <LabelGroup>
+            {user.roles.map((role) => (
+              <Label key={role?.id}>{role?.name}</Label>
+            ))}
+          </LabelGroup>
+        </PageDetail>
+      )}
+    </PageDetails>
   );
 }

--- a/frontend/eda/access/roles/EdaRoleDetails.tsx
+++ b/frontend/eda/access/roles/EdaRoleDetails.tsx
@@ -6,7 +6,6 @@ import {
   PageDetails,
   PageHeader,
   PageLayout,
-  Scrollable,
   useGetPageUrl,
 } from '../../../../framework';
 import { useGet } from '../../../common/crud/useGet';
@@ -28,20 +27,18 @@ export function EdaRoleDetails() {
         title={role?.name}
         breadcrumbs={[{ label: t('Roles'), to: getPageUrl(EdaRoute.Roles) }, { label: role?.name }]}
       />
-      <Scrollable>
-        <PageDetails>
-          <PageDetail label={t('Name')}>{role?.name || ''}</PageDetail>
-          <PageDetail label={t('Description')}>{role?.description || ''}</PageDetail>
-          <PageDetail label={t('Created')}>
-            <DateTimeCell value={role?.created_at} />
-          </PageDetail>
-        </PageDetails>
-        <PageDetails numberOfColumns={'single'}>
-          <PageDetail label={t('Permissions')}>
-            <EdaRolePermissions role={role} />
-          </PageDetail>
-        </PageDetails>
-      </Scrollable>
+      <PageDetails>
+        <PageDetail label={t('Name')}>{role?.name || ''}</PageDetail>
+        <PageDetail label={t('Description')}>{role?.description || ''}</PageDetail>
+        <PageDetail label={t('Created')}>
+          <DateTimeCell value={role?.created_at} />
+        </PageDetail>
+      </PageDetails>
+      <PageDetails numberOfColumns={'single'}>
+        <PageDetail label={t('Permissions')}>
+          <EdaRolePermissions role={role} />
+        </PageDetail>
+      </PageDetails>
     </PageLayout>
   );
 }

--- a/frontend/eda/event-streams/EventStreamInstancePage/EventStreamInstanceDetails.tsx
+++ b/frontend/eda/event-streams/EventStreamInstancePage/EventStreamInstanceDetails.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { LoadingPage, PageDetail, PageDetails, Scrollable } from '../../../../framework';
+import { LoadingPage, PageDetail, PageDetails } from '../../../../framework';
 import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { AwxItemsResponse } from '../../../awx/common/AwxItemsResponse';
@@ -30,21 +30,19 @@ export function EventStreamInstanceDetails() {
     return <LoadingPage />;
   }
   return (
-    <Scrollable>
-      <PageDetails>
-        <PageDetail label={t('Name')}>
-          {`${eventStreamInstance?.id || ''} - ${eventStreamInstance?.name || ''}`}
-        </PageDetail>
-        <PageDetail label={t('Status')}>
-          {<StatusCell status={eventStreamInstance?.status || 'unknown'} />}
-        </PageDetail>
-        <PageDetail label={t('Start date')}>
-          {eventStreamInstance?.started_at ? formatDateString(eventStreamInstance?.started_at) : ''}
-        </PageDetail>
-        <PageDetail label={t('End date')}>
-          {eventStreamInstance?.ended_at ? formatDateString(eventStreamInstance?.ended_at) : ''}
-        </PageDetail>
-      </PageDetails>
+    <PageDetails>
+      <PageDetail label={t('Name')}>
+        {`${eventStreamInstance?.id || ''} - ${eventStreamInstance?.name || ''}`}
+      </PageDetail>
+      <PageDetail label={t('Status')}>
+        {<StatusCell status={eventStreamInstance?.status || 'unknown'} />}
+      </PageDetail>
+      <PageDetail label={t('Start date')}>
+        {eventStreamInstance?.started_at ? formatDateString(eventStreamInstance?.started_at) : ''}
+      </PageDetail>
+      <PageDetail label={t('End date')}>
+        {eventStreamInstance?.ended_at ? formatDateString(eventStreamInstance?.ended_at) : ''}
+      </PageDetail>
       <PageDetailsSection>
         {eventStreamInstanceLog?.results?.length ? (
           <PageDetailCodeEditor
@@ -55,6 +53,6 @@ export function EventStreamInstanceDetails() {
           />
         ) : null}
       </PageDetailsSection>
-    </Scrollable>
+    </PageDetails>
   );
 }

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
@@ -1,13 +1,8 @@
 import { Label, LabelGroup, PageSection } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
-import {
-  LoadingPage,
-  PageDetail,
-  PageDetails,
-  Scrollable,
-  useGetPageUrl,
-} from '../../../../framework';
+import { LoadingPage, PageDetail, PageDetails, useGetPageUrl } from '../../../../framework';
+import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
@@ -17,7 +12,6 @@ import { edaAPI } from '../../common/eda-utils';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { RestartPolicyEnum } from '../../interfaces/generated/eda-api';
 import { EdaRoute } from '../../main/EdaRoutes';
-import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 
 export function EventStreamDetails() {
   const { t } = useTranslation();
@@ -38,50 +32,48 @@ export function EventStreamDetails() {
     return <LoadingPage />;
   }
   return (
-    <Scrollable>
-      <PageDetails>
-        <PageDetail label={t('Event stream ID')}>{eventStream?.id || ''}</PageDetail>
-        <PageDetail label={t('Name')}>{eventStream?.name || ''}</PageDetail>
-        <PageDetail label={t('Description')}>{eventStream?.description || ''}</PageDetail>
-        <PageDetail label={t('Source type')}>{eventStream?.source_type || ''}</PageDetail>
-        {eventStream.credentials && eventStream.credentials.length > 0 && (
-          <PageDetail label={t('Credential(s)')}>
-            <LabelGroup>
-              {eventStream.credentials.map((credential) => (
-                <Label key={credential?.id}>{credential?.name}</Label>
-              ))}
-            </LabelGroup>
-          </PageDetail>
+    <PageDetails>
+      <PageDetail label={t('Event stream ID')}>{eventStream?.id || ''}</PageDetail>
+      <PageDetail label={t('Name')}>{eventStream?.name || ''}</PageDetail>
+      <PageDetail label={t('Description')}>{eventStream?.description || ''}</PageDetail>
+      <PageDetail label={t('Source type')}>{eventStream?.source_type || ''}</PageDetail>
+      {eventStream.credentials && eventStream.credentials.length > 0 && (
+        <PageDetail label={t('Credential(s)')}>
+          <LabelGroup>
+            {eventStream.credentials.map((credential) => (
+              <Label key={credential?.id}>{credential?.name}</Label>
+            ))}
+          </LabelGroup>
+        </PageDetail>
+      )}
+      <PageDetail
+        label={t('Decision environment')}
+        helpText={t('Decision environments are a container image to run Ansible rulebooks.')}
+      >
+        {eventStream && eventStream?.decision_environment?.id ? (
+          <Link
+            to={getPageUrl(EdaRoute.DecisionEnvironmentPage, {
+              params: { id: eventStream?.decision_environment?.id },
+            })}
+          >
+            {eventStream?.decision_environment?.name}
+          </Link>
+        ) : (
+          eventStream?.decision_environment?.name || ''
         )}
-        <PageDetail
-          label={t('Decision environment')}
-          helpText={t('Decision environments are a container image to run Ansible rulebooks.')}
-        >
-          {eventStream && eventStream?.decision_environment?.id ? (
-            <Link
-              to={getPageUrl(EdaRoute.DecisionEnvironmentPage, {
-                params: { id: eventStream?.decision_environment?.id },
-              })}
-            >
-              {eventStream?.decision_environment?.name}
-            </Link>
-          ) : (
-            eventStream?.decision_environment?.name || ''
-          )}
-        </PageDetail>
-        <PageDetail label={t('Event stream status')}>
-          <StatusCell status={eventStream?.status || ''} />
-        </PageDetail>
-        <PageDetail label={t('Restart policy')} helpText={restartPolicyHelpBlock}>
-          {eventStream?.restart_policy ? restartPolicyName(eventStream?.restart_policy, t) : ''}
-        </PageDetail>
-        <PageDetail label={t('Created')}>
-          {eventStream?.created_at ? formatDateString(eventStream?.created_at) : ''}
-        </PageDetail>
-        <LastModifiedPageDetail
-          value={eventStream?.modified_at ? formatDateString(eventStream?.modified_at) : ''}
-        />
-      </PageDetails>
+      </PageDetail>
+      <PageDetail label={t('Event stream status')}>
+        <StatusCell status={eventStream?.status || ''} />
+      </PageDetail>
+      <PageDetail label={t('Restart policy')} helpText={restartPolicyHelpBlock}>
+        {eventStream?.restart_policy ? restartPolicyName(eventStream?.restart_policy, t) : ''}
+      </PageDetail>
+      <PageDetail label={t('Created')}>
+        {eventStream?.created_at ? formatDateString(eventStream?.created_at) : ''}
+      </PageDetail>
+      <LastModifiedPageDetail
+        value={eventStream?.modified_at ? formatDateString(eventStream?.modified_at) : ''}
+      />
       {eventStream?.source_args && (
         <PageSection variant="light">
           <PageDetailCodeEditor
@@ -92,7 +84,7 @@ export function EventStreamDetails() {
           />
         </PageSection>
       )}
-    </Scrollable>
+    </PageDetails>
   );
 }
 

--- a/frontend/eda/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectDetails.tsx
@@ -1,5 +1,4 @@
 import { DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
-import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import {
@@ -28,63 +27,58 @@ export function ProjectDetails() {
     return <LoadingPage />;
   }
   return (
-    <Fragment>
-      <PageDetails>
-        <PageDetail label={t('Name')}>{project?.name || ''}</PageDetail>
-        <PageDetail label={t('Description')}>{project?.description || ''}</PageDetail>
-        <PageDetail
-          label={t('SCM type')}
-          helpText={t('There is currently only one SCM type available for use.')}
-        >
-          <TextCell text={'Git'} />
-        </PageDetail>
-        <PageDetail
-          label={t('SCM URL')}
-          helpText={t('HTTP[S] protocol address of a repository, such as GitHub or GitLab.')}
-        >
-          {project?.url || ''}
-        </PageDetail>
-        <PageDetail
-          label={t('Credential')}
-          helpText={t('The token needed to utilize the SCM URL.')}
-        >
-          {project && project.credential ? (
-            <Link
-              to={getPageUrl(EdaRoute.CredentialPage, { params: { id: project?.credential?.id } })}
-            >
-              {project?.credential?.name}
-            </Link>
-          ) : (
-            project?.credential?.name || ''
-          )}
-        </PageDetail>
-        <PageDetail label={t('Git hash')}>
-          <CopyCell text={project?.git_hash ? project.git_hash : ''} />
-        </PageDetail>
-        <PageDetail label={t('Status')}>
-          <StatusCell status={project?.import_state || ''} />
-        </PageDetail>
-        <PageDetail label={t('Import error')}>{project?.import_error || ''}</PageDetail>
-        <PageDetail label={t('Created')}>
-          {project?.created_at ? formatDateString(project.created_at) : ''}
-        </PageDetail>
-        <LastModifiedPageDetail
-          value={project?.modified_at ? formatDateString(project.modified_at) : ''}
-        />
-        {!!project?.verify_ssl && (
-          <PageDetail label={t('Enabled option')}>
-            <DescriptionListGroup>
-              <DescriptionListTerm style={{ opacity: 0.6 }}>
-                {t('Verify SSL')}
-                <StandardPopover
-                  header={t('Verify SSL')}
-                  content={t('Verifies the SSL with HTTPS when the project is imported.')}
-                />
-              </DescriptionListTerm>
-            </DescriptionListGroup>
-          </PageDetail>
+    <PageDetails>
+      <PageDetail label={t('Name')}>{project?.name || ''}</PageDetail>
+      <PageDetail label={t('Description')}>{project?.description || ''}</PageDetail>
+      <PageDetail
+        label={t('SCM type')}
+        helpText={t('There is currently only one SCM type available for use.')}
+      >
+        <TextCell text={'Git'} />
+      </PageDetail>
+      <PageDetail
+        label={t('SCM URL')}
+        helpText={t('HTTP[S] protocol address of a repository, such as GitHub or GitLab.')}
+      >
+        {project?.url || ''}
+      </PageDetail>
+      <PageDetail label={t('Credential')} helpText={t('The token needed to utilize the SCM URL.')}>
+        {project && project.credential ? (
+          <Link
+            to={getPageUrl(EdaRoute.CredentialPage, { params: { id: project?.credential?.id } })}
+          >
+            {project?.credential?.name}
+          </Link>
+        ) : (
+          project?.credential?.name || ''
         )}
-      </PageDetails>
-    </Fragment>
+      </PageDetail>
+      <PageDetail label={t('Git hash')}>
+        <CopyCell text={project?.git_hash ? project.git_hash : ''} />
+      </PageDetail>
+      <PageDetail label={t('Status')}>
+        <StatusCell status={project?.import_state || ''} />
+      </PageDetail>
+      <PageDetail label={t('Import error')}>{project?.import_error || ''}</PageDetail>
+      <PageDetail label={t('Created')}>
+        {project?.created_at ? formatDateString(project.created_at) : ''}
+      </PageDetail>
+      <LastModifiedPageDetail
+        value={project?.modified_at ? formatDateString(project.modified_at) : ''}
+      />
+      {!!project?.verify_ssl && (
+        <PageDetail label={t('Enabled option')}>
+          <DescriptionListGroup>
+            <DescriptionListTerm style={{ opacity: 0.6 }}>
+              {t('Verify SSL')}
+              <StandardPopover
+                header={t('Verify SSL')}
+                content={t('Verifies the SSL with HTTPS when the project is imported.')}
+              />
+            </DescriptionListTerm>
+          </DescriptionListGroup>
+        </PageDetail>
+      )}
+    </PageDetails>
   );
 }

--- a/frontend/eda/rule-audit/EventPayloadDialog.tsx
+++ b/frontend/eda/rule-audit/EventPayloadDialog.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageDetail, PageDetails, Scrollable, usePageDialog } from '../../../framework';
+import { PageDetail, PageDetails, usePageDialog } from '../../../framework';
 import { PageDetailCodeEditor } from '../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../framework/utils/formatDateString';
 import { EdaRuleAuditEvent } from '../interfaces/EdaRuleAuditEvent';
@@ -30,14 +30,12 @@ export function EventPayloadDialog(props: EventPayloadModalProps) {
         </Button>,
       ]}
     >
-      <Scrollable>
-        <PageDetails>
-          <PageDetail label={t('Name')}>{props?.event?.source_name || ''}</PageDetail>
-          <PageDetail label={t('Source type')}>{props?.event?.source_type || ''}</PageDetail>
-          <PageDetail label={t('Timestamp')}>
-            {props?.event?.received_at ? formatDateString(props.event?.received_at) : ''}
-          </PageDetail>
-        </PageDetails>
+      <PageDetails>
+        <PageDetail label={t('Name')}>{props?.event?.source_name || ''}</PageDetail>
+        <PageDetail label={t('Source type')}>{props?.event?.source_type || ''}</PageDetail>
+        <PageDetail label={t('Timestamp')}>
+          {props?.event?.received_at ? formatDateString(props.event?.received_at) : ''}
+        </PageDetail>
         {props?.event?.payload && (
           <PageDetails numberOfColumns="single">
             <PageDetailCodeEditor
@@ -47,7 +45,7 @@ export function EventPayloadDialog(props: EventPayloadModalProps) {
             />
           </PageDetails>
         )}
-      </Scrollable>
+      </PageDetails>
     </Modal>
   );
 }

--- a/frontend/eda/rule-audit/RuleAuditPage/RuleAuditDetails.tsx
+++ b/frontend/eda/rule-audit/RuleAuditPage/RuleAuditDetails.tsx
@@ -1,12 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
-import {
-  LabelsCell,
-  PageDetail,
-  PageDetails,
-  Scrollable,
-  useGetPageUrl,
-} from '../../../../framework';
+import { LabelsCell, PageDetail, PageDetails, useGetPageUrl } from '../../../../framework';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { StatusCell } from '../../../common/Status';
 import { useGet } from '../../../common/crud/useGet';
@@ -21,40 +15,38 @@ export function RuleAuditDetails() {
 
   const { data: ruleAudit } = useGet<EdaRuleAudit>(edaAPI`/audit-rules/${params.id ?? ''}/`);
   return (
-    <Scrollable>
-      <PageDetails>
-        <PageDetail label={t('Name')}>{ruleAudit?.name || ''}</PageDetail>
-        <PageDetail label={t('Status')}>
-          <StatusCell status={ruleAudit?.status || ''} />
-        </PageDetail>
-        <PageDetail
-          label={t('Rulebook activation')}
-          helpText={t`Rulebook activations are rulebooks that have been activated to run.`}
-        >
-          {ruleAudit && ruleAudit.activation_instance?.id ? (
-            <Link
-              to={getPageUrl(EdaRoute.RulebookActivationInstancePage, {
-                params: { id: ruleAudit.id, instanceId: ruleAudit.activation_instance?.id },
-              })}
-            >
-              {ruleAudit?.activation_instance?.name}
-            </Link>
-          ) : (
-            <LabelsCell
-              labels={[
-                ruleAudit?.activation_instance?.name === 'DELETED' ? t('Deleted') : t('Unknown'),
-              ]}
-            />
-          )}
-        </PageDetail>
-        <PageDetail label={t('Rule set')}>{ruleAudit?.ruleset_name || ''}</PageDetail>
-        <PageDetail label={t('Created')}>
-          {ruleAudit?.created_at ? formatDateString(ruleAudit?.created_at) : ''}
-        </PageDetail>
-        <PageDetail label={t('Fired date')}>
-          {ruleAudit?.fired_at ? formatDateString(ruleAudit?.fired_at) : ''}
-        </PageDetail>
-      </PageDetails>
-    </Scrollable>
+    <PageDetails>
+      <PageDetail label={t('Name')}>{ruleAudit?.name || ''}</PageDetail>
+      <PageDetail label={t('Status')}>
+        <StatusCell status={ruleAudit?.status || ''} />
+      </PageDetail>
+      <PageDetail
+        label={t('Rulebook activation')}
+        helpText={t`Rulebook activations are rulebooks that have been activated to run.`}
+      >
+        {ruleAudit && ruleAudit.activation_instance?.id ? (
+          <Link
+            to={getPageUrl(EdaRoute.RulebookActivationInstancePage, {
+              params: { id: ruleAudit.id, instanceId: ruleAudit.activation_instance?.id },
+            })}
+          >
+            {ruleAudit?.activation_instance?.name}
+          </Link>
+        ) : (
+          <LabelsCell
+            labels={[
+              ruleAudit?.activation_instance?.name === 'DELETED' ? t('Deleted') : t('Unknown'),
+            ]}
+          />
+        )}
+      </PageDetail>
+      <PageDetail label={t('Rule set')}>{ruleAudit?.ruleset_name || ''}</PageDetail>
+      <PageDetail label={t('Created')}>
+        {ruleAudit?.created_at ? formatDateString(ruleAudit?.created_at) : ''}
+      </PageDetail>
+      <PageDetail label={t('Fired date')}>
+        {ruleAudit?.fired_at ? formatDateString(ruleAudit?.fired_at) : ''}
+      </PageDetail>
+    </PageDetails>
   );
 }

--- a/frontend/eda/rulebook-activations/ActivationInstancePage/ActivationInstanceDetails.tsx
+++ b/frontend/eda/rulebook-activations/ActivationInstancePage/ActivationInstanceDetails.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { LoadingPage, PageDetail, PageDetails, Scrollable } from '../../../../framework';
+import { LoadingPage, PageDetail, PageDetails } from '../../../../framework';
 import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { AwxItemsResponse } from '../../../awx/common/AwxItemsResponse';
@@ -30,21 +30,19 @@ export function ActivationInstanceDetails() {
     return <LoadingPage />;
   }
   return (
-    <Scrollable>
-      <PageDetails>
-        <PageDetail label={t('Name')}>
-          {`${activationInstance?.id || ''} - ${activationInstance?.name || ''}`}
-        </PageDetail>
-        <PageDetail label={t('Status')}>
-          {<StatusCell status={activationInstance?.status || 'unknown'} />}
-        </PageDetail>
-        <PageDetail label={t('Start date')}>
-          {activationInstance?.started_at ? formatDateString(activationInstance?.started_at) : ''}
-        </PageDetail>
-        <PageDetail label={t('End date')}>
-          {activationInstance?.ended_at ? formatDateString(activationInstance?.ended_at) : ''}
-        </PageDetail>
-      </PageDetails>
+    <PageDetails>
+      <PageDetail label={t('Name')}>
+        {`${activationInstance?.id || ''} - ${activationInstance?.name || ''}`}
+      </PageDetail>
+      <PageDetail label={t('Status')}>
+        {<StatusCell status={activationInstance?.status || 'unknown'} />}
+      </PageDetail>
+      <PageDetail label={t('Start date')}>
+        {activationInstance?.started_at ? formatDateString(activationInstance?.started_at) : ''}
+      </PageDetail>
+      <PageDetail label={t('End date')}>
+        {activationInstance?.ended_at ? formatDateString(activationInstance?.ended_at) : ''}
+      </PageDetail>
       <PageDetailsSection>
         {activationInstanceLog?.results?.length ? (
           <PageDetailCodeEditor
@@ -54,6 +52,6 @@ export function ActivationInstanceDetails() {
           />
         ) : null}
       </PageDetailsSection>
-    </Scrollable>
+    </PageDetails>
   );
 }

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
@@ -6,11 +6,9 @@ import {
   LoadingPage,
   PageDetail,
   PageDetails,
-  Scrollable,
-  useGetPageUrl,
+  useGetPageUrl
 } from '../../../../framework';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
-import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
 import { StatusCell } from '../../../common/Status';
 import { useGetItem } from '../../../common/crud/useGet';
@@ -42,111 +40,103 @@ export function RulebookActivationDetails() {
     return <LoadingPage />;
   }
   return (
-    <Scrollable>
-      <PageDetails
-        alertPrompts={
-          rulebookActivation.status === Status906Enum.Error ||
-          rulebookActivation.status === Status906Enum.Failed
-            ? [`${t('Rulebook Activation error: ')}${rulebookActivation?.status_message || ''}`]
-            : []
-        }
+    <PageDetails
+      alertPrompts={
+        rulebookActivation.status === Status906Enum.Error ||
+        rulebookActivation.status === Status906Enum.Failed
+          ? [`${t('Rulebook Activation error: ')}${rulebookActivation?.status_message || ''}`]
+          : []
+      }
+    >
+      <PageDetail label={t('Activation ID')}>{rulebookActivation?.id || ''}</PageDetail>
+      <PageDetail label={t('Name')}>{rulebookActivation?.name || ''}</PageDetail>
+      <PageDetail label={t('Description')}>{rulebookActivation?.description || ''}</PageDetail>
+      <PageDetail
+        label={t('Project')}
+        helpText={t('Projects are a logical collection of rulebooks.')}
       >
-        <PageDetail label={t('Activation ID')}>{rulebookActivation?.id || ''}</PageDetail>
-        <PageDetail label={t('Name')}>{rulebookActivation?.name || ''}</PageDetail>
-        <PageDetail label={t('Description')}>{rulebookActivation?.description || ''}</PageDetail>
-        <PageDetail
-          label={t('Project')}
-          helpText={t('Projects are a logical collection of rulebooks.')}
-        >
-          {rulebookActivation && rulebookActivation.project?.id ? (
-            <Link
-              to={getPageUrl(EdaRoute.ProjectPage, {
-                params: { id: rulebookActivation.project.id },
-              })}
-            >
-              {rulebookActivation?.project?.name}
-            </Link>
-          ) : (
-            rulebookActivation?.project?.name || ''
-          )}
-        </PageDetail>
-        <PageDetail
-          label={t('Rulebook')}
-          helpText={t('Rulebooks will be shown according to the project selected.')}
-        >
-          {rulebookActivation?.rulebook?.name || rulebookActivation?.rulebook_name || ''}
-        </PageDetail>
-        {rulebookActivation.event_streams && rulebookActivation.event_streams.length > 0 && (
-          <PageDetail label={t('Event stream(s)')}>
-            <LabelGroup>
-              {rulebookActivation.event_streams.map((stream) => (
-                <Label key={stream?.id}>{stream?.name}</Label>
-              ))}
-            </LabelGroup>
-          </PageDetail>
+        {rulebookActivation && rulebookActivation.project?.id ? (
+          <Link
+            to={getPageUrl(EdaRoute.ProjectPage, {
+              params: { id: rulebookActivation.project.id },
+            })}
+          >
+            {rulebookActivation?.project?.name}
+          </Link>
+        ) : (
+          rulebookActivation?.project?.name || ''
         )}
-        {rulebookActivation.credentials && rulebookActivation.credentials.length > 0 && (
-          <PageDetail label={t('Credential(s)')}>
-            <LabelGroup>
-              {rulebookActivation.credentials.map((credential) => (
-                <Label key={credential?.id}>{credential?.name}</Label>
-              ))}
-            </LabelGroup>
-          </PageDetail>
+      </PageDetail>
+      <PageDetail
+        label={t('Rulebook')}
+        helpText={t('Rulebooks will be shown according to the project selected.')}
+      >
+        {rulebookActivation?.rulebook?.name || rulebookActivation?.rulebook_name || ''}
+      </PageDetail>
+      {rulebookActivation.event_streams && rulebookActivation.event_streams.length > 0 && (
+        <PageDetail label={t('Event stream(s)')}>
+          <LabelGroup>
+            {rulebookActivation.event_streams.map((stream) => (
+              <Label key={stream?.id}>{stream?.name}</Label>
+            ))}
+          </LabelGroup>
+        </PageDetail>
+      )}
+      {rulebookActivation.credentials && rulebookActivation.credentials.length > 0 && (
+        <PageDetail label={t('Credential(s)')}>
+          <LabelGroup>
+            {rulebookActivation.credentials.map((credential) => (
+              <Label key={credential?.id}>{credential?.name}</Label>
+            ))}
+          </LabelGroup>
+        </PageDetail>
+      )}
+      <PageDetail
+        label={t('Decision environment')}
+        helpText={t('Decision environments are a container image to run Ansible rulebooks.')}
+      >
+        {rulebookActivation && rulebookActivation?.decision_environment?.id ? (
+          <Link
+            to={getPageUrl(EdaRoute.DecisionEnvironmentPage, {
+              params: { id: rulebookActivation?.decision_environment?.id },
+            })}
+          >
+            {rulebookActivation?.decision_environment?.name}
+          </Link>
+        ) : (
+          rulebookActivation?.decision_environment?.name || ''
         )}
-        <PageDetail
-          label={t('Decision environment')}
-          helpText={t('Decision environments are a container image to run Ansible rulebooks.')}
-        >
-          {rulebookActivation && rulebookActivation?.decision_environment?.id ? (
-            <Link
-              to={getPageUrl(EdaRoute.DecisionEnvironmentPage, {
-                params: { id: rulebookActivation?.decision_environment?.id },
-              })}
-            >
-              {rulebookActivation?.decision_environment?.name}
-            </Link>
-          ) : (
-            rulebookActivation?.decision_environment?.name || ''
-          )}
-        </PageDetail>
-        <PageDetail label={t('Restart policy')} helpText={restartPolicyHelpBlock}>
-          {rulebookActivation?.restart_policy
-            ? restartPolicyName(rulebookActivation?.restart_policy, t)
-            : ''}
-        </PageDetail>
-        <PageDetail label={t('Activation status')}>
-          <StatusCell status={rulebookActivation?.status || ''} />
-        </PageDetail>
-        {rulebookActivation.status !== Status906Enum.Error &&
-          rulebookActivation.status !== Status906Enum.Failed &&
-          !!rulebookActivation?.status_message && (
-            <PageDetail label={t('Status message')}>
-              {rulebookActivation?.status_message}
-            </PageDetail>
-          )}
-        <PageDetail label={t('Project git hash')}>
-          <CopyCell text={rulebookActivation?.git_hash ?? ''} />
-        </PageDetail>
-        <PageDetail label={t('Number of rules')}>{rulebookActivation?.rules_count || 0}</PageDetail>
-        <PageDetail label={t('Fire count')}>
-          {rulebookActivation?.rules_fired_count || 0}
-        </PageDetail>
-        <PageDetail label={t('Last restarted')}>
-          {rulebookActivation?.restarted_at
-            ? formatDateString(rulebookActivation.restarted_at)
-            : ''}
-        </PageDetail>
-        <PageDetail label={t('Restart count')}>{rulebookActivation?.restart_count || 0}</PageDetail>
-        <PageDetail label={t('Created')}>
-          {rulebookActivation?.created_at ? formatDateString(rulebookActivation?.created_at) : ''}
-        </PageDetail>
-        <LastModifiedPageDetail
-          value={
-            rulebookActivation?.modified_at ? formatDateString(rulebookActivation?.modified_at) : ''
-          }
-        />
-      </PageDetails>
+      </PageDetail>
+      <PageDetail label={t('Restart policy')} helpText={restartPolicyHelpBlock}>
+        {rulebookActivation?.restart_policy
+          ? restartPolicyName(rulebookActivation?.restart_policy, t)
+          : ''}
+      </PageDetail>
+      <PageDetail label={t('Activation status')}>
+        <StatusCell status={rulebookActivation?.status || ''} />
+      </PageDetail>
+      {rulebookActivation.status !== Status906Enum.Error &&
+        rulebookActivation.status !== Status906Enum.Failed &&
+        !!rulebookActivation?.status_message && (
+          <PageDetail label={t('Status message')}>{rulebookActivation?.status_message}</PageDetail>
+        )}
+      <PageDetail label={t('Project git hash')}>
+        <CopyCell text={rulebookActivation?.git_hash ?? ''} />
+      </PageDetail>
+      <PageDetail label={t('Number of rules')}>{rulebookActivation?.rules_count || 0}</PageDetail>
+      <PageDetail label={t('Fire count')}>{rulebookActivation?.rules_fired_count || 0}</PageDetail>
+      <PageDetail label={t('Last restarted')}>
+        {rulebookActivation?.restarted_at ? formatDateString(rulebookActivation.restarted_at) : ''}
+      </PageDetail>
+      <PageDetail label={t('Restart count')}>{rulebookActivation?.restart_count || 0}</PageDetail>
+      <PageDetail label={t('Created')}>
+        {rulebookActivation?.created_at ? formatDateString(rulebookActivation?.created_at) : ''}
+      </PageDetail>
+      <LastModifiedPageDetail
+        value={
+          rulebookActivation?.modified_at ? formatDateString(rulebookActivation?.modified_at) : ''
+        }
+      />
       {rulebookActivation?.extra_var?.id && (
         <PageSection variant="light">
           <EdaExtraVarsCell
@@ -158,7 +148,7 @@ export function RulebookActivationDetails() {
           />
         </PageSection>
       )}
-    </Scrollable>
+    </PageDetails>
   );
 }
 
@@ -168,9 +158,3 @@ function restartPolicyName(policy: RestartPolicyEnum, t: (str: string) => string
       return t('On failure');
     case RestartPolicyEnum.Always:
       return t('Always');
-    case RestartPolicyEnum.Never:
-      return t('Never');
-    default:
-      return capitalizeFirstLetter(policy);
-  }
-}

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationDetails.tsx
@@ -6,9 +6,10 @@ import {
   LoadingPage,
   PageDetail,
   PageDetails,
-  useGetPageUrl
+  useGetPageUrl,
 } from '../../../../framework';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
+import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
 import { StatusCell } from '../../../common/Status';
 import { useGetItem } from '../../../common/crud/useGet';
@@ -158,3 +159,9 @@ function restartPolicyName(policy: RestartPolicyEnum, t: (str: string) => string
       return t('On failure');
     case RestartPolicyEnum.Always:
       return t('Always');
+    case RestartPolicyEnum.Never:
+      return t('Never');
+    default:
+      return capitalizeFirstLetter(policy);
+  }
+}

--- a/frontend/hub/access/roles/RolePage/RoleDetails.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleDetails.tsx
@@ -6,7 +6,6 @@ import {
   PageDetail,
   PageDetails,
   PageLayout,
-  Scrollable,
 } from '../../../../../framework';
 import { useGet } from '../../../../common/crud/useGet';
 import { HubError } from '../../../common/HubError';
@@ -30,22 +29,20 @@ export function RoleDetails() {
 
   return (
     <PageLayout>
-      <Scrollable>
-        <PageDetails>
-          <PageDetail label={t('Name')}>{role.name || ''}</PageDetail>
-          <PageDetail label={t('Description')}>
-            {lockedRolesWithDescription[role.name] ?? role.description}
-          </PageDetail>
-          <PageDetail label={t('Created')}>
-            <DateTimeCell value={role.pulp_created} />
-          </PageDetail>
-        </PageDetails>
-        <PageDetails numberOfColumns={'single'}>
-          <PageDetail label={t('Permissions')}>
-            <RolePermissions role={role} showCustom={true} />
-          </PageDetail>
-        </PageDetails>
-      </Scrollable>
+      <PageDetails>
+        <PageDetail label={t('Name')}>{role.name || ''}</PageDetail>
+        <PageDetail label={t('Description')}>
+          {lockedRolesWithDescription[role.name] ?? role.description}
+        </PageDetail>
+        <PageDetail label={t('Created')}>
+          <DateTimeCell value={role.pulp_created} />
+        </PageDetail>
+      </PageDetails>
+      <PageDetails numberOfColumns={'single'}>
+        <PageDetail label={t('Permissions')}>
+          <RolePermissions role={role} showCustom={true} />
+        </PageDetail>
+      </PageDetails>
     </PageLayout>
   );
 }

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentActivity.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentActivity.tsx
@@ -3,13 +3,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import {
-  DateTimeCell,
-  LoadingPage,
-  PageDetail,
-  PageDetails,
-  Scrollable,
-} from '../../../../framework';
+import { DateTimeCell, LoadingPage, PageDetail, PageDetails } from '../../../../framework';
 import { EmptyStateNoData } from '../../../../framework/components/EmptyStateNoData';
 import { useGet } from '../../../common/crud/useGet';
 import { HubError } from '../../common/HubError';
@@ -181,29 +175,27 @@ export function ExecutionEnvironmentActivity() {
     );
 
   return (
-    <Scrollable>
-      <PageDetails numberOfColumns="single">
-        <PageDetail>
-          <Table data-cy="activities-table">
-            <Thead>
-              <Tr>
-                <Th width={15}>{t('Change')}</Th>
-                <Th width={10}>{t('Date')}</Th>
+    <PageDetails numberOfColumns="single">
+      <PageDetail>
+        <Table data-cy="activities-table">
+          <Thead>
+            <Tr>
+              <Th width={15}>{t('Change')}</Th>
+              <Th width={10}>{t('Date')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {activities?.map((activity, i) => (
+              <Tr key={i}>
+                <Td>{activity.action}</Td>
+                <Td>
+                  <DateTimeCell value={activity.created} />
+                </Td>
               </Tr>
-            </Thead>
-            <Tbody>
-              {activities?.map((activity, i) => (
-                <Tr key={i}>
-                  <Td>{activity.action}</Td>
-                  <Td>
-                    <DateTimeCell value={activity.created} />
-                  </Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </PageDetail>
-      </PageDetails>
-    </Scrollable>
+            ))}
+          </Tbody>
+        </Table>
+      </PageDetail>
+    </PageDetails>
   );
 }

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.tsx
@@ -1,25 +1,24 @@
-import { useTranslation } from 'react-i18next';
-import { ClipboardCopy, Title, Button } from '@patternfly/react-core';
+import { Button, ClipboardCopy, Title } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import {
   LoadingPage,
   PageDetail,
   PageDetails,
-  Scrollable,
-  usePageNavigate,
   usePageAlertToaster,
+  usePageNavigate,
 } from '../../../../framework';
 import { EmptyStateNoData } from '../../../../framework/components/EmptyStateNoData';
 import { useClipboard } from '../../../../framework/hooks/useClipboard';
-import { hubAPIPut } from '../../common/api/hub-api-utils';
-import { getContainersURL } from '../../common/utils/getContainersURL';
+import { useGet } from '../../../common/crud/useGet';
+import { HubError } from '../../common/HubError';
 import { MarkdownEditor } from '../../common/MarkdownEditor';
 import { hubAPI } from '../../common/api/formatPath';
-import { useGet } from '../../../common/crud/useGet';
+import { hubAPIPut } from '../../common/api/hub-api-utils';
+import { getContainersURL } from '../../common/utils/getContainersURL';
 import { HubRoute } from '../../main/HubRoutes';
-import { HubError } from '../../common/HubError';
 
 const ControlButtons = styled.div`
   display: flex;
@@ -87,86 +86,84 @@ export function ExecutionEnvironmentDetails() {
     });
 
   return (
-    <Scrollable>
-      <PageDetails numberOfColumns={'single'}>
-        <Title headingLevel="h2">{t('Instructions')}</Title>
-        <PageDetail label={t('Pull this image')}>
-          <ClipboardCopy
-            data-cy="clipboard-copy"
-            hoverTip={t('Copy to clipboard')}
-            clickTip={t('Successfully copied to clipboard!')}
-            textAriaLabel={t('Copyable input')}
-            toggleAriaLabel={t('Show content')}
-            onCopy={() => {
-              writeToClipboard(instructions ?? '');
+    <PageDetails numberOfColumns={'single'}>
+      <Title headingLevel="h2">{t('Instructions')}</Title>
+      <PageDetail label={t('Pull this image')}>
+        <ClipboardCopy
+          data-cy="clipboard-copy"
+          hoverTip={t('Copy to clipboard')}
+          clickTip={t('Successfully copied to clipboard!')}
+          textAriaLabel={t('Copyable input')}
+          toggleAriaLabel={t('Show content')}
+          onCopy={() => {
+            writeToClipboard(instructions ?? '');
+          }}
+          isReadOnly
+        >
+          {instructions}
+        </ClipboardCopy>
+      </PageDetail>
+      <PageDetail label={(markdownEditing || readme) && t('README')}>
+        {!markdownEditing && readme && (
+          <EditButtonWrapper>
+            <Button
+              variant={'primary'}
+              onClick={() => {
+                setMarkdownEditing(true);
+              }}
+            >
+              {t`Edit`}
+            </Button>
+          </EditButtonWrapper>
+        )}
+        {!markdownEditing && !readme ? (
+          <EmptyStateNoData
+            title={t`No README`}
+            description={t`Add a README with instructions for using this container.`}
+            button={
+              <Button
+                data-cy="add-readme"
+                variant="primary"
+                onClick={() => setMarkdownEditing(true)}
+              >
+                {t`Add`}
+              </Button>
+            }
+          />
+        ) : (
+          <MarkdownEditor
+            text={readme}
+            placeholder={''}
+            helperText={''}
+            updateText={(value: string) => {
+              setReadme(value);
             }}
-            isReadOnly
-          >
-            {instructions}
-          </ClipboardCopy>
-        </PageDetail>
-        <PageDetail label={(markdownEditing || readme) && t('README')}>
-          {!markdownEditing && readme && (
-            <EditButtonWrapper>
+            editing={markdownEditing}
+          />
+        )}
+        {markdownEditing && (
+          <ControlButtons>
+            <div data-cy="save-readme">
               <Button
                 variant={'primary'}
                 onClick={() => {
-                  setMarkdownEditing(true);
+                  void saveMarkdown(id);
                 }}
               >
-                {t`Edit`}
+                {t`Save`}
               </Button>
-            </EditButtonWrapper>
-          )}
-          {!markdownEditing && !readme ? (
-            <EmptyStateNoData
-              title={t`No README`}
-              description={t`Add a README with instructions for using this container.`}
-              button={
-                <Button
-                  data-cy="add-readme"
-                  variant="primary"
-                  onClick={() => setMarkdownEditing(true)}
-                >
-                  {t`Add`}
-                </Button>
-              }
-            />
-          ) : (
-            <MarkdownEditor
-              text={readme}
-              placeholder={''}
-              helperText={''}
-              updateText={(value: string) => {
-                setReadme(value);
+            </div>
+            <Button
+              variant={'link'}
+              onClick={() => {
+                pageNavigate(HubRoute.ExecutionEnvironmentPage, { params: { id } });
               }}
-              editing={markdownEditing}
-            />
-          )}
-          {markdownEditing && (
-            <ControlButtons>
-              <div data-cy="save-readme">
-                <Button
-                  variant={'primary'}
-                  onClick={() => {
-                    void saveMarkdown(id);
-                  }}
-                >
-                  {t`Save`}
-                </Button>
-              </div>
-              <Button
-                variant={'link'}
-                onClick={() => {
-                  pageNavigate(HubRoute.ExecutionEnvironmentPage, { params: { id } });
-                }}
-              >
-                {t`Cancel`}
-              </Button>
-            </ControlButtons>
-          )}
-        </PageDetail>
-      </PageDetails>
-    </Scrollable>
+            >
+              {t`Cancel`}
+            </Button>
+          </ControlButtons>
+        )}
+      </PageDetail>
+    </PageDetails>
   );
 }


### PR DESCRIPTION
Fixes a hidden bug where many PageDetails were not setup to scroll, making the user unable to get to all the details.
IF we run into a case where this is not the default we want, then we should add a flag to the PageDetails to disableScrolling.