### PR TITLE
Advanced Search Filtering Enhancements

### DIFF
--- a/framework/PageInputs/PageMultiSelect.tsx
+++ b/framework/PageInputs/PageMultiSelect.tsx
@@ -59,6 +59,8 @@ export interface PageMultiSelectProps<ValueT> {
   disableClearChips?: boolean;
 
   maxChipSize?: string;
+
+  disableSortOptions?: boolean;
 }
 
 /**
@@ -234,14 +236,16 @@ export function PageMultiSelect<
     }
   }, [isOpen]);
 
-  const visibleOptions = useMemo(
-    () =>
-      options.filter((option) => {
-        if (searchValue === '') return true;
-        else return option.label.toLowerCase().includes(searchValue.toLowerCase());
-      }),
-    [options, searchValue]
-  );
+  const visibleOptions = useMemo(() => {
+    const newOptions = options.filter((option) => {
+      if (searchValue === '') return true;
+      else return option.label.toLowerCase().includes(searchValue.toLowerCase());
+    });
+    if (!props.disableSortOptions) {
+      newOptions.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+    }
+    return newOptions;
+  }, [options, props.disableSortOptions, searchValue]);
 
   const groups = useMemo(() => {
     const hasGroups = options.some((option) => !!option.group);

--- a/framework/PageInputs/PageSingleSelect.tsx
+++ b/framework/PageInputs/PageSingleSelect.tsx
@@ -59,6 +59,8 @@ export interface PageSingleSelectProps<ValueT> {
 
   /** Disables the toggle to open and close the menu */
   isDisabled?: boolean;
+
+  disableSortOptions?: boolean;
 }
 
 /**
@@ -170,14 +172,16 @@ export function PageSingleSelect<
     }
   }, [onSelect, options, props.isRequired, selectedOption]);
 
-  const visibleOptions = useMemo(
-    () =>
-      options.filter((option) => {
-        if (searchValue === '') return true;
-        else return option.label.toLowerCase().includes(searchValue.toLowerCase());
-      }),
-    [options, searchValue]
-  );
+  const visibleOptions = useMemo(() => {
+    const newOptions = options.filter((option) => {
+      if (searchValue === '') return true;
+      else return option.label.toLowerCase().includes(searchValue.toLowerCase());
+    });
+    if (!props.disableSortOptions) {
+      newOptions.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+    }
+    return newOptions;
+  }, [options, props.disableSortOptions, searchValue]);
 
   const groups = useMemo(() => {
     const hasGroups = options.some((option) => !!option.group);

--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -123,6 +123,7 @@ function FiltersToolbarItem(props: PageToolbarFiltersProps) {
             }))}
             placeholder=""
             data-cy={selectedFilter}
+            disableSortOptions
           />
           <ToolbarFilterComponent
             id="filter-input"
@@ -222,6 +223,7 @@ export function PageToolbarFilters(props: PageToolbarFiltersProps) {
                   switch (filter.type) {
                     case ToolbarFilterType.SingleSelect:
                     case ToolbarFilterType.MultiSelect:
+                    case ToolbarFilterType.DateRange:
                       // The value is a label, we need to get the real value from the option
                       value = filter.options.find((o) => o.label === value)?.value ?? value;
                       break;
@@ -353,6 +355,7 @@ function ToolbarFilterComponent(props: {
           onSelect={(item) => setFilterValues(() => [item])}
           options={filter.options}
           isRequired={filter.isRequired}
+          disableSortOptions={filter.disableSortOptions}
         />
       );
 
@@ -383,6 +386,7 @@ function ToolbarFilterComponent(props: {
               </Button>
             ) : undefined
           }
+          disableSortOptions={filter.disableSortOptions}
         />
       );
 
@@ -414,6 +418,7 @@ function ToolbarFilterComponent(props: {
                 </Button>
               ) : undefined
             }
+            disableSortOptions={filter.disableSortOptions}
           />
         );
       }
@@ -444,6 +449,7 @@ function ToolbarFilterComponent(props: {
           }
           variant="count"
           disableClearSelection
+          disableSortOptions={filter.disableSortOptions}
         />
       );
 
@@ -457,6 +463,7 @@ function ToolbarFilterComponent(props: {
             value={filterValues && filterValues?.length > 0 ? filterValues[0] : ''}
             onSelect={(item) => setFilterValues(() => [item])}
             options={filter.options}
+            disableSortOptions={filter.disableSortOptions}
           />
         );
       }
@@ -470,6 +477,7 @@ function ToolbarFilterComponent(props: {
           options={filter.options}
           variant="count"
           disableClearSelection
+          disableSortOptions={filter.disableSortOptions}
         />
       );
 

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncMultiSelectFilter.tsx
@@ -35,6 +35,8 @@ export interface IToolbarAsyncMultiSelectFilter extends ToolbarFilterCommon {
    * else the select will contain a clear button.
    */
   isRequired?: boolean;
