### PR TITLE
Revert Cypress Upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "@types/js-yaml": "4.0.9",
         "@typescript-eslint/eslint-plugin": "7.1.0",
         "@typescript-eslint/parser": "7.1.0",
-        "cypress": "13.6.6",
+        "cypress": "13.5.1",
         "cypress-react-selector": "3.0.0",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
@@ -7021,20 +7021,21 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "13.6.6",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.6.tgz",
-      "integrity": "sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==",
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.1.tgz",
+      "integrity": "sha512-yqLViT0D/lPI8Kkm7ciF/x/DCK/H/DnogdGyiTnQgX4OVR2aM30PtK+kvklTOD1u3TuItiD9wUQAF8EYWtyZug==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.7.1",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -7052,7 +7053,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.1",
+        "is-ci": "^3.0.0",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -7083,6 +7084,15 @@
       "license": "MIT",
       "dependencies": {
         "resq": "1.10.2"
+      }
+    },
+    "node_modules/cypress/node_modules/@types/node": {
+      "version": "18.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.21.tgz",
+      "integrity": "sha512-2Q2NeB6BmiTFQi4DHBzncSoq/cJMLDdhPaAoJFnFCyD9a8VPZRf7a1GAwp1Edb7ROaZc5Jz/tnZyL6EsWMRaqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@types/js-yaml": "4.0.9",
     "@typescript-eslint/eslint-plugin": "7.1.0",
     "@typescript-eslint/parser": "7.1.0",
-    "cypress": "13.6.6",
+    "cypress": "13.5.1",
     "cypress-react-selector": "3.0.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",


### PR DESCRIPTION
Cypress Component Tests - Seeing Random Failure
  1) An uncaught error was detected outside of a test:
     ChunkLoadError: The following error originated from your test code, not from Cypress.

  > Loading chunk vendors-node_modules_yaml_browser_index_js failed.
This is a know issue and the Cypress team is working on a fix. [Issue](https://github.com/cypress-io/cypress/issues/28644)
Until they have a fix, I am going to back our version of Cypress back down to 13.5.1.