### PR TITLE
completing test automation for Instances

### DIFF
--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -8,7 +8,7 @@ describe('Instances - Add/Edit', () => {
   beforeEach(() => {
     cy.awxLogin();
     cy.navigateTo('awx', 'instances');
-    cy.createAwxInstance('E2EInstanceTest' + randomString(5)).then((ins: Instance) => {
+    cy.createAwxInstance('E2EInstanceTestAddEdit' + randomString(5)).then((ins: Instance) => {
       instance = ins;
     });
   });
@@ -22,28 +22,27 @@ describe('Instances - Add/Edit', () => {
   });
 
   it('user can add a new instance and navigate to the details page', () => {
-    const instanceHostname = 'E2EInstanceTestAdd' + randomString(5);
+    const instanceHostname = 'E2EInstanceTestAddEdit' + randomString(5);
 
-    cy.get('[data-cy="add-instance"]').click();
-    cy.get('[data-cy="page-title"]').should('contain', 'Add instance');
+    cy.getByDataCy('add-instance').click();
+    cy.getByDataCy('page-title').should('contain', 'Add instance');
 
-    cy.get('[data-cy="hostname"]').type(instanceHostname);
-    cy.get('[data-cy="listener-port"]').type('9999');
-    cy.get('[data-cy="enabled"]').click();
-    cy.get('[data-cy="managed_by_policy"]').click();
-    cy.get('[data-cy="peers_from_control_nodes"]').click();
+    cy.getByDataCy('hostname').type(instanceHostname);
+    cy.getByDataCy('listener-port').type('9999');
+    cy.getByDataCy('managed_by_policy').click();
+    cy.getByDataCy('peers_from_control_nodes').click();
 
     cy.intercept('POST', awxAPI`/instances/`).as('newInstance');
-    cy.get('[data-cy="Submit"]').click();
+    cy.getByDataCy('Submit').click();
     cy.wait('@newInstance')
       .its('response.body')
       .then((instance: Instance) => {
         cy.navigateTo('awx', 'instances');
         cy.clickTableRow(instanceHostname);
-        cy.get('[data-cy="name"]').should('contain', instanceHostname);
-        cy.get('[data-cy="node-type"]').should('contain', 'Execution');
-        cy.get('[data-cy="status"]').should('contain', 'Installed');
-        cy.get('[data-cy="listener-port"]').should('contain', '9999');
+        cy.getByDataCy('name').should('contain', instanceHostname);
+        cy.getByDataCy('node-type').should('contain', 'Execution');
+        cy.getByDataCy('status').should('contain', 'Installed');
+        cy.getByDataCy('listener-port').should('contain', '9999');
         cy.removeAwxInstance(instance.id.toString(), { failOnStatusCode: false });
       });
   });
@@ -55,11 +54,11 @@ describe('Instances - Add/Edit', () => {
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
     });
-    cy.get('[data-cy="edit-instance"]').click();
-    cy.get('[data-cy="listener-port"]').type('9999');
-    cy.get('[data-cy="enabled"]').check();
-    cy.get('[data-cy="managed_by_policy"]').check();
-    cy.get('[data-cy="peers_from_control_nodes"]').check();
+    cy.getByDataCy('edit-instance').click();
+    cy.getByDataCy('listener-port').type('9999');
+    cy.getByDataCy('enabled').check();
+    cy.getByDataCy('managed_by_policy').check();
+    cy.getByDataCy('peers_from_control_nodes').check();
 
     cy.clickButton(/^Save$/);
     cy.wait('@editedInstance')
@@ -100,11 +99,11 @@ describe('Instances - Remove', () => {
       expect(currentUrl.includes('details')).to.be.true;
     });
 
-    cy.get('[data-cy="remove-instance"]').click();
+    cy.getByDataCy('remove-instance').click();
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
       cy.get('header').contains('Permanently remove instances');
       cy.get('button').contains('Remove instance').should('have.attr', 'aria-disabled', 'true');
-      cy.get('[data-cy="name-column-cell"]').should('have.text', instance.hostname);
+      cy.getByDataCy('name-column-cell').should('have.text', instance.hostname);
       cy.get('input[id="confirm"]').click();
       cy.get('button').contains('Remove instance').click();
     });
@@ -127,7 +126,7 @@ describe('Instances - Remove', () => {
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
       cy.get('header').contains('Permanently remove instances');
       cy.get('button').contains('Remove instance').should('have.attr', 'aria-disabled', 'true');
-      cy.get('[data-cy="name-column-cell"]').should('have.text', instance.hostname);
+      cy.getByDataCy('name-column-cell').should('have.text', instance.hostname);
       cy.get('input[id="confirm"]').click();
       cy.get('button').contains('Remove instance').click();
     });
@@ -194,11 +193,11 @@ describe('Instances - Peers', () => {
 
     cy.intercept('PATCH', '/api/v2/instances/*').as('associatePeer');
     cy.clickTableRow(instance.hostname);
-    cy.get('[data-cy="instances-peers-tab"]').click();
+    cy.getByDataCy('instances-peers-tab').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('peers')).to.be.true;
     });
-    cy.get('[data-cy="associate-peer"]').click();
+    cy.getByDataCy('associate-peer').click();
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
       cy.get('header').contains('Select peer addresses');
       cy.get('button').contains('Associate peer(s)').should('have.attr', 'aria-disabled', 'true');
@@ -213,12 +212,12 @@ describe('Instances - Peers', () => {
       .then((response) => {
         expect(response?.statusCode).to.eql(200);
         cy.filterTableBySingleText(instanceToAssociate.hostname, true);
-        cy.get('[data-cy="instance-name-column-cell"]').click();
+        cy.getByDataCy('instance-name-column-cell').click();
       });
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
     });
-    cy.get('[data-cy="instances-details-tab"]').should('be.visible');
+    cy.getByDataCy('instances-details-tab').should('be.visible');
   });
 });
 
