### PR TITLE
Cypress command cleanup

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -76,8 +76,8 @@ describe('teams', function () {
 
     // Select users
     cy.getModal().within(() => {
-      cy.selectTableRowNew('username', user1.username);
-      cy.selectTableRowNew('username', user2.username);
+      cy.selectTableRowCheckbox('username', user1.username);
+      cy.selectTableRowCheckbox('username', user2.username);
       cy.get('#submit').click();
     });
 

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -43,10 +43,10 @@ describe('teams', function () {
     const teamName = 'E2E Team ' + randomString(4);
     cy.intercept('POST', awxAPI`/teams/`).as('newTeam');
     cy.navigateTo('awx', 'teams');
-    cy.clickLink(/^Create team$/);
-    cy.typeByDataCy('name', teamName);
+    cy.containsBy('a', /^Create team$/).click();
+    cy.getByDataCy('name').type(teamName);
     cy.singleSelectByDataCy('organization', (this.globalOrganization as Organization).name);
-    cy.clickByDataCy('Submit');
+    cy.getByDataCy('Submit').click();
     cy.wait('@newTeam')
       .its('response.body')
       .then((team: Team) => {
@@ -68,32 +68,42 @@ describe('teams', function () {
     cy.requestPost<User>(awxAPI`/users/${user2.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
+
     cy.navigateTo('awx', 'teams');
-    cy.searchAndDisplayResource(team.name);
-    cy.get(`[data-cy="row-id-${team.id}"]`).within(() => {
-      cy.get('[data-cy="actions-dropdown"]').click();
-      cy.get('[data-cy="remove-users"]').click();
+
+    // Remove users
+    cy.clickTableRowAction('name', team.name, 'remove-users', { inKebab: true });
+
+    // Select users
+    cy.getModal().within(() => {
+      cy.selectTableRowNew('username', user1.username);
+      cy.selectTableRowNew('username', user2.username);
+      cy.get('#submit').click();
     });
-    cy.get(`[data-cy="row-id-${user1.id}"]`).find('input').click();
-    cy.get(`[data-cy="row-id-${user2.id}"]`).find('input').click();
-    cy.get('#confirm').click();
-    cy.get('#confirm').click();
-    cy.clickButton(/^Remove user/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
+
+    // Confirm and remove users
+    cy.getModal().within(() => {
+      cy.get('#confirm').click();
+      cy.get('#submit').click();
+      cy.contains(/^Success$/).should('be.visible');
+      cy.containsBy('button', /^Close$/).click();
+    });
+
+    // Verify modal is closed
+    cy.getModal().should('not.exist');
   });
 
   it('can render the team details page', function () {
     cy.navigateTo('awx', 'teams');
-    cy.clickTableRow(team.name);
+    cy.clickTableRowLink('name', team.name);
     cy.verifyPageTitle(team.name);
-    cy.clickLink(/^Details$/);
-    cy.get('[data-cy="name"]').should('contain', team.name);
+    cy.clickTab(/^Details$/, true);
+    cy.hasDetail('Name', team.name);
   });
 
   it('can edit a team from the details page', function () {
     cy.navigateTo('awx', 'teams');
-    cy.clickTableRow(team.name);
+    cy.clickTableRowLink('name', team.name);
     cy.clickButton(/^Edit team$/);
     cy.verifyPageTitle('Edit Team');
     cy.get('[data-cy="name"]')

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -187,7 +187,7 @@ describe('inventories', () => {
     cy.clickButton(/^Clear all filters$/);
   });
 
-  it('can add and remove new related groups', () => {
+  it.only('can add and remove new related groups', () => {
     cy.createInventoryHostGroup(organization).then((result) => {
       const { inventory, group } = result;
       const newRelatedGroup = 'New test group' + randomString(4);
@@ -205,7 +205,7 @@ describe('inventories', () => {
       cy.contains(newRelatedGroup);
       cy.selectTableRow(newRelatedGroup, true);
       cy.clickToolbarKebabAction('disassociate-selected-groups');
-      cy.get('#submit').click();
+      cy.get('#confirm').click();
       cy.clickButton(/^Disassociate groups/);
       cy.contains(/^Success$/);
       cy.clickButton(/^Close/);
@@ -233,7 +233,7 @@ describe('inventories', () => {
       cy.contains(newGroup);
       cy.selectTableRow(newGroup, true);
       cy.clickToolbarKebabAction('disassociate-selected-groups');
-      cy.get('#submit').click();
+      cy.get('#confirm').click();
       cy.clickButton(/^Disassociate groups/);
       cy.contains(/^Success$/);
       cy.clickButton(/^Close/);

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -187,7 +187,7 @@ describe('inventories', () => {
     cy.clickButton(/^Clear all filters$/);
   });
 
-  it.only('can add and remove new related groups', () => {
+  it('can add and remove new related groups', () => {
     cy.createInventoryHostGroup(organization).then((result) => {
       const { inventory, group } = result;
       const newRelatedGroup = 'New test group' + randomString(4);

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -93,7 +93,7 @@ describe('inventories', () => {
     cy.verifyPageTitle(inventory.name);
     cy.clickButton(/^Edit inventory/);
     cy.selectDropdownOptionByResourceName('labels', label.name);
-    cy.typeBy('[data-cy="variables"]', 'remote_install_path: /opt/my_app_config');
+    cy.getByDataCy('variables').type('remote_install_path: /opt/my_app_config');
     cy.contains('button', 'Save inventory').click();
     cy.verifyPageTitle(inventory.name);
     cy.assertMonacoTextField('remote_install_path: /opt/my_app_config');
@@ -205,7 +205,7 @@ describe('inventories', () => {
       cy.contains(newRelatedGroup);
       cy.selectTableRow(newRelatedGroup, true);
       cy.clickToolbarKebabAction('disassociate-selected-groups');
-      cy.get('#confirm').click();
+      cy.get('#submit').click();
       cy.clickButton(/^Disassociate groups/);
       cy.contains(/^Success$/);
       cy.clickButton(/^Close/);
@@ -233,7 +233,7 @@ describe('inventories', () => {
       cy.contains(newGroup);
       cy.selectTableRow(newGroup, true);
       cy.clickToolbarKebabAction('disassociate-selected-groups');
-      cy.get('#confirm').click();
+      cy.get('#submit').click();
       cy.clickButton(/^Disassociate groups/);
       cy.contains(/^Success$/);
       cy.clickButton(/^Close/);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -55,7 +55,7 @@ describe('inventory group', () => {
     cy.verifyPageTitle('Create new group');
     cy.get('[data-cy="name"]').type(groupName);
     cy.get('[data-cy="description"]').type('This is a description');
-    cy.typeBy('[data-cy="variables"]', 'test: true');
+    cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Save/);
     cy.hasDetail(/^Name$/, groupName);
     cy.hasDetail(/^Description$/, 'This is a description');

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -74,7 +74,7 @@ describe('Inventory source page', () => {
     cy.getBy('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
       cy.searchAndDisplayResource(credentialName);
       cy.getBy('[data-cy="checkbox-column-cell"] > label').click();
-      cy.getBy('#confirm').click();
+      cy.getBy('#submit').click();
     });
     cy.getBy('[data-cy="host-filter"]').type('/^test$/');
     cy.getBy('[data-cy="verbosity"]').type('1');

--- a/cypress/e2e/awx/views/jobs.cy.ts
+++ b/cypress/e2e/awx/views/jobs.cy.ts
@@ -100,7 +100,7 @@ describe('jobs', () => {
   it('filters jobs by id', () => {
     cy.navigateTo('awx', 'jobs');
     const jobId = jobList.id ? jobList.id.toString() : '';
-    cy.selectToolbarFilterType('ID');
+    cy.selectToolbarFilterByLabel('ID');
     cy.get('#filter-input').type(jobId, { delay: 0 });
     cy.get('[aria-label="apply filter"]').click();
     cy.get('tr').should('have.length.greaterThan', 0);

--- a/cypress/e2e/eda/Rulebook-Activations/rulebook-activations-crud.cy.ts
+++ b/cypress/e2e/eda/Rulebook-Activations/rulebook-activations-crud.cy.ts
@@ -1,13 +1,13 @@
 //Tests a user's ability to create, edit, and delete rulebook activations in the EDA UI.
 //IMPORTANT: rulebook activations do not have Edit capability in the UI. They can only be enabled or disabled.
 import { randomString } from '../../../../framework/utils/random-string';
+import { EdaControllerToken } from '../../../../frontend/eda/interfaces/EdaControllerToken';
 import { EdaDecisionEnvironment } from '../../../../frontend/eda/interfaces/EdaDecisionEnvironment';
 import { EdaProject } from '../../../../frontend/eda/interfaces/EdaProject';
 import { EdaRulebook } from '../../../../frontend/eda/interfaces/EdaRulebook';
 import { EdaRulebookActivation } from '../../../../frontend/eda/interfaces/EdaRulebookActivation';
 import { ActivationRead } from '../../../../frontend/eda/interfaces/generated/eda-api';
 import { edaAPI } from '../../../support/formatApiPathForEDA';
-import { EdaControllerToken } from '../../../../frontend/eda/interfaces/EdaControllerToken';
 
 describe('EDA rulebook activations - Create', () => {
   let edaProject: EdaProject;

--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -181,7 +181,7 @@ describe('Execution Environment Details tab', () => {
     cy.get('[data-cy="readme"]').within(() => {
       cy.contains('Heading 1');
       cy.clickButton('Edit');
-      cy.getByDataCy('raw-markdown').clear().type('{enter}**bold text**');
+      cy.getByDataCy('raw-markdown').type('{enter}**bold text**');
       cy.contains('Preview').parent().get('strong').contains('bold text');
       cy.intercept(
         'PUT',

--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -163,7 +163,7 @@ describe('Execution Environment Details tab', () => {
     cy.get('[data-cy="readme"]').within(() => {
       cy.contains('Raw Markdown');
       cy.contains('Preview');
-      cy.typeBy('[data-cy="raw-markdown"]', '# Heading 1');
+      cy.getByDataCy('raw-markdown').type('# Heading 1');
       cy.contains('Preview').parent().get('h1').contains('Heading 1');
       cy.contains('Cancel');
       cy.intercept(
@@ -181,7 +181,7 @@ describe('Execution Environment Details tab', () => {
     cy.get('[data-cy="readme"]').within(() => {
       cy.contains('Heading 1');
       cy.clickButton('Edit');
-      cy.typeBy('[data-cy="raw-markdown"]', '{enter}**bold text**');
+      cy.getByDataCy('raw-markdown').clear().type('{enter}**bold text**');
       cy.contains('Preview').parent().get('strong').contains('bold text');
       cy.intercept(
         'PUT',
@@ -198,7 +198,7 @@ describe('Execution Environment Details tab', () => {
     cy.visit(`/execution-environments/${executionEnvironment.name}/`);
     cy.get('[data-cy="readme"]').within(() => {
       cy.clickButton('Edit');
-      cy.typeBy('[data-cy="raw-markdown"]', '{enter}this should not be saved.');
+      cy.getByDataCy('raw-markdown').clear().type('{enter}this should not be saved.');
       cy.contains('Preview').parent().contains('this should not be saved.');
       cy.clickButton('Cancel');
     });

--- a/cypress/e2e/hub/tasks.cy.ts
+++ b/cypress/e2e/hub/tasks.cy.ts
@@ -75,7 +75,7 @@ describe('Tasks', () => {
         cy.get('[data-cy="Submit"]').click();
         cy.hasAlert(`Sync started for repository "${repository.name}"`).should('be.visible');
         cy.navigateTo('hub', Tasks.url);
-        cy.selectToolbarFilterType(/^Task name$/);
+        cy.selectToolbarFilterByLabel(/^Task name$/);
         cy.filterTableByText('pulp_ansible.app.tasks.collections.sync', 'SingleText');
         cy.filterBySingleSelection(/^Status$/, 'Running');
         cy.clickTableRowKebabAction('pulp_ansible.app.tasks.collections.sync', 'stop-task', false);

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -265,11 +265,11 @@ Cypress.Commands.add(
     cy.get('[data-cy="description"]').type(`${credentialTypeDesc}`);
     if (inputConfig && injectorConfig) {
       if (defaultFormat === 'json') {
-        cy.configFormatToggle('inputs');
+        cy.dataEditorSetFormat('inputs');
       }
       cy.inputCustomCredTypeConfig('inputs', inputConfig);
       if (defaultFormat === 'json') {
-        cy.configFormatToggle('injectors');
+        cy.dataEditorSetFormat('injectors');
       }
       cy.inputCustomCredTypeConfig('injectors', injectorConfig);
     }
@@ -283,13 +283,8 @@ Cypress.Commands.add(
   }
 );
 
-/** @param
- * Configuration format YAML-JSON and JSON-YAML toggle switch
- *
- */
-
-Cypress.Commands.add('configFormatToggle', (configType: string) => {
-  cy.get(`[data-cy="${configType}-form-group"] [data-cy=toggle-json]`).click();
+Cypress.Commands.add('dataEditorSetFormat', (dataCy: string, format: 'json' | 'yaml' = 'json') => {
+  cy.get(`[data-cy="${dataCy}-form-group"] [data-cy=toggle-${format}]`).click();
 });
 
 Cypress.Commands.add('assertMonacoTextField', (textString: string) => {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -352,15 +352,6 @@ Cypress.Commands.add('selectDropdownOptionByResourceName', (resource: string, it
     });
 });
 
-Cypress.Commands.add('setTablePageSize', (text: '10' | '20' | '50' | '100') => {
-  cy.get('[data-cy="pagination"]')
-    .first()
-    .within(() => {
-      cy.get('#options-menu-bottom-toggle').click();
-      cy.contains('button', `${text} per page`).click();
-    });
-});
-
 Cypress.Commands.add('clickLink', (label: string | RegExp) => {
   cy.containsBy('a', label).click();
 });
@@ -442,7 +433,7 @@ Cypress.Commands.add('selectDetailsPageKebabAction', (dataCy: string) => {
   cy.get('[data-cy="actions-dropdown"]')
     .click()
     .then(() => {
-      cy.clickByDataCy(dataCy);
+      cy.getByDataCy(dataCy).click();
       cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
         cy.get('[data-ouia-component-id="confirm"]').click();
         cy.get('[data-ouia-component-id="submit"]').click();
@@ -457,7 +448,7 @@ Cypress.Commands.add(
       cy.get('[data-cy*="actions-dropdown"]')
         .click()
         .then(() => {
-          cy.clickByDataCy(dataCyLabel);
+          cy.getByDataCy(dataCyLabel).click();
         });
     });
   }

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -114,68 +114,99 @@ declare global {
       /** Contains by selector, making sure it is not disabled or hidden */
       containsBy(selector: string, text: string | number | RegExp): Chainable<JQuery<HTMLElement>>;
 
-      /** @deprecated use cy.getBy('selector').click() */
-      clickByDataCy(dataCy: string): Chainable<void>;
-
-      /** Type input by selector, making sure it is not disabled or hidden */
-      /** @deprecated use cy.getBy('selector').type("text") */
-      typeBy(selector: string, text: string): Chainable<void>;
-
-      /** Type input by data-cy attribute, making sure it is not disabled or hidden */
-      /** @deprecated use cy.getByDataCy('dataCy').type("text") */
-      typeByDataCy(dataCy: string, text: string): Chainable<void>;
-
-      /**
-       * Select a value from a single select input by selector, making sure it is not disabled or hidden.
-       * - Opens the dropdown
-       * - Loads all items if it is an async select
-       * - Searches for the value
-       * - Selects the value
-       * - Closes the dropdown
-       */
-      singleSelectBy(selector: string, value: string): Chainable<void>;
-
-      /**
-       * Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden.
-       * - Opens the dropdown
-       * - Loads all items if it is an async select
-       * - Searches for the value
-       * - Selects the value
-       * - Closes the dropdown
-       */
-      singleSelectByDataCy(dataCy: string, value: string): Chainable<void>;
-
-      /**
-       * Select a value from a multi select input by selector, making sure it is not disabled or hidden.
-       * - Opens the dropdown
-       * - Loads all items if it is an async select
-       * - Searches for the value
-       * - Selects the value
-       * - Closes the dropdown
-       */
-      multiSelectBy(selector: string, value: string): Chainable<void>;
-
-      /**
-       * Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden.
-       * - Opens the dropdown
-       * - Loads all items if it is an async select
-       * - Searches for the value
-       * - Selects the value
-       * - Closes the dropdown
-       */
-      multiSelectByDataCy(dataCy: string, value: string): Chainable<void>;
-
-      /** Used internally to load all items in the singleSelectBy and multiSelectBy commands */
-      selectLoadAll(): Chainable<void>;
+      /** Contains by data-cy attribute, making sure it is not disabled or hidden */
+      containsByDataCy(
+        dataCy: string,
+        text: string | number | RegExp
+      ): Chainable<JQuery<HTMLElement>>;
 
       // ==============================================================================================================
       // Input Commands
       // ==============================================================================================================
 
-      /** @deprecated use cy.getBy('selector').click() */
+      /**
+       * Select a value from a single select input by selector, making sure it is not disabled or hidden.
+       *
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       *
+       * @example Select inventory
+       * ```
+       * cy.singleSelectBy('#inventory-select', 'inventory1');
+       * ```
+       *
+       * @param selector - The selector of the single select input
+       * @param value - The value to select
+       */
+      singleSelectBy(selector: string, value: string): Chainable<void>;
+
+      /**
+       * Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden.
+       *
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       *
+       * @example Select inventory
+       * ```
+       * cy.singleSelectByDataCy('inventory-select', 'inventory1');
+       * ```
+       *
+       * @param dataCy - The data-cy attribute of the single select input
+       * @param value - The value to select
+       */
+      singleSelectByDataCy(dataCy: string, value: string): Chainable<void>;
+
+      /**
+       * Select a value from a multi select input by selector, making sure it is not disabled or hidden.
+       *
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the values
+       * - Closes the dropdown
+       *
+       * @example Adding uses to a team
+       * ```
+       * cy.multiSelectByDataCy('#user-select', ['user1', 'user2']);
+       * ```
+       *
+       * @param selector - The selector of the multi select input
+       * @param values - The values to select
+       */
+      multiSelectBy(selector: string, values: string[]): Chainable<void>;
+
+      /**
+       * Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden.
+       *
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the values
+       * - Closes the dropdown
+       *
+       * @example Adding uses to a team
+       * ```
+       * cy.multiSelectByDataCy('user-select', ['user1', 'user2']);
+       * ```
+       *
+       * @param dataCy - The data-cy attribute of the multi select input
+       * @param values - The values to select
+       */
+      multiSelectByDataCy(dataCy: string, values: string[]): Chainable<void>;
+
+      /** Used internally to load all items in the singleSelectBy and multiSelectBy commands */
+      selectLoadAll(): Chainable<void>;
+
+      /** @deprecated use cy.containsBy('a', 'label').click() or cy.getByDataCy */
       clickLink(label: string | RegExp): Chainable<void>;
 
-      /** @deprecated use cy.getBy('selector').click() */
+      /** @deprecated use cy.containsBy('button', 'label').click() or cy.getByDataCy */
       clickButton(label: string | RegExp): Chainable<void>;
 
       /** Finds a tooltip by its label. Does not make an assertion. */
@@ -221,6 +252,12 @@ declare global {
 
       selectMultiSelectOption(selector: string, label: string | RegExp): Chainable<void>;
 
+      searchAndDisplayResource(resourceName: string): Chainable<void>;
+
+      // ==============================================================================================================
+      // Table Commands
+      // ==============================================================================================================
+
       /**
        * Find the toolbar filter select, click it and returns the opened menu element.
        *
@@ -233,45 +270,193 @@ declare global {
        */
       openToolbarFilterTypeSelect(): Chainable<JQuery<HTMLElement>>;
 
-      searchAndDisplayResource(resourceName: string): Chainable<void>;
-
-      // ==============================================================================================================
-      // Table Commands
-      // ==============================================================================================================
-
+      /** @deprecated use cy.contains('th', 'text').click() */
       clickTableHeader(name: string | RegExp): Chainable<void>;
 
-      setTableView(viewType: string): Chainable<void>;
-      setTablePageSize(text: '10' | '20' | '50' | '100'): Chainable<void>;
+      setTableView(
+        view: 'table' | 'list' | 'cards',
+        options?: { ignoreNotFound?: boolean }
+      ): Chainable<void>;
 
-      /** Change the current filter type in the table toolbar. */
-      selectToolbarFilterType(filterLabel: string | RegExp): Chainable<void>;
+      setTablePageSize(text: string): Chainable<void>;
 
-      getFiltersToolbarItem(): Chainable<JQuery<HTMLElement>>;
+      /** Select the active table toolbar filter by data-cy */
+      selectTableFilter(dataCy: string): Chainable<void>;
 
-      filterTableByTextFilter(text: string): Chainable<void>;
+      /**
+       * Select the active table toolbar filter by label
+       * @deprecated prefer cy.selectTableFilter instead which uses data-cy
+       */
+      selectToolbarFilterByLabel(label: string | RegExp): Chainable<void>;
+
+      /**
+       * Filters the table by using a filter that has a text input.
+       * This is used when the filter is a text input.
+       * @example
+       * ```
+       * cy.filterTableByText('name', organization.name);
+       * cy.filterTableByText('description', organization.description);
+       * ```
+       */
       filterTableByTextFilter(filterDataCy: string, text: string): Chainable<void>;
 
+      /** @deprecated use cy.filterTableByText2 instead */
+      filterTableByText(text: string, variant?: 'SingleText' | 'MultiText'): Chainable<void>;
+
+      /**
+       * Filters the table by using a filter that has a single select input.
+       * This is used when the filter is a single select dropdown.
+       * @example
+       * ```
+       * cy.filterTableBySingleSelect('status', "Success");
+       * cy.filterTableBySingleSelect('status', "Pending");
+       * ```
+       */
+      filterTableBySingleSelect(filterDataCy: string, optionLabel: string): Chainable<void>;
+
+      /**
+       * Filters the table by using a filter that has a multi select input.
+       * This is used when the filter is a multi select dropdown.
+       * @example
+       * ```
+       * cy.filterTableByMultiSelect('status', ["Success", "Pending"]);
+       * ```
+       */
+      filterTableByMultiSelect(filterDataCy: string, optionLabels: string[]): Chainable<void>;
+
+      /**
+       * Gets a table row containing the specified text for the specified column.
+       *
+       * @example
+       * ```
+       * cy.getTableRow('name', organization.name).within(() => {});
+       * cy.getTableRow('id', organization.id).within(() => {});
+       * ```
+       *
+       * @param columnDataCy - The data-cy attribute of the column to filter by.
+       * @param text - The text to search for in the column.
+       * @param options.disableFilter - This should not be used in general.
+       *
+       * @note Filtering will use the filter that has the same data-cy as the columnDataCy.
+       */
+      getTableRow(
+        columnDataCy: string,
+        text: string,
+        options?: { disableFilter?: boolean }
+      ): Chainable<JQuery<HTMLTableRowElement>>;
+
+      /**
+       * Gets a table cell containing the specified text for the specified column.
+       *
+       * @example
+       * ```
+       * cy.getTableCell('name', organization.name).within(() => {
+       *  cy.get('a').click();
+       * });
+       * ```
+       *
+       * @param cellDataCy - The data-cy attribute of the column to filter by.
+       * @param text - The text to search for in the column.
+       * @param options.disableFilter - This should not be used in general.
+       *
+       * @note Filtering will use the filter that has the same data-cy as the columnDataCy.
+       */
+      getTableCell(
+        cellDataCy: string,
+        text: string,
+        options?: { disableFilter?: boolean }
+      ): Chainable<JQuery<HTMLTableRowElement>>;
+
+      /**
+       * Click the link in the table row that contains the specified text for the specified column.
+       * Often used to navigate to a detail page.
+       *
+       * @example
+       * ```
+       * cy.clickTableRowLink('name', organization.name)
+       * ```
+       *
+       * @param columnDataCy - The data-cy attribute of the column to filter by.
+       * @param text - The text to search for in the column.
+       * @param options.disableFilter - This should not be used in general.
+       *
+       * @note Filtering will use the filter that has the same data-cy as the columnDataCy.
+       */
+      clickTableRowLink(columnDataCy: string, text: string, options?: { disableFilter?: boolean });
+
+      /**
+       * Click and action in a kebab dropdown
+       *
+       * @example
+       * ```
+       * cy.clickKebabAction('kebab-dropdown', 'edit')
+       * ```
+       *
+       * @param kebabDataCy - The data-cy attribute of the kebab dropdown.
+       * @param actionDataCy - The data-cy attribute of the action to click.
+       */
+      clickKebabAction(kebabDataCy: string, actionDataCy: string): Chainable<void>;
+
+      /**
+       * Click the action in the table row that contains the specified text for the specified column.
+       *
+       * @example
+       * ```
+       * cy.clickTableRowAction('name', organization.name, 'edit')
+       * cy.clickTableRowAction('name', organization.name, 'delete', { inKebab: true })
+       * ```
+       *
+       * @param columnDataCy - The data-cy attribute of the column to filter by.
+       * @param text - The text to search for in the column.
+       * @param actionDataCy - The data-cy attribute of the action to click.
+       * @param options.inKebab - Indicates that the action is in a kebab dropdown.
+       * @param options.disableFilter - This should not be used in general.
+       *
+       * @note Filtering will use the filter that has the same data-cy as the columnDataCy.
+       */
+      clickTableRowAction(
+        columnDataCy: string,
+        text: string,
+        actionDataCy: string,
+        options?: { inKebab?: boolean; disableFilter?: boolean }
+      );
+
+      /** Selects a table row by clicking on the row checkbox. */
+      selectTableRowNew(
+        columnDataCy: string,
+        text: string,
+        options?: { disableFilter?: boolean }
+      ): Chainable<void>;
+
+      /** @deprecated use cy.getTableRow instead */
+      clickTableRow(name: string | RegExp, filter?: boolean): Chainable<void>;
+
+      /** @deprecated use cy.getTableRow instead */
+      getTableRowByText(
+        name: string | RegExp,
+        filter?: boolean,
+        variant?: 'MultiText' | 'SingleText'
+      ): Chainable<void>;
+
+      /** @deprecated use cy.filterTableBySelect instead */
       filterBySingleSelection(
         filterType: RegExp | string,
         selectLabel: RegExp | string
       ): Chainable<void>;
 
+      /** @deprecated use cy.filterTableBySelect instead */
       filterByMultiSelection(
         filterType: RegExp | string,
         selectLabel: RegExp | string
       ): Chainable<void>;
 
-      /** Filter the table using it's current filter by entering text. */
-      filterTableByText(text: string, variant?: 'SingleText' | 'MultiText'): Chainable<void>;
-
-      /** Filter the table using it's current filter by entering text in 'ToolbarFilterType.SingleText' filter. */
+      /** @deprecated use cy.filterTableBySelect instead */
       filterTableBySingleText(text: string, disableWait?: boolean): Chainable<void>;
 
-      /** Filter the table using specified filter and text. */
+      /** @deprecated use cy.filterTableByText instead */
       filterTableByTypeAndText(filterLabel: string | RegExp, text: string): Chainable<void>;
 
-      /** Filter the table using specified filter and text with 'ToolbarFilterType.SingleText' filter. */
+      /** @deprecated use cy.filterTableByText instead */
       filterTableByTypeAndSingleText(
         filterLabel: string | RegExp,
         text: string,
@@ -282,13 +467,6 @@ declare global {
 
       /** Click an action in the table toolbar kebab dropdown actions menu. */
       clickToolbarKebabAction(dataCy: string): Chainable<void>;
-
-      /** Get the table row containing the specified text. */
-      getTableRowByText(
-        name: string | RegExp,
-        filter?: boolean,
-        variant?: 'MultiText' | 'SingleText'
-      ): Chainable<void>;
 
       /** Get the table row containing the specified text with 'ToolbarFilterType.SingleText' filter. */
       getTableRowBySingleText(name: string | RegExp, filter?: boolean): Chainable<void>;

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
 import { SetOptional, SetRequired } from 'type-fest';
 import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
@@ -71,26 +69,41 @@ import {
 declare global {
   namespace Cypress {
     interface Chainable {
-      // =====================================================================
-      // Core Commands - Commands to help interact with elements ensuring they are not disabled or hidden
-      // Login Commands - Commands to help login to the different applications
-      // Navigation Commands - Commands to help navigate to different pages
-      // Input Commands - Commands to help input data into forms
-      // Table Commands - Commands to help interact with tables
-      // Modal Commands - Commands to help interact with modals
-      // Details Commands - Commands to help interact with details pages
-      // REST API Commands - Commands to help interact with the REST API
-      // AWX Commands - Commands to help interact with AWX
-      // EDA Commands - Commands to help interact with EDA
-      // HUB Commands - Commands to help interact with HUB
-      // =====================================================================
+      // ==============================================================================================================
+      // Login Commands
+      // ==============================================================================================================
 
-      // =====================================================================
+      /** Login to the AWX application */
+      awxLogin(): Chainable<void>;
+
+      /** Login to the EDA application */
+      edaLogin(): Chainable<void>;
+
+      /** Logout of the EDA application */
+      edaLogout(): Chainable<EdaUser | undefined>;
+
+      /** Login to the HUB application */
+      hubLogin(): Chainable<void>;
+
+      /** Check that the required environment variables are set */
+      requiredVariablesAreSet(requiredVariables: string[]): Chainable<void>;
+
+      // ==============================================================================================================
+      // Navigation Commands
+      // ==============================================================================================================
+
+      /**
+       * Navigates to a page of the UI using using the links on the page sidebar.
+       * Intended as an alternative to cy.visit().
+       */
+      navigateTo(component: 'platform' | 'awx' | 'eda' | 'hub', label: string): Chainable<void>;
+
+      /** Locates a title using its label. No assertion is made. */
+      verifyPageTitle(label: string): Chainable<void>;
+
+      // ==============================================================================================================
       // Core Commands
-      // ---------------------------------------------------------------------
-      // Commands to help interact with elements ensuring they are not disabled or hidden.
-      // They are used to interact with the UI in a way that is consistent and reliable.
-      // =====================================================================
+      // ==============================================================================================================
 
       /** Get by selector, making sure it is not disabled or hidden */
       getBy(selector: string): Chainable<JQuery<HTMLElement>>;
@@ -101,74 +114,78 @@ declare global {
       /** Contains by selector, making sure it is not disabled or hidden */
       containsBy(selector: string, text: string | number | RegExp): Chainable<JQuery<HTMLElement>>;
 
-      /** Click by data-cy attribute, making sure it is not disabled or hidden */
+      /** @deprecated use cy.getBy('selector').click() */
       clickByDataCy(dataCy: string): Chainable<void>;
 
       /** Type input by selector, making sure it is not disabled or hidden */
+      /** @deprecated use cy.getBy('selector').type("text") */
       typeBy(selector: string, text: string): Chainable<void>;
 
       /** Type input by data-cy attribute, making sure it is not disabled or hidden */
+      /** @deprecated use cy.getByDataCy('dataCy').type("text") */
       typeByDataCy(dataCy: string, text: string): Chainable<void>;
 
-      /** Select a value from a single select input by selector, making sure it is not disabled or hidden */
+      /**
+       * Select a value from a single select input by selector, making sure it is not disabled or hidden.
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       */
       singleSelectBy(selector: string, value: string): Chainable<void>;
 
-      /** Used internally to load all items in the singleSelectBy command */
-      selectLoadAll(): Chainable<void>;
-
-      /** Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden */
+      /**
+       * Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden.
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       */
       singleSelectByDataCy(dataCy: string, value: string): Chainable<void>;
 
-      /** Select a value from a multi select input by selector, making sure it is not disabled or hidden */
+      /**
+       * Select a value from a multi select input by selector, making sure it is not disabled or hidden.
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       */
       multiSelectBy(selector: string, value: string): Chainable<void>;
 
-      /** Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden */
+      /**
+       * Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden.
+       * - Opens the dropdown
+       * - Loads all items if it is an async select
+       * - Searches for the value
+       * - Selects the value
+       * - Closes the dropdown
+       */
       multiSelectByDataCy(dataCy: string, value: string): Chainable<void>;
 
-      // =====================================================================
-      // Login Commands
-      // ---------------------------------------------------------------------
-      // Commands to help login to the different applications
-      // =====================================================================
+      /** Used internally to load all items in the singleSelectBy and multiSelectBy commands */
+      selectLoadAll(): Chainable<void>;
 
-      /** Login to the AWX application */
-      awxLogin(): Chainable<void>;
-
-      /** Login to the EDA application */
-      edaLogin(): Chainable<void>;
-
-      /** Login to the HUB application */
-      edaLogout(): Chainable<EdaUser | undefined>;
-
-      /** Login to the HUB application */
-      hubLogin(): Chainable<void>;
-
-      /** Check that the required environment variables are set */
-      requiredVariablesAreSet(requiredVariables: string[]): Chainable<void>;
-
-      // --- NAVIGATION COMMANDS ---
-      // createGlobalProject(): Chainable<Project>;
-      /**Navigates to a page of the UI using using the links on the page sidebar. Intended as an alternative to cy.visit(). */
-      navigateTo(component: 'platform' | 'awx' | 'eda' | 'hub', label: string): Chainable<void>;
-
-      /**Locates a title using its label. No assertion is made. */
-      verifyPageTitle(label: string): Chainable<void>;
-
-      // ---- UI COMMANDS ---
-
-      setTableView(viewType: string): Chainable<void>;
-
-      // ---------------------------------------------------------------------
+      // ==============================================================================================================
       // Input Commands
-      // ---------------------------------------------------------------------
+      // ==============================================================================================================
 
-      inputCustomCredTypeConfig(configType: string, config: string): Chainable<void>;
+      /** @deprecated use cy.getBy('selector').click() */
+      clickLink(label: string | RegExp): Chainable<void>;
 
-      configFormatToggle(configType: string): Chainable<void>;
+      /** @deprecated use cy.getBy('selector').click() */
+      clickButton(label: string | RegExp): Chainable<void>;
 
-      assertMonacoTextField(textString: string): Chainable<void>;
+      /** Finds a tooltip by its label. Does not make an assertion. */
+      hasTooltip(label: string | RegExp): Chainable<void>;
 
+      dataEditorSetFormat(configType: string): Chainable<void>;
       dataEditorShouldContain(selector: string, value: string | object): Chainable<void>;
+
+      /** @deprecated use cy.dataEditorShouldContain */
+      assertMonacoTextField(textString: string): Chainable<void>;
 
       /** This command works for a form field to look up item from table
        * (used for components that do not utilize the PageFormAsyncSelect component yet) */
@@ -183,8 +200,6 @@ declare global {
        * */
       selectDropdownOptionByResourceName(resource: string, itemName: string): Chainable<void>;
 
-      selectPromptOnLaunch(resourceName: string): Chainable<void>;
-
       singleSelectShouldHaveSelectedOption(
         selector: string,
         label: string | RegExp
@@ -192,34 +207,19 @@ declare global {
       singleSelectShouldContainOption(selector: string, label: string | RegExp): Chainable<void>;
       selectSingleSelectOption(selector: string, label: string | RegExp): Chainable<void>;
 
-      editNodeInVisualizer(
-        nodeName: string,
-        newNodeType: string,
-        newNodeName?: string
-      ): Chainable<void>;
-
-      removeAllNodesFromVisualizerToolbar(): Chainable<void>;
-      removeNodeInVisualizer(nodeName: string): Chainable<void>;
+      // TODO REMOVE only needed in one test
       multiSelectShouldHaveSelectedOption(
         selector: string,
         label: string | RegExp
       ): Chainable<void>;
+
+      // TODO REMOVE only needed in one test
       multiSelectShouldNotHaveSelectedOption(
         selector: string,
         label: string | RegExp
       ): Chainable<void>;
+
       selectMultiSelectOption(selector: string, label: string | RegExp): Chainable<void>;
-
-      clickTableHeader(name: string | RegExp): Chainable<void>;
-
-      // --- TABLE COMMANDS ---
-
-      /** Change the current filter type in the table toolbar. */
-      selectToolbarFilterType(filterLabel: string | RegExp): Chainable<void>;
-
-      setTablePageSize(text: '10' | '20' | '50' | '100'): Chainable<void>;
-
-      getFiltersToolbarItem(): Chainable<JQuery<HTMLElement>>;
 
       /**
        * Find the toolbar filter select, click it and returns the opened menu element.
@@ -234,6 +234,23 @@ declare global {
       openToolbarFilterTypeSelect(): Chainable<JQuery<HTMLElement>>;
 
       searchAndDisplayResource(resourceName: string): Chainable<void>;
+
+      // ==============================================================================================================
+      // Table Commands
+      // ==============================================================================================================
+
+      clickTableHeader(name: string | RegExp): Chainable<void>;
+
+      setTableView(viewType: string): Chainable<void>;
+      setTablePageSize(text: '10' | '20' | '50' | '100'): Chainable<void>;
+
+      /** Change the current filter type in the table toolbar. */
+      selectToolbarFilterType(filterLabel: string | RegExp): Chainable<void>;
+
+      getFiltersToolbarItem(): Chainable<JQuery<HTMLElement>>;
+
+      filterTableByTextFilter(text: string): Chainable<void>;
+      filterTableByTextFilter(filterDataCy: string, text: string): Chainable<void>;
 
       filterBySingleSelection(
         filterType: RegExp | string,
@@ -263,8 +280,6 @@ declare global {
 
       clearAllFilters(): Chainable<void>;
 
-      selectDetailsPageKebabAction(dataCy: string): Chainable<void>;
-
       /** Click an action in the table toolbar kebab dropdown actions menu. */
       clickToolbarKebabAction(dataCy: string): Chainable<void>;
 
@@ -280,12 +295,6 @@ declare global {
 
       /** Get the list row containing the specified text. */
       getListRowByText(name: string | RegExp, filter?: boolean): Chainable<void>;
-
-      /** Select the create resource option from a toolbar create dropdown button.  ie. AWX template list toolbar **/
-      clickToolbarDropdownCreateButton(
-        createButtonLabel: string | RegExp,
-        createButtonOption: string
-      ): Chainable<void>;
 
       /**
        * Get the list card containing the specified text.
@@ -329,7 +338,28 @@ declare global {
       /**Expands a table row by locating the row using the provided name and thenclicking the "expand-toggle" button on that row.*/
       expandTableRow(name: string | RegExp, filter?: boolean): Chainable<void>;
 
-      // --- MODAL COMMANDS ---
+      /** Selects a table row in the active modal dialog, by clicking on the row checkbox. */
+      selectTableRowInDialog(name: string | RegExp, filter?: boolean): Chainable<void>;
+
+      // ==============================================================================================================
+      // Details Commands
+      // ==============================================================================================================
+
+      selectDetailsPageKebabAction(dataCy: string): Chainable<void>;
+
+      /**Finds a button with a particular label and clicks it. */
+      clickTab(label: string | RegExp, isLink?: boolean): Chainable<void>;
+
+      /**Asserts that a specific detail term (dt) is displayed and contains text fromthe provided detail description (dd)*/
+      hasDetail(detailTerm: string | RegExp, detailDescription: string | RegExp): Chainable<void>;
+
+      clickPageAction(dataCy: string): Chainable<void>;
+
+      // ==============================================================================================================
+      // Modal Commands
+      // ==============================================================================================================
+
+      getModal(): Chainable<JQuery<HTMLElement>>;
 
       /** Clicks a button in the active modal dialog. */
       clickModalButton(label: string | RegExp): Chainable<void>;
@@ -340,32 +370,19 @@ declare global {
       /** Assert that the active modal dialog contains "Success". */
       assertModalSuccess(): Chainable<void>;
 
-      /** Selects a table row in the active modal dialog, by clicking on the row checkbox. */
-      selectTableRowInDialog(name: string | RegExp, filter?: boolean): Chainable<void>;
+      // ==============================================================================================================
+      // Alert Commands
+      // ==============================================================================================================
 
-      getModal(): Chainable<JQuery<HTMLElement>>;
-
-      // --- DETAILS COMMANDS ---
-      /**Finds a button with a particular label and clicks it. */
-      clickTab(label: string | RegExp, isLink?: boolean): Chainable<void>;
-
-      /**Asserts that a specific detail term (dt) is displayed and contains text fromthe provided detail description (dd)*/
-      hasDetail(detailTerm: string | RegExp, detailDescription: string | RegExp): Chainable<void>;
-
-      clickLink(label: string | RegExp): Chainable<void>;
-      clickButton(label: string | RegExp): Chainable<void>;
-
-      clickPageAction(dataCy: string): Chainable<void>;
-
-      /**Finds an alert by its label. Does not make an assertion.  */
+      /** Finds an alert by its label. Does not make an assertion. */
       hasAlert(label: string | RegExp): Chainable<void>;
 
-      /**Finds a tooltip by its label. Does not make an assertion.  */
-      hasTooltip(label: string | RegExp): Chainable<void>;
+      // ==============================================================================================================
+      // REST API Commands
+      // ==============================================================================================================
 
-      // --- REST API COMMANDS ---
+      requestGet<T>(url: string): Chainable<T>;
 
-      /** Sends a request to the API to create a particular resource. */
       requestPost<ResponseT, RequestT = ResponseT>(
         url: string,
         data: Partial<RequestT>
@@ -381,10 +398,6 @@ declare global {
         data: Partial<RequestT>
       ): Chainable<ResponseT>;
 
-      /** Sends a request to the API to get a particular resource. */
-      requestGet<T>(url: string): Chainable<T>;
-
-      /** Sends a request to the API to delete a particular resource. */
       requestDelete(
         url: string,
         options?: {
@@ -393,20 +406,16 @@ declare global {
         }
       ): Chainable;
 
-      /** Sends a request to the API to patch a particular resource. */
-      requestPatch<RequestBodyT extends Cypress.RequestBody, ResponseBodyT = RequestBodyT>(
-        url: string,
-        body: RequestBodyT
-      ): Chainable<ResponseBodyT>;
-
+      /** Polls a GET request to the API until the check function returns a result. */
       requestPoll<ResponseT, ResultT = ResponseT>(options: {
         url: string;
         check: (response: Cypress.Response<ResponseT>) => ResultT | undefined;
         interval?: number;
-        timeout?: number;
       }): Chainable<ResponseT>;
 
-      // --- AWX COMMANDS ---
+      // ==============================================================================================================
+      // AWX Commands
+      // ==============================================================================================================
 
       /**
        * This command is written to allow asynchronous resource creation in an AWX build using
@@ -869,7 +878,22 @@ declare global {
 
       deleteCustomAWXApplicationFromListView(customAppName: string): Chainable<void>;
 
-      // --- EDA COMMANDS ---
+      editNodeInVisualizer(
+        nodeName: string,
+        newNodeType: string,
+        newNodeName?: string
+      ): Chainable<void>;
+
+      removeAllNodesFromVisualizerToolbar(): Chainable<void>;
+      removeNodeInVisualizer(nodeName: string): Chainable<void>;
+
+      inputCustomCredTypeConfig(configType: string, config: string): Chainable<void>;
+
+      selectPromptOnLaunch(resourceName: string): Chainable<void>;
+
+      // ==============================================================================================================
+      // EDA Commands
+      // ==============================================================================================================
 
       /**
        * selects Eda role that is passed inside the role selection modal
@@ -1065,6 +1089,10 @@ declare global {
       deleteEdaDecisionEnvironment(decisionEnvironment: EdaDecisionEnvironment): Chainable<void>;
       waitEdaDESync(edaDE: EdaDecisionEnvironment): Chainable<EdaDecisionEnvironment>;
 
+      // ==============================================================================================================
+      // HUB Commands
+      // ==============================================================================================================
+
       // HUB Request Commands
       hubRequest<T>(options: HubRequestOptions): Cypress.Chainable<Response<T>>;
       hubGetRequest<T>(options: HubGetRequestOptions): Cypress.Chainable<Response<T>>;
@@ -1176,16 +1204,9 @@ declare global {
         repository: string
       ): Cypress.Chainable<void>;
 
-      // =====================================================================
+      // ==============================================================================================================
       // END OF COMMANDS
-      // =====================================================================
-
-      // =====================================================================
-      // Platform Commands
-      // =====================================================================
-
-      // Login to the platform
-      platformLogin(): Chainable<void>;
+      // ==============================================================================================================
     }
   }
 }

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -71,19 +71,26 @@ import {
 declare global {
   namespace Cypress {
     interface Chainable {
-      edaLogout(): Chainable<EdaUser | undefined>;
-      awxLogin(): Chainable<void>;
-      edaLogin(): Chainable<void>;
-      hubLogin(): Chainable<void>;
-      platformLogin(): Chainable<void>;
-      requiredVariablesAreSet(requiredVariables: string[]): Chainable<void>;
+      // =====================================================================
+      // Core Commands - Commands to help interact with elements ensuring they are not disabled or hidden
+      // Login Commands - Commands to help login to the different applications
+      // Navigation Commands - Commands to help navigate to different pages
+      // Input Commands - Commands to help input data into forms
+      // Table Commands - Commands to help interact with tables
+      // Modal Commands - Commands to help interact with modals
+      // Details Commands - Commands to help interact with details pages
+      // REST API Commands - Commands to help interact with the REST API
+      // AWX Commands - Commands to help interact with AWX
+      // EDA Commands - Commands to help interact with EDA
+      // HUB Commands - Commands to help interact with HUB
+      // =====================================================================
 
-      // ---------------------------------------------------------------------
+      // =====================================================================
       // Core Commands
       // ---------------------------------------------------------------------
-      // These commands are the core commands that are used to interact with the UI.
+      // Commands to help interact with elements ensuring they are not disabled or hidden.
       // They are used to interact with the UI in a way that is consistent and reliable.
-      // They check that the element is not disabled or hidden before interacting with it.
+      // =====================================================================
 
       /** Get by selector, making sure it is not disabled or hidden */
       getBy(selector: string): Chainable<JQuery<HTMLElement>>;
@@ -106,6 +113,7 @@ declare global {
       /** Select a value from a single select input by selector, making sure it is not disabled or hidden */
       singleSelectBy(selector: string, value: string): Chainable<void>;
 
+      /** Used internally to load all items in the singleSelectBy command */
       selectLoadAll(): Chainable<void>;
 
       /** Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden */
@@ -116,6 +124,27 @@ declare global {
 
       /** Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden */
       multiSelectByDataCy(dataCy: string, value: string): Chainable<void>;
+
+      // =====================================================================
+      // Login Commands
+      // ---------------------------------------------------------------------
+      // Commands to help login to the different applications
+      // =====================================================================
+
+      /** Login to the AWX application */
+      awxLogin(): Chainable<void>;
+
+      /** Login to the EDA application */
+      edaLogin(): Chainable<void>;
+
+      /** Login to the HUB application */
+      edaLogout(): Chainable<EdaUser | undefined>;
+
+      /** Login to the HUB application */
+      hubLogin(): Chainable<void>;
+
+      /** Check that the required environment variables are set */
+      requiredVariablesAreSet(requiredVariables: string[]): Chainable<void>;
 
       // --- NAVIGATION COMMANDS ---
       // createGlobalProject(): Chainable<Project>;
@@ -1146,6 +1175,17 @@ declare global {
         namespaceName: string,
         repository: string
       ): Cypress.Chainable<void>;
+
+      // =====================================================================
+      // END OF COMMANDS
+      // =====================================================================
+
+      // =====================================================================
+      // Platform Commands
+      // =====================================================================
+
+      // Login to the platform
+      platformLogin(): Chainable<void>;
     }
   }
 }

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -300,7 +300,7 @@ declare global {
        */
       filterTableByTextFilter(filterDataCy: string, text: string): Chainable<void>;
 
-      /** @deprecated use cy.filterTableByText2 instead */
+      /** @deprecated use cy.filterTableByTextFilter instead */
       filterTableByText(text: string, variant?: 'SingleText' | 'MultiText'): Chainable<void>;
 
       /**

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -422,7 +422,7 @@ declare global {
       );
 
       /** Selects a table row by clicking on the row checkbox. */
-      selectTableRowNew(
+      selectTableRowCheckbox(
         columnDataCy: string,
         text: string,
         options?: { disableFilter?: boolean }

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -10,10 +10,6 @@ Cypress.Commands.add('searchAndDisplayResource', (resourceName: string) => {
     });
 });
 
-Cypress.Commands.add('getFiltersToolbarItem', () => {
-  cy.get('#filter').parent().parent().parent().parent();
-});
-
 Cypress.Commands.add('getListRowByText', (name: string | RegExp, filter?: boolean) => {
   if (filter !== false && typeof name === 'string') {
     cy.filterTableByText(name);
@@ -26,12 +22,6 @@ Cypress.Commands.add('openToolbarFilterTypeSelect', () => {
   cy.get('#filter-select');
 });
 
-Cypress.Commands.add('selectToolbarFilterType', (text: string | RegExp) => {
-  cy.openToolbarFilterTypeSelect().within(() => {
-    cy.clickButton(text);
-  });
-});
-
 Cypress.Commands.add(
   'filterTableByText',
   (text: string, variant: 'SingleText' | 'MultiText' = 'MultiText') => {
@@ -39,34 +29,11 @@ Cypress.Commands.add(
       cy.get('input').clear().type(text, { delay: 0 });
     });
     if (variant === 'MultiText') {
-      cy.clickByDataCy('apply-filter');
+      cy.getByDataCy('apply-filter').click();
     }
     cy.contains('.pf-v5-c-chip__text', text);
   }
 );
-
-Cypress.Commands.add('filterTableByTextFilter', (param1: string, param2?: string) => {
-  // Change filter type if needed
-  const selector = param2 ? param1 : undefined;
-  if (selector) {
-    cy.selectToolbarFilterType(selector);
-  }
-
-  // Filter by text
-  const text = param2 ? param2 : param1;
-  cy.getFiltersToolbarItem().within(() => {
-    cy.get('[data-cy="text-input"]').within(() => {
-      cy.get('input').clear().type(text, { delay: 0 });
-    });
-  });
-
-  // Only click the apply filter if it is a multi text filter
-  cy.get('[data-cy="apply-filter"]').then((jqueryResult) => {
-    if (jqueryResult.length === 1 && jqueryResult[0].tagName === 'BUTTON') {
-      jqueryResult[0].click();
-    }
-  });
-});
 
 Cypress.Commands.add('filterTableBySingleText', (text: string, disableWait?: boolean) => {
   cy.filterTableByText(text, 'SingleText');
@@ -77,14 +44,14 @@ Cypress.Commands.add('filterTableBySingleText', (text: string, disableWait?: boo
 });
 
 Cypress.Commands.add('filterTableByTypeAndText', (filterLabel: string | RegExp, text: string) => {
-  cy.selectToolbarFilterType(filterLabel);
+  cy.selectToolbarFilterByLabel(filterLabel);
   cy.filterTableByText(text);
 });
 
 Cypress.Commands.add(
   'filterTableByTypeAndSingleText',
   (filterLabel: string | RegExp, text: string) => {
-    cy.selectToolbarFilterType(filterLabel);
+    cy.selectToolbarFilterByLabel(filterLabel);
     cy.filterTableByText(text, 'SingleText');
   }
 );
@@ -103,7 +70,7 @@ Cypress.Commands.add('clearAllFilters', () => {
 Cypress.Commands.add(
   'filterBySingleSelection',
   (filterType: RegExp | string, selectLabel: RegExp | string) => {
-    cy.selectToolbarFilterType(filterType);
+    cy.selectToolbarFilterByLabel(filterType);
     cy.get('#filter-input').click();
     cy.get('#filter-input-select').within(() => {
       cy.contains(selectLabel).click();
@@ -114,7 +81,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'filterByMultiSelection',
   (filterType: RegExp | string, selectLabel: RegExp | string) => {
-    cy.selectToolbarFilterType(filterType);
+    cy.selectToolbarFilterByLabel(filterType);
     cy.get('#filter-input').click();
     cy.get('#filter-input-select').within(() => {
       cy.contains(selectLabel).click();

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -43,6 +43,30 @@ Cypress.Commands.add(
     }
   }
 );
+
+Cypress.Commands.add('filterTableByTextFilter', (param1: string, param2?: string) => {
+  // Change filter type if needed
+  const selector = param2 ? param1 : undefined;
+  if (selector) {
+    cy.selectToolbarFilterType(selector);
+  }
+
+  // Filter by text
+  const text = param2 ? param2 : param1;
+  cy.getFiltersToolbarItem().within(() => {
+    cy.get('[data-cy="text-input"]').within(() => {
+      cy.get('input').clear().type(text, { delay: 0 });
+    });
+  });
+
+  // Only click the apply filter if it is a multi text filter
+  cy.get('[data-cy="apply-filter"]').then((jqueryResult) => {
+    if (jqueryResult.length === 1 && jqueryResult[0].tagName === 'BUTTON') {
+      jqueryResult[0].click();
+    }
+  });
+});
+
 Cypress.Commands.add('filterTableBySingleText', (text: string, disableWait?: boolean) => {
   cy.filterTableByText(text, 'SingleText');
   // TODO - this should be in future better sync, but for now, we need to have tests more stable

--- a/cypress/support/core-commands.ts
+++ b/cypress/support/core-commands.ts
@@ -1,93 +1,39 @@
-// ---------------------------------------------------------------------
-// Core Commands
-// ---------------------------------------------------------------------
-// These commands are the core commands that are used to interact with the UI.
-// They are used to interact with the UI in a way that is consistent and reliable.
-// They check that the element is not disabled or hidden before interacting with it.
-
-/** Get by selector, making sure it is not disabled or hidden */
 Cypress.Commands.add('getBy', (selector: string) => {
   cy.get(selector)
     .should('not.be.disabled')
     .should('not.have.attr', 'aria-disabled', 'true')
     .should('not.be.hidden')
     .should('be.visible');
+
+  // The following line is necessary to avoid flakiness in the tests
+  // It's a workaround when the element is found and while assertions are running, the element is replaced
   cy.get(selector);
 });
 
-/** Get by data-cy attribute, making sure it is not disabled or hidden */
 Cypress.Commands.add('getByDataCy', (dataCy: string) => {
   cy.getBy(`[data-cy="${dataCy}"]`);
 });
 
-/** Contains by selector, making sure it is not disabled or hidden */
 Cypress.Commands.add('containsBy', (selector: string, text: string | number | RegExp) => {
   cy.contains(selector, text)
     .should('not.be.disabled')
     .should('not.have.attr', 'aria-disabled', 'true')
     .should('not.be.hidden')
     .should('be.visible');
+
+  // The following line is necessary to avoid flakiness in the tests
+  // It's a workaround when the element is found and while assertions are running, the element is replaced
   cy.contains(selector, text);
 });
 
-/** Click by data-cy attribute, making sure it is not disabled or hidden */
-Cypress.Commands.add('clickByDataCy', (dataCy: string) => {
-  cy.getBy(`[data-cy="${dataCy}"]`).click();
-});
+Cypress.Commands.add('containsByDataCy', (dataCy: string, text: string | number | RegExp) => {
+  cy.contains(`[data-cy="${dataCy}"]`, text)
+    .should('not.be.disabled')
+    .should('not.have.attr', 'aria-disabled', 'true')
+    .should('not.be.hidden')
+    .should('be.visible');
 
-/** Type input by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('typeBy', (selector: string, text: string) => {
-  cy.getBy(selector).type(text);
-});
-
-/** Type input by data-cy attribute, making sure it is not disabled or hidden */
-Cypress.Commands.add('typeByDataCy', (dataCy: string, text: string) => {
-  cy.typeBy(`[data-cy="${dataCy}"]`, text);
-});
-
-Cypress.Commands.add('selectLoadAll', () => {
-  cy.get('#loading').should('not.exist');
-  cy.get('button').then((buttons) => {
-    for (let i = 0; i <= buttons.length; i++) {
-      const button = buttons[i];
-      if (button?.innerText === 'Load more') {
-        button.click();
-        cy.selectLoadAll();
-      }
-    }
-  });
-});
-
-/** Select a value from a single select input by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('singleSelectBy', (selector: string, value: string) => {
-  cy.getBy(selector).click();
-  cy.get('.pf-v5-c-menu__content').within(() => {
-    cy.selectLoadAll();
-    cy.getByDataCy('search-input').type(value);
-    cy.contains('.pf-v5-c-menu__item-text', value).parent().click();
-  });
-});
-
-/** Select a value from a single select input by data-cy attribute, making sure it is not disabled or hidden */
-Cypress.Commands.add('singleSelectByDataCy', (dataCy: string, value: string) => {
-  cy.singleSelectBy(`[data-cy="${dataCy}"]`, value);
-});
-
-/** Select a value from a multi select input by selector, making sure it is not disabled or hidden */
-Cypress.Commands.add('multiSelectBy', (selector: string, value: string) => {
-  cy.getBy(selector).click();
-  cy.get('.pf-v5-c-menu__content').within(() => {
-    cy.selectLoadAll();
-    cy.getByDataCy('search-input').type(value);
-    cy.contains('.pf-v5-c-menu__item-text', value)
-      .parent()
-      .within(() => {
-        cy.get('input').click();
-      });
-  });
-});
-
-/** Select a value from a multi select input by data-cy attribute, making sure it is not disabled or hidden */
-Cypress.Commands.add('multiSelectByDataCy', (dataCy: string, value: string) => {
-  cy.multiSelectBy(`[data-cy="${dataCy}"]`, value);
+  // The following line is necessary to avoid flakiness in the tests
+  // It's a workaround when the element is found and while assertions are running, the element is replaced
+  cy.contains(`[data-cy="${dataCy}"]`, text);
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -13,7 +13,9 @@ import './e2e';
 import './eda-commands';
 import { hubAPI } from './formatApiPathForHub';
 import './hub-commands';
+import './input-commands';
 import './rest-commands';
+import './table-commands';
 
 export const galaxykitUsername: string = `e2e-${randomString(4)}`;
 export const galaxykitPassword: string = randomString(9);
@@ -71,3 +73,5 @@ Cypress.on('uncaught:exception', (_err, _runnable) => {
   // fixes problems with monaco loading workers
   return false;
 });
+
+// Cypress.Keyboard.defaults({ keystrokeDelay: 0 });

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -211,7 +211,7 @@ Cypress.Commands.add('addAndApproveMultiCollections', (numberOfCollections = 1) 
   const approveMultiCollections = (namespace: string) => {
     cy.visit('/administration/approvals?page=1&perPage=100');
     cy.verifyPageTitle('Collection Approvals');
-    cy.selectToolbarFilterType('Namespace');
+    cy.selectToolbarFilterByLabel('Namespace');
     cy.intercept(
       'GET',
       hubAPI`/v3/plugin/ansible/search/collection-versions/?repository_label=pipeline=staging&namespace=${namespace}&order_by=namespace&offset=0&limit=100`

--- a/cypress/support/input-commands.ts
+++ b/cypress/support/input-commands.ts
@@ -46,13 +46,10 @@ Cypress.Commands.add('multiSelectByDataCy', (dataCy: string, values: string[]) =
 
 Cypress.Commands.add('selectLoadAll', () => {
   cy.get('#loading').should('not.exist');
-  cy.get('button').then((buttons) => {
-    for (let i = 0; i <= buttons.length; i++) {
-      const button = buttons[i];
-      if (button?.innerText === 'Load more') {
-        button.click();
-        cy.selectLoadAll();
-      }
+  cy.get('#load-more').then(($el) => {
+    if ($el.length) {
+      $el[0].click();
+      cy.selectLoadAll();
     }
   });
 });

--- a/cypress/support/input-commands.ts
+++ b/cypress/support/input-commands.ts
@@ -1,0 +1,58 @@
+Cypress.Commands.add('singleSelectBy', (selector: string, value: string) => {
+  cy.getBy(selector).click();
+  // PF Selects open the menu at the body level
+  // We need to use document() to get the body of the page
+  // and then find the .pf-v5-c-menu__content within that body
+  // This fixes the issue where this command would fail inside a within() block
+  cy.document()
+    .its('body')
+    .find('.pf-v5-c-menu__content')
+    .within(() => {
+      cy.selectLoadAll();
+      cy.getByDataCy('search-input').type(value);
+      cy.contains('.pf-v5-c-menu__item-text', value).parent().click();
+    });
+});
+
+Cypress.Commands.add('singleSelectByDataCy', (dataCy: string, value: string) => {
+  cy.singleSelectBy(`[data-cy="${dataCy}"]`, value);
+});
+
+Cypress.Commands.add('multiSelectBy', (selector: string, values: string[]) => {
+  cy.getBy(selector).click();
+  // PF Selects open the menu at the body level
+  // We need to use document() to get the body of the page
+  // and then find the .pf-v5-c-menu__content within that body
+  // This fixes the issue where this command would fail inside a within() block
+  cy.document()
+    .its('body')
+    .find('.pf-v5-c-menu__content')
+    .within(() => {
+      cy.selectLoadAll();
+      for (const value of values) {
+        cy.getByDataCy('search-input').clear().type(value);
+        cy.contains('.pf-v5-c-menu__item-text', value)
+          .parent()
+          .within(() => {
+            cy.get('input').click();
+          });
+      }
+    });
+});
+
+Cypress.Commands.add('multiSelectByDataCy', (dataCy: string, values: string[]) => {
+  cy.multiSelectBy(`[data-cy="${dataCy}"]`, values);
+});
+
+Cypress.Commands.add('selectLoadAll', () => {
+  cy.get('#loading').should('not.exist');
+  cy.get('button').then((buttons) => {
+    for (let i = 0; i <= buttons.length; i++) {
+      const button = buttons[i];
+      if (button?.innerText === 'Load more') {
+        button.click();
+        cy.selectLoadAll();
+      }
+    }
+  });
+});

--- a/cypress/support/input-commands.ts
+++ b/cypress/support/input-commands.ts
@@ -46,10 +46,13 @@ Cypress.Commands.add('multiSelectByDataCy', (dataCy: string, values: string[]) =
 
 Cypress.Commands.add('selectLoadAll', () => {
   cy.get('#loading').should('not.exist');
-  cy.get('#load-more').then(($el) => {
-    if ($el.length) {
-      $el[0].click();
-      cy.selectLoadAll();
-    }
+  cy.document().then((document) => {
+    document.body.querySelectorAll('.pf-v5-c-menu__content').forEach((menu) => {
+      const loadMore = menu.querySelector('#load-more');
+      if (loadMore) {
+        loadMore.dispatchEvent(new Event('click', { bubbles: true }));
+        cy.selectLoadAll();
+      }
+    });
   });
 });

--- a/cypress/support/table-commands.ts
+++ b/cypress/support/table-commands.ts
@@ -71,8 +71,8 @@ Cypress.Commands.add('filterTableByTextFilter', (filterDataCy: string, text: str
       cy.get('input').clear().type(text, { delay: 0 });
     });
     // Only click the apply filter if it is a multi text filter
-    cy.get('[data-cy="apply-filter"]').then((jqueryResult) => {
-      if (jqueryResult.length === 1 && jqueryResult[0].tagName === 'BUTTON') {
+    cy.get('button').then((jqueryResult) => {
+      if (jqueryResult.length === 1 && jqueryResult[0].getAttribute('data-cy') === 'apply-filter') {
         jqueryResult[0].click();
       }
     });
@@ -85,19 +85,12 @@ Cypress.Commands.add('filterTableByTextFilter', (filterDataCy: string, text: str
 
 Cypress.Commands.add('filterTableBySingleSelect', (filterDataCy: string, optionLabel: string) => {
   cy.selectTableFilter(filterDataCy);
-  cy.get('.pf-v5-c-menu__content').within(() => {
-    cy.contains('.pf-v5-c-menu__item-text', optionLabel).click();
-  });
+  cy.singleSelectByDataCy('filter-input', optionLabel);
 });
 
 Cypress.Commands.add('filterTableByMultiSelect', (filterDataCy: string, optionLabels: string[]) => {
   cy.selectTableFilter(filterDataCy);
-  cy.get('.pf-v5-c-menu__content').within(() => {
-    for (const optionLabel of optionLabels) {
-      cy.contains('.pf-v5-c-menu__item-text', optionLabel).click();
-    }
-  });
-  cy.get('.pf-v5-c-menu__content').click('topRight');
+  cy.multiSelectByDataCy('filter-input', optionLabels);
 });
 
 Cypress.Commands.add(

--- a/cypress/support/table-commands.ts
+++ b/cypress/support/table-commands.ts
@@ -1,0 +1,169 @@
+Cypress.Commands.add(
+  'setTableView',
+  (
+    view: 'table' | 'list' | 'cards',
+    options?: {
+      ignoreNotFound?: boolean;
+    }
+  ) => {
+    cy.get('table').should('exist');
+    if (options?.ignoreNotFound) {
+      cy.get('button').then((jqueryResult) => {
+        if (jqueryResult.length === 0) {
+          return;
+        }
+
+        if (jqueryResult.length === 1) {
+          if (jqueryResult[0].getAttribute('data-cy') === `${view}-view`) {
+            jqueryResult[0].click();
+          }
+          return;
+        }
+
+        for (let i = 0; i < jqueryResult.length; i++) {
+          if (jqueryResult[i].getAttribute('data-cy') === `${view}-view`) {
+            jqueryResult[i].click();
+            break;
+          }
+        }
+      });
+    } else {
+      cy.getByDataCy(`${view}-view`).within(() => {
+        cy.get('button').click();
+      });
+    }
+  }
+);
+
+Cypress.Commands.add('setTablePageSize', (text: string) => {
+  cy.get('[data-cy="pagination"]')
+    .first()
+    .within(() => {
+      cy.get('#options-menu-bottom-toggle').click();
+      cy.contains('button', `${text} per page`).click();
+    });
+});
+
+Cypress.Commands.add('selectTableFilter', (dataCy: string) => {
+  cy.get('#filter').click();
+  // PF Selects open the menu at the body level
+  // We need to use document() to get the body of the page
+  // and then find the filter-select within that body
+  // This fixes the issue where this command would fail inside a within() block
+  cy.document()
+    .its('body')
+    .find('#filter-select')
+    .within(() => {
+      cy.getByDataCy(dataCy).click();
+    });
+});
+
+Cypress.Commands.add('selectToolbarFilterByLabel', (text: string | RegExp) => {
+  cy.openToolbarFilterTypeSelect().within(() => {
+    cy.clickButton(text);
+  });
+});
+
+Cypress.Commands.add('filterTableByTextFilter', (filterDataCy: string, text: string) => {
+  cy.selectTableFilter(filterDataCy);
+  cy.get('#filters').within(() => {
+    cy.get('#filter-input').within(() => {
+      cy.get('input').clear().type(text, { delay: 0 });
+    });
+    // Only click the apply filter if it is a multi text filter
+    cy.get('[data-cy="apply-filter"]').then((jqueryResult) => {
+      if (jqueryResult.length === 1 && jqueryResult[0].tagName === 'BUTTON') {
+        jqueryResult[0].click();
+      }
+    });
+  });
+
+  // Wait for the chip to show up
+  // This handles the debounce of the single text filter
+  cy.contains('.pf-v5-c-chip__text', text);
+});
+
+Cypress.Commands.add('filterTableBySingleSelect', (filterDataCy: string, optionLabel: string) => {
+  cy.selectTableFilter(filterDataCy);
+  cy.get('.pf-v5-c-menu__content').within(() => {
+    cy.contains('.pf-v5-c-menu__item-text', optionLabel).click();
+  });
+});
+
+Cypress.Commands.add('filterTableByMultiSelect', (filterDataCy: string, optionLabels: string[]) => {
+  cy.selectTableFilter(filterDataCy);
+  cy.get('.pf-v5-c-menu__content').within(() => {
+    for (const optionLabel of optionLabels) {
+      cy.contains('.pf-v5-c-menu__item-text', optionLabel).click();
+    }
+  });
+  cy.get('.pf-v5-c-menu__content').click('topRight');
+});
+
+Cypress.Commands.add(
+  'getTableRow',
+  (columnDataCy: string, text: string, options?: { disableFilter?: boolean }) => {
+    if (options?.disableFilter !== true) {
+      cy.filterTableByTextFilter(columnDataCy, text);
+    }
+    cy.contains(`[data-cy="${columnDataCy}-column-cell"]`, text).parents('tr');
+  }
+);
+
+Cypress.Commands.add(
+  'getTableCell',
+  (cellDataCy: string, text: string, options?: { disableFilter?: boolean }) => {
+    if (options?.disableFilter !== true) {
+      cy.filterTableByTextFilter(cellDataCy, text);
+    }
+    cy.contains(`[data-cy='${cellDataCy}-column-cell']`, text);
+  }
+);
+
+Cypress.Commands.add(
+  'clickTableRowLink',
+  (columnDataCy: string, text: string, options?: { disableFilter?: boolean }) => {
+    cy.getTableCell(columnDataCy, text, options).within(() => {
+      cy.get('a').click();
+    });
+  }
+);
+
+Cypress.Commands.add('clickKebabAction', (kebabDataCy: string, actionDataCy: string) => {
+  cy.getByDataCy(kebabDataCy).click();
+  cy.getByDataCy(actionDataCy).click();
+});
+
+Cypress.Commands.add(
+  'clickTableRowAction',
+  (
+    columnDataCy: string,
+    text: string,
+    actionDataCy: string,
+    options?: {
+      inKebab?: boolean;
+      disableFilter?: boolean;
+    }
+  ) => {
+    cy.getTableRow(columnDataCy, text, options).within(() => {
+      cy.get(`[data-cy="actions-column-cell"]`).within(() => {
+        if (options?.inKebab) {
+          cy.clickKebabAction('actions-dropdown', actionDataCy);
+        } else {
+          cy.getByDataCy(actionDataCy).click();
+        }
+      });
+    });
+  }
+);
+
+Cypress.Commands.add(
+  'selectTableRowNew',
+  (columnDataCy: string, text: string, options?: { disableFilter?: boolean }) => {
+    cy.getTableRow(columnDataCy, text, options).within(() => {
+      cy.get('[data-cy="checkbox-column-cell"]').within(() => {
+        cy.get('input').click();
+      });
+    });
+  }
+);

--- a/cypress/support/table-commands.ts
+++ b/cypress/support/table-commands.ts
@@ -151,7 +151,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  'selectTableRowNew',
+  'selectTableRowCheckbox',
   (columnDataCy: string, text: string, options?: { disableFilter?: boolean }) => {
     cy.getTableRow(columnDataCy, text, options).within(() => {
       cy.get('[data-cy="checkbox-column-cell"]').within(() => {

--- a/cypress/support/table-commands.ts
+++ b/cypress/support/table-commands.ts
@@ -9,17 +9,6 @@ Cypress.Commands.add(
     cy.get('table').should('exist');
     if (options?.ignoreNotFound) {
       cy.get('button').then((jqueryResult) => {
-        if (jqueryResult.length === 0) {
-          return;
-        }
-
-        if (jqueryResult.length === 1) {
-          if (jqueryResult[0].getAttribute('data-cy') === `${view}-view`) {
-            jqueryResult[0].click();
-          }
-          return;
-        }
-
         for (let i = 0; i < jqueryResult.length; i++) {
           if (jqueryResult[i].getAttribute('data-cy') === `${view}-view`) {
             jqueryResult[i].click();
@@ -72,8 +61,11 @@ Cypress.Commands.add('filterTableByTextFilter', (filterDataCy: string, text: str
     });
     // Only click the apply filter if it is a multi text filter
     cy.get('button').then((jqueryResult) => {
-      if (jqueryResult.length === 1 && jqueryResult[0].getAttribute('data-cy') === 'apply-filter') {
-        jqueryResult[0].click();
+      for (let i = 0; i < jqueryResult.length; i++) {
+        if (jqueryResult[i].getAttribute('data-cy') === 'apply-filter') {
+          jqueryResult[i].click();
+          break;
+        }
       }
     });
   });

--- a/framework/PageDialogs/BulkConfirmationDialog.tsx
+++ b/framework/PageDialogs/BulkConfirmationDialog.tsx
@@ -160,6 +160,7 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
       onClose={onCloseClicked}
       actions={[
         <Button
+          id="submit"
           key="submit"
           ouiaId="submit"
           variant={isDanger ? 'danger' : 'primary'}

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -72,9 +72,9 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
       tabIndex={0}
       actions={[
         <Button
-          key="confirm"
+          key="submit"
           variant="primary"
-          id="confirm"
+          id="submit"
           onClick={() => {
             onClose();
             onSelect(view.selectedItems);

--- a/framework/PageDialogs/SingleSelectDialog.tsx
+++ b/framework/PageDialogs/SingleSelectDialog.tsx
@@ -42,9 +42,9 @@ export function SingleSelectDialog<T extends object>(props: SingleSelectDialogPr
       tabIndex={0}
       actions={[
         <Button
-          key="confirm"
+          key="submit"
           variant="primary"
-          id="confirm"
+          id="submit"
           onClick={() => {
             onClose();
             if (view.selectedItems.length > 0) {

--- a/framework/PageInputs/PageAsyncMultiSelect.tsx
+++ b/framework/PageInputs/PageAsyncMultiSelect.tsx
@@ -137,6 +137,7 @@ export function PageAsyncMultiSelect<
           <SplitItem isFilled>
             {options?.length !== total && (
               <Button
+                id="load-lmore"
                 variant="link"
                 isInline
                 onClick={(e) => {

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -139,6 +139,7 @@ export function PageAsyncSingleSelect<
           <SplitItem isFilled>
             {options?.length !== total && (
               <Button
+                id="load-lmore"
                 variant="link"
                 isInline
                 onClick={(e) => {

--- a/frontend/awx/access/common/DeleteRoleConfirmation.tsx
+++ b/frontend/awx/access/common/DeleteRoleConfirmation.tsx
@@ -43,6 +43,7 @@ export function DeleteRoleConfirmation(props: DeleteRoleConfirmationProps) {
       onClose={onCloseClicked}
       actions={[
         <Button
+          id="submit"
           ouiaId="delete-role-modal-delete-button"
           key="delete"
           variant="danger"

--- a/frontend/awx/access/teams/hooks/useTeamsColumns.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamsColumns.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { ITableColumn, usePageNavigate } from '../../../../../framework';
 import {
   useCreatedColumn,
@@ -13,14 +12,13 @@ import { Team } from '../../../interfaces/Team';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
 export function useTeamsColumns(options?: { disableLinks?: boolean; disableSort?: boolean }) {
-  const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const nameColumnClick = useCallback(
     (team: Team) => pageNavigate(AwxRoute.TeamDetails, { params: { id: team.id } }),
     [pageNavigate]
   );
   const idColumn = useIdColumn();
-  const nameColumn = useNameColumn({ header: t('Team'), ...options, onClick: nameColumnClick });
+  const nameColumn = useNameColumn({ ...options, onClick: nameColumnClick });
   const descriptionColumn = useDescriptionColumn();
 
   const organizationColumn = useOrganizationNameColumn(AwxRoute.OrganizationDetails, options);

--- a/frontend/awx/administration/instance-groups/InstanceGroups.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroups.cy.tsx
@@ -1,5 +1,5 @@
-import { InstanceGroups } from './InstanceGroups';
 import * as useOptions from '../../../common/crud/useOptions';
+import { InstanceGroups } from './InstanceGroups';
 
 describe('Instance Groups List', () => {
   describe('Non-empty list', () => {

--- a/frontend/awx/views/jobs/Jobs.cy.tsx
+++ b/frontend/awx/views/jobs/Jobs.cy.tsx
@@ -74,7 +74,7 @@ describe('Jobs.cy.ts', () => {
       .should('be.an', 'array')
       .then((results: UnifiedJob[]) => {
         const job = results[4]; // job with summary_fields.user_capabilities.delete: false
-        cy.selectToolbarFilterType('ID');
+        cy.selectToolbarFilterByLabel('ID');
         cy.selectTableRow(job.id.toString(), false);
         cy.clickToolbarKebabAction('delete-selected-jobs');
         cy.contains(
@@ -145,7 +145,7 @@ describe('Jobs.cy.ts', () => {
       .should('be.an', 'array')
       .then((results: UnifiedJob[]) => {
         const job = results[0];
-        cy.selectToolbarFilterType('ID');
+        cy.selectToolbarFilterByLabel('ID');
         cy.selectTableRow(job.id.toString(), false);
         cy.clickToolbarKebabAction('cancel-selected-jobs');
         cy.contains(


### PR DESCRIPTION
Cleaned up custom commands.
Working on moving out common commands from awx-commands.ts.
Added new versions that fix many issues.

Examples:
- Waiting for buttons to be enabled
- Properly selecting dropdown menus that have been attached to the body when in a dialog
- Being more specific on finding a table row by requiring the column name for matching (needed for several pages)
- Being clearer on options such as `disableFilter`
- Handling both singleSelectTextFilter and multiSelectTextFilter in filterTableByTextFilter command

### Input Commands

- singleSelectBy
- multiSelectBy

### Table Filtering

- filterTableByTextFilter
- filterTableBySingleSelect
- filterTableByMultiSelect

### Table Helpers

- getTableRow
- clickTableRowLink
- clickTableRowAction
- selectTableRowCheckbox