### PR TITLE
Ensure workflow save functionality does not cancel client-side API requests

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowTopology.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowTopology.tsx
@@ -210,6 +210,7 @@ export const WorkflowTopology = ({ data: { workflowNodes = [], template } }: Top
 
     visualization.fromModel(model, true);
     visualization.getGraph().reset();
+    visualization.getGraph().layout();
   }, [t, visualization, createEdge, workflowNodes, dedupeOldNodes]);
 
   return (


### PR DESCRIPTION
Bug: The workflow visualizer's save functionality cancels API requests on the client-side, particularly when multiple POST requests are made to the same `usePostRequest` instance.

By default, `usePostRequest` initializes a ref to handle the `AbortController` instance. It then checks if there is another instance of `AbortController`, and if it exists, it calls its abort() method. If we don't pass in our own custom signal, then the `AbortController` instance's signal will be used in the fetch request. 

A bug arises when `usePostRequest` is used more than once, leading to request cancellations. These multiple instances reference the same instance of the `AbortController`, resulting in unintended aborts. 

```
if (abortControllerRef.current.abortController) {
  abortControllerRef.current.abortController.abort();
}
```



Bug screenshot
![Screenshot 2024-03-13 at 4 03 49 PM](https://github.com/ansible/ansible-ui/assets/15881645/a5d9f9a1-64d1-49f3-b9b9-226e31e3e0d0)

Bug fix working:
![add_wf_nodes](https://github.com/ansible/ansible-ui/assets/15881645/de3d0fa6-24be-4072-a716-891c95d19520)
