### PR TITLE
PageMultiSelectList component

### DIFF
--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -1,27 +1,12 @@
-import {
-  Button,
-  Label,
-  LabelGroup,
-  Modal,
-  ModalBoxBody,
-  ModalVariant,
-  Skeleton,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+import { Button, Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core';
 import { useCallback } from 'react';
-import { PageTable } from '../PageTable/PageTable';
-import {
-  ITableColumn,
-  TableColumnCell,
-  useVisibleModalColumns,
-} from '../PageTable/PageTableColumn';
+import { ITableColumn, useVisibleModalColumns } from '../PageTable/PageTableColumn';
 import { ISelected } from '../PageTable/useTableItems';
 import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
-import { Collapse } from '../components/Collapse';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { IView } from '../useView';
 import { usePageDialog } from './PageDialog';
+import { PageMultiSelectList } from '../PageTable/PageMultiSelectList';
 
 export type MultiSelectDialogProps<T extends object> = {
   title: string;
@@ -47,6 +32,8 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     view,
     tableColumns,
     toolbarFilters,
+    emptyStateTitle,
+    errorStateTitle,
     confirmText,
     cancelText,
     onSelect,
@@ -90,62 +77,15 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
       hasNoBodyWrapper
     >
       <ModalBoxBody style={{ overflow: 'hidden' }}>
-        <Split hasGutter>
-          <SplitItem style={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-            {translations.selectedText}
-          </SplitItem>
-          {view.selectedItems.length > 0 ? (
-            <LabelGroup>
-              {view.selectedItems.map((item, i) => {
-                if (modalColumns && modalColumns.length > 0) {
-                  return (
-                    <Label key={i} onClose={() => view.unselectItem(item)}>
-                      <TableColumnCell
-                        item={item}
-                        column={
-                          modalColumns.find(
-                            (column) => column.card === 'name' || column.list === 'name'
-                          ) ?? modalColumns[0]
-                        }
-                      />
-                    </Label>
-                  );
-                }
-                return <></>;
-              })}
-            </LabelGroup>
-          ) : (
-            <SplitItem style={{ fontStyle: 'italic' }}>{translations.noneSelectedText}</SplitItem>
-          )}
-        </Split>
+        <PageMultiSelectList
+          view={view}
+          tableColumns={modalColumns}
+          toolbarFilters={toolbarFilters}
+          emptyStateTitle={emptyStateTitle}
+          errorStateTitle={errorStateTitle}
+          maxSelections={maxSelections}
+        />
       </ModalBoxBody>
-      <Collapse open={view.itemCount === undefined}>
-        <Skeleton height="80px" />
-      </Collapse>
-      <Collapse open={view.itemCount !== undefined}>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            maxHeight: 500,
-            overflow: 'hidden',
-          }}
-        >
-          <PageTable<T>
-            tableColumns={modalColumns}
-            toolbarFilters={toolbarFilters}
-            {...view}
-            emptyStateTitle={props.emptyStateTitle ?? translations.noItemsFound}
-            errorStateTitle={props.errorStateTitle ?? translations.errorText}
-            showSelect
-            disableCardView
-            disableListView
-            compact
-            disableBodyPadding
-            maxSelections={maxSelections}
-          />
-        </div>
-      </Collapse>
     </Modal>
   );
 }

--- a/framework/PageTable/PageMultiSelectList.tsx
+++ b/framework/PageTable/PageMultiSelectList.tsx
@@ -1,0 +1,86 @@
+import { Label, LabelGroup, Skeleton, Split, SplitItem } from '@patternfly/react-core';
+import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
+import { IView } from '../useView';
+import { ITableColumn, TableColumnCell } from './PageTableColumn';
+import { ISelected } from './useTableItems';
+import { useFrameworkTranslations } from '../useFrameworkTranslations';
+import { Collapse } from '../components/Collapse';
+import { PageTable } from './PageTable';
+
+export type PageMultiSelectListProps<T extends object> = {
+  labelForSelectedItems?: string;
+  view: IView & ISelected<T> & { itemCount?: number; pageItems: T[] | undefined };
+  tableColumns: ITableColumn<T>[];
+  toolbarFilters: IToolbarFilter[];
+  // onSelect: (items: T[]) => void;
+  emptyStateTitle?: string;
+  errorStateTitle?: string;
+  defaultSort?: string;
+  maxSelections?: number;
+};
+
+export function PageMultiSelectList<T extends object>(props: PageMultiSelectListProps<T>) {
+  const { view, tableColumns, toolbarFilters, maxSelections, labelForSelectedItems } = props;
+  const [translations] = useFrameworkTranslations();
+
+  return (
+    <>
+      <Collapse open={view.itemCount === undefined}>
+        <Skeleton height="80px" />
+      </Collapse>
+      <Collapse open={view.itemCount !== undefined}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            maxHeight: 500,
+            overflow: 'hidden',
+          }}
+        >
+          {' '}
+          <Split hasGutter>
+            <SplitItem style={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+              {labelForSelectedItems ?? translations.selectedText}
+            </SplitItem>
+            {view.selectedItems.length > 0 ? (
+              <LabelGroup>
+                {view.selectedItems.map((item, i) => {
+                  if (tableColumns && tableColumns.length > 0) {
+                    return (
+                      <Label key={i} onClose={() => view.unselectItem(item)}>
+                        <TableColumnCell
+                          item={item}
+                          column={
+                            tableColumns.find(
+                              (column) => column.card === 'name' || column.list === 'name'
+                            ) ?? tableColumns[0]
+                          }
+                        />
+                      </Label>
+                    );
+                  }
+                  return <></>;
+                })}
+              </LabelGroup>
+            ) : (
+              <SplitItem style={{ fontStyle: 'italic' }}>{translations.noneSelectedText}</SplitItem>
+            )}
+          </Split>
+          <PageTable<T>
+            tableColumns={tableColumns}
+            toolbarFilters={toolbarFilters}
+            {...view}
+            emptyStateTitle={props.emptyStateTitle ?? translations.noItemsFound}
+            errorStateTitle={props.errorStateTitle ?? translations.errorText}
+            showSelect
+            disableCardView
+            disableListView
+            compact
+            disableBodyPadding
+            maxSelections={maxSelections}
+          />
+        </div>
+      </Collapse>
+    </>
+  );
+}

