### PR TITLE
[AAP-9121] Icon actions unification for hub

### DIFF
--- a/cypress/e2e/hub/approvals.cy.ts
+++ b/cypress/e2e/hub/approvals.cy.ts
@@ -38,7 +38,7 @@ describe('Approvals', () => {
   it('should be able to view import logs', () => {
     // View Import Logs
     cy.filterTableBySingleText(collectionName, true);
-    cy.clickTableRowPinnedAction(collectionName, 'view-import-logs', false);
+    cy.clickTableRowKebabAction(collectionName, 'view-import-logs', false);
     cy.verifyPageTitle(MyImports.title);
     cy.url().should('include', MyImports.url);
     cy.url().should('include', namespace.name);

--- a/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
+++ b/frontend/hub/administration/collection-approvals/hooks/useApprovalActions.tsx
@@ -40,7 +40,6 @@ export function useApprovalActions(callback: (collections: CollectionVersionSear
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        isPinned: true,
         variant: ButtonVariant.primary,
         icon: UploadIcon,
         label: t('Upload signature'),
@@ -86,7 +85,6 @@ export function useApprovalActions(callback: (collections: CollectionVersionSear
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        isPinned: true,
         icon: ImportIcon,
         label: t('View Import Logs'),
         onClick: (collection) =>

--- a/frontend/hub/administration/tasks/Tasks.cy.tsx
+++ b/frontend/hub/administration/tasks/Tasks.cy.tsx
@@ -46,29 +46,18 @@ describe('Tasks List', () => {
   it('Row action for stopping a task is disabled if the task is not running/waiting', () => {
     cy.mount(<Tasks />);
     cy.contains('tr', 'pulp_ansible.app.tasks.copy.move_collection').within(() => {
-      cy.get('button.toggle-kebab').click();
-      cy.contains('.pf-v5-c-dropdown__menu-item', /^Stop task$/).should(
-        'have.attr',
-        'aria-disabled',
-        'true'
-      );
+      cy.get('[data-cy="stop-task"]').should('have.attr', 'aria-disabled', 'true');
     });
   });
   it('Row action for stopping a task is enabled if the task is running', () => {
     cy.mount(<Tasks />);
     cy.contains('tr', 'galaxy_ng.app.tasks.namespaces._create_pulp_namespace').within(() => {
-      cy.get('button.toggle-kebab').click();
-      cy.contains('.pf-v5-c-dropdown__menu-item', /^Stop task$/).should(
-        'have.attr',
-        'aria-disabled',
-        'false'
-      );
+      cy.get('[data-cy="stop-task"]').should('have.attr', 'aria-disabled', 'false');
     });
   });
   it('Stop a running task', () => {
     cy.mount(<Tasks />);
     cy.contains('tr', 'galaxy_ng.app.tasks.namespaces._create_pulp_namespace').within(() => {
-      cy.get('button.toggle-kebab').click();
       cy.get('[data-cy="stop-task"]').click();
     });
     cy.clickModalConfirmCheckbox();

--- a/frontend/hub/administration/tasks/hooks/useTasksRowActions.tsx
+++ b/frontend/hub/administration/tasks/hooks/useTasksRowActions.tsx
@@ -17,6 +17,7 @@ export function useTasksRowActions(onComplete?: (tasks: Task[]) => void) {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: StopIcon,
+        isPinned: true,
         label: t('Stop task'),
         onClick: (task) => stopTask([task]),
         isDanger: true,

--- a/frontend/hub/administration/tasks/hooks/useTasksRowActions.tsx
+++ b/frontend/hub/administration/tasks/hooks/useTasksRowActions.tsx
@@ -1,4 +1,4 @@
-import { StopIcon } from '@patternfly/react-icons';
+import { StopCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
@@ -16,7 +16,7 @@ export function useTasksRowActions(onComplete?: (tasks: Task[]) => void) {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: StopIcon,
+        icon: StopCircleIcon,
         isPinned: true,
         label: t('Stop task'),
         onClick: (task) => stopTask([task]),

--- a/frontend/hub/administration/tasks/hooks/useTasksToolbarActions.tsx
+++ b/frontend/hub/administration/tasks/hooks/useTasksToolbarActions.tsx
@@ -1,4 +1,4 @@
-import { StopIcon } from '@patternfly/react-icons';
+import { StopCircleIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -25,7 +25,7 @@ export function useTasksToolbarActions(onComplete?: (tasks: Task[]) => void) {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Multiple,
-        icon: StopIcon,
+        icon: StopCircleIcon,
         label: t('Stop tasks'),
         onClick: (tasks) => stopTasks(tasks),
         isDanger: true,

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
@@ -39,17 +39,6 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete environment'),
-        onClick: (ee) => deleteExecutionEnvironments([ee]),
-        isDanger: true,
-        isDisabled: context.hasPermission('container.delete_containerrepository')
-          ? ''
-          : t`You do not have rights to this operation`,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
         label: t('Sync selected environments'),
         isHidden: (ee: ExecutionEnvironment) => !ee.pulp?.repository?.remote,
         onClick: (ee) => syncExecutionEnvironments([ee]),
@@ -69,6 +58,17 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
           context.featureFlags.container_signing
             ? ''
             : t`You do not have rights to this operation`,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete environment'),
+        onClick: (ee) => deleteExecutionEnvironments([ee]),
+        isDanger: true,
+        isDisabled: context.hasPermission('container.delete_containerrepository')
+          ? ''
+          : t`You do not have rights to this operation`,
       },
     ],
     [

--- a/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
+++ b/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
@@ -38,19 +38,19 @@ export function useHubNamespaceActions(options?: {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete namespace'),
-        onClick: (namespace) => deleteHubNamespaces([namespace]),
-        isDanger: true,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
         variant: ButtonVariant.primary,
         icon: ImportIcon,
         label: t('Imports'),
         onClick: (namespace) =>
           pageNavigate(HubRoute.MyImports, { query: { namespace: namespace.name } }),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete namespace'),
+        onClick: (namespace) => deleteHubNamespaces([namespace]),
+        isDanger: true,
       },
     ];
     return actions;


### PR DESCRIPTION
This pr unifies the in-line actions for page tables across the ui.
For one or more actions, the 'frequently used' action is an icon outside of the kebab, and the others are within. 

Affected screens: 
<img width="823" alt="Screenshot 2024-03-07 at 3 35 35 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/f30d5b36-8a09-46cd-93f4-6f4c09633c38">
<img width="830" alt="Screenshot 2024-03-11 at 2 54 20 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/2d0c764e-7d9b-423c-9def-09fe710a6abc">
<img width="829" alt="Screenshot 2024-03-07 at 3 00 50 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/0031b51e-1d43-4b4b-bcb2-c8ee0c6652c8">
<img width="824" alt="Screenshot 2024-03-11 at 1 26 04 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/b8d41136-3243-485b-98fa-c06c7f9e906c">
![namespaces](https://github.com/ansible/ansible-ui/assets/64337863/24054977-6e6a-430c-a178-ac9f4fdcd58f)