@@ -239,7 +238,7 @@ describe('Instances - Listener Addresses', () => {
 
   it('user can navigate to the listener addresses tab in details page', () => {
     cy.clickTableRow(instance?.hostname);
-    cy.get('[data-cy="instances-listener-addresses-tab"]').click();
+    cy.getByDataCy('instances-listener-addresses-tab').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('listener-addresses')).to.be.true;
     });

--- a/frontend/awx/administration/instances/InstancesPage.cy.tsx
+++ b/frontend/awx/administration/instances/InstancesPage.cy.tsx
@@ -14,18 +14,18 @@ describe('Instances Page', () => {
     cy.mount(<InstancePage />);
     cy.get('[data-cy="page-title"]').should('have.text', 'receptor-1');
     cy.contains('nav[aria-label="Breadcrumb"]', 'receptor-1').should('exist');
-    cy.get('[data-cy="back-to instances"]').should('be.visible');
-    cy.get('[data-cy="back-to instances"]').should('be.enabled');
-    cy.get('[data-cy="instances-details-tab"]').should('be.visible');
-    cy.get('[data-cy="instances-details-tab"]').should('be.enabled');
-    cy.get('[data-cy="instances-peers-tab"]').should('be.visible');
-    cy.get('[data-cy="instances-peers-tab"]').should('be.enabled');
-    cy.get('[data-cy="edit-instance"]').should('be.visible');
-    cy.get('[data-cy="edit-instance"]').should('be.enabled');
-    cy.get('[data-cy="remove-instance"]').should('be.visible');
-    cy.get('[data-cy="remove-instance"]').should('be.enabled');
-    cy.get('[data-cy="run-health-check"]').should('be.visible');
-    cy.get('[data-cy="run-health-check"]').should('be.enabled');
+    cy.getByDataCy('back-to instances').should('be.visible');
+    cy.getByDataCy('back-to instances').should('be.enabled');
+    cy.getByDataCy('instances-details-tab').should('be.visible');
+    cy.getByDataCy('instances-details-tab').should('be.enabled');
+    cy.getByDataCy('instances-peers-tab').should('be.visible');
+    cy.getByDataCy('instances-peers-tab').should('be.enabled');
+    cy.getByDataCy('edit-instance').should('be.visible');
+    cy.getByDataCy('edit-instance').should('be.enabled');
+    cy.getByDataCy('remove-instance').should('be.visible');
+    cy.getByDataCy('remove-instance').should('be.enabled');
+    cy.getByDataCy('run-health-check').should('be.visible');
+    cy.getByDataCy('run-health-check').should('be.enabled');
   });
 
   it('edit instance button should be hidden for non-k8s system', () => {
@@ -33,7 +33,7 @@ describe('Instances Page', () => {
       IS_K8S: false,
     }).as('isK8s');
     cy.mount(<InstancePage />);
-    cy.get('[data-cy="edit-instance"]').should('not.exist');
+    cy.getByDataCy('edit-instance').should('not.exist');
   });
 
   it('edit instance button should be shown for k8s system', () => {
@@ -41,8 +41,8 @@ describe('Instances Page', () => {
       IS_K8S: true,
     }).as('isK8s');
     cy.mount(<InstancePage />);
-    cy.get('[data-cy="edit-instance"]').should('be.visible');
-    cy.get('[data-cy="edit-instance"]').should('have.attr', 'aria-disabled', 'false');
+    cy.getByDataCy('edit-instance').should('be.visible');
+    cy.getByDataCy('edit-instance').should('have.attr', 'aria-disabled', 'false');
   });
 
   it('only admin users can edit instance', () => {
@@ -53,8 +53,8 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
-        cy.get('[data-cy="edit-instance"]').should('be.visible');
-        cy.get('[data-cy="edit-instance"]').should('have.attr', 'aria-disabled', 'false');
+        cy.getByDataCy('edit-instance').should('be.visible');
+        cy.getByDataCy('edit-instance').should('have.attr', 'aria-disabled', 'false');
       });
   });
 