--- a/frontend/awx/access/users/UserForm.tsx
+++ b/frontend/awx/access/users/UserForm.tsx
@@ -19,6 +19,11 @@ import { awxAPI } from '../../common/api/awx-utils';
 import { User } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
+import { useOrganizationsColumns, useOrganizationsFilters } from '../organizations/Organizations';
+import { Organization } from '../../interfaces/Organization';
+import { useAwxView } from '../../common/useAwxView';
+import { PageMultiSelectList } from '../../../../framework/PageTable/PageMultiSelectList';
+import { useEffect } from 'react';
 
 const UserType = {
   SystemAdministrator: 'System administrator',
@@ -154,6 +159,19 @@ type IUserInput = User & { userType: string; confirmPassword: string };
 function UserInputs(props: { mode: 'create' | 'edit' }) {
   const { mode } = props;
   const { t } = useTranslation();
+
+  const toolbarFilters = useOrganizationsFilters();
+  const tableColumns = useOrganizationsColumns({ disableLinks: true });
+  const view = useAwxView<Organization>({
+    url: awxAPI`/organizations/`,
+    toolbarFilters,
+    tableColumns,
+    disableQueryString: true,
+  });
+  useEffect(() => {
+    console.log('🚀 ~ useEffect ~ view.selectedItems:', view.selectedItems);
+  }, [view.selectedItems]);
+
   return (
     <>
       <PageFormTextInput<IUserInput>
@@ -232,6 +250,12 @@ function UserInputs(props: { mode: 'create' | 'edit' }) {
         name="email"
         label={t('Email')}
         placeholder={t('Enter email')}
+      />
+      <PageMultiSelectList
+        {...props}
+        toolbarFilters={toolbarFilters}
+        tableColumns={tableColumns}
+        view={view}
       />
     </>
   );

--- a/frontend/awx/access/users/UserForm.tsx
+++ b/frontend/awx/access/users/UserForm.tsx
@@ -19,11 +19,6 @@ import { awxAPI } from '../../common/api/awx-utils';
 import { User } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
-import { useOrganizationsColumns, useOrganizationsFilters } from '../organizations/Organizations';
-import { Organization } from '../../interfaces/Organization';
-import { useAwxView } from '../../common/useAwxView';
-import { PageMultiSelectList } from '../../../../framework/PageTable/PageMultiSelectList';
-import { useEffect } from 'react';
 
 const UserType = {
   SystemAdministrator: 'System administrator',
@@ -159,19 +154,6 @@ type IUserInput = User & { userType: string; confirmPassword: string };
 function UserInputs(props: { mode: 'create' | 'edit' }) {
   const { mode } = props;
   const { t } = useTranslation();
-
-  const toolbarFilters = useOrganizationsFilters();
-  const tableColumns = useOrganizationsColumns({ disableLinks: true });
-  const view = useAwxView<Organization>({
-    url: awxAPI`/organizations/`,
-    toolbarFilters,
-    tableColumns,
-    disableQueryString: true,
-  });
-  useEffect(() => {
-    console.log('🚀 ~ useEffect ~ view.selectedItems:', view.selectedItems);
-  }, [view.selectedItems]);
-
   return (
     <>
       <PageFormTextInput<IUserInput>
@@ -250,12 +232,6 @@ function UserInputs(props: { mode: 'create' | 'edit' }) {
         name="email"
         label={t('Email')}
         placeholder={t('Enter email')}
-      />
-      <PageMultiSelectList
-        {...props}
-        toolbarFilters={toolbarFilters}
-        tableColumns={tableColumns}
-        view={view}
       />
     </>
   );

--- a/frontend/hub/collections/hooks/useSelectCollections.cy.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.cy.tsx
@@ -12,7 +12,10 @@ describe('CollectionMultiSelectDialog', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '**/plugin/ansible/search/collection-versions**&offset=0&*',
+        url: '**/plugin/ansible/search/collection-versions/*',
+        query: {
+          offset: '0',
+        },
         hostname: 'localhost',
       },
       {
@@ -22,7 +25,10 @@ describe('CollectionMultiSelectDialog', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '**/plugin/ansible/search/collection-versions/**&offset=10&*',
+        url: '**/plugin/ansible/search/collection-versions/*',
+        query: {
+          offset: '10',
+        },
         hostname: 'localhost',
       },
       {


### PR DESCRIPTION
Adds a new `PageMultiSelectList` component for displaying a multi-selection enabled list with labels indicating selected values.

This pulls the internals of the `MultiSelectDialog` out in to a common component that can be used within `MultiSelectDialog` as well in places where we will need to display a multi-selection enabled list without a modal.

Usage:

```
      <PageMultiSelectList
          view={view}
          tableColumns={tableColumns}
          toolbarFilters={toolbarFilters}
          emptyStateTitle={emptyStateTitle}
          errorStateTitle={errorStateTitle}
          maxSelections={maxSelections}
      />

```
The calling component can access selected items in `view.selectedItems`.


Example

<img width="1002" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/19de3792-c175-433d-a64e-51a3afb2b526">


