### PR TITLE
Fix overlapping dropdowns menus over modals

### DIFF
--- a/framework/PageInputs/PageSingleSelect.tsx
+++ b/framework/PageInputs/PageSingleSelect.tsx
@@ -310,12 +310,3 @@ export const PageSingleSelectContext = createContext<{
 export function usePageSingleSelectContext() {
   return useContext(PageSingleSelectContext);
 }
-
-export function PageSingleSelectProvider(props: { children: ReactNode }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <PageSingleSelectContext.Provider value={{ open, setOpen }}>
-      {props.children}
-    </PageSingleSelectContext.Provider>
-  );
-}

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -4,7 +4,7 @@ import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 import { PageAsyncMultiSelect } from '../PageInputs/PageAsyncMultiSelect';
 import { PageAsyncSingleSelect } from '../PageInputs/PageAsyncSingleSelect';
 import { PageMultiSelect } from '../PageInputs/PageMultiSelect';
-import { PageSingleSelect } from '../PageInputs/PageSingleSelect';
+import { PageSingleSelect, PageSingleSelectContext } from '../PageInputs/PageSingleSelect';
 import { useBreakpoint } from '../components/useBreakPoint';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import {
@@ -365,17 +365,23 @@ function ToolbarFilterComponent(props: {
           isRequired={filter.isRequired}
           footer={
             filter.openBrowse ? (
-              <Button
-                variant="link"
-                onClick={() => {
-                  filter.openBrowse?.(
-                    (selection) => setFilterValues(() => [selection]),
-                    filterValues && filterValues.length > 0 ? filterValues[0] : undefined
-                  );
-                }}
-              >
-                Browse
-              </Button>
+              <PageSingleSelectContext.Consumer>
+                {(context) => (
+                  <Button
+                    variant="link"
+                    onClick={() => {
+                      // close the menu before opening browse modal
+                      context.setOpen(false);
+                      filter.openBrowse?.(
+                        (selection) => setFilterValues(() => [selection]),
+                        filterValues && filterValues.length > 0 ? filterValues[0] : undefined
+                      );
+                    }}
+                  >
+                    Browse
+                  </Button>
+                )}
+              </PageSingleSelectContext.Consumer>
             ) : undefined
           }
         />

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -25,6 +25,7 @@ import { HubRoute } from '../../main/HubRoutes';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionActions } from '../hooks/useCollectionActions';
 import { useSelectCollectionVersionSingle } from '../hooks/useCollectionVersionSelector';
+import { PageSingleSelectContext } from '../../../../framework/PageInputs/PageSingleSelect';
 
 export function CollectionPage() {
   const { t } = useTranslation();
@@ -166,19 +167,24 @@ export function CollectionPage() {
               placeholder={''}
               value={collection?.collection_version?.version || version || ''}
               footer={
-                <Button
-                  variant="link"
-                  onClick={() => {
-                    singleSelectorBrowser?.(
-                      (selection) => {
-                        setVersionParams(selection);
-                      },
-                      collection?.collection_version?.version || version || ''
-                    );
-                  }}
-                >
-                  {t`Browse`}
-                </Button>
+                <PageSingleSelectContext.Consumer>
+                  {(context) => (
+                    <Button
+                      variant="link"
+                      onClick={() => {
+                        context.setOpen(false);
+                        singleSelectorBrowser?.(
+                          (selection) => {
+                            setVersionParams(selection);
+                          },
+                          collection?.collection_version?.version || version || ''
+                        );
+                      }}
+                    >
+                      {t`Browse`}
+                    </Button>
+                  )}
+                </PageSingleSelectContext.Consumer>
               }
             />
             {collection?.collection_version &&


### PR DESCRIPTION
Dropdown now hides when Browse button opens modal for selecting filtered item. Tested in Collections Repository filter and Approvals Repository filter. Also repaired in Collection Detail in Collection Version Dropdown.