@@ -94,8 +94,8 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
-        cy.get('[data-cy="remove-instance"]').should('be.visible');
-        cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
+        cy.getByDataCy('remove-instance').should('be.visible');
+        cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'true');
       });
   });
 
@@ -112,8 +112,8 @@ describe('Instances Page', () => {
       IS_K8S: true,
     }).as('isK8s');
     cy.mount(<InstancePage />);
-    cy.get('[data-cy="remove-instance"]').should('be.visible');
-    cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
+    cy.getByDataCy('remove-instance').should('be.visible');
+    cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
   });
 
   it('only admin users can remove instance', () => {
@@ -124,8 +124,8 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
-        cy.get('[data-cy="remove-instance"]').should('be.visible');
-        cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
+        cy.getByDataCy('remove-instance').should('be.visible');
+        cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
       });
   });
 
@@ -172,6 +172,24 @@ describe('Instances Page', () => {
       IS_K8S: true,
     }).as('isK8s');
     cy.mount(<InstancePage />);
-    cy.get('[data-cy="instances-peers-tab"]').should('not.exist');
+    cy.getByDataCy('instances-peers-tab').should('be.visible');
+    cy.getByDataCy('instances-peers-tab').should('be.enabled');
+  });
+
+  it('listener addresses tab should be hidden for non-k8s system', () => {
+    cy.intercept('GET', '/api/v2/settings/system*', {
+      IS_K8S: false,
+    }).as('isK8s');
+    cy.mount(<InstancePage />);
+    cy.get('[data-cy="instances-listener-addresses-tab"]').should('not.exist');
+  });
+
+  it('listener addresses tab should be shown for k8s system', () => {
+    cy.intercept('GET', '/api/v2/settings/system*', {
+      IS_K8S: true,
+    }).as('isK8s');
+    cy.mount(<InstancePage />);
+    cy.getByDataCy('instances-listener-addresses-tab').should('be.visible');
+    cy.getByDataCy('instances-listener-addresses-tab').should('be.enabled');
   });
 });


### PR DESCRIPTION
This PR is closing [AAP-21398](https://issues.redhat.com/browse/AAP-21398)

- It's refactoring existing tests to use `getByDataCy` instead of `get`
- Adding two component tests for Listener Addresses tab:
`listener addresses tab should be hidden for non-k8s system`
`listener addresses tab should be shown for k8s system`