+
+  disableSortOptions?: boolean;
 }
 
 /**

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter.tsx
@@ -36,6 +36,8 @@ export interface IToolbarAsyncSingleSelectFilter extends ToolbarFilterCommon {
    * else the select will contain a clear button.
    */
   isRequired?: boolean;
+
+  disableSortOptions?: boolean;
 }
 
 /**

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
@@ -22,6 +22,7 @@ interface IToolbarDateFilterOption {
 }
 
 export enum DateRangeFilterPresets {
+  LastHour = 'lastHour',
   Last24Hours = 'last24hours',
   LastWeek = 'last7days',
   LastMonth = 'last30days',
@@ -85,6 +86,7 @@ export function ToolbarDateRangeFilter(props: IToolbarDateRangeFilterProps) {
         onSelect={onSelectChange}
         options={props.options}
         placeholder={placeholder}
+        disableSortOptions
       />
       {selectedOption && selectedOption.isCustom && (
         <DateRange to={to} setTo={setTo} from={from} setFrom={setFrom} />

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarMultiSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarMultiSelectFilter.tsx
@@ -6,4 +6,5 @@ export interface IToolbarMultiSelectFilter extends ToolbarFilterCommon {
   type: ToolbarFilterType.MultiSelect;
   options: PageSelectOption<string>[];
   placeholder: string;
+  disableSortOptions?: boolean;
 }

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarSingleSelectFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarSingleSelectFilter.tsx
@@ -7,4 +7,5 @@ export interface IToolbarSingleSelectFilter extends ToolbarFilterCommon {
   options: PageSelectOption<string>[];
   isRequired?: boolean;
   placeholder: string;
+  disableSortOptions?: boolean;
 }

--- a/frontend/awx/access/common/useDynamicFilters.tsx
+++ b/frontend/awx/access/common/useDynamicFilters.tsx
@@ -17,7 +17,7 @@ interface DynamicToolbarFiltersProps {
   preSortedKeys?: string[];
 
   /** Keys and options for filters that will be loaded asynchronously */
-  asyncKeys?: { [key: string]: AsyncKeyOptions | undefined };
+  asyncFilterKeys?: { [key: string]: AsyncKeyOptions | undefined };
 
   /** Additional filters in addition to the dynamic filters */
   additionalFilters?: IToolbarFilter[];
