### PR TITLE
Collection approve/reject - fix most bulk actions failing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ Dockerfile
 *.svg
 *.sh
 .prettierignore
+.*.sw[po]

--- a/frontend/hub/administration/collection-approvals/hooks/useRejectCollections.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useRejectCollections.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { compareStrings } from '../../../../../framework';
-import { useGetRequest } from '../../../../common/crud/useGet';
+import { requestGet } from '../../../../common/crud/Data';
 import { pulpAPI } from '../../../common/api/formatPath';
 import { collectionKeyFn, hubAPIPost, parsePulpIDFromURL } from '../../../common/api/hub-api-utils';
 import { useHubBulkConfirmation } from '../../../common/useHubBulkConfirmation';
@@ -17,8 +17,6 @@ export function useRejectCollections(
   const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
 
   const bulkAction = useHubBulkConfirmation<CollectionVersionSearch>();
-
-  const getRequest = useGetRequest();
 
   return useCallback(
     (collections: CollectionVersionSearch[]) => {
@@ -39,23 +37,20 @@ export function useRejectCollections(
         confirmationColumns,
         actionColumns,
         onComplete,
-        actionFn: (collection: CollectionVersionSearch) => rejectCollection(collection, getRequest),
+        actionFn: (collection: CollectionVersionSearch) => rejectCollection(collection),
       });
     },
-    [actionColumns, bulkAction, confirmationColumns, onComplete, t, getRequest]
+    [actionColumns, bulkAction, confirmationColumns, onComplete, t]
   );
 }
 
-export function rejectCollection(
-  collection: CollectionVersionSearch,
-  getRequest: ReturnType<typeof useGetRequest>
-) {
+export function rejectCollection(collection: CollectionVersionSearch) {
   let rejectedRepo = '';
 
   async function innerAsync() {
-    const repoRes = (await getRequest(
+    const repoRes = await requestGet<PulpItemsResponse<Repository>>(
       pulpAPI`/repositories/ansible/ansible/?name=rejected`
-    )) as PulpItemsResponse<Repository>;
+    );
     rejectedRepo = repoRes.results[0].pulp_href;
 
     await hubAPIPost(


### PR DESCRIPTION
useGet will fail when a request for the same url is made twice at the same time, only one call succeeds, the others all fail

but bulk approve/reject need to query the repository first ... so if multiple approvals/rejects query the same repo, only one of those actions succeeds

fixing by using requestGet which doesn't have the same problem

---

Before:
![image](https://github.com/ansible/ansible-ui/assets/289743/d9074162-17e0-4280-b0dc-ad07e76e8f8b)

After:
![20240306183204](https://github.com/ansible/ansible-ui/assets/289743/a8ea9698-2b34-4738-91d9-fe821e0703ee)

