### PR TITLE
Refactors the Custom Node 

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
@@ -24,6 +24,8 @@ import {
   TopologyView as PFTopologyView,
   ElementModel,
   Edge,
+  NodeStatus,
+  LabelPosition,
 } from '@patternfly/react-topology';
 import { EmptyStateNoData } from '../../../../../framework/components/EmptyStateNoData';
 import type { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
@@ -50,7 +52,7 @@ const TopologyView = styled(PFTopologyView)`
     display: none;
   }
 `;
-const graphModel: Model = {
+export const graphModel: Model = {
   nodes: [],
   edges: [],
   graph: {
@@ -175,10 +177,11 @@ export const Visualizer = ({ data: { workflowNodes = [], template } }: TopologyP
         width: NODE_DIAMETER,
         height: NODE_DIAMETER,
         shape: NodeShape.circle,
+        status: NodeStatus.default,
+        labelPosition: LabelPosition.bottom,
         data: {
           resource: n,
         },
-        state: { isInvalidLinkTarget: false },
       };
 
       return node;

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
@@ -11,13 +11,13 @@ import {
 } from '@patternfly/react-icons';
 import {
   DefaultNode,
-  LabelPosition,
-  NodeStatus,
   WithContextMenuProps,
   WithCreateConnectorProps,
   WithSelectionProps,
+  isNode,
   observer,
 } from '@patternfly/react-topology';
+
 import { useViewOptions } from '../ViewOptionsProvider';
 import type { CustomNodeProps, UnifiedJobType } from '../types';
 import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
@@ -35,34 +35,22 @@ const NodeIcon: Record<UnifiedJobType, ElementType<SVGIconProps>> = {
 export const CustomNode: FC<
   CustomNodeProps & WithContextMenuProps & WithSelectionProps & WithCreateConnectorProps
 > = observer((props) => {
+  const { element, onSelect, ...rest } = props;
   const { setSidebarMode } = useViewOptions();
-
-  const { element, contextMenuOpen, onContextMenu, onSelect, selected, ...rest } = props;
   const data = element.getData();
-  const isInvalidLinkTarget = element.getState<{ isInvalidLinkTarget: boolean }>()
-    .isInvalidLinkTarget;
-
   const id = element.getId();
-  const jobType = data && data.resource.summary_fields?.unified_job_template?.unified_job_type;
-  if (!data && id !== START_NODE_ID) return null;
+  const jobType = data && data.resource?.summary_fields?.unified_job_template?.unified_job_type;
+  if ((!data && id !== START_NODE_ID) || !isNode(element)) return null;
   const Icon = jobType ? NodeIcon[jobType] : TrashIcon;
   return id !== START_NODE_ID ? (
     <DefaultNode
-      dragging={false}
-      nodeStatus={isInvalidLinkTarget ? NodeStatus.danger : NodeStatus.default}
-      showStatusDecorator
-      canDrop={!isInvalidLinkTarget}
       element={element}
       labelClassName={`${id}-node-label`}
-      contextMenuOpen={contextMenuOpen}
-      labelPosition={LabelPosition.right}
-      onContextMenu={onContextMenu}
       onSelect={(e) => {
         if (!jobType) return;
         setSidebarMode('view');
         onSelect && onSelect(e);
       }}
-      selected={selected}
       truncateLength={20}
       {...rest}
     >
@@ -72,13 +60,10 @@ export const CustomNode: FC<
     </DefaultNode>
   ) : (
     <DefaultNode
+      {...rest}
       element={element}
       labelClassName={`${id}-node-label`}
-      contextMenuOpen={contextMenuOpen}
-      labelPosition={LabelPosition.right}
-      onContextMenu={onContextMenu}
       dragging={false}
-      selected={false}
       truncateLength={20}
     >
       <g transform={`translate(13, 13)`}>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useCreateNodeComponent.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useCreateNodeComponent.tsx
@@ -8,8 +8,10 @@ import {
   GraphModel,
   Node,
   NodeModel,
+  NodeStatus,
   TargetType,
   WithCreateConnectorProps,
+  isNode,
   nodeDragSourceSpec,
   withContextMenu,
   withCreateConnector,
@@ -56,8 +58,9 @@ export function useCreateNodeComponent(): () => FunctionComponent<
           source: Node<NodeModel, GraphNodeData>,
           target: Node<NodeModel, GraphNodeData> | Graph<GraphModel, GraphModel>
         ) => {
-          const targetState = target.getState<{ isInvalidLinkTarget: boolean }>();
-          if (targetState.isInvalidLinkTarget) {
+          if (!isNode(target)) return;
+          const nodeStatus = target.getNodeStatus();
+          if (nodeStatus === NodeStatus.danger) {
             return;
           }
           createConnector(source, target);

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useHandleCollectNodeProps.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useHandleCollectNodeProps.tsx
@@ -4,6 +4,7 @@ import {
   Node,
   NodeModel,
   NodeShape,
+  NodeStatus,
   action,
 } from '@patternfly/react-topology';
 import { useCallback } from 'react';
@@ -17,22 +18,23 @@ export function useHandleCollectNodeProps() {
       const isDragging = monitor.isDragging();
 
       const target = monitor.getDropResult() as Node;
-      const isInvalidLinkTarget: boolean =
-        target?.getState<{ isInvalidLinkTarget: boolean }>()?.isInvalidLinkTarget ?? false;
+      const nodeStatus = target?.getNodeStatus() || NodeStatus.default;
 
       const sourceNode = monitor.getItem() as Node;
 
       if (!isDragging) {
         const iteratedNode = props.element as Node<NodeModel, GraphNodeData>;
-        iteratedNode.setState({ ...props.element.getState(), isInvalidLinkTarget: false });
-        action(() => iteratedNode.setNodeShape(NodeShape.circle))();
+        action(() => {
+          iteratedNode.setNodeShape(NodeShape.circle);
+          iteratedNode.setNodeStatus(NodeStatus.default);
+        })();
       }
       if (isDragging) {
         targetNodeAncestors(sourceNode);
       }
       return {
         ...props,
-        canDrop: isInvalidLinkTarget,
+        canDrop: nodeStatus !== NodeStatus.danger,
         edgeDragging: isDragging,
       };
     },

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useRemoveGraphElements.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useRemoveGraphElements.tsx
@@ -9,6 +9,7 @@ import {
   Edge,
   Node,
   useVisualizationController,
+  NodeStatus,
 } from '@patternfly/react-topology';
 import { GraphNode, type GraphEdgeData, type GraphNodeData, EdgeStatus } from '../types';
 import { Label } from '@patternfly/react-core';
@@ -137,9 +138,10 @@ export function useRemoveGraphElements() {
 
   const handleRemoveLink = action((element: Edge) => {
     element.setVisible(false);
-    element.getSource().setState({ modified: true, isInvalidLinkTarget: false });
-
-    element.getTarget().setState({ modified: true, isInvalidLinkTarget: false });
+    element.getSource().setState({ modified: true });
+    element.getTarget().setState({ modified: true });
+    element.getSource().setNodeStatus(NodeStatus.default);
+    element.getTarget().setNodeStatus(NodeStatus.default);
     const controller = element.getController();
     const model = controller.toModel();
 

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useTargetNodeAncestors.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useTargetNodeAncestors.tsx
@@ -1,4 +1,10 @@
-import { ElementModel, GraphElement, NodeShape, action } from '@patternfly/react-topology';
+import {
+  ElementModel,
+  GraphElement,
+  NodeShape,
+  NodeStatus,
+  action,
+} from '@patternfly/react-topology';
 import { useCallback } from 'react';
 import { WorkflowNode } from '../../../../interfaces/WorkflowNode';
 
@@ -47,8 +53,10 @@ export function useTargetNodeAncestors() {
       .forEach((ancestorId) => {
         newNodes.forEach((node) => {
           if (node.getId() === ancestorId) {
-            node.setState({ ...node.getState(), isInvalidLinkTarget: true });
-            action(() => node.setNodeShape(NodeShape.hexagon))();
+            action(() => {
+              node.setNodeShape(NodeShape.hexagon);
+              node.setNodeStatus(NodeStatus.danger);
+            })();
           }
         });
       });


### PR DESCRIPTION
This PR refactors the custom Node component.  Primarily the reason for doing so is to take advantage of the node Status, from PF topology, to indicate to the user which nodes are valid link targets, and which are not.  In so doing, we were also able to remove the `invalidLinkTarget` value on the node state.

Functionally, nothing should change.