### PR TITLE
[AAP-21458] cancel job action in job output toolbar

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.tsx
@@ -42,7 +42,7 @@ export function JobOutputInner(props: { job: Job; reloadJob: () => void }) {
   }
   return (
     <Section variant="light">
-      <JobStatusBar job={job} />
+      <JobStatusBar job={job} reloadJob={reloadJob} />
       <HostStatusBar counts={job.host_status_counts || {}} />
       <JobOutputToolbar
         toolbarFilters={toolbarFilters}


### PR DESCRIPTION
Issue: AAP-21458

![Screenshot from 2024-03-12 18-15-27](https://github.com/ansible/ansible-ui/assets/19647757/1521279a-55fe-42ba-976a-e547f6a23ea3)

I'm wondering if we still need this since https://github.com/ansible/ansible-ui/pull/1816 ([AAP-21533](https://issues.redhat.com/browse/AAP-21533)) adds `Cancel job` button to header? 
CC @marshmalien @resoluteCoder 