### PR TITLE
[AAP-8160] Host Groups List

### DIFF
--- a/frontend/awx/main/routes/useAwxHostRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxHostRoutes.tsx
@@ -11,6 +11,7 @@ import {
   EditHost,
 } from '../../resources/inventories/inventoryHostsPage/InventoryHostForm';
 import { InventoryHostDetails } from '../../resources/inventories/inventoryHostsPage/InventoryHostDetails';
+import { InventoryHostGroups } from '../../resources/inventories/inventoryHostsPage/InventoryHostGroups';
 
 export function useAwxHostRoutes() {
   const { t } = useTranslation();
@@ -38,7 +39,7 @@ export function useAwxHostRoutes() {
             {
               id: AwxRoute.HostGroups,
               path: 'groups',
-              element: <PageNotImplemented />,
+              element: <InventoryHostGroups page="host" />,
             },
             {
               id: AwxRoute.HostJobs,

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -226,7 +226,7 @@ export function useAwxInventoryRoutes() {
             {
               id: AwxRoute.InventoryHostGroups,
               path: 'groups',
-              element: <InventoryHostGroups />,
+              element: <InventoryHostGroups page="inventory" />,
             },
             {
               id: AwxRoute.InventoryHostJobs,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
@@ -26,7 +26,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Inventory Host Groups list renders', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -34,7 +34,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Filter Host Groups by name', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -53,7 +53,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Filter Host Groups by created by', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -72,7 +72,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Filter Host Groups by modified by', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -91,7 +91,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Add group button is enabled if the user has permission to add a group', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -99,7 +99,7 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Edit inventory group row action is enabled if the user has permission to edit inventory group', () => {
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -116,7 +116,7 @@ describe('Inventory Host Groups List', () => {
           actions: {},
         },
       }));
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -141,7 +141,7 @@ describe('Inventory Host Groups List', () => {
           );
         })
         .then(() => {
-          cy.mount(<InventoryHostGroups />, {
+          cy.mount(<InventoryHostGroups page={'inventory'} />, {
             path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
             initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
           });
@@ -172,7 +172,7 @@ describe('Inventory Host Groups List', () => {
           statusCode: 500,
         }
       );
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -209,7 +209,7 @@ describe('Inventory Host Groups List', () => {
           },
         },
       }));
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
@@ -223,7 +223,7 @@ describe('Inventory Host Groups List', () => {
           actions: {},
         },
       }));
-      cy.mount(<InventoryHostGroups />, {
+      cy.mount(<InventoryHostGroups page={'inventory'} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -34,10 +34,10 @@ export function InventoryHostGroups(props: { page: string }) {
   });
 
   const toolbarActions = useHostsGroupsToolbarActions(view, inventoryId, hostId, isHostPage);
-  const rowActions = useHostsGroupsActions();
+  const rowActions = useHostsGroupsActions(inventoryId);
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();
-  const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh);
+  const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh, hostId);
 
   const groupOptions = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/groups/`).data;
   const canCreateGroup = Boolean(

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
@@ -9,8 +9,8 @@ describe('Inventory Host Groups List', () => {
     onAdd: (items: InventoryGroup[]) => {
       items;
     },
-    inventoryId: '',
-    hostId: '',
+    inventoryId: '1',
+    hostId: '1',
   };
   describe('Non-empty list', () => {
     beforeEach(() => {

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
@@ -9,6 +9,8 @@ describe('Inventory Host Groups List', () => {
     onAdd: (items: InventoryGroup[]) => {
       items;
     },
+    inventoryId: '',
+    hostId: '',
   };
   describe('Non-empty list', () => {
     beforeEach(() => {

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
@@ -1,6 +1,5 @@
 import { t } from 'i18next';
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
 import { MultiSelectDialog, usePageDialog } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -10,17 +9,21 @@ import { useHostsGroupsFilters } from './hooks/useHostsGroupsFilters';
 
 export interface InventoryHostGroupsAddModalProps {
   onAdd: (items: InventoryGroup[]) => void;
+  inventoryId: string;
+  hostId: string;
 }
 
-export function InventoryHostGroupsAddModal(props: { onAdd: (items: InventoryGroup[]) => void }) {
-  const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
-
+export function InventoryHostGroupsAddModal(props: {
+  onAdd: (items: InventoryGroup[]) => void;
+  inventoryId: string;
+  hostId: string;
+}) {
   const toolbarFilters = useHostsGroupsFilters();
   const tableColumns = useHostsGroupsColumns({ disableLinks: true });
 
   const view = useAwxView<InventoryGroup>({
-    url: awxAPI`/inventories/${params.id ?? ''}/groups/`,
-    queryParams: { not__hosts: params.host_id ?? '' },
+    url: awxAPI`/inventories/${props.inventoryId ?? ''}/groups/`,
+    queryParams: { not__hosts: props.hostId ?? '' },
     toolbarFilters,
     tableColumns,
   });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useAssociateGroupsToHost.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useAssociateGroupsToHost.tsx
@@ -5,15 +5,16 @@ import { useNameColumn } from '../../../../../common/columns';
 import { getItemKey, postRequest } from '../../../../../common/crud/Data';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { InventoryGroup } from '../../../../interfaces/InventoryGroup';
-import { useParams } from 'react-router-dom';
 import { useAwxBulkActionDialog } from '../../../../common/useAwxBulkActionDialog';
 
-export function useAssociateGroupsToHost(onComplete: (groups: InventoryGroup[]) => void) {
+export function useAssociateGroupsToHost(
+  onComplete: (groups: InventoryGroup[]) => void,
+  hostId: string
+) {
   const { t } = useTranslation();
   const addActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [addActionNameColumn], [addActionNameColumn]);
   const bulkAction = useAwxBulkActionDialog<InventoryGroup>();
-  const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const associateGroupsToHost = (groups: InventoryGroup[]) => {
     bulkAction({
       title: t('Add host to groups', { count: groups.length }),
@@ -23,7 +24,7 @@ export function useAssociateGroupsToHost(onComplete: (groups: InventoryGroup[]) 
       onComplete,
       actionFn: async (group: InventoryGroup, signal: AbortSignal) => {
         await postRequest(
-          awxAPI`/hosts/${params.host_id ?? ''}/groups/`,
+          awxAPI`/hosts/${hostId ?? ''}/groups/`,
           {
             id: group.id,
           },

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useDisassociateGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useDisassociateGroups.tsx
@@ -7,9 +7,11 @@ import { awxAPI } from '../../../../common/api/awx-utils';
 import { useAwxBulkConfirmation } from '../../../../common/useAwxBulkConfirmation';
 import { useHostsGroupsColumns } from './useHostsGroupsColumns';
 import { InventoryGroup } from '../../../../interfaces/InventoryGroup';
-import { useParams } from 'react-router-dom';
 
-export function useDisassociateGroups(onComplete: (groups: InventoryGroup[]) => void) {
+export function useDisassociateGroups(
+  onComplete: (groups: InventoryGroup[]) => void,
+  hostId: string
+) {
   const { t } = useTranslation();
   const confirmationColumns = useHostsGroupsColumns({
     disableLinks: true,
@@ -18,7 +20,7 @@ export function useDisassociateGroups(onComplete: (groups: InventoryGroup[]) => 
   const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
   const bulkAction = useAwxBulkConfirmation<InventoryGroup>();
-  const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
+  // const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const disassociateGroups = (groups: InventoryGroup[]) => {
     bulkAction({
       title: t('Disassociate group from host?', { count: groups.length }),
@@ -37,7 +39,7 @@ export function useDisassociateGroups(onComplete: (groups: InventoryGroup[]) => 
       onComplete,
       actionFn: async (group: InventoryGroup, signal) => {
         await postRequest(
-          awxAPI`/hosts/${params.host_id ?? ''}/groups/`,
+          awxAPI`/hosts/${hostId ?? ''}/groups/`,
           {
             disassociate: true,
             id: group.id,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsActions.tsx
@@ -10,12 +10,16 @@ import {
 import { cannotEditResource } from '../../../../../common/utils/RBAChelpers';
 import { AwxRoute } from '../../../../main/AwxRoutes';
 import { InventoryGroup } from '../../../../interfaces/InventoryGroup';
-import { useParams } from 'react-router-dom';
+import { useGetItem } from '../../../../../common/crud/useGet';
+import { Inventory } from '../../../../interfaces/generated-from-swagger/api';
+import { awxAPI } from '../../../../common/api/awx-utils';
 
-export function useHostsGroupsActions() {
+export function useHostsGroupsActions(inventoryId: string) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const params = useParams<{ inventory_type: string; id: string }>();
+
+  const { data: inventory } = useGetItem<Inventory>(awxAPI`/inventories/`, inventoryId);
+  const inventoryType = inventory?.type;
 
   return useMemo<IPageAction<InventoryGroup>[]>(
     () => [
@@ -27,11 +31,11 @@ export function useHostsGroupsActions() {
         label: t('Edit group'),
         onClick: (group) =>
           pageNavigate(AwxRoute.InventoryGroupEdit, {
-            params: { inventory_type: params.inventory_type, id: params.id, group_id: group.id },
+            params: { inventory_type: inventoryType, id: inventoryId, group_id: group.id },
           }),
         isDisabled: (group) => cannotEditResource(group, t),
       },
     ],
-    [t, pageNavigate, params.id, params.inventory_type]
+    [t, pageNavigate, inventoryId, inventoryType]
   );
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -27,7 +27,7 @@ export function useHostsGroupsToolbarActions(
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
 
-  const disassociateGroups = useDisassociateGroups(view.unselectItemsAndRefresh);
+  const disassociateGroups = useDisassociateGroups(view.unselectItemsAndRefresh, hostId);
 
   const adhocOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/${inventoryId ?? ''}/ad_hoc_commands/`
@@ -42,7 +42,7 @@ export function useHostsGroupsToolbarActions(
   );
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();
-  const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh);
+  const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh, hostId);
 
   return useMemo<IPageAction<InventoryGroup>[]>(
     () => [

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -2,7 +2,6 @@ import { ButtonVariant } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import {
   IPageAction,
   PageActionType,
@@ -19,15 +18,19 @@ import { useDisassociateGroups } from './useDisassociateGroups';
 import { useInventoryHostGroupsAddModal } from '../InventoryHostGroupsModal';
 import { useAssociateGroupsToHost } from './useAssociateGroupsToHost';
 
-export function useHostsGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
+export function useHostsGroupsToolbarActions(
+  view: IAwxView<InventoryGroup>,
+  inventoryId: string,
+  hostId: string,
+  hostPage: boolean
+) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
 
   const disassociateGroups = useDisassociateGroups(view.unselectItemsAndRefresh);
 
   const adhocOptions = useOptions<OptionsResponse<ActionsResponse>>(
-    awxAPI`/inventories/${params.id ?? ''}/ad_hoc_commands/`
+    awxAPI`/inventories/${inventoryId ?? ''}/ad_hoc_commands/`
   ).data;
   const canRunAdHocCommand = Boolean(
     adhocOptions && adhocOptions.actions && adhocOptions.actions['POST']
@@ -50,7 +53,12 @@ export function useHostsGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
         isPinned: true,
         icon: PlusCircleIcon,
         label: t('Associate'),
-        onClick: () => openInventoryHostsGroupsAddModal({ onAdd: associateGroups }),
+        onClick: () =>
+          openInventoryHostsGroupsAddModal({
+            onAdd: associateGroups,
+            inventoryId: inventoryId ?? '',
+            hostId: hostId ?? '',
+          }),
         isDisabled: () =>
           canCreateGroup
             ? undefined
@@ -62,6 +70,7 @@ export function useHostsGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
         type: PageActionType.Button,
         selection: PageActionSelection.None,
         variant: ButtonVariant.secondary,
+        isHidden: () => hostPage,
         isPinned: true,
         label: t('Run Command'),
         onClick: () => pageNavigate(AwxRoute.Inventories),
@@ -92,6 +101,9 @@ export function useHostsGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
       canCreateGroup,
       pageNavigate,
       canRunAdHocCommand,
+      hostId,
+      hostPage,
+      inventoryId,
     ]
   );
 }


### PR DESCRIPTION
This PR is for [AAP-8160](https://issues.redhat.com/browse/AAP-8160). The changes in this PR update the host groups tab section to display a list of groups the host is associated with. The already existing `InventoryHostGroups` component was modified to enable to component to be displayed correctly on both the inventory host groups and host groups pages.