### PR TITLE
[AAP-9121] delete actions are beneath separator and other actions

### DIFF
--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -79,7 +79,7 @@ describe('Execution Environments', () => {
             cy.get('[data-cy="actions-dropdown"]')
               .click()
               .then(() => {
-                cy.get(`[data-cy="delete-environment"]`).click();
+                cy.get(`[data-cy="delete-execution-environment"]`).click();
               });
           });
           cy.get('[data-ouia-component-id="Permanently delete execution environments"]').within(

--- a/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
@@ -85,6 +85,7 @@ export function useRepositoryActions(options: {
         selection: PageActionSelection.Single,
         type: PageActionType.Button,
       },
+      { type: PageActionType.Seperator },
       {
         icon: TrashIcon,
         label: t('Delete repository'),

--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -55,66 +55,6 @@ export function useCollectionActions(
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: UploadIcon,
-        variant: ButtonVariant.secondary,
-        isPinned: true,
-        label: t('Upload new version'),
-        onClick: () => pageNavigate(HubRoute.UploadCollection),
-      },
-      { type: PageActionType.Seperator },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete entire collection from system'),
-        onClick: (collection) => deleteCollections([collection]),
-        isDanger: true,
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete entire collection from repository'),
-        onClick: (collection) => deleteCollectionsFromRepository([collection]),
-        isDanger: true,
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete version from system'),
-        isDanger: true,
-        onClick: (collection) => {
-          deleteCollectionsVersions([collection]);
-        },
-        isHidden: () => (detail ? false : true),
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete version from repository'),
-        isDanger: true,
-        onClick: (collection) => {
-          deleteCollectionsVersionsFromRepository([collection]);
-        },
-        isHidden: () => (detail ? false : true),
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
         icon: KeyIcon,
         label: t('Sign collection'),
         onClick: (collection) => {
@@ -158,6 +98,66 @@ export function useCollectionActions(
         isDisabled: context.featureFlags.display_repositories
           ? ''
           : t`You dont have rights to this operation`,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: UploadIcon,
+        variant: ButtonVariant.secondary,
+        isPinned: true,
+        label: t('Upload new version'),
+        onClick: () => pageNavigate(HubRoute.UploadCollection),
+      },
+      { type: PageActionType.Seperator },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete version from system'),
+        isDanger: true,
+        onClick: (collection) => {
+          deleteCollectionsVersions([collection]);
+        },
+        isHidden: () => (detail ? false : true),
+        isDisabled: context.hasPermission('ansible.delete_collection')
+          ? ''
+          : t('You do not have rights to this operation'),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete version from repository'),
+        isDanger: true,
+        onClick: (collection) => {
+          deleteCollectionsVersionsFromRepository([collection]);
+        },
+        isHidden: () => (detail ? false : true),
+        isDisabled: context.hasPermission('ansible.delete_collection')
+          ? ''
+          : t('You do not have rights to this operation'),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete entire collection from repository'),
+        onClick: (collection) => deleteCollectionsFromRepository([collection]),
+        isDanger: true,
+        isDisabled: context.hasPermission('ansible.delete_collection')
+          ? ''
+          : t('You do not have rights to this operation'),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t('Delete entire collection from system'),
+        onClick: (collection) => deleteCollections([collection]),
+        isDanger: true,
+        isDisabled: context.hasPermission('ansible.delete_collection')
+          ? ''
+          : t('You do not have rights to this operation'),
       },
     ],
     [

--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -97,7 +97,7 @@ export function useCollectionActions(
         },
         isDisabled: context.featureFlags.display_repositories
           ? ''
-          : t`You dont have rights to this operation`,
+          : t`You do not have rights to this operation`,
       },
       {
         type: PageActionType.Button,

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
@@ -64,7 +64,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: TrashIcon,
-        label: t('Delete environment'),
+        label: t('Delete execution environment'),
         onClick: (ee) => deleteExecutionEnvironments([ee]),
         isDanger: true,
         isDisabled: context.hasPermission('container.delete_containerrepository')

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
@@ -59,6 +59,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
             ? ''
             : t`You do not have rights to this operation`,
       },
+      { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,

--- a/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
+++ b/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
@@ -45,6 +45,9 @@ export function useHubNamespaceActions(options?: {
           pageNavigate(HubRoute.MyImports, { query: { namespace: namespace.name } }),
       },
       {
+        type: PageActionType.Seperator,
+      },
+      {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: TrashIcon,


### PR DESCRIPTION
All in-line actions show delete buttons at the bottom of the kebab and beneath a separator line. Screens not shown do not have delete actions.

Affected screens:
<img width="823" alt="Screenshot 2024-03-12 at 1 57 42 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/2a9e9b5c-f3a7-4d5b-be49-28788d2cd69a">
<img width="827" alt="Screenshot 2024-03-12 at 1 57 33 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/4ad21e9a-5a1f-4dca-98de-a72e18802735">
<img width="819" alt="Screenshot 2024-03-12 at 1 58 46 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/45111ba1-0e5a-4505-b41d-09e6b1c4ae30">
<img width="821" alt="Screenshot 2024-03-12 at 1 11 09 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/6c69bb9a-f2b5-4571-9abb-d06feac60f8f">
<img width="831" alt="Screenshot 2024-03-12 at 1 11 19 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/14fe9e42-d504-40b1-bada-5289812e9d9e">
<img width="828" alt="Screenshot 2024-03-12 at 1 11 40 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/c3bf2140-639e-45bf-ad78-5e10de460b71">
<img width="819" alt="Screenshot 2024-03-12 at 1 11 49 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/3ce64c6c-5550-450b-acda-9fbb0721cbbf">
