### PR TITLE
Make JobsList reusable and add Host > Jobs List

### DIFF
--- a/frontend/awx/main/routes/useAwxHostRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxHostRoutes.tsx
@@ -5,6 +5,7 @@ import { PageNotImplemented } from '../../../../framework/PageEmptyStates/PageNo
 import { HostPage } from '../../resources/hosts/HostPage/HostPage';
 import { Hosts } from '../../resources/hosts/Hosts';
 import { AwxRoute } from '../AwxRoutes';
+import { HostJobs } from '../../resources/hosts/HostPage/HostJobs';
 
 export function useAwxHostRoutes() {
   const { t } = useTranslation();
@@ -37,7 +38,7 @@ export function useAwxHostRoutes() {
             {
               id: AwxRoute.HostJobs,
               path: 'jobs',
-              element: <PageNotImplemented />,
+              element: <HostJobs />,
             },
           ],
         },

--- a/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
+++ b/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { usePersistentFilters } from '../../../../common/PersistentFilters';
 import { JobsList } from '../../../views/jobs/JobsList';
 
-export function InventoryHostJobs() {
+export function HostJobs() {
   usePersistentFilters('inventories');
   const { id = '' } = useParams<{ id: string }>();
   return <JobsList jobHosts={id} />;

--- a/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
+++ b/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router-dom';
 import { usePersistentFilters } from '../../../../common/PersistentFilters';
 import { JobsList } from '../../../views/jobs/JobsList';
+import { useHostsJobsColumns } from '../../inventories/inventoryHostsPage/hooks/useHostsJobsColumns';
 
 export function HostJobs() {
   usePersistentFilters('inventories');
+  const jobsColumns = useHostsJobsColumns();
   const { id = '' } = useParams<{ id: string }>();
-  return <JobsList jobHosts={id} />;
+  return <JobsList jobHosts={id} columns={jobsColumns} />;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router-dom';
 import { usePersistentFilters } from '../../../../common/PersistentFilters';
 import { JobsList } from '../../../views/jobs/JobsList';
+import { useHostsJobsColumns } from './hooks/useHostsJobsColumns';
 
 export function InventoryHostJobs() {
   usePersistentFilters('inventories');
+  const jobsColumns = useHostsJobsColumns();
   const { id = '' } = useParams<{ id: string }>();
-  return <JobsList jobHosts={id} />;
+  return <JobsList jobHosts={id} columns={jobsColumns} />;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns.tsx
@@ -43,9 +43,11 @@ export function useHostsJobsColumns(options?: { disableSort?: boolean; disableLi
       }),
     [jobPaths, pageNavigate]
   );
+
   const nameColumn = useNameColumn({
     ...options,
     onClick: nameClick,
+    defaultSort: false,
   });
 
   const statusColumn = useMemo<ITableColumn<UnifiedJob>>(
@@ -77,6 +79,8 @@ export function useHostsJobsColumns(options?: { disableSort?: boolean; disableLi
         return <DateTimeCell value={job.finished} />;
       },
       sort: 'finished',
+      defaultSortDirection: 'desc',
+      defaultSort: true,
     }),
     [t]
   );

--- a/frontend/awx/views/jobs/Jobs.tsx
+++ b/frontend/awx/views/jobs/Jobs.tsx
@@ -19,6 +19,7 @@ export function Jobs() {
   const product: string = process.env.PRODUCT ?? t('AWX');
   const toolbarFilters = useJobsFilters();
   const tableColumns = useJobsColumns();
+
   const view = useAwxView<UnifiedJob>({
     url: awxAPI`/unified_jobs/`,
     queryParams: {
@@ -27,6 +28,7 @@ export function Jobs() {
     toolbarFilters,
     tableColumns,
   });
+
   usePersistentFilters('jobs');
   const config = useAwxConfig();
 

--- a/frontend/awx/views/jobs/Jobs.tsx
+++ b/frontend/awx/views/jobs/Jobs.tsx
@@ -1,4 +1,4 @@
-import { PageHeader, PageLayout, PageTable } from '../../../../framework';
+import { PageHeader, PageLayout } from '../../../../framework';
 
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,11 +9,10 @@ import { useAwxView } from '../../common/useAwxView';
 import { useAwxWebSocketSubscription } from '../../common/useAwxWebSocket';
 import { getDocsBaseUrl } from '../../common/util/getDocsBaseUrl';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
-import { useJobRowActions } from './hooks/useJobRowActions';
-import { useJobToolbarActions } from './hooks/useJobToolbarActions';
 import { useJobsColumns } from './hooks/useJobsColumns';
 import { useJobsFilters } from './hooks/useJobsFilters';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
+import { JobsList } from './JobsList';
 
 export function Jobs() {
   const { t } = useTranslation();
@@ -28,8 +27,6 @@ export function Jobs() {
     toolbarFilters,
     tableColumns,
   });
-  const toolbarActions = useJobToolbarActions(view.unselectItemsAndRefresh);
-  const rowActions = useJobRowActions(view.unselectItemsAndRefresh);
   usePersistentFilters('jobs');
   const config = useAwxConfig();
 
@@ -76,37 +73,8 @@ export function Jobs() {
           { product }
         )}
         headerActions={<ActivityStreamIcon type={'job'} />}
-        // headerActions={
-        //   <ToggleGroup aria-label={t('show graph toggle')}>
-        //     <ToggleGroupItem
-        //       icon={<TachometerAltIcon />}
-        //       aria-label={t('toggle show graph')}
-        //       isSelected={showGraph}
-        //       onChange={() => setShowGraph((show) => !show)}
-        //     />
-        //   </ToggleGroup>
-        // }
       />
-      <PageTable
-        id="awx-jobs-table"
-        toolbarFilters={toolbarFilters}
-        tableColumns={tableColumns}
-        toolbarActions={toolbarActions}
-        rowActions={rowActions}
-        errorStateTitle={t('Error loading jobs')}
-        emptyStateTitle={t('No jobs yet')}
-        emptyStateDescription={t('Please run a job to populate this list.')}
-        {...view}
-        defaultSubtitle={t('Job')}
-        // topContent={
-        //   showGraph && (
-        //     <PageSection>
-        //       <JobsChart height={250} />
-        //     </PageSection>
-        //   )
-        // }
-        limitFiltersToOneOrOperation
-      />
+      <JobsList />
     </PageLayout>
   );
 }

--- a/frontend/awx/views/jobs/Jobs.tsx
+++ b/frontend/awx/views/jobs/Jobs.tsx
@@ -76,7 +76,7 @@ export function Jobs() {
         )}
         headerActions={<ActivityStreamIcon type={'job'} />}
       />
-      <JobsList />
+      <JobsList columns={tableColumns} />
     </PageLayout>
   );
 }

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -5,6 +5,7 @@ import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxView } from '../../common/useAwxView';
 import { useHostsJobsColumns } from '../../resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns';
