### PR TITLE
[AAP-14314] Shaiah circle icons

### DIFF
--- a/frontend/awx/access/common/ResourceAccessList.tsx
+++ b/frontend/awx/access/common/ResourceAccessList.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -88,7 +88,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add users'),
         isDisabled: canAddAndRemoveUsers
           ? undefined

--- a/frontend/awx/access/credentials/hooks/useCredentialToolbarActions.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -24,7 +24,7 @@ export function useCredentialToolbarActions(view: IAwxView<Credential>) {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Create credential'),
         onClick: () => pageNavigate(AwxRoute.CreateCredential),
       },

--- a/frontend/awx/access/organizations/Organizations.tsx
+++ b/frontend/awx/access/organizations/Organizations.tsx
@@ -1,11 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import {
-  MinusCircleIcon,
-  PencilAltIcon,
-  PlusCircleIcon,
-  PlusIcon,
-  TrashIcon,
-} from '@patternfly/react-icons';
+import { MinusCircleIcon, PencilAltIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -75,7 +69,7 @@ export function Organizations() {
         selection: PageActionSelection.None,
         isPinned: true,
         variant: ButtonVariant.primary,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Create organization'),
         href: getPageUrl(AwxRoute.CreateOrganization),
       },

--- a/frontend/awx/access/teams/TeamPage/TeamRoles.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamRoles.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -47,7 +47,7 @@ export function TeamRolesInner(props: { team: Team }) {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add role to team'),
         href: getPageUrl(AwxRoute.AddRolesToTeam, { params: { id: team.id } }),
       },

--- a/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusCircleIcon, PlusIcon, SyncIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, SyncIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -33,7 +33,7 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
         selection: PageActionSelection.None,
         isPinned: true,
         variant: ButtonVariant.primary,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Create team'),
         isDisabled: canCreateTeam
           ? undefined

--- a/frontend/awx/access/users/UserPage/UserOrganizations.tsx
+++ b/frontend/awx/access/users/UserPage/UserOrganizations.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -54,7 +54,7 @@ function UserOrganizationsInternal(props: { user: User }) {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add user to organizations'),
         onClick: () => selectOrganizationsAddUsers([user]),
       },

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
 } from '@patternfly/react-core';
