### PR TITLE
Dedupe old workflow nodes after fetching new nodes

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/Topology.tsx
@@ -41,7 +41,7 @@ import {
 } from './components';
 import { EdgeStatus } from './types';
 import { ViewOptionsContext, ViewOptionsProvider } from './ViewOptionsProvider';
-import { useCreateEdge } from './hooks';
+import { useCreateEdge, useDedupeOldNodes } from './hooks';
 import { getNodeLabel } from './wizard/helpers';
 import { GRAPH_ID, NODE_DIAMETER, START_NODE_ID } from './constants';
 import { useCreateNodeComponent } from './hooks/useCreateNodeComponent';
@@ -72,6 +72,7 @@ interface TopologyProps {
 
 export const Visualizer = ({ data: { workflowNodes = [], template } }: TopologyProps) => {
   const { t } = useTranslation();
+  const dedupeOldNodes = useDedupeOldNodes();
   const createEdge = useCreateEdge();
   const createNodeComponent = useCreateNodeComponent();
   const handleSelectedNode = useCallback(
@@ -205,8 +206,11 @@ export const Visualizer = ({ data: { workflowNodes = [], template } }: TopologyP
       },
     };
 
+    dedupeOldNodes(visualization);
+
     visualization.fromModel(model, true);
-  }, [t, visualization, createEdge, workflowNodes]);
+    visualization.getGraph().reset();
+  }, [t, visualization, createEdge, workflowNodes, dedupeOldNodes]);
 
   return (
     <VisualizationProvider controller={visualization}>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/index.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/index.ts
@@ -1,5 +1,6 @@
 import { useCloseSidebar } from './useCloseSidebar';
 import { useCreateEdge } from './useCreateEdge';
+import { useDedupeOldNodes } from './useDedupeOldNodes';
 import { useGetDetailComponent } from './useGetDetailComponent';
 import { useRemoveGraphElements } from './useRemoveGraphElements';
 import { useRemoveNode } from './useRemoveNode';
@@ -10,6 +11,7 @@ import { useGetInitialValues, useNodeTypeStepDefaults } from './useGetInitialVal
 export {
   useCloseSidebar,
   useCreateEdge,
+  useDedupeOldNodes,
   useGetDetailComponent,
   useGetInitialValues,
   useNodeTypeStepDefaults,

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useDedupeOldNodes.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useDedupeOldNodes.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { GraphElement, Controller, action } from '@patternfly/react-topology';
+
+/*
+  This function is designed to deduplicate stale nodes after fetching new nodes from the API.
+
+  Explanation:
+  The topology library expects node IDs to be immutable. It uses the old ID as a key in the
+  list of `this.elements`. This poses an issue when trying to remove a node using the new ID. 
+  Additionally, the library creates an additional node with the new ID since it doesn't find 
+  an existing node with the new ID in the list of `this.elements`. This results in duplicate nodes. 
+
+  To address this issue, we've implemented this workaround to clean up and deduplicate stale nodes.
+*/
+
+type IController = Controller & {
+  elements: { [id: string]: GraphElement };
+};
+export function useDedupeOldNodes() {
+  return useCallback((controller: IController) => {
+    const staleNodeKeys = Object.keys(controller?.elements).filter((key) =>
+      key.endsWith('-unsavedNode')
+    );
+    staleNodeKeys.forEach((key) => {
+      const staleNode = controller.getNodeById(key);
+      if (staleNode) {
+        action(() => {
+          staleNode.setId(key);
+          controller.removeElement(staleNode);
+        })();
+      }
+    });
+  }, []);
+}


### PR DESCRIPTION
Fix addresses duplicate orphaned nodes after save

![Screenshot 2024-02-28 at 10 37 53 AM](https://github.com/ansible/ansible-ui/assets/15881645/de187a0f-a97d-4d15-9a96-1813ad4a8ce3)