+import { useJobsColumns } from './hooks/useJobsColumns';
 import { useJobRowActions } from '../../views/jobs/hooks/useJobRowActions';
 import { useJobToolbarActions } from '../../views/jobs/hooks/useJobToolbarActions';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
@@ -12,8 +13,21 @@ import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
 
 export function JobsList(props: { jobHosts?: string }) {
   const { t } = useTranslation();
-  const tableColumns = useHostsJobsColumns();
+  const tableColumns = useJobsColumns();
   const toolbarFilters = useJobsFilters();
+  const hostJobsColumns = useHostsJobsColumns();
+  const jobsColumns = useJobsColumns();
+  const getTableColumns = (jobHosts?: string) => {
+    if (jobHosts) {
+      console.log('using hostJobsColumns');
+      console.log(hostJobsColumns);
+      return hostJobsColumns;
+    } else {
+      console.log('using JobsColumns');
+      console.log(jobsColumns);
+      return jobsColumns;
+    }
+  };
   const getQueryParams = (jobHosts?: string) => {
     const jobsQueryParams: { [key: string]: string } = {};
     if (jobHosts) {
@@ -24,7 +38,7 @@ export function JobsList(props: { jobHosts?: string }) {
   const view = useAwxView<UnifiedJob>({
     url: awxAPI`/unified_jobs/`,
     toolbarFilters,
-    tableColumns,
+    tableColumns: getTableColumns(props.jobHosts),
     queryParams: getQueryParams(props.jobHosts),
   });
   const rowActions = useJobRowActions(view.unselectItemsAndRefresh);

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -1,0 +1,50 @@
+import { CubesIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import { PageLayout, PageTable } from '../../../../framework';
+import { usePersistentFilters } from '../../../common/PersistentFilters';
+import { awxAPI } from '../../common/api/awx-utils';
+import { useAwxView } from '../../common/useAwxView';
+import { useHostsJobsColumns } from '../../resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns';
+import { useJobRowActions } from '../../views/jobs/hooks/useJobRowActions';
+import { useJobToolbarActions } from '../../views/jobs/hooks/useJobToolbarActions';
+import { UnifiedJob } from '../../interfaces/UnifiedJob';
+import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
+
+export function JobsList(props: { jobHosts?: string }) {
+  const { t } = useTranslation();
+  const tableColumns = useHostsJobsColumns();
+  const toolbarFilters = useJobsFilters();
+  const getQueryParams = (jobHosts?: string) => {
+    const jobsQueryParams: { [key: string]: string } = {};
+    if (jobHosts) {
+      jobsQueryParams.job__hosts = jobHosts;
+    }
+    return jobsQueryParams;
+  };
+  const view = useAwxView<UnifiedJob>({
+    url: awxAPI`/unified_jobs/`,
+    toolbarFilters,
+    tableColumns,
+    queryParams: getQueryParams(props.jobHosts),
+  });
+  const rowActions = useJobRowActions(view.unselectItemsAndRefresh);
+  const toolbarActions = useJobToolbarActions(view.unselectItemsAndRefresh);
+
+  usePersistentFilters('jobs');
+
+  return (
+    <PageLayout>
+      <PageTable<UnifiedJob>
+        id="awx-jobs-table"
+        toolbarFilters={toolbarFilters}
+        tableColumns={tableColumns}
+        rowActions={rowActions}
+        toolbarActions={toolbarActions}
+        errorStateTitle={t('Error loading jobs')}
+        emptyStateTitle={t('There are no related jobs')}
+        emptyStateIcon={CubesIcon}
+        {...view}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -1,33 +1,18 @@
 import { CubesIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { PageLayout, PageTable } from '../../../../framework';
+import { ITableColumn, PageLayout, PageTable } from '../../../../framework';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxView } from '../../common/useAwxView';
-import { useHostsJobsColumns } from '../../resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns';
-import { useJobsColumns } from './hooks/useJobsColumns';
 import { useJobRowActions } from '../../views/jobs/hooks/useJobRowActions';
 import { useJobToolbarActions } from '../../views/jobs/hooks/useJobToolbarActions';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
 
-export function JobsList(props: { jobHosts?: string }) {
+export function JobsList(props: { jobHosts?: string; columns: ITableColumn<UnifiedJob>[] }) {
   const { t } = useTranslation();
-  const tableColumns = useJobsColumns();
   const toolbarFilters = useJobsFilters();
-  const hostJobsColumns = useHostsJobsColumns();
-  const jobsColumns = useJobsColumns();
-  const getTableColumns = (jobHosts?: string) => {
-    if (jobHosts) {
-      console.log('using hostJobsColumns');
-      console.log(hostJobsColumns);
-      return hostJobsColumns;
-    } else {
-      console.log('using JobsColumns');
-      console.log(jobsColumns);
-      return jobsColumns;
-    }
-  };
+  const tableColumns = props.columns;
   const getQueryParams = (jobHosts?: string) => {
     const jobsQueryParams: { [key: string]: string } = {};
     if (jobHosts) {
@@ -38,7 +23,7 @@ export function JobsList(props: { jobHosts?: string }) {
   const view = useAwxView<UnifiedJob>({
     url: awxAPI`/unified_jobs/`,
     toolbarFilters,
-    tableColumns: getTableColumns(props.jobHosts),
+    tableColumns,
     queryParams: getQueryParams(props.jobHosts),
   });
   const rowActions = useJobRowActions(view.unselectItemsAndRefresh);

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -52,6 +52,7 @@ export function useNameColumn<
   sort?: string;
   disableSort?: boolean;
   disableLinks?: boolean;
+  defaultSort?: boolean;
 }) {
   const { url, onClick, disableSort, disableLinks } = options ?? {};
   const { t } = useTranslation();

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -74,7 +74,7 @@ export function useNameColumn<
       sort: disableSort ? undefined : options?.sort ?? 'name',
       card: 'name',
       list: 'name',
-      defaultSort: options?.defaultSort,
+      defaultSort: typeof options?.defaultSort !== 'undefined' ? options?.defaultSort : true,
     }),
     [
       options?.header,

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -74,9 +74,18 @@ export function useNameColumn<
       sort: disableSort ? undefined : options?.sort ?? 'name',
       card: 'name',
       list: 'name',
-      defaultSort: true,
+      defaultSort: options?.defaultSort,
     }),
-    [disableLinks, disableSort, options?.sort, onClick, options?.header, t, url]
+    [
+      options?.header,
+      options?.sort,
+      options?.defaultSort,
+      t,
+      disableSort,
+      disableLinks,
+      url,
+      onClick,
+    ]
   );
   return column;
 }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-8161

Uses work from InventoryHostJobs to create reusable JobsList component . Uses this component for Inventory > Host Jobs and Host > Jobs pages.