### PR TITLE
[AAH-9294] use MinusCircleIcon vs RemoveIcon

### DIFF
--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
 } from '@patternfly/react-core';
-import { CubesIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -63,7 +63,7 @@ function UserRolesInternal(props: { user: User }) {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Multiple,
-        icon: TrashIcon,
+        icon: MinusCircleIcon,
         label: t('Remove selected roles from user'),
         onClick: () => alert('TODO'),
         isDanger: true,
@@ -78,7 +78,7 @@ function UserRolesInternal(props: { user: User }) {
         selection: PageActionSelection.Single,
         variant: ButtonVariant.primary,
         isPinned: true,
-        icon: TrashIcon,
+        icon: MinusCircleIcon,
         label: t('Remove role from user'),
         onClick: () => alert('TODO'),
         isDanger: true,

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -5,7 +5,7 @@ import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Instance } from '../../../interfaces/Instance';
 import { InstanceGroup } from '../../../interfaces/InstanceGroup';
-import { HeartbeatIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { HeartbeatIcon, PencilAltIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import {
   usePageNavigate,
@@ -167,7 +167,7 @@ export function useInstanceDetailsActions(options: {
         type: PageActionType.Button,
         isHidden: () => isK8s === false || !instancesType,
         selection: PageActionSelection.Single,
-        icon: TrashIcon,
+        icon: MinusCircleIcon,
         label: t('Remove instance'),
         onClick: (instance: Instance) => removeInstances([instance]),
         isDisabled: () =>

--- a/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { HeartbeatIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { HeartbeatIcon, PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
@@ -68,7 +68,7 @@ export function useInstanceToolbarActions(view: IAwxView<Instance>) {
         type: PageActionType.Button,
         isHidden: () => isK8s === false,
         selection: PageActionSelection.Multiple,
-        icon: TrashIcon,
+        icon: MinusCircleIcon,
         label: t('Remove instance'),
         onClick: (instance: Instance[]) => removeInstances(instance),
         isDisabled: (instances: Instance[]) => cannotRemoveInstances(instances, t),


### PR DESCRIPTION
This pr swaps out the RemoveIcon in favor of the MinusCircleIcon for the action "Remove selected roles from user" and "Remove role from user". This part of the UX enhancements for 2.5. The screenshot below is an example of the precedent we are following:
<img width="583" alt="Screenshot 2024-03-19 at 1 48 27 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/da61a933-bd8a-4055-b524-a5ec06f07b20">


<img width="675" alt="Screenshot 2024-03-19 at 1 30 58 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/f8258dc2-a31b-46f6-a816-71212da42223">