@@ -96,7 +96,7 @@ function craftRequestUrl(optionsPath: string, params: QueryParams | undefined, p
 }
 
 export function useDynamicToolbarFilters<T>(props: DynamicToolbarFiltersProps) {
-  const { optionsPath, preSortedKeys, asyncKeys, additionalFilters } = props;
+  const { optionsPath, preSortedKeys, asyncFilterKeys: asyncKeys, additionalFilters } = props;
   const { t } = useTranslation();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/${optionsPath}/`);
   const filterableFields = useFilters(data?.actions?.GET);

--- a/frontend/awx/access/common/useDynamicFilters.tsx
+++ b/frontend/awx/access/common/useDynamicFilters.tsx
@@ -20,34 +20,32 @@ interface DynamicToolbarFiltersProps {
   preSortedKeys?: string[];
 
   /** Keys and options for filters that will be loaded asynchronously */
-  asyncKeys?: {
-    [key: string]:
-      | {
-          /** The API endpoint for the options that will be loaded asynchronously
-           * @example 'execution_environments'
-           */
-          resourcePath: string;
-          /**
-           * The query parameters for the options that will be loaded asynchronously
-           * @example { order_by: '-created' }
-           */
-          params: QueryParams;
-          /**
-           * The key to be used as the label for the resource
-           * @example 'name'
-           */
-          resourceLabelKey?: string;
-          /**
-           * The key to be used as the value for the resource
-           * @example 'id'
-           */
-          resourceKey?: string;
-        }
-      | undefined;
-  };
+  asyncKeys?: { [key: string]: AsyncKeyOptions | undefined };
 
   /** Additional filters in addition to the dynamic filters */
   additionalFilters?: IToolbarFilter[];
+}
+
+interface AsyncKeyOptions {
+  /** The API endpoint for the options that will be loaded asynchronously
+   * @example 'execution_environments'
+   */
+  resourcePath: string;
+  /**
+   * The query parameters for the options that will be loaded asynchronously
+   * @example { order_by: '-created' }
+   */
+  params: QueryParams;
+  /**
+   * The key to be used as the label for the resource
+   * @example 'name'
+   */
+  resourceLabelKey?: string;
+  /**
+   * The key to be used as the value for the resource
+   * @example 'id'
+   */
+  resourceKey?: string;
 }
 
 interface FilterableFields {
@@ -147,15 +145,7 @@ export function useDynamicToolbarFilters<T extends Organization | UnifiedJob | U
     const getToolbars = (
       filterableFields: FilterableFields[],
       preSortedKeys?: string[],
-      asyncKeys?: {
-        [key: string]:
-          | {
-              optionsPath: string;
-              params: QueryParams;
-              resourceKey: string;
-            }
-          | undefined;
-      },
+      asyncKeys?: { [key: string]: AsyncKeyOptions | undefined },
       additionalFilters?: IToolbarFilter[]
     ): IToolbarFilter[] => {
       const toolbarFilters: IToolbarFilter[] = [];
@@ -252,7 +242,15 @@ export function useDynamicToolbarFilters<T extends Organization | UnifiedJob | U
       return toolbarFilters;
     };
     return getToolbars(filterableFields, preSortedKeys, asyncKeys, additionalFilters);
-  }, [filterableFields, preSortedKeys, asyncKeys, additionalFilters, t, queryResource]);
+  }, [
+    filterableFields,
+    preSortedKeys,
+    asyncKeys,
+    additionalFilters,
+    t,
+    queryResource,
+    queryResourceLabel,
+  ]);
 
   return filters;
 }

--- a/frontend/awx/access/common/useDynamicFilters.tsx
+++ b/frontend/awx/access/common/useDynamicFilters.tsx
@@ -27,7 +27,7 @@ interface AsyncKeyOptions {
   /** The API endpoint for the options that will be loaded asynchronously
    * @example 'execution_environments'
    */
-  resourcePath: string;
+  resourceType: string;
   /**
    * The query parameters for the options that will be loaded asynchronously
    * @example { order_by: '-created' }
@@ -37,12 +37,12 @@ interface AsyncKeyOptions {
    * The key to be used as the label for the resource
    * @example 'name'
    */
-  resourceLabelKey?: string;
+  labelKey?: string;
   /**
    * The key to be used as the value for the resource
    * @example 'id'
    */
-  resourceKey?: string;
+  valueKey?: string;
 }
 
 interface FilterableFields {
@@ -103,10 +103,10 @@ export function useDynamicToolbarFilters<T>(props: DynamicToolbarFiltersProps) {
   const queryResource = useCallback(
     async (page: number, signal: AbortSignal, key: string) => {
       const asyncKey = asyncKeys?.[key];
-      const resourceKey = asyncKey?.resourceKey || key;
-      const resourceLabelKey = asyncKey?.resourceLabelKey || resourceKey;
+      const resourceKey = asyncKey?.valueKey || key;
+      const resourceLabelKey = asyncKey?.labelKey || resourceKey;
       const resources = await requestGet<AwxItemsResponse<T>>(
-        craftRequestUrl(asyncKey ? asyncKey.resourcePath : optionsPath, asyncKey?.params, page),
+        craftRequestUrl(asyncKey ? asyncKey.resourceType : optionsPath, asyncKey?.params, page),
         signal
       );
       return {
@@ -123,11 +123,11 @@ export function useDynamicToolbarFilters<T>(props: DynamicToolbarFiltersProps) {
   const queryResourceLabel = useCallback(
     async (value: string, key: string) => {
       const asyncKey = asyncKeys?.[key];
-      const resourceKey = asyncKey?.resourceKey;
+      const resourceKey = asyncKey?.valueKey;
       if (!resourceKey) return value;
-      const resourceLabelKey = asyncKey?.resourceLabelKey || resourceKey;
+      const resourceLabelKey = asyncKey?.labelKey || resourceKey;
       try {
-        const resource = await requestGet<T>(awxAPI`/${asyncKey?.resourcePath}/${value}/`);
+        const resource = await requestGet<T>(awxAPI`/${asyncKey?.resourceType}/${value}/`);
         return resource[resourceLabelKey as keyof typeof resource]?.toString() || '';
       } catch {
         return value;

--- a/frontend/awx/access/common/useDynamicFilters.tsx
+++ b/frontend/awx/access/common/useDynamicFilters.tsx
@@ -8,9 +8,6 @@ import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { awxAPI } from '../../common/api/awx-utils';
 import { QueryParams } from '../../common/useAwxView';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
-import { Organization } from '../../interfaces/Organization';
-import { UnifiedJob } from '../../interfaces/UnifiedJob';
-import { UnifiedJobTemplate } from '../../interfaces/generated-from-swagger/api';
 
 interface DynamicToolbarFiltersProps {
   /** API endpoint for the options that generated the filters */
@@ -98,9 +95,7 @@ function craftRequestUrl(optionsPath: string, params: QueryParams | undefined, p
   return url;
 }
 
-export function useDynamicToolbarFilters<T extends Organization | UnifiedJob | UnifiedJobTemplate>(
-  props: DynamicToolbarFiltersProps
-) {
+export function useDynamicToolbarFilters<T>(props: DynamicToolbarFiltersProps) {
   const { optionsPath, preSortedKeys, asyncKeys, additionalFilters } = props;
   const { t } = useTranslation();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/${optionsPath}/`);

