### PR TITLE
Cypress add command for typing in data editor

### DIFF
--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -87,13 +87,13 @@ describe('inventories', () => {
     }
   });
 
-  it('edits an inventory from the inventory details page', () => {
+  it.only('edits an inventory from the inventory details page', () => {
     cy.navigateTo('awx', 'inventories');
     cy.clickTableRow(inventory.name);
     cy.verifyPageTitle(inventory.name);
     cy.clickButton(/^Edit inventory/);
     cy.selectDropdownOptionByResourceName('labels', label.name);
-    cy.getByDataCy('variables').type('remote_install_path: /opt/my_app_config');
+    cy.dataEditorTypeByDataCy('variables', 'remote_install_path: /opt/my_app_config');
     cy.contains('button', 'Save inventory').click();
     cy.verifyPageTitle(inventory.name);
     cy.assertMonacoTextField('remote_install_path: /opt/my_app_config');

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -87,7 +87,7 @@ describe('inventories', () => {
     }
   });
 
-  it.only('edits an inventory from the inventory details page', () => {
+  it('edits an inventory from the inventory details page', () => {
     cy.navigateTo('awx', 'inventories');
     cy.clickTableRow(inventory.name);
     cy.verifyPageTitle(inventory.name);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -55,7 +55,7 @@ describe('inventory group', () => {
     cy.verifyPageTitle('Create new group');
     cy.get('[data-cy="name"]').type(groupName);
     cy.get('[data-cy="description"]').type('This is a description');
-    cy.getByDataCy('variables').type('test: true');
+    cy.dataEditorTypeByDataCy('variables', 'test: true');
     cy.clickButton(/^Save/);
     cy.hasDetail(/^Name$/, groupName);
     cy.hasDetail(/^Description$/, 'This is a description');

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -218,6 +218,8 @@ declare global {
 
       dataEditorSetFormat(configType: string): Chainable<void>;
       dataEditorShouldContain(selector: string, value: string | object): Chainable<void>;
+      dataEditorType(selector: string, value: string, clear?: boolean): Chainable<void>;
+      dataEditorTypeByDataCy(dataCy: string, value: string, clear?: boolean): Chainable<void>;
 
       /** @deprecated use cy.dataEditorShouldContain */
       assertMonacoTextField(textString: string): Chainable<void>;

--- a/cypress/support/input-commands.ts
+++ b/cypress/support/input-commands.ts
@@ -56,3 +56,14 @@ Cypress.Commands.add('selectLoadAll', () => {
     });
   });
 });
+
+Cypress.Commands.add('dataEditorType', (selector: string, value: string, clear?: boolean) => {
+  cy.getBy(selector)
+    .click()
+    .focused()
+    .type(clear ? '{ctrl}a' + value : value, { delay: 0 });
+});
+
+Cypress.Commands.add('dataEditorTypeByDataCy', (dataCy: string, value: string, clear?: boolean) => {
+  cy.dataEditorType(`[data-cy="${dataCy}"]`, value, clear);
+});


### PR DESCRIPTION
Randomly the data editor doesnt handle typing correctly.
I think it may be related to the workers loading.

Adding a command where we can try to handle this complexity.
cy.dataEditorTypeByDataCy