### PR TITLE
AWX hosts add edit form

### DIFF
--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -118,6 +118,7 @@ export function useAwxView<T extends { id: number }>(options: {
 
   url += queryString;
   const fetcher = useFetcher();
+
   const response = useSWR<AwxItemsResponse<T>>(url, fetcher, swrOptions);
   const { data, mutate } = response;
   const refresh = useCallback(async () => {

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -118,7 +118,6 @@ export function useAwxView<T extends { id: number }>(options: {
 
   url += queryString;
   const fetcher = useFetcher();
-
   const response = useSWR<AwxItemsResponse<T>>(url, fetcher, swrOptions);
   const { data, mutate } = response;
   const refresh = useCallback(async () => {

--- a/frontend/awx/main/routes/useAwxHostRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxHostRoutes.tsx
@@ -44,12 +44,12 @@ export function useAwxHostRoutes() {
               path: 'jobs',
               element: <HostJobs />,
             },
-            {
-              id: AwxRoute.EditHost,
-              path: 'edit',
-              element: <EditHost />,
-            },
           ],
+        },
+        {
+          id: AwxRoute.EditHost,
+          path: ':id/edit',
+          element: <EditHost />,
         },
         {
           id: AwxRoute.CreateHost,

--- a/frontend/awx/main/routes/useAwxHostRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxHostRoutes.tsx
@@ -6,6 +6,10 @@ import { HostPage } from '../../resources/hosts/HostPage/HostPage';
 import { Hosts } from '../../resources/hosts/Hosts';
 import { AwxRoute } from '../AwxRoutes';
 import { HostJobs } from '../../resources/hosts/HostPage/HostJobs';
+import {
+  CreateHost,
+  EditHost,
+} from '../../resources/inventories/inventoryHostsPage/InventoryHostForm';
 
 export function useAwxHostRoutes() {
   const { t } = useTranslation();
@@ -40,7 +44,17 @@ export function useAwxHostRoutes() {
               path: 'jobs',
               element: <HostJobs />,
             },
+            {
+              id: AwxRoute.EditHost,
+              path: 'edit',
+              element: <EditHost />,
+            },
           ],
+        },
+        {
+          id: AwxRoute.CreateHost,
+          path: 'create',
+          element: <CreateHost />,
         },
         {
           path: '',

--- a/frontend/awx/resources/hosts/hooks/useHostsActions.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostsActions.tsx
@@ -67,9 +67,8 @@ export function useHostsActions(
             });
           } else if (params.id) {
             pageNavigate(AwxRoute.EditHost, { params: { id: params.id } });
-          } else
-          {
-            pageNavigate(AwxRoute.EditHost, { params: { host_id: host.id } });
+          } else {
+            pageNavigate(AwxRoute.EditHost, { params: { id: host.id } });
           }
         },
         isDisabled: (host) => cannotEditResource(host, t),

--- a/frontend/awx/resources/hosts/hooks/useHostsActions.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostsActions.tsx
@@ -67,6 +67,9 @@ export function useHostsActions(
             });
           } else if (params.id) {
             pageNavigate(AwxRoute.EditHost, { params: { id: params.id } });
+          } else
+          {
+            pageNavigate(AwxRoute.EditHost, { params: { host_id: host.id } });
           }
         },
         isDisabled: (host) => cannotEditResource(host, t),

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -242,7 +242,7 @@ export function EditHost() {
     name: host.name,
     description: host.description,
     variables: host.variables,
-    inventory: { name: host.summary_fields?.inventory.name },
+    inventory: { name: host.summary_fields?.inventory?.name },
   };
 
   let breadcrumbs: ICatalogBreadcrumb[] = [];
@@ -251,7 +251,7 @@ export function EditHost() {
     breadcrumbs = [
       { label: t('Inventories'), to: getPageUrl(AwxRoute.Inventories) },
       {
-        label: t(`${hostResponse?.summary_fields?.inventory.name}`),
+        label: t(`${hostResponse?.summary_fields?.inventory?.name}`),
         to: getPageUrl(AwxRoute.InventoryDetails, {
           params: { id: params.id, inventory_type: params.inventory_type },
         }),
@@ -315,8 +315,8 @@ function HostInputs(props: { edit_mode?: boolean; inventory_host?: boolean }) {
       total: response.count,
       options:
         response.results?.map((resource) => ({
-          label: resource.name,
-          value: resource.id,
+          label: resource?.name,
+          value: resource?.id,
           description: resource.description,
         })) ?? [],
     });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -139,12 +139,29 @@ export function CreateHost() {
   );
 }
 
+function useHostParams() : { id?: string; inventory_type?: string; host_id?: string, group_id? : string }
+{
+  const params = useParams<{ id: string; inventory_type: string; host_id: string, group_id : string }>();
+
+  let id = params.id;
+  let host_id = params.host_id;
+
+  if (!host_id)
+  {
+    // this means the form was opened from host list, which passes host_id as id, so we have to rename it
+    host_id = id;
+    id = undefined;
+  }
+
+  return { id, host_id, inventory_type : params.inventory_type, group_id : params.group_id  };
+}
+
 export function EditHost() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
+  const params = useHostParams();
 
   const { host: hostResponse } = useGetHost(params.host_id ?? '');
   const inventoryResponse = useGetInventory(params.id, params.inventory_type);

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -28,7 +28,6 @@ import { requestGet } from '../../../../common/crud/Data';
 import { useCallback } from 'react';
 import { Inventory } from '../../../interfaces/Inventory';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
-import { PageAsyncSingleSelectOptionsFn } from '../../../../../framework/PageInputs/PageAsyncSingleSelect';
 import { PageSingleSelectContext } from '../../../../../framework/PageInputs/PageSingleSelect';
 import { Button } from '@patternfly/react-core';
 import { useSelectInventorySingle } from './hooks/useInventorySelector';
@@ -307,7 +306,7 @@ export function EditHost() {
 function HostInputs(props: { edit_mode?: boolean; inventory_host?: boolean }) {
   const { t } = useTranslation();
 
-  const queryOptions = useCallback<PageAsyncSingleSelectOptionsFn<number>>(async () => {
+  const queryOptions = useCallback(async () => {
     const response = await requestGet<AwxItemsResponse<Inventory>>(
       awxAPI`/inventories/?order_by=name`
     );

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -184,7 +184,6 @@ function useHostParams(mode: 'edit' | 'create'): {
   let inventory_host = false;
 
   if (!host_id && mode === 'edit') {
-    // this means the form was opened from host list, which passes host_id as id, so we have to rename it
     host_id = id;
     id = undefined;
   }
@@ -350,6 +349,7 @@ function HostInputs(props: { edit_mode?: boolean; inventory_host?: boolean }) {
       {!props.inventory_host && !props.edit_mode && (
         <PageFormAsyncSingleSelect
           name="inventory.id"
+          isRequired
           label={t('Inventory')}
           placeholder={t('Select Inventory')}
           queryOptions={queryOptions}

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -72,54 +72,69 @@ export function CreateHost() {
   const inventoryResponse = useGetInventory(params.id, params.inventory_type);
 
 
-  
+  let breadcrumbs : ICatalogBreadcrumb[] = [];
+
+  if (params.inventory_host)
+  {
+    breadcrumbs =  [
+      { label: t('Inventories'), to: getPageUrl(AwxRoute.Inventories) },
+      {
+        label: t(`${inventoryResponse?.name}`),
+        to: getPageUrl(AwxRoute.InventoryDetails, {
+          params: { id: params.id, inventory_type: params.inventory_type },
+        }),
+      },
+      params?.group_id
+        ? {
+            label: t('Groups'),
+            id: 'group',
+            to: getPageUrl(AwxRoute.InventoryGroups, {
+              params: {
+                id: params.group_id,
+                inventory_type: params.inventory_type,
+              },
+            }),
+          }
+        : {
+            label: t('Hosts'),
+            id: 'hosts',
+            to: getPageUrl(AwxRoute.InventoryHosts, {
+              params: {
+                id: params.id,
+                inventory_type: params.inventory_type,
+                host_id: params.host_id,
+              },
+            }),
+          },
+      params?.group_id
+        ? {
+            label: t(`${groupName}`),
+            to: getPageUrl(AwxRoute.InventoryGroupDetails, {
+              params: {
+                id: params.group_id,
+                inventory_type: params.inventory_type,
+                group_id: params.group_id,
+              },
+            }),
+          }
+        : {},
+      { label: t('Add') },
+    ];
+  }else
+  {
+    breadcrumbs = [
+      {
+        label: t('Hosts'),
+        to: getPageUrl(AwxRoute.Hosts),
+      },
+      { label: t('Create') },
+    ];
+  }
+
   return (
     <PageLayout>
       <PageHeader
-        breadcrumbs={[
-          { label: t('Inventories'), to: getPageUrl(AwxRoute.Inventories) },
-          {
-            label: t(`${inventoryResponse?.name}`),
-            to: getPageUrl(AwxRoute.InventoryDetails, {
-              params: { id: params.id, inventory_type: params.inventory_type },
-            }),
-          },
-          params?.group_id
-            ? {
-                label: t('Groups'),
-                id: 'group',
-                to: getPageUrl(AwxRoute.InventoryGroups, {
-                  params: {
-                    id: params.group_id,
-                    inventory_type: params.inventory_type,
-                  },
-                }),
-              }
-            : {
-                label: t('Hosts'),
-                id: 'hosts',
-                to: getPageUrl(AwxRoute.InventoryHosts, {
-                  params: {
-                    id: params.id,
-                    inventory_type: params.inventory_type,
-                    host_id: params.host_id,
-                  },
-                }),
-              },
-          params?.group_id
-            ? {
-                label: t(`${groupName}`),
-                to: getPageUrl(AwxRoute.InventoryGroupDetails, {
-                  params: {
-                    id: params.group_id,
-                    inventory_type: params.inventory_type,
-                    group_id: params.group_id,
-                  },
-                }),
-              }
-            : {},
-          { label: t('Add') },
-        ]}
+        breadcrumbs={breadcrumbs}
         title={t('Create Host')}
       />
       <AwxPageForm

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -37,12 +37,8 @@ export function CreateHost() {
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const params = useParams<{
-    id: string;
-    inventory_type: string;
-    host_id: string;
-    group_id: string;
-  }>();
+  const params = useHostParams();
+
   const postRequest = usePostRequest<AwxHost>();
   const getRequest = useGetRequest<InventoryGroup>();
 
@@ -158,13 +154,17 @@ function useHostParams(): {
   let id = params.id;
   let host_id = params.host_id;
 
-  let inventory_host = true;
+  let inventory_host = false;
 
   if (!host_id) {
     // this means the form was opened from host list, which passes host_id as id, so we have to rename it
     host_id = id;
     id = undefined;
-    inventory_host = false;
+  }
+
+  if (id)
+  {
+    inventory_host = true;
   }
 
   return {

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -191,9 +191,14 @@ export function EditHost() {
 
   const onSubmit: PageFormSubmitHandler<IHostInput> = async (hostInput: IHostInput) => {
     await requestPatch<AwxHost>(awxAPI`/hosts/${params.host_id ?? ''}/`, hostInput);
-    pageNavigate(AwxRoute.InventoryHostDetails, {
-      params: { inventory_type: params.inventory_type, id: params.id, host_id: params.host_id },
-    });
+
+    if (params.inventory_host) {
+      pageNavigate(AwxRoute.InventoryHostDetails, {
+        params: { inventory_type: params.inventory_type, id: params.id, host_id: params.host_id },
+      });
+    } else {
+      pageNavigate(AwxRoute.Hosts);
+    }
   };
 
   const onCancel = () => navigate(-1);

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.tsx
@@ -37,7 +37,7 @@ export function CreateHost() {
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const params = useHostParams();
+  const params = useHostParams('create');
 
   const postRequest = usePostRequest<AwxHost>();
   const getRequest = useGetRequest<InventoryGroup>();
@@ -71,6 +71,8 @@ export function CreateHost() {
 
   const inventoryResponse = useGetInventory(params.id, params.inventory_type);
 
+
+  
   return (
     <PageLayout>
       <PageHeader
@@ -137,7 +139,7 @@ export function CreateHost() {
   );
 }
 
-function useHostParams(): {
+function useHostParams(mode : 'edit' | 'create'): {
   id?: string;
   inventory_type?: string;
   host_id?: string;
@@ -156,7 +158,7 @@ function useHostParams(): {
 
   let inventory_host = false;
 
-  if (!host_id) {
+  if (!host_id && mode == 'edit') {
     // this means the form was opened from host list, which passes host_id as id, so we have to rename it
     host_id = id;
     id = undefined;
@@ -181,7 +183,7 @@ export function EditHost() {
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const params = useHostParams();
+  const params = useHostParams('edit');
 
   const { host: hostResponse } = useGetHost(params.host_id ?? '');
 

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useInventorySelector.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useInventorySelector.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+import {
+  AsyncSelectFilterBuilderProps,
+  useAsyncSingleSelectFilterBuilder,
+} from '../../../../../../framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSelectFilterBuilder';
+
+import { useAwxView } from '../../../../common/useAwxView';
+
+import { useInventoriesColumns } from '../../hooks/useInventoriesColumns';
+import { useInventoriesFilters } from '../../hooks/useInventoriesFilters';
+import { Inventory } from '../../../../interfaces/Inventory';
+
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { useMemo } from 'react';
+import { ITableColumn } from '../../../../../../framework';
+import { TextCell } from '../../../../../../framework';
+
+function useParameters(): AsyncSelectFilterBuilderProps<Inventory> {
+  const tableColumns = useInventoriesColumns();
+  const toolbarFilters = useInventoriesFilters();
+
+  const { t } = useTranslation();
+
+  return {
+    title: t`Select Inventory`,
+    tableColumns,
+    useView: useAwxView,
+    toolbarFilters,
+    viewParams: {
+      url: awxAPI`/inventories/`,
+      toolbarFilters,
+      tableColumns,
+      keyFn: (item) => item?.name,
+    },
+  };
+}
+
+export function useSelectInventorySingle() {
+  const params = useParameters();
+
+  return useAsyncSingleSelectFilterBuilder<Inventory>(params);
+}
+
+export function useColumns() {
+  const { t } = useTranslation();
+  return useMemo<ITableColumn<Inventory>[]>(
+    () => [
+      {
+        header: t('Name'),
+        value: (inventory) => inventory.name,
+        cell: (inventory) => <TextCell text={inventory.name} />,
+      },
+    ],
+    [t]
+  );
+}

--- a/frontend/common/crud/Data.tsx
+++ b/frontend/common/crud/Data.tsx
@@ -91,7 +91,7 @@ export function usePostFetcher() {
 }
 
 export function getItemKey(item: { id: number | string }) {
-  return item.id.toString();
+  return item?.id.toString();
 }
 
 export const swrOptions: SWRConfiguration = {


### PR DESCRIPTION
Adds create and edit form for host list.

It uses existing forms in inventories - hosts. It only modifies them so:

it can work with new URL, when inventory id params is missing, the form knows it is accessed from hosts list. It will then either display inventory (in edit mode), or it will offer inventory dropdown (in create mode). 

![image](https://github.com/ansible/ansible-ui/assets/23277791/44a6cb45-045f-49ea-b6e4-de59fdf80f39)

After clicking Browse:
![image](https://github.com/ansible/ansible-ui/assets/23277791/27f270c7-f25a-4d29-9ee5-2baf585a3c70)

![image](https://github.com/ansible/ansible-ui/assets/23277791/f66faa84-9fef-451e-beb1-485892283e66)