--- a/frontend/awx/access/common/useDynamicFilters.tsx
+++ b/frontend/awx/access/common/useDynamicFilters.tsx
@@ -83,7 +83,7 @@ export function useFilters(actions?: { [key: string]: ActionsResponse }) {
 }
 
 function craftRequestUrl(optionsPath: string, params: QueryParams | undefined, page: number) {
-  let url = `api/v2/${optionsPath}/?page=${page}&page_size=100`;
+  let url = awxAPI`/${optionsPath}/?page=${page.toString()}&page_size=100`;
 
   if (params) {
     const queryParams = Object.entries(params)
@@ -127,7 +127,7 @@ export function useDynamicToolbarFilters<T>(props: DynamicToolbarFiltersProps) {
       if (!resourceKey) return value;
       const resourceLabelKey = asyncKey?.resourceLabelKey || resourceKey;
       try {
-        const resource = await requestGet<T>(`api/v2/${asyncKey?.resourcePath}/${value}/`);
+        const resource = await requestGet<T>(awxAPI`/${asyncKey?.resourcePath}/${value}/`);
         return resource[resourceLabelKey as keyof typeof resource]?.toString() || '';
       } catch {
         return value;

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -7,6 +7,7 @@ import {
   ToolbarFilterType,
   useSelected,
 } from '../../../framework';
+import { DateRangeFilterPresets } from '../../../framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter';
 import { IView, useView } from '../../../framework/useView';
 import { getItemKey, swrOptions, useFetcher } from '../../common/crud/Data';
 import { RequestError } from '../../common/crud/RequestError';
@@ -109,19 +110,23 @@ export function useAwxView<T extends { id: number }>(options: {
                 const date = new Date(Date.now() - 24 * 60 * 60 * 1000);
                 date.setSeconds(0);
                 date.setMilliseconds(0);
-                switch (values[0]) {
-                  case 'last24hours':
+                switch (values[0] as DateRangeFilterPresets) {
+                  case DateRangeFilterPresets.LastHour:
+                    queryString += `${toolbarFilter.query}__gte=${new Date(
+                      date.getTime() - 60 * 60 * 1000
+                    ).toISOString()}`;
+                    break;
+                  case DateRangeFilterPresets.Last24Hours:
                     queryString += `${toolbarFilter.query}__gte=${new Date(
                       date.getTime() - 24 * 60 * 60 * 1000
                     ).toISOString()}`;
                     break;
-
-                  case 'last7days':
+                  case DateRangeFilterPresets.LastWeek:
                     queryString += `${toolbarFilter.query}__gte=${new Date(
                       date.getTime() - 7 * 24 * 60 * 60 * 1000
                     ).toISOString()}`;
                     break;
-                  case 'last30days':
+                  case DateRangeFilterPresets.LastMonth:
                     queryString += `${toolbarFilter.query}__gte=${new Date(
                       date.getTime() - 30 * 24 * 60 * 60 * 1000
                     ).toISOString()}`;

--- a/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
@@ -11,16 +11,7 @@ export function useProjectsFilters() {
   const toolbarFilters = useDynamicToolbarFilters<Project>({
     optionsPath: 'projects',
     preSortedKeys: ['name', 'id', 'status', 'scm_type', 'created-by', 'modified-by'],
-    asyncFilterKeys: {
-      name: { resourceType: 'projects', params: { order_by: '-created' } },
-      id: { resourceType: 'projects', params: { order_by: '-id' } },
-      organization: {
-        resourceType: 'organizations',
-        params: { order_by: '-created' },
-        labelKey: 'name',
-        valueKey: 'id',
-      },
-    },
+    preFilledValueKeys: ['name', 'id'],
     additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
   });
   return toolbarFilters;

--- a/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
@@ -1,8 +1,8 @@
+import { useDynamicToolbarFilters } from '../../../access/common/useDynamicFilters';
 import {
   useCreatedByToolbarFilter,
   useModifiedByToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
-import { useDynamicToolbarFilters } from '../../../access/common/useDynamicFilters';
 import { Project } from '../../../interfaces/Project';
 
 export function useProjectsFilters() {
@@ -11,8 +11,11 @@ export function useProjectsFilters() {
 
   const toolbarFilters = useDynamicToolbarFilters<Project>({
     optionsPath: 'projects',
-    preFilledValueKeys: ['name', 'id'],
     preSortedKeys: ['name', 'id', 'status', 'scm_type', 'created-by', 'modified-by'],
+    asyncKeys: {
+      name: { resourcePath: 'projects', params: { order_by: '-created' } },
+      id: { resourcePath: 'projects', params: { order_by: '-id' } },
+    },
     additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
   });
   return toolbarFilters;

--- a/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
@@ -11,7 +11,7 @@ export function useProjectsFilters() {
   const toolbarFilters = useDynamicToolbarFilters<Project>({
     optionsPath: 'projects',
     preSortedKeys: ['name', 'id', 'status', 'scm_type', 'created-by', 'modified-by'],
-    asyncKeys: {
+    asyncFilterKeys: {
       name: { resourceType: 'projects', params: { order_by: '-created' } },
       id: { resourceType: 'projects', params: { order_by: '-id' } },
       organization: {

--- a/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
@@ -8,13 +8,18 @@ import { Project } from '../../../interfaces/Project';
 export function useProjectsFilters() {
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
-
   const toolbarFilters = useDynamicToolbarFilters<Project>({
     optionsPath: 'projects',
     preSortedKeys: ['name', 'id', 'status', 'scm_type', 'created-by', 'modified-by'],
     asyncKeys: {
       name: { resourcePath: 'projects', params: { order_by: '-created' } },
       id: { resourcePath: 'projects', params: { order_by: '-id' } },
+      organization: {
+        resourcePath: 'organizations',
+        params: { order_by: '-created' },
+        resourceLabelKey: 'name',
+        resourceKey: 'id',
+      },
     },
     additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
   });

--- a/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectsFilters.tsx
@@ -12,13 +12,13 @@ export function useProjectsFilters() {
     optionsPath: 'projects',
     preSortedKeys: ['name', 'id', 'status', 'scm_type', 'created-by', 'modified-by'],
     asyncKeys: {
-      name: { resourcePath: 'projects', params: { order_by: '-created' } },
-      id: { resourcePath: 'projects', params: { order_by: '-id' } },
+      name: { resourceType: 'projects', params: { order_by: '-created' } },
+      id: { resourceType: 'projects', params: { order_by: '-id' } },
       organization: {
-        resourcePath: 'organizations',
+        resourceType: 'organizations',
         params: { order_by: '-created' },
-        resourceLabelKey: 'name',
-        resourceKey: 'id',
+        labelKey: 'name',
+        valueKey: 'id',
       },
     },
     additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -1,12 +1,12 @@
 import { CubesIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, PageLayout, PageTable } from '../../../../framework';
+import { ITableColumn, PageTable } from '../../../../framework';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxView } from '../../common/useAwxView';
+import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { useJobRowActions } from '../../views/jobs/hooks/useJobRowActions';
 import { useJobToolbarActions } from '../../views/jobs/hooks/useJobToolbarActions';
-import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
 
 type QueryParams = { [key: string]: string };
@@ -30,20 +30,18 @@ export function JobsList(props: {
   usePersistentFilters('jobs');
 
   return (
-    <PageLayout>
-      <PageTable<UnifiedJob>
-        id="awx-jobs-table"
-        toolbarFilters={toolbarFilters}
-        tableColumns={tableColumns}
-        rowActions={rowActions}
-        toolbarActions={toolbarActions}
-        errorStateTitle={t('Error loading jobs')}
-        emptyStateTitle={t('No jobs yet')}
-        emptyStateDescription={t('Please run a job to populate this list.')}
-        emptyStateIcon={CubesIcon}
-        {...view}
-        limitFiltersToOneOrOperation
-      />
-    </PageLayout>
+    <PageTable<UnifiedJob>
+      id="awx-jobs-table"
+      toolbarFilters={toolbarFilters}
+      tableColumns={tableColumns}
+      rowActions={rowActions}
+      toolbarActions={toolbarActions}
+      errorStateTitle={t('Error loading jobs')}
+      emptyStateTitle={t('No jobs yet')}
+      emptyStateDescription={t('Please run a job to populate this list.')}
+      emptyStateIcon={CubesIcon}
+      {...view}
+      limitFiltersToOneOrOperation
+    />
   );
 }

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -41,7 +41,6 @@ export function JobsList(props: {
       emptyStateDescription={t('Please run a job to populate this list.')}
       emptyStateIcon={CubesIcon}
       {...view}
-      limitFiltersToOneOrOperation
     />
   );
 }

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -5,22 +5,7 @@ export function useJobsFilters() {
   const toolBarFilters = useDynamicToolbarFilters<UnifiedJob>({
     optionsPath: 'unified_jobs',
     preSortedKeys: ['name', 'description', 'status'],
-    asyncFilterKeys: {
-      name: { resourceType: 'unified_jobs', params: { order_by: '-finished' } },
-      id: { resourceType: 'unified_jobs', params: { order_by: '-id' } },
-      execution_environment: {
-        resourceType: 'execution_environments',
-        params: { order_by: '-created' },
-        labelKey: 'name',
-        valueKey: 'id',
-      },
-      unified_job_template: {
-        resourceType: 'unified_job_templates',
-        params: { order_by: '-created' },
-        labelKey: 'name',
-        valueKey: 'id',
-      },
-    },
+    preFilledValueKeys: ['name', 'id'],
   });
 
   return toolBarFilters;

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -5,7 +5,7 @@ export function useJobsFilters() {
   const toolBarFilters = useDynamicToolbarFilters<UnifiedJob>({
     optionsPath: 'unified_jobs',
     preSortedKeys: ['name', 'description', 'status'],
-    asyncKeys: {
+    asyncFilterKeys: {
       name: { resourceType: 'unified_jobs', params: { order_by: '-finished' } },
       id: { resourceType: 'unified_jobs', params: { order_by: '-id' } },
       execution_environment: {

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -6,19 +6,19 @@ export function useJobsFilters() {
     optionsPath: 'unified_jobs',
     preSortedKeys: ['name', 'description', 'status'],
     asyncKeys: {
-      name: { resourcePath: 'unified_jobs', params: { order_by: '-finished' } },
-      id: { resourcePath: 'unified_jobs', params: { order_by: '-id' } },
+      name: { resourceType: 'unified_jobs', params: { order_by: '-finished' } },
+      id: { resourceType: 'unified_jobs', params: { order_by: '-id' } },
       execution_environment: {
-        resourcePath: 'execution_environments',
+        resourceType: 'execution_environments',
         params: { order_by: '-created' },
-        resourceLabelKey: 'name',
-        resourceKey: 'id',
+        labelKey: 'name',
+        valueKey: 'id',
       },
       unified_job_template: {
-        resourcePath: 'unified_job_templates',
+        resourceType: 'unified_job_templates',
         params: { order_by: '-created' },
-        resourceLabelKey: 'name',
-        resourceKey: 'id',
+        labelKey: 'name',
+        valueKey: 'id',
       },
     },
   });

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -5,7 +5,22 @@ export function useJobsFilters() {
   const toolBarFilters = useDynamicToolbarFilters<UnifiedJob>({
     optionsPath: 'unified_jobs',
     preSortedKeys: ['name', 'description', 'status'],
-    preFilledValueKeys: ['name', 'id'],
+    asyncKeys: {
+      name: { resourcePath: 'unified_jobs', params: { order_by: '-finished' } },
+      id: { resourcePath: 'unified_jobs', params: { order_by: '-id' } },
+      execution_environment: {
+        resourcePath: 'execution_environments',
+        params: { order_by: '-created' },
+        resourceLabelKey: 'name',
+        resourceKey: 'id',
+      },
+      unified_job_template: {
+        resourcePath: 'unified_job_templates',
+        params: { order_by: '-created' },
+        resourceLabelKey: 'name',
+        resourceKey: 'id',
+      },
+    },
   });
 
   return toolBarFilters;


### PR DESCRIPTION
Enhances the awesome advanced searching PR to support async filters on object other than the table object.
Example: Jobs table filtering on execution environment

![Screenshot 2024-03-08 at 11 36 52 AM](https://github.com/ansible/ansible-ui/assets/6277895/5509cf61-8ed8-4e3a-a407-857842f7da30)


```
execution_environment: {
  resourcePath: 'execution_environments',
  params: { order_by: '-created' },
  resourceLabelKey: 'name',
  resourceKey: 'id',
},
```

Also added sorting of dropdown items by default with a flag to disable.