-import { CubesIcon, PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -55,7 +55,7 @@ function UserRolesInternal(props: { user: User }) {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add role to user'),
         onClick: () => pageNavigate(AwxRoute.AddRolesToUser, { params: { id: user.id } }),
       },

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -4,7 +4,6 @@ import {
   MinusCircleIcon,
   PencilAltIcon,
   PlusCircleIcon,
-  PlusIcon,
   TrashIcon,
 } from '@patternfly/react-icons';
 import { useMemo } from 'react';
@@ -68,7 +67,7 @@ export function Users() {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Create user'),
         isDisabled: canCreateUser
           ? undefined
@@ -266,7 +265,7 @@ export function AccessTable(props: { url: string }) {
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add users'),
         shortLabel: t('Add access'),
         href: getPageUrl(AwxRoute.CreateUser),

--- a/frontend/hub/administration/remote-registries/RemoteRegistries.tsx
+++ b/frontend/hub/administration/remote-registries/RemoteRegistries.tsx
@@ -10,6 +10,7 @@ import { useRemoteRegistriesToolbarActions } from './hooks/useRemoteRegistriesTo
 import { useRemoteRegistryActions } from './hooks/useRemoteRegistryActions';
 import { useRemoteRegistryFilters } from './hooks/useRemoteRegistryFilters';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export function RemoteRegistries() {
   const { t } = useTranslation();
@@ -42,7 +43,11 @@ export function RemoteRegistries() {
           pageNavigate(HubRoute.CreateRemoteRegistry);
         }}
         emptyStateButtonText={t('Create remote registry')}
-        emptyStateButtonIcon={<PlusCircleIcon />}
+        emptyStateButtonIcon={
+          <Icon>
+            <PlusCircleIcon />
+          </Icon>
+        }
         emptyStateTitle={t('No remote registries yet')}
         errorStateTitle={t('Error loading remote registries')}
         rowActions={rowActions}

--- a/frontend/hub/administration/remote-registries/RemoteRegistries.tsx
+++ b/frontend/hub/administration/remote-registries/RemoteRegistries.tsx
@@ -9,6 +9,7 @@ import { useRemoteRegistriesColumns } from './hooks/useRemoteRegistriesColumns';
 import { useRemoteRegistriesToolbarActions } from './hooks/useRemoteRegistriesToolbarActions';
 import { useRemoteRegistryActions } from './hooks/useRemoteRegistryActions';
 import { useRemoteRegistryFilters } from './hooks/useRemoteRegistryFilters';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function RemoteRegistries() {
   const { t } = useTranslation();
@@ -41,6 +42,7 @@ export function RemoteRegistries() {
           pageNavigate(HubRoute.CreateRemoteRegistry);
         }}
         emptyStateButtonText={t('Create remote registry')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateTitle={t('No remote registries yet')}
         errorStateTitle={t('Error loading remote registries')}
         rowActions={rowActions}

--- a/frontend/hub/administration/remote-registries/hooks/useRemoteRegistriesToolbarActions.tsx
+++ b/frontend/hub/administration/remote-registries/hooks/useRemoteRegistriesToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,7 +21,7 @@ export function useRemoteRegistriesToolbarActions(view: IHubView<RemoteRegistry>
   const actions = useMemo<IPageAction<RemoteRegistry>[]>(
     () => [
       {
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         isPinned: true,
         label: t('Create remote registry'),
         onClick: () => pageNavigate(HubRoute.CreateRemoteRegistry),

--- a/frontend/hub/administration/remotes/Remotes.tsx
+++ b/frontend/hub/administration/remotes/Remotes.tsx
@@ -9,6 +9,7 @@ import { useRemoteColumns } from './hooks/useRemoteColumns';
 import { useRemoteFilters } from './hooks/useRemoteFilters';
 import { useRemoteToolbarActions } from './hooks/useRemoteToolbarActions';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export interface HubRemote {
   auth_url?: string | null;
@@ -54,7 +55,11 @@ export function Remotes() {
         defaultSubtitle={t('Remote')}
         emptyStateButtonClick={() => pageNavigate(HubRoute.CreateRemote)}
         emptyStateButtonText={t('Create remote')}
-        emptyStateButtonIcon={<PlusCircleIcon />}
+        emptyStateButtonIcon={
+          <Icon>
+            <PlusCircleIcon />
+          </Icon>
+        }
         emptyStateTitle={t('No remotes yet')}
         errorStateTitle={t('Error loading remotes')}
         rowActions={rowActions}

--- a/frontend/hub/administration/remotes/Remotes.tsx
+++ b/frontend/hub/administration/remotes/Remotes.tsx
@@ -8,6 +8,7 @@ import { useRemoteActions } from './hooks/useRemoteActions';
 import { useRemoteColumns } from './hooks/useRemoteColumns';
 import { useRemoteFilters } from './hooks/useRemoteFilters';
 import { useRemoteToolbarActions } from './hooks/useRemoteToolbarActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export interface HubRemote {
   auth_url?: string | null;
@@ -53,6 +54,7 @@ export function Remotes() {
         defaultSubtitle={t('Remote')}
         emptyStateButtonClick={() => pageNavigate(HubRoute.CreateRemote)}
         emptyStateButtonText={t('Create remote')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateTitle={t('No remotes yet')}
         errorStateTitle={t('Error loading remotes')}
         rowActions={rowActions}

--- a/frontend/hub/administration/remotes/hooks/useRemoteToolbarActions.tsx
+++ b/frontend/hub/administration/remotes/hooks/useRemoteToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,7 +21,7 @@ export function useRemoteToolbarActions(view: IHubView<HubRemote>) {
   const actions = useMemo<IPageAction<HubRemote>[]>(
     () => [
       {
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         isPinned: true,
         label: t('Create remote'),
         onClick: () => pageNavigate(HubRoute.CreateRemote),

--- a/frontend/hub/administration/repositories/Repositories.tsx
+++ b/frontend/hub/administration/repositories/Repositories.tsx
@@ -9,6 +9,7 @@ import { useRepositoriesColumns } from './hooks/useRepositoriesColumns';
 import { useRepositoryActions } from './hooks/useRepositoryActions';
 import { useRepositoryFilters } from './hooks/useRepositorySelector';
 import { useRepositoryToolbarActions } from './hooks/useRepositoryToolbarActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Repositories() {
   const { t } = useTranslation();
@@ -39,6 +40,7 @@ export function Repositories() {
         defaultSubtitle={t('Repository')}
         emptyStateButtonClick={() => pageNavigate(HubRoute.CreateRepository)}
         emptyStateButtonText={t('Create repository')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateTitle={t('No repositories yet')}
         errorStateTitle={t('Error loading repositories')}
         rowActions={rowActions}

--- a/frontend/hub/administration/repositories/Repositories.tsx
+++ b/frontend/hub/administration/repositories/Repositories.tsx
@@ -10,6 +10,7 @@ import { useRepositoryActions } from './hooks/useRepositoryActions';
 import { useRepositoryFilters } from './hooks/useRepositorySelector';
 import { useRepositoryToolbarActions } from './hooks/useRepositoryToolbarActions';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export function Repositories() {
   const { t } = useTranslation();
@@ -40,7 +41,11 @@ export function Repositories() {
         defaultSubtitle={t('Repository')}
         emptyStateButtonClick={() => pageNavigate(HubRoute.CreateRepository)}
         emptyStateButtonText={t('Create repository')}
-        emptyStateButtonIcon={<PlusCircleIcon />}
+        emptyStateButtonIcon={
+          <Icon>
+            <PlusCircleIcon />
+          </Icon>
+        }
         emptyStateTitle={t('No repositories yet')}
         errorStateTitle={t('Error loading repositories')}
         rowActions={rowActions}

--- a/frontend/hub/administration/repositories/hooks/useRepositoryToolbarActions.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositoryToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -20,7 +20,7 @@ export function useRepositoryToolbarActions(view: IHubView<Repository>) {
   const actions = useMemo<IPageAction<Repository>[]>(
     () => [
       {
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         isPinned: true,
         label: t('Create repository'),
         onClick: () => pageNavigate(HubRoute.CreateRepository),

--- a/frontend/hub/collections/Collections.tsx
+++ b/frontend/hub/collections/Collections.tsx
@@ -9,6 +9,7 @@ import { useCollectionActions } from './hooks/useCollectionActions';
 import { useCollectionColumns } from './hooks/useCollectionColumns';
 import { useCollectionFilters } from './hooks/useCollectionFilters';
 import { useCollectionsActions } from './hooks/useCollectionsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Collections() {
   const { t } = useTranslation();
@@ -54,6 +55,7 @@ export function Collections() {
         emptyStateTitle={t('No collections yet')}
         emptyStateDescription={t('To get started, upload a collection.')}
         emptyStateButtonText={t('Upload collection')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonClick={() => pageNavigate(HubRoute.UploadCollection)}
         {...view}
         defaultTableView="list"

--- a/frontend/hub/collections/Collections.tsx
+++ b/frontend/hub/collections/Collections.tsx
@@ -10,6 +10,7 @@ import { useCollectionColumns } from './hooks/useCollectionColumns';
 import { useCollectionFilters } from './hooks/useCollectionFilters';
 import { useCollectionsActions } from './hooks/useCollectionsActions';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export function Collections() {
   const { t } = useTranslation();
@@ -55,7 +56,11 @@ export function Collections() {
         emptyStateTitle={t('No collections yet')}
         emptyStateDescription={t('To get started, upload a collection.')}
         emptyStateButtonText={t('Upload collection')}
-        emptyStateButtonIcon={<PlusCircleIcon />}
+        emptyStateButtonIcon={
+          <Icon>
+            <PlusCircleIcon />
+          </Icon>
+        }
         emptyStateButtonClick={() => pageNavigate(HubRoute.UploadCollection)}
         {...view}
         defaultTableView="list"

--- a/frontend/hub/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironments.tsx
@@ -9,6 +9,7 @@ import { useExecutionEnvironmentActions } from './hooks/useExecutionEnvironmentA
 import { useExecutionEnvironmentFilters } from './hooks/useExecutionEnvironmentFilters';
 import { useExecutionEnvironmentsActions } from './hooks/useExecutionEnvironmentsActions';
 import { useExecutionEnvironmentsColumns } from './hooks/useExecutionEnvironmentsColumns';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function ExecutionEnvironments() {
   const { t } = useTranslation();
@@ -41,6 +42,7 @@ export function ExecutionEnvironments() {
         errorStateTitle={t('Error loading execution environments')}
         emptyStateTitle={t('No execution environments yet')}
         emptyStateButtonText={t('Add Execution Environment')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonClick={() => navigate(HubRoute.CreateExecutionEnvironment)}
         {...view}
         defaultSubtitle={t('Execution Environment')}

--- a/frontend/hub/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironments.tsx
@@ -10,6 +10,7 @@ import { useExecutionEnvironmentFilters } from './hooks/useExecutionEnvironmentF
 import { useExecutionEnvironmentsActions } from './hooks/useExecutionEnvironmentsActions';
 import { useExecutionEnvironmentsColumns } from './hooks/useExecutionEnvironmentsColumns';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export function ExecutionEnvironments() {
   const { t } = useTranslation();
@@ -42,7 +43,11 @@ export function ExecutionEnvironments() {
         errorStateTitle={t('Error loading execution environments')}
         emptyStateTitle={t('No execution environments yet')}
         emptyStateButtonText={t('Add Execution Environment')}
-        emptyStateButtonIcon={<PlusCircleIcon />}
+        emptyStateButtonIcon={
+          <Icon>
+            <PlusCircleIcon />
+          </Icon>
+        }
         emptyStateButtonClick={() => navigate(HubRoute.CreateExecutionEnvironment)}
         {...view}
         defaultSubtitle={t('Execution Environment')}

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { ExternalLinkAltIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +36,7 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Add execution environment'),
         onClick: () => {
           pageNavigate(HubRoute.CreateExecutionEnvironment);

--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -17,6 +17,7 @@ import { useHubNamespaceFilters } from './hooks/useHubNamespaceFilters';
 import { useHubNamespaceToolbarActions } from './hooks/useHubNamespaceToolbarActions';
 import { useHubNamespacesColumns } from './hooks/useHubNamespacesColumns';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
 
 export function Namespaces() {
   const { t } = useTranslation();
@@ -79,7 +80,11 @@ export function CommonNamespaces({ url }: { url: string }) {
       emptyStateTitle={t('No namespaces yet')}
       emptyStateDescription={t('To get started, create an namespace.')}
       emptyStateButtonText={t('Create namespace')}
-      emptyStateButtonIcon={<PlusCircleIcon />}
+      emptyStateButtonIcon={
+        <Icon>
+          <PlusCircleIcon />
+        </Icon>
+      }
       emptyStateButtonClick={() => pageNavigate(HubRoute.CreateNamespace)}
       {...view}
       defaultSubtitle={t('Namespace')}

--- a/frontend/hub/namespaces/HubNamespaces.tsx
+++ b/frontend/hub/namespaces/HubNamespaces.tsx
@@ -16,6 +16,7 @@ import { useHubNamespaceActions } from './hooks/useHubNamespaceActions';
 import { useHubNamespaceFilters } from './hooks/useHubNamespaceFilters';
 import { useHubNamespaceToolbarActions } from './hooks/useHubNamespaceToolbarActions';
 import { useHubNamespacesColumns } from './hooks/useHubNamespacesColumns';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Namespaces() {
   const { t } = useTranslation();
@@ -78,6 +79,7 @@ export function CommonNamespaces({ url }: { url: string }) {
       emptyStateTitle={t('No namespaces yet')}
       emptyStateDescription={t('To get started, create an namespace.')}
       emptyStateButtonText={t('Create namespace')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonClick={() => pageNavigate(HubRoute.CreateNamespace)}
       {...view}
       defaultSubtitle={t('Namespace')}

--- a/frontend/hub/namespaces/hooks/useHubNamespaceToolbarActions.tsx
+++ b/frontend/hub/namespaces/hooks/useHubNamespaceToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -25,7 +25,7 @@ export function useHubNamespaceToolbarActions(view: IHubView<HubNamespace>) {
         selection: PageActionSelection.None,
         isPinned: true,
         variant: ButtonVariant.primary,
-        icon: PlusIcon,
+        icon: PlusCircleIcon,
         label: t('Create namespace'),
         href: getPageUrl(HubRoute.CreateNamespace),
       },


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-14314
This pr addresses inconsistencies with PlusCircleIcons and adds icons to the buttons.
Affected screens:
Collections
Namespaces
Execution Environments
Remote logs
Remotes

<img width="346" alt="Screenshot 2024-03-06 at 3 11 54 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/65f03a50-8b8b-4e8c-b778-78ace513d6cf">
<img width="327" alt="Screenshot 2024-03-06 at 3 08 53 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/e358b152-5410-4cf3-8872-a1ae45cb6bd6">
<img width="318" alt="Screenshot 2024-03-06 at 3 06 58 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/be2c0834-1b63-42a5-a51e-1e2069bf3e0b">
<img width="332" alt="Screenshot 2024-03-06 at 3 00 33 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/533584dc-fd01-4731-9628-1f1ccdc79ba8">


