### PR TITLE
Add validate support to Wizard steps

### DIFF
--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -37,25 +37,31 @@ export function PageWizardBody<T>({
   }, [navigate, onCancel]);
 
   const onNext = useCallback(
-    (formData: object) => {
+    async (formData: object) => {
       const filteredSteps = allSteps.filter((step) =>
         isStepVisible(step, { ...wizardData, ...formData })
       );
 
-      if (activeStep !== null) {
-        const isLastStep = activeStep?.id === filteredSteps[filteredSteps.length - 1]?.id;
-        if (isLastStep) {
-          return onSubmit(wizardData as T);
-        }
-
-        const activeStepIndex = filteredSteps.findIndex((step) => step.id === activeStep?.id);
-        const nextStep = filteredSteps[activeStepIndex + 1];
-
-        setWizardData((prev: object) => ({ ...prev, ...formData }));
-        setStepData((prev) => ({ ...prev, [activeStep?.id]: formData }));
-        setVisibleSteps(filteredSteps);
-        setActiveStep(nextStep);
+      if (activeStep === null) {
+        return Promise.resolve();
       }
+
+      if (activeStep.validate) {
+        await activeStep.validate(formData, wizardData);
+      }
+
+      const isLastStep = activeStep?.id === filteredSteps[filteredSteps.length - 1]?.id;
+      if (isLastStep) {
+        return onSubmit(wizardData as T);
+      }
+
+      const activeStepIndex = filteredSteps.findIndex((step) => step.id === activeStep?.id);
+      const nextStep = filteredSteps[activeStepIndex + 1];
+
+      setWizardData((prev: object) => ({ ...prev, ...formData }));
+      setStepData((prev) => ({ ...prev, [activeStep?.id]: formData }));
+      setVisibleSteps(filteredSteps);
+      setActiveStep(nextStep);
       return Promise.resolve();
     },
     [

--- a/framework/PageWizard/types.ts
+++ b/framework/PageWizard/types.ts
@@ -7,6 +7,12 @@ export interface PageWizardStep {
   inputs?: React.ReactNode;
   element?: React.ReactNode;
   hidden?: (wizardData: object) => boolean;
+  /*
+    Validate is called before proceeding to the next step. If it throws an
+    error, the wizard will stay on the current step and pass the error to
+    the wizard's errorAdapter for handling.
+  */
+  validate?: (formData: object, wizardData: object) => Promise<void> | void;
 }
 
 export interface PageWizardState {


### PR DESCRIPTION
* Adds optional `validate` callback to wizard step definition
* This allows for more customizable validation of the form on one step before allowing the user to proceed to the next step
* If the validate function throws an error, the wizard catches the error and passes it to the errorAdapter which can then display it for user feedback on the form/wizard step

This also includes a slight refactor of the `onNext` function in the wizard to return early/un-nest most of the function a bit