### PR TITLE
Add node styles to unexecuted workflow output job runs

### DIFF
--- a/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputNode.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputNode.tsx
@@ -25,6 +25,12 @@ import type { WorkflowNode } from '../../../interfaces/WorkflowNode';
 
 const StyledNode = styled(DefaultNode)`
   cursor: pointer;
+  &.unexecuted-job {
+    .pf-topology__node__background {
+      fill: var(--pf-v5-chart-color-black-300);
+      stroke: var(--pf-v5-global--Color--200);
+    }
+  }
   ${({ hover }) => (hover === true ? `cursor: pointer;` : `cursor: default;`)}
 `;
 
@@ -100,6 +106,7 @@ export const WorkflowOutputNode = observer(({ element, selected }: WorkflowOutpu
       badgeColor={data?.badgeColor}
       badgeTextColor={data?.badgeTextColor}
       badgeBorderColor={data?.badgeBorderColor}
+      className={job ? '' : 'unexecuted-job'}
     >
       <g transform={`translate(13, 13)`} ref={hoverRef as LegacyRef<SVGGElement>}>
         <Icon style={{ color: '#393F44' }} width={25} height={25} />


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-21523

Visually de-emphasize workflow jobs that did not run during the workflow template job run. 

<img width="225" alt="Screenshot 2024-03-18 at 3 14 14 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/8e9a07f5-3cae-4098-b11b-44100b256d60">
