### PR TITLE
Add terraform state inventory source

### DIFF
--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -107,6 +107,12 @@ describe('Inventory source page', () => {
     cy.verifyPageTitle('amazon ec2 source');
     cy.clickButton('Edit inventory source');
     cy.verifyPageTitle('Edit source');
+    cy.getBy('[data-cy="name"]').clear().type('updated amazon ec2 source');
+    cy.getBy('[data-cy="overwrite_vars"]').check();
+    cy.getBy('[data-cy="Submit"]').click();
+    cy.verifyPageTitle('updated amazon ec2 source');
+    cy.clickButton('Edit inventory source');
+    cy.verifyPageTitle('Edit source');
     cy.getBy('[data-cy="name"]').clear().type('new project');
     cy.selectDropdownOptionByResourceName('source_control_type', 'Sourced from a Project');
     cy.getBy('[data-cy="overwrite_vars"]').check();

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -78,17 +78,17 @@ describe('Inventory source page', () => {
     cy.selectDropdownOptionByResourceName('project', project.name);
     cy.selectDropdownOptionByResourceName('inventory', 'Dockerfile');
     cy.getBy('[data-cy="execution-environment-select-form-group"]').within(() => {
-      cy.getBy('.pf-v5-c-input-group > .pf-v5-c-button').click();
+      cy.getBy('[data-ouia-component-id="lookup-execution_environment-button"]').click();
     });
-    cy.getBy('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+    cy.getBy('[data-ouia-component-id="Select an execution environment-dialog"]').within(() => {
       cy.searchAndDisplayResource(executionEnvironmentName);
       cy.getBy('[data-cy="checkbox-column-cell"] > label').click();
       cy.contains('button', 'Confirm').click();
     });
     cy.getBy('[data-cy="credential-select-form-group"]').within(() => {
-      cy.getBy('.pf-v5-c-input-group > .pf-v5-c-button').click();
+      cy.getBy('[data-ouia-component-id="lookup-credential-button"]').click();
     });
-    cy.getBy('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+    cy.getBy('[data-ouia-component-id="Select credential"]').within(() => {
       cy.searchAndDisplayResource(credentialName);
       cy.getBy('[data-cy="checkbox-column-cell"] > label').click();
       cy.getBy('#submit').click();

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -775,6 +775,22 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'deleteAwxExecutionEnvironment',
+  (
+    execution_environment: ExecutionEnvironment,
+    options?: {
+      /** Whether to fail on response codes other than 2xx and 3xx */
+      failOnStatusCode?: boolean;
+    }
+  ) => {
+    cy.awxRequestDelete(
+      awxAPI`/execution_environments/${execution_environment.id.toString()}/`,
+      options
+    );
+  }
+);
+
+Cypress.Commands.add(
   'createEdaSpecificAwxProject',
   (options?: { project?: Partial<Omit<Project, 'id'>> }) => {
     cy.createAwxProject({

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -858,6 +858,13 @@ declare global {
           failOnStatusCode?: boolean;
         }
       ): Chainable<void>;
+      deleteAwxExecutionEnvironment(
+        executionEnvironment: ExecutionEnvironment,
+        options?: {
+          /** Whether to fail on response codes other than 2xx and 3xx */
+          failOnStatusCode?: boolean;
+        }
+      ): Chainable<void>;
       deleteAwxCredential(
         credential: Credential,
         options?: {

--- a/frontend/awx/interfaces/InventorySource.ts
+++ b/frontend/awx/interfaces/InventorySource.ts
@@ -84,7 +84,7 @@ export interface InventorySourceCreate {
   inventory: number;
   source_path: string | undefined | null;
   source_script?: string | undefined;
-  execution_environment?: SummaryFieldsExecutionEnvironment | undefined;
+  execution_environment?: number;
   description: string;
   name: string | undefined;
   overwrite: boolean | undefined | null;
@@ -107,7 +107,8 @@ export interface InventorySourceForm {
   inventory?: number;
   source_path: { name: string | undefined | null };
   source_script?: string;
-  execution_environment?: SummaryFieldsExecutionEnvironment;
+  execution_environment?: string;
+  execution_environmentIdPath?: number;
   description: string;
   name: string | undefined;
   overwrite: boolean | undefined | null;

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
@@ -157,6 +157,8 @@ export function InventorySourceDetails(props: {
     satellite6:
       'https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/foreman_inventory.html',
     rhv: 'https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_inventory.html',
+    terraform:
+      'https://github.com/ansible-collections/cloud.terraform/blob/main/plugins/inventory/terraform_state.py',
     vmware:
       'https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_inventory_inventory.html',
     constructed:

--- a/frontend/awx/resources/sources/InventorySourceForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceForm.tsx
@@ -60,6 +60,7 @@ export function CreateInventorySource() {
   const onSubmit: PageFormSubmitHandler<InventorySourceForm> = async (values) => {
     const formValues: InventorySourceCreate = {
       ...values,
+      execution_environment: values?.execution_environmentIdPath,
       credential: values?.credentialIdPath,
       source_path: values?.source_path?.name,
       inventory: parseInt(params.id ?? ''),
@@ -132,6 +133,7 @@ export function EditInventorySource() {
     () => ({
       name: inventorySource?.name,
       description: inventorySource?.description ?? '',
+      execution_environment: inventorySource?.summary_fields?.execution_environment?.name,
       source: inventorySource?.source,
       credential: inventorySource?.summary_fields?.credential?.name,
       source_project: inventorySource?.summary_fields?.source_project,
@@ -154,6 +156,7 @@ export function EditInventorySource() {
   const onSubmit: PageFormSubmitHandler<InventorySourceForm> = async (values) => {
     const formValues: InventorySourceCreate = {
       ...values,
+      execution_environment: values?.execution_environmentIdPath,
       credential: values?.credentialIdPath,
       source_path: values?.source_path?.name ?? '',
       inventory: parseInt(params.id ?? ''),

--- a/frontend/awx/resources/sources/InventorySourceForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceForm.tsx
@@ -41,6 +41,7 @@ export interface SourceFields extends FieldValues {
       | 'rhv'
       | 'controller'
       | 'insights'
+      | 'terraform'
       | null;
   };
   id: number;

--- a/frontend/awx/resources/sources/InventorySourceForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceForm.tsx
@@ -135,10 +135,7 @@ export function EditInventorySource() {
       credential: inventorySource?.summary_fields?.credential?.name,
       source_project: inventorySource?.summary_fields?.source_project,
       source_path: {
-        name:
-          inventorySource?.source_path?.length === 0
-            ? '/ (project root)'
-            : inventorySource?.source_path,
+        name: inventorySource?.source_path,
       },
       verbosity: inventorySource?.verbosity,
       host_filter: inventorySource?.host_filter,
@@ -157,7 +154,7 @@ export function EditInventorySource() {
     const formValues: InventorySourceCreate = {
       ...values,
       credential: values?.credentialIdPath,
-      source_path: values?.source_path?.name,
+      source_path: values?.source_path?.name ?? '',
       inventory: parseInt(params.id ?? ''),
       source_project: values?.source_project?.id,
     };

--- a/frontend/awx/resources/sources/InventorySourceSubForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceSubForm.tsx
@@ -7,6 +7,7 @@ import { PageFormHidden } from '../../../../framework/PageForm/Utils/PageFormHid
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 import { Help } from '../../../../framework/components/Help';
 import { PageFormCredentialSelect } from '../../access/credentials/components/PageFormCredentialSelect';
+import { PageFormExecutionEnvironmentSelect } from '../../administration/execution-environments/components/PageFormExecutionEnvironmentSelect';
 import { InventorySourceForm } from '../../interfaces/InventorySource';
 import { PageFormProjectSelect } from '../projects/components/PageFormProjectSelect';
 import { PageFormInventoryFileSelect } from './component/PageFormInventoryFileSelect';
@@ -50,6 +51,12 @@ export function InventorySourceSubForm() {
             isRequired={sourceTypes.slice(1).includes(source as string)}
             credentialIdPath="credentialIdPath"
             sourceType={source as string}
+          />
+          <PageFormExecutionEnvironmentSelect<InventorySourceForm>
+            name="execution_environment"
+            label={t('Execution environment')}
+            executionEnvironmentIdPath="execution_environmentIdPath"
+            isRequired={source === 'terraform'}
           />
           <PageFormHidden watch="source" hidden={(type: string) => type !== 'scm'}>
             <PageFormProjectSelect<InventorySourceForm> name="source_project" isRequired />

--- a/frontend/awx/resources/sources/InventorySourceSubForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceSubForm.tsx
@@ -29,6 +29,7 @@ export function InventorySourceSubForm() {
     'rhv',
     'controller',
     'insights',
+    'terraform',
   ];
 
   return (


### PR DESCRIPTION
A new Terraform state inventory source was added to AWX in [PR 14840](https://github.com/ansible/awx/pull/14840). This PR updates the UI to include the new source type. It also adds Execution Environment selection to the inventory source add/edit forms, as an EE selection is required for the Terraform source -- users must provide and select an EE containing a Terraform binary, as we cannot ship one with the Terraform binary for licensing reasons.

In addition, this PR fixes a related bug: when trying to edit an inventory source that is not sourced from a project, the API returns a 400: Bad request error with detail "Cannot set source_path if not SCM type." due to a default value in the form for the source_path field.