### PR TITLE
Instances List Updates

### DIFF
--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -99,6 +99,7 @@ describe('Instances - Remove', () => {
       expect(currentUrl.includes('details')).to.be.true;
     });
 
+    cy.getByDataCy('actions-dropdown').click();
     cy.getByDataCy('remove-instance').click();
     cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
       cy.get('header').contains('Permanently remove instances');

--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -118,9 +118,11 @@ describe('Instances - Remove', () => {
 
   it('user can remove an instance from instance page toolbar', () => {
     cy.intercept('PATCH', '/api/v2/instances/*').as('removedInstance');
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
     cy.filterTableByText(instance.hostname);
     cy.contains('tr', instance.hostname).find('input').check();
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
     cy.get('[data-cy="remove-instance"]').click();
 
@@ -145,10 +147,12 @@ describe('Instances - Remove', () => {
       cy.createAwxInstance(instanceName);
     }
     cy.intercept('PATCH', '/api/v2/instances/*').as('removedInstance');
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
     cy.filterTableByText(testSignature);
     cy.get('tbody').find('tr').should('have.length', 5);
     cy.get('[data-cy="select-all"]', { timeout: 30000 }).click();
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
     cy.get('[data-cy="remove-instance"]').click();
 

--- a/cypress/e2e/awx/administration/topology-view.cy.ts
+++ b/cypress/e2e/awx/administration/topology-view.cy.ts
@@ -94,7 +94,7 @@ describe('Topology view', () => {
         cy.get('button[aria-label="Close"]').click();
       });
   });
-  it('should show disabled instance forks slider when instance has 0 cpu and memory capacity', () => {
+  it('should show no forks slider when instance has 0 cpu and memory capacity', () => {
     // Adjusting instance capacity while other concurrent tests are running could have unwanted side-effects affecting job runs. We should mock the response data in this scenario.
     cy.intercept(
       { method: 'GET', url: awxAPI`/instances/1/` },
@@ -110,42 +110,7 @@ describe('Topology view', () => {
           .its('response.body')
           .then((instance: Instance) => {
             if (instance.enabled) {
-              cy.get('.pf-v5-c-slider__thumb').should('have.attr', 'aria-disabled');
-              cy.get('.pf-v5-c-slider__thumb').should('have.attr', 'aria-disabled', 'true');
-            }
-          });
-        cy.get('button[aria-label="Close"]').click();
-      });
-  });
-  it('should show enabled/disabled when instance is toggled from sidebar', () => {
-    // Enabling/disabling an instance while other concurrent tests are running could have unwanted side-effects affecting job runs. We should mock the response data in this scenario.
-    cy.intercept({ method: 'GET', url: awxAPI`/instances/1/` }).as('getInstance');
-    cy.navigateTo('awx', 'topology-view');
-    cy.wait('@getMeshVisualizer')
-      .its('response.body')
-      .then((data: MeshVisualizer) => {
-        cy.get(`[data-id="${data.nodes[0].id}"]`).click();
-        cy.get('[data-cy="mesh-viz-sidebar"]').should('be.visible');
-        cy.wait('@getInstance')
-          .its('response.body')
-          .then((instance: Instance) => {
-            if (instance.enabled) {
-              cy.get('#enable-instance-on').should('have.text', 'Enabled');
-              cy.get('[data-cy="enabled"] .pf-v5-c-switch__toggle').click();
-              cy.wait('@editInstance')
-                .its('response')
-                .then((res) => {
-                  expect(res?.statusCode).to.eql(200);
-                });
-            }
-            if (!instance.enabled) {
-              cy.get('#enable-instance-off').should('have.text', 'Disabled');
-              cy.get('[data-cy="enabled"] .pf-v5-c-switch__toggle').click();
-              cy.wait('@editInstance')
-                .its('response')
-                .then((res) => {
-                  expect(res?.statusCode).to.eql(200);
-                });
+              cy.get('.pf-v5-c-slider__thumb').should('not.exist');
             }
           });
         cy.get('button[aria-label="Close"]').click();

--- a/framework/components/Unavailable.tsx
+++ b/framework/components/Unavailable.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { getPatternflyColor } from './pfcolors';
+
+export function Unavailable(props: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        color: getPatternflyColor('red'),
+      }}
+    >
+      {props.children}
+    </span>
+  );
+}

--- a/frontend/awx/administration/instances/InstanceDetails.cy.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.cy.tsx
@@ -24,7 +24,7 @@ describe('Instance Details', () => {
           'have.text',
           `${capitalizeFirstLetter(instance.node_type)}`
         );
-        cy.get('[data-cy="node-label-status"]').should(
+        cy.get('[data-cy="status"]').should(
           'have.text',
           `${capitalizeFirstLetter(instance.node_state)}`
         );
@@ -51,7 +51,6 @@ describe('Instance Details', () => {
           formatDateString(instance.modified)
         );
         cy.get('[data-cy="forks"]').should('exist');
-        cy.get('[data-cy="enabled"]').should('exist');
       });
   });
 
@@ -71,29 +70,6 @@ describe('Instance Details', () => {
     ).as('getInstanceGroups');
     cy.mount(<InstanceDetails />);
     cy.get('[data-cy="instance-groups"]').should('not.exist');
-  });
-
-  it('Enabled/Diabled switch is disabled if user does not have the right permissions', () => {
-    cy.mount(<InstanceDetails />);
-    cy.intercept({ method: 'GET', url: '/api/v2/me' }, { fixture: 'normalUser.json' });
-    cy.wait('@getInstance')
-      .its('response.body')
-      .then(() => {
-        cy.get('[data-cy="enabled"] #enable-instance').should('be.disabled');
-      });
-  });
-
-  it('non admin users cannot edit instance', () => {
-    cy.intercept('GET', '/api/v2/settings/system*', {
-      IS_K8S: true,
-    }).as('isK8s');
-    cy.intercept({ method: 'GET', url: '/api/v2/me' }, { fixture: 'normalUser.json' });
-    cy.mount(<InstanceDetails />);
-    cy.wait('@getInstance')
-      .its('response.body')
-      .then(() => {
-        cy.get('[data-cy="enabled"] #enable-instance').should('be.disabled');
-      });
   });
 
   it('Instance forks disabled if user does not have the right permissions', () => {

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -112,7 +112,7 @@ export function InstanceDetailsTab(props: {
           ))}
         </PageDetail>
       )}
-      {instance.related?.install_bundle && (
+      {!instance.managed && instance.related?.install_bundle && (
         <PageDetail label={t`Download bundle`} data-cy="download-bundle">
           <Button
             size="sm"

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -97,15 +97,7 @@ export function InstanceDetailsTab(props: {
         </Tooltip>
       </PageDetail>
       <PageDetail label={t('Status')} data-cy="node-status">
-        <StatusCell
-          status={
-            !instance.enabled
-              ? 'disabled'
-              : instance.health_check_pending
-                ? 'running'
-                : instance.node_state
-          }
-        />
+        <StatusCell status={instance.health_check_pending ? 'running' : instance.node_state} />
       </PageDetail>
       {instanceGroups && instanceGroups.results.length > 0 && (
         <PageDetail label={t(`Instance groups`)} data-cy="instance-groups">

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -39,8 +39,9 @@ import { useNodeTypeTooltip } from './hooks/useNodeTypeTooltip';
 export function InstanceDetails() {
   const params = useParams<{ id: string }>();
   const { error, data: instance, refresh } = useGetItem<Instance>(awxAPI`/instances`, params.id);
-  const { instanceGroups, instanceForks, handleToggleInstance, handleInstanceForksSlider } =
-    useInstanceActions(params.id as string);
+  const { instanceGroups, instanceForks, handleInstanceForksSlider } = useInstanceActions(
+    params.id as string
+  );
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!instance) return <LoadingPage breadcrumbs tabs />;
   return (

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -6,7 +6,6 @@ import {
   Skeleton,
   Slider,
   SliderOnChangeEvent,
-  Switch,
   Tooltip,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
@@ -25,7 +24,7 @@ import { LoadingPage } from '../../../../framework/components/LoadingPage';
 import { formatDateString } from '../../../../framework/utils/formatDateString';
 import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
-import { StatusLabel } from '../../../common/Status';
+import { StatusCell } from '../../../common/Status';
 import { useGetItem } from '../../../common/crud/useGet';
 import { AwxError } from '../../common/AwxError';
 import { AwxItemsResponse } from '../../common/AwxItemsResponse';
@@ -50,7 +49,6 @@ export function InstanceDetails() {
         <InstanceDetailsTab
           instance={instance}
           instanceGroups={instanceGroups}
-          handleToggleInstance={handleToggleInstance}
           instanceForks={instanceForks}
           handleInstanceForksSlider={handleInstanceForksSlider}
         />
@@ -67,7 +65,6 @@ export function InstanceDetailsTab(props: {
   instance: Instance;
   instanceGroups: AwxItemsResponse<InstanceGroup> | undefined;
   instanceForks: number;
-  handleToggleInstance: (instance: Instance, isEnabled: boolean) => Promise<void>;
   handleInstanceForksSlider: (instance: Instance, value: number) => Promise<void>;
   numberOfColumns?: 'multiple' | 'single' | undefined;
 }) {
@@ -75,126 +72,120 @@ export function InstanceDetailsTab(props: {
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
   const activeUser = useAwxActiveUser();
-  const {
-    instance,
-    instanceGroups,
-    handleToggleInstance,
-    instanceForks,
-    handleInstanceForksSlider,
-  } = props;
+  const { instance, instanceGroups, instanceForks, handleInstanceForksSlider } = props;
   const toolTipMap: { [item: string]: string } = useNodeTypeTooltip();
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
 
   return (
-    <>
-      <PageDetails numberOfColumns={props.numberOfColumns} disableScroll>
-        <PageDetail label={t('Name')} data-cy="name">
+    <PageDetails numberOfColumns={props.numberOfColumns} disableScroll>
+      <PageDetail label={t('Name')} data-cy="name">
+        <Button
+          variant="link"
+          isInline
+          onClick={() =>
+            pageNavigate(AwxRoute.InstanceDetails, {
+              params: { id: instance.id },
+            })
+          }
+        >
+          {instance.hostname}
+        </Button>
+      </PageDetail>
+      <PageDetail label={t('Node type')} data-cy="node-type">
+        <Tooltip content={toolTipMap[instance.node_type]}>
+          <Dotted>{`${capitalizeFirstLetter(instance.node_type)}`}</Dotted>
+        </Tooltip>
+      </PageDetail>
+      <PageDetail label={t('Status')} data-cy="node-status">
+        <StatusCell
+          status={
+            !instance.enabled
+              ? 'disabled'
+              : instance.health_check_pending
+                ? 'running'
+                : instance.node_state
+          }
+        />
+      </PageDetail>
+      {instanceGroups && instanceGroups.results.length > 0 && (
+        <PageDetail label={t(`Instance groups`)} data-cy="instance-groups">
+          {instanceGroups.results.map((instance) => (
+            <Label color="blue" style={{ marginRight: '10px' }} key={instance.id}>
+              <Link to={getPageUrl(AwxRoute.InstanceGroupDetails, { params: { id: instance.id } })}>
+                {/* eslint-disable-next-line i18next/no-literal-string */}
+                {instance.name}
+              </Link>
+            </Label>
+          ))}
+        </PageDetail>
+      )}
+      {instance.related?.install_bundle && (
+        <PageDetail label={t`Download bundle`} data-cy="download-bundle">
           <Button
-            variant="link"
-            isInline
-            onClick={() =>
-              pageNavigate(AwxRoute.InstanceDetails, {
-                params: { id: instance.id },
-              })
-            }
+            size="sm"
+            aria-label={t`Download Bundle`}
+            component="a"
+            download={`${instance.related?.install_bundle}`}
+            href={`${instance.related?.install_bundle}`}
+            target="_blank"
+            variant="secondary"
+            rel="noopener noreferrer"
           >
-            {instance.hostname}
+            <DownloadIcon />
           </Button>
         </PageDetail>
-        <PageDetail label={t('Node type')} data-cy="node-type">
-          <Tooltip content={toolTipMap[instance.node_type]}>
-            <Dotted>{`${capitalizeFirstLetter(instance.node_type)}`}</Dotted>
-          </Tooltip>
+      )}
+      {instance.listener_port && (
+        <PageDetail label={t`Listener port`} data-cy="listener-port">
+          {instance.listener_port}
         </PageDetail>
-        <PageDetail label={t('Status')} data-cy="node-status">
-          <StatusLabel dataCy="node-label-status" status={instance.node_state} />
-        </PageDetail>
-        {instanceGroups && instanceGroups.results.length > 0 && (
-          <PageDetail label={t(`Instance groups`)} data-cy="instance-groups">
-            {instanceGroups.results.map((instance) => (
-              <Label color="blue" style={{ marginRight: '10px' }} key={instance.id}>
-                <Link
-                  to={getPageUrl(AwxRoute.InstanceGroupDetails, { params: { id: instance.id } })}
-                >
-                  {/* eslint-disable-next-line i18next/no-literal-string */}
-                  {instance.name}
-                </Link>
-              </Label>
-            ))}
-          </PageDetail>
-        )}
-        {instance.related?.install_bundle && (
-          <PageDetail label={t`Download bundle`} data-cy="download-bundle">
-            <Button
-              size="sm"
-              aria-label={t`Download Bundle`}
-              component="a"
-              download={`${instance.related?.install_bundle}`}
-              href={`${instance.related?.install_bundle}`}
-              target="_blank"
-              variant="secondary"
-              rel="noopener noreferrer"
-            >
-              <DownloadIcon />
-            </Button>
-          </PageDetail>
-        )}
-        {instance.listener_port && (
-          <PageDetail label={t`Listener port`} data-cy="listener-port">
-            {instance.listener_port}
-          </PageDetail>
-        )}
-        <PageDetail label={t('Used capacity')} data-cy="used-capacity">
+      )}
+      <PageDetail label={t('Used capacity')} data-cy="used-capacity">
+        {instance.enabled ? (
           <Progress value={Math.round(100 - instance.percent_capacity_remaining)} />
-        </PageDetail>
-        <PageDetail label={t('Running jobs')} data-cy="running-jobs">
-          {instance.jobs_running.toString()}
-        </PageDetail>
-        <PageDetail label={t('Total jobs')} data-cy="total-jobs">
-          {instance.jobs_total.toString()}
-        </PageDetail>
-        <PageDetail label={t('Policy type')} data-cy="policy-type">
-          {instance.managed_by_policy ? t('Auto') : t('Manual')}
-        </PageDetail>
-        <PageDetail label={t('Memory')} data-cy="memory">
-          <BytesCell bytes={instance.memory} />
-        </PageDetail>
-        <PageDetail label={t('Last health check')} data-cy="last-health-check">
-          {formatDateString(instance.last_health_check)}
-        </PageDetail>
-        <PageDetail label={t('Created')} data-cy="created">
-          {formatDateString(instance.created)}
-        </PageDetail>
-        <LastModifiedPageDetail value={instance.modified} data-cy="modified" />
+        ) : (
+          t('Unavailable')
+        )}
+      </PageDetail>
+      <PageDetail label={t('Running jobs')} data-cy="running-jobs">
+        {instance.jobs_running.toString()}
+      </PageDetail>
+      <PageDetail label={t('Total jobs')} data-cy="total-jobs">
+        {instance.jobs_total.toString()}
+      </PageDetail>
+      <PageDetail label={t('Policy type')} data-cy="policy-type">
+        {instance.managed_by_policy ? t('Auto') : t('Manual')}
+      </PageDetail>
+      <PageDetail label={t('Memory')} data-cy="memory">
+        <BytesCell bytes={instance.memory} />
+      </PageDetail>
+      <PageDetail label={t('Last health check')} data-cy="last-health-check">
+        {formatDateString(instance.last_health_check)}
+      </PageDetail>
+      <PageDetail label={t('Created')} data-cy="created">
+        {formatDateString(instance.created)}
+      </PageDetail>
+      <LastModifiedPageDetail value={instance.modified} data-cy="modified" />
+      {instance.node_type !== 'hop' ? (
         <PageDetail label={t('Forks')} data-cy="forks">
           <div>
             {t('Total forks: ')}
             {instanceForks}
           </div>
-          <Slider
-            areCustomStepsContinuous
-            max={instance.mem_capacity}
-            min={instance.cpu_capacity}
-            value={instanceForks}
-            onChange={(_event: SliderOnChangeEvent, value: number) =>
-              void handleInstanceForksSlider(instance, value)
-            }
-            isDisabled={!activeUser?.is_superuser || !instance.enabled || !capacityAvailable}
-          />
+          {instanceForks > 0 ? (
+            <Slider
+              areCustomStepsContinuous
+              max={instance.mem_capacity}
+              min={instance.cpu_capacity}
+              value={instanceForks}
+              onChange={(_event: SliderOnChangeEvent, value: number) =>
+                void handleInstanceForksSlider(instance, value)
+              }
+              isDisabled={!activeUser?.is_superuser || !instance.enabled || !capacityAvailable}
+            />
+          ) : undefined}
         </PageDetail>
-        <PageDetail label={t('Enabled')} data-cy="enabled">
-          <Switch
-            id="enable-instance"
-            isDisabled={!activeUser?.is_superuser}
-            label={t('Enabled')}
-            labelOff={t('Disabled')}
-            isChecked={instance.enabled}
-            onChange={() => {
-              void handleToggleInstance(instance, !instance.enabled);
-            }}
-          />
-        </PageDetail>
-      </PageDetails>
-    </>
+      ) : undefined}
+    </PageDetails>
   );
 }

--- a/frontend/awx/administration/instances/Instances.cy.tsx
+++ b/frontend/awx/administration/instances/Instances.cy.tsx
@@ -27,6 +27,7 @@ describe('Instances list', () => {
       'contain',
       'Ansible node instances dedicated for a particular purpose indicated by node type.'
     );
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="add-instance"]').should('be.visible');
     cy.get('[data-cy="remove-instance"]').should('be.visible');
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
@@ -47,6 +48,7 @@ describe('Instances list', () => {
       'Ansible node instances dedicated for a particular purpose indicated by node type.'
     );
     cy.get('[data-cy="add-instance"]').should('not.exist');
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('be.visible');
     cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
     cy.get('tbody').find('tr').should('have.length', 10);
@@ -82,6 +84,7 @@ describe('Instances list', () => {
       .its('response.body')
       .then(() => {
         cy.get('[data-cy="checkbox-column-cell"]').first().click();
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('be.visible');
         cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
       });
@@ -97,6 +100,7 @@ describe('Instances list', () => {
       .its('response.body')
       .then(() => {
         cy.get('[data-cy="checkbox-column-cell"]').first().click();
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('be.visible');
         cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
       });
@@ -112,6 +116,7 @@ describe('Instances list', () => {
       .its('response.body')
       .then(() => {
         cy.get('[data-cy="checkbox-column-cell"]').first().click();
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('be.visible');
         cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'false');
       });
@@ -127,6 +132,7 @@ describe('Instances list', () => {
       .its('response.body')
       .then(() => {
         cy.get('[data-cy="checkbox-column-cell"]').first().click();
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('be.visible');
         cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
       });

--- a/frontend/awx/administration/instances/InstancesPage.cy.tsx
+++ b/frontend/awx/administration/instances/InstancesPage.cy.tsx
@@ -22,10 +22,12 @@ describe('Instances Page', () => {
     cy.getByDataCy('instances-peers-tab').should('be.enabled');
     cy.getByDataCy('edit-instance').should('be.visible');
     cy.getByDataCy('edit-instance').should('be.enabled');
+    cy.getByDataCy('actions-dropdown').click();
     cy.getByDataCy('remove-instance').should('be.visible');
-    cy.getByDataCy('remove-instance').should('be.enabled');
+    cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
     cy.getByDataCy('run-health-check').should('be.visible');
-    cy.getByDataCy('run-health-check').should('be.enabled');
+    cy.getByDataCy('run-health-check').should('have.attr', 'aria-disabled', 'false');
+    cy.getByDataCy('toggle-switch').should('be.visible');
   });
 
   it('edit instance button should be hidden for non-k8s system', () => {
@@ -94,6 +96,7 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
+        cy.getByDataCy('actions-dropdown').click();
         cy.getByDataCy('remove-instance').should('be.visible');
         cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'true');
       });
@@ -104,6 +107,7 @@ describe('Instances Page', () => {
       IS_K8S: false,
     }).as('isK8s');
     cy.mount(<InstancePage />);
+    cy.get('[data-cy="actions-dropdown"]').click();
     cy.get('[data-cy="remove-instance"]').should('not.exist');
   });
 
@@ -112,6 +116,7 @@ describe('Instances Page', () => {
       IS_K8S: true,
     }).as('isK8s');
     cy.mount(<InstancePage />);
+    cy.getByDataCy('actions-dropdown').click();
     cy.getByDataCy('remove-instance').should('be.visible');
     cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
   });
@@ -124,6 +129,7 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
+        cy.getByDataCy('actions-dropdown').click();
         cy.getByDataCy('remove-instance').should('be.visible');
         cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
       });
@@ -140,6 +146,7 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('not.exist');
       });
   });
@@ -155,6 +162,7 @@ describe('Instances Page', () => {
     cy.wait('@getInstance')
       .its('response.body')
       .then(() => {
+        cy.get('[data-cy="actions-dropdown"]').click();
         cy.get('[data-cy="remove-instance"]').should('not.exist');
       });
   });
@@ -191,5 +199,15 @@ describe('Instances Page', () => {
     cy.mount(<InstancePage />);
     cy.getByDataCy('instances-listener-addresses-tab').should('be.visible');
     cy.getByDataCy('instances-listener-addresses-tab').should('be.enabled');
+  });
+
+  it('Enabled/Disabled switch is disabled if user does not have the right permissions', () => {
+    cy.mount(<InstancePage />);
+    cy.intercept({ method: 'GET', url: '/api/v2/me' }, { fixture: 'normalUser.json' });
+    cy.wait('@getInstance')
+      .its('response.body')
+      .then(() => {
+        cy.get('.pf-v5-c-switch__input').should('be.disabled');
+      });
   });
 });

--- a/frontend/awx/administration/instances/InstancesPage.cy.tsx
+++ b/frontend/awx/administration/instances/InstancesPage.cy.tsx
@@ -97,8 +97,8 @@ describe('Instances Page', () => {
       .its('response.body')
       .then(() => {
         cy.getByDataCy('actions-dropdown').click();
-        cy.getByDataCy('remove-instance').should('be.visible');
-        cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'true');
+        cy.get('[data-cy="remove-instance"]').should('be.visible');
+        cy.get('[data-cy="remove-instance"]').should('have.attr', 'aria-disabled', 'true');
       });
   });
 

--- a/frontend/awx/administration/instances/InstancesPage.tsx
+++ b/frontend/awx/administration/instances/InstancesPage.tsx
@@ -28,6 +28,8 @@ export function InstancePage() {
   const isK8s = !data?.IS_K8S;
   const itemActions = useInstanceDetailsActions({
     onInstancesRemoved: () => pageNavigate(AwxRoute.Instances),
+    onInstanceToggled: refresh,
+    onHealthCheckComplete: refresh,
     isDetailsPageAction: true,
   });
   const viewActivityStreamAction = useViewActivityStream('instance');

--- a/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
+++ b/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
@@ -1,0 +1,41 @@
+import { Slider, SliderOnChangeEvent, Tooltip } from '@patternfly/react-core';
+import { t } from 'i18next';
+import { Dotted } from '../../../../../framework/components/Dotted';
+import { Instance } from '../../../interfaces/Instance';
+import { useInstanceActions } from '../hooks/useInstanceActions';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+
+export function InstanceForksSlider(props: { instance: Instance }) {
+  const { instance } = props;
+  const { instanceForks, handleInstanceForksSlider } = useInstanceActions(String(instance.id));
+  const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
+  const activeUser = useAwxActiveUser();
+
+  if (instanceForks > 0) {
+    return (
+      <>
+        <div data-cy="number-forks">{t(`${instanceForks} forks`)}</div>
+        <Slider
+          areCustomStepsContinuous
+          max={instance.mem_capacity}
+          min={instance.cpu_capacity}
+          value={instanceForks}
+          onChange={(_event: SliderOnChangeEvent, value: number) =>
+            void handleInstanceForksSlider(instance, value)
+          }
+          isDisabled={!activeUser?.is_superuser || !instance.enabled || !capacityAvailable}
+        />
+      </>
+    );
+  } else {
+    return instance.node_type === 'hop' ? (
+      <Tooltip isContentLeftAligned={true} content={t('Cannot adjust capacity for hop nodes.')}>
+        <Dotted>{t('Unavailable')}</Dotted>
+      </Tooltip>
+    ) : (
+      <Tooltip isContentLeftAligned={true} content={t('0 forks. Cannot adjust capacity.')}>
+        <Dotted>{t('Unavailable')}</Dotted>
+      </Tooltip>
+    );
+  }
+}

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -175,11 +175,11 @@ export function useInstanceDetailsActions(options: {
       },
       {
         type: PageActionType.Button,
-        isHidden: () => isK8s === false || !instancesType,
+        isHidden: () => isK8s === false || !(instance?.node_type === 'execution'),
         selection: PageActionSelection.Single,
-        icon: instance?.health_check_pending ? SpinnerIcon : HeartbeatIcon,
+        icon: HeartbeatIcon,
         variant: ButtonVariant.secondary,
-        label: instance?.health_check_pending ? t('Health check running') : t('Run health check'),
+        label: t('Run health check'),
         isDisabled: (instance) =>
           instance.node_type !== 'execution'
             ? t('Cannot run health check on a {{ type }} instance', { type: instance.node_type })

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -142,6 +142,11 @@ export function useInstanceDetailsActions(options: {
         labelOff: t('Disabled'),
         showPinnedLabel: false,
         isHidden: () => instance?.node_type === 'hop',
+        isDisabled: canEditAndRemoveInstances
+          ? undefined
+          : t(
+              'You do not have permission to edit instances. Please contact your organization administrator if there is an issue with your access.'
+            ),
       },
       {
         type: PageActionType.Button,

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -5,7 +5,7 @@ import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Instance } from '../../../interfaces/Instance';
 import { InstanceGroup } from '../../../interfaces/InstanceGroup';
-import { HeartbeatIcon, PencilAltIcon, SpinnerIcon, TrashIcon } from '@patternfly/react-icons';
+import { HeartbeatIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   usePageNavigate,
@@ -217,7 +217,6 @@ export function useInstanceDetailsActions(options: {
       removeInstances,
       alertToaster,
       handleToggleInstance,
-      instance?.health_check_pending,
       instance?.node_type,
       onHealthCheckComplete,
     ]

--- a/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
@@ -48,6 +48,14 @@ export function useInstanceRowActions(onComplete: (instances: Instance[]) => voi
         labelOff: t('Disabled'),
         showPinnedLabel: false,
         isHidden: (instance) => instance.node_type === 'hop',
+        isDisabled: (instance) =>
+          !userAccess ||
+          !isK8s ||
+          (instance?.node_type !== 'execution' && instance?.node_type !== 'hop')
+            ? t(
+                'You do not have permission to edit instances. Please contact your organization administrator if there is an issue with your access.'
+              )
+            : undefined,
       },
       {
         type: PageActionType.Button,

--- a/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
@@ -57,15 +57,7 @@ export function useInstancesColumns(options?: { disableSort?: boolean; disableLi
       {
         header: t('Status'),
         cell: (instance) => (
-          <StatusCell
-            status={
-              !instance.enabled
-                ? 'disabled'
-                : instance.health_check_pending
-                  ? 'running'
-                  : instance.node_state
-            }
-          />
+          <StatusCell status={instance.health_check_pending ? 'running' : instance.node_state} />
         ),
         sort: 'errors',
       },

--- a/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
@@ -15,7 +15,7 @@ import { Instance } from '../../../interfaces/Instance';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useNodeTypeTooltip } from './useNodeTypeTooltip';
 import { InstanceForksSlider } from '../components/InstanceForksSlider';
-import { StatusCell, StatusLabel } from '../../../../common/Status';
+import { StatusCell } from '../../../../common/Status';
 import { Unavailable } from '../../../../../framework/components/Unavailable';
 
 export function useInstancesColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {

--- a/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
@@ -3,18 +3,19 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   BytesCell,
+  ColumnModalOption,
   ColumnTableOption,
-  DateTimeCell,
   ITableColumn,
   usePageNavigate,
 } from '../../../../../framework';
 import { Dotted } from '../../../../../framework/components/Dotted';
 import { capitalizeFirstLetter } from '../../../../../framework/utils/strings';
-import { StatusCell } from '../../../../common/Status';
 import { useCreatedColumn, useModifiedColumn, useNameColumn } from '../../../../common/columns';
 import { Instance } from '../../../interfaces/Instance';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useNodeTypeTooltip } from './useNodeTypeTooltip';
+import { InstanceForksSlider } from '../components/InstanceForksSlider';
+import { StatusCell } from '../../../../common/Status';
 
 export function useInstancesColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -57,7 +58,13 @@ export function useInstancesColumns(options?: { disableSort?: boolean; disableLi
         header: t('Status'),
         cell: (instance) => (
           <StatusCell
-            status={!instance.enabled ? 'disabled' : instance.errors ? 'error' : 'healthy'}
+            status={
+              !instance.enabled
+                ? 'disabled'
+                : instance.health_check_pending
+                  ? 'running'
+                  : instance.node_state
+            }
           />
         ),
         sort: 'errors',
@@ -70,38 +77,41 @@ export function useInstancesColumns(options?: { disableSort?: boolean; disableLi
         list: 'subtitle',
       },
       {
+        header: t('Capacity Adjustment'),
+        cell: (instance: Instance) => <InstanceForksSlider instance={instance} />,
+        modal: ColumnModalOption.hidden,
+      },
+      {
         header: t('Running jobs'),
         cell: (instance) => instance.jobs_running,
+        table: ColumnTableOption.expanded,
       },
       {
         header: t('Total jobs'),
         cell: (instance) => instance.jobs_total,
-        list: 'secondary',
         table: ColumnTableOption.expanded,
       },
       {
         header: t('Used capacity'),
-        cell: (instance) => (
-          <Progress value={Math.round(100 - instance.percent_capacity_remaining)} />
-        ),
+        cell: (instance) =>
+          instance.node_type === 'hop' ? undefined : instance.enabled ? (
+            <Progress value={Math.round(100 - instance.percent_capacity_remaining)} />
+          ) : (
+            t('Unavailable')
+          ),
         list: 'secondary',
-        table: ColumnTableOption.expanded,
       },
       {
         header: t('Memory'),
         cell: (instance) => instance.memory && <BytesCell bytes={instance.memory} />,
         sort: 'memory',
         list: 'secondary',
+        table: ColumnTableOption.expanded,
       },
       {
         header: t('Policy type'),
         cell: (instance) => (instance.managed_by_policy ? t('Auto') : t('Manual')),
         table: ColumnTableOption.expanded,
-      },
-      {
-        header: t('Last health check'),
-        cell: (instance) => <DateTimeCell value={instance.last_health_check} />,
-        card: 'hidden',
       },
       createdColumn,
       modifiedColumn,

--- a/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
@@ -15,7 +15,8 @@ import { Instance } from '../../../interfaces/Instance';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useNodeTypeTooltip } from './useNodeTypeTooltip';
 import { InstanceForksSlider } from '../components/InstanceForksSlider';
-import { StatusCell } from '../../../../common/Status';
+import { StatusCell, StatusLabel } from '../../../../common/Status';
+import { Unavailable } from '../../../../../framework/components/Unavailable';
 
 export function useInstancesColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
@@ -89,7 +90,7 @@ export function useInstancesColumns(options?: { disableSort?: boolean; disableLi
           instance.node_type === 'hop' ? undefined : instance.enabled ? (
             <Progress value={Math.round(100 - instance.percent_capacity_remaining)} />
           ) : (
-            t('Unavailable')
+            <Unavailable>{t(`Unavailable`)}</Unavailable>
           ),
         list: 'secondary',
       },

--- a/frontend/awx/administration/topology/Sidebar.tsx
+++ b/frontend/awx/administration/topology/Sidebar.tsx
@@ -8,22 +8,14 @@ export function InstanceDetailInner(props: {
   instance: Instance;
   instanceGroups: AwxItemsResponse<InstanceGroup> | undefined;
   instanceForks: number;
-  handleToggleInstance: (instance: Instance, isEnabled: boolean) => Promise<void>;
   handleInstanceForksSlider: (instance: Instance, value: number) => Promise<void>;
 }) {
-  const {
-    instance,
-    instanceGroups,
-    instanceForks,
-    handleToggleInstance,
-    handleInstanceForksSlider,
-  } = props;
+  const { instance, instanceGroups, instanceForks, handleInstanceForksSlider } = props;
   return (
     <InstanceDetailsTab
       numberOfColumns="single"
       instance={instance}
       instanceGroups={instanceGroups}
-      handleToggleInstance={handleToggleInstance}
       instanceForks={instanceForks}
       handleInstanceForksSlider={handleInstanceForksSlider}
     />
@@ -32,19 +24,13 @@ export function InstanceDetailInner(props: {
 
 export function InstanceDetailSidebar(props: { selectedId: string }) {
   const { selectedId } = props;
-  const {
-    instance,
-    instanceGroups,
-    handleToggleInstance,
-    handleInstanceForksSlider,
-    instanceForks,
-  } = useInstanceActions(selectedId);
+  const { instance, instanceGroups, handleInstanceForksSlider, instanceForks } =
+    useInstanceActions(selectedId);
 
   return instance ? (
     <InstanceDetailInner
       instance={instance}
       instanceGroups={instanceGroups ? instanceGroups : undefined}
-      handleToggleInstance={handleToggleInstance}
       handleInstanceForksSlider={handleInstanceForksSlider}
       instanceForks={instanceForks}
     />

--- a/frontend/awx/interfaces/Instance.ts
+++ b/frontend/awx/interfaces/Instance.ts
@@ -48,6 +48,7 @@ export interface Instance {
   ip_address: null;
   listener_port: number;
   protocol: string;
+  managed: boolean;
 }
 
 export interface Peer extends Instance {


### PR DESCRIPTION
This PR addresses a few updates suggested by UXD for instances list. Which includes the following:

**Instances Table View:**

- remove Last Health Check from being shown as the default column on the instance table view and have it just live in the details view of the instance
- Add Used Capacity as a column to the instances table and have the bar and percentage fit to scale
- On the top toolbar the "Remove instance" and "Run Health Check" should live in a kebab menu, both should only become enabled when at least one of the instances is checked/selected in the table

**Instance Details View:**

- Enable/disable toggle that is currently in the details section should be in the top header to the left of the primary "Edit instance" button
- "Remove instance" should be in the kebab menu
- "Last Health Check" should be added to the details view, before the Created and Modified fields

In addition to this the following has also been added: 

the status column has been updated to display the instances `node_state` along with a tooltip indicating the last time an health check was run on an instance

A new capacity adjustment column which uses a new `InstanceForksSlider` component to render an interactive slider to adjust instance forks from the list page

An improved UX for the health check flow...

1. Running a health check from the toolbar: 
- A health check button is present in the kebab menu of the instance list toolbar which is only enabled if all selected instances are a execution nodes that currently do not have a running/pending health checks on them. Upon clicking the health check button a classic AWX `bulkconfirmationdialog` is shown to the user. After confirming the instances to run health checks on, the user is notified if the request was sent successfully and the status column of all chosen instances will update to indicate to the user a health check is currently running on them. In addition, the toolbar health check button is disabled if any instance is selected with a currently pending/running health check or a hop or control node is selected. 

3. Running a health check using the row actions: 
 - A health check button is present in the row actions of all instances. The health check button is only enabled if the instance is an execution node that currently does not have a running/pending health check running against it. Upon clicking the row action health check, a temp toast is shown to the user indicating a health check has been triggered against the instance, the status column is updated to `running` to indicate to the user a health check is running against the instance. In addition, through the duration of the health check, the row action button for health check is disabled with a tooltip reading `Health check pending` to ensure only one health check is attempted on an instance at a time. 

4. Running a health check using the instance page action:
-  A health check button is present in the top header of the tabbed instance page behind a kebab button. It is only visible for execution nodes and is only enabled when there is no pending/running health check on the instance. Clicking on this button triggers a health check on the instance and a temp toast displays to the user indicating a health check has been triggered against the instance, and the status field is updated to `running` to indicate to the user a health check is running against the instance. In addition, through the duration of the health check, the health check button is disabled with a tooltip reading `Health check pending` to ensure only one health check is attempted on an instance at a time. 

**Known Issues:**
There is an issue with displaying expandable columns. When setting the table property to `ColumnTableOption.expanded` the column does not appear at all.

**Future improvements:**
Use websockets to update status of instance once health check is completed. Not sure if it's possible to do that for instances right now. I see websockets being used in other parts of the UI for example `Projects` and `Inventories`. 