### PR TITLE
Cleanup duplicate, unused edges in workflow visualizer

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowVisualizerToolbar.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowVisualizerToolbar.tsx
@@ -42,11 +42,11 @@ export const ToolbarHeader = observer(() => {
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const pageNavigate = usePageNavigate();
-  const handleSave = useSaveVisualizer();
   const alertToaster = usePageAlertToaster();
   const { isFullScreen } = useViewOptions();
   const controller = useVisualizationController();
   const { workflowTemplate } = controller.getState<ControllerState>();
+  const handleSave = useSaveVisualizer(workflowTemplate?.id?.toString());
   const isModified = controller
     .getElements()
     .some((element) => element.getState<ControllerState>().modified);
@@ -160,7 +160,6 @@ export const WorkflowVisualizerToolbar = observer(() => {
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
   const { isFullScreen, toggleFullScreen } = useViewOptions();
   const { removeNodes } = useRemoveGraphElements();
-  const handleSave = useSaveVisualizer();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const launch = useLaunchTemplate();
@@ -170,6 +169,7 @@ export const WorkflowVisualizerToolbar = observer(() => {
     .getNodes()
     .filter((n) => n.isVisible() && n.getId() !== START_NODE_ID) as GraphNode[];
   const { workflowTemplate, RBAC, modified } = controller.getState<ControllerState>();
+  const handleSave = useSaveVisualizer(workflowTemplate?.id?.toString());
 
   const handleLaunchWorkflow = useCallback(async () => {
     await launch(workflowTemplate);

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useDedupeOldNodes.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useDedupeOldNodes.tsx
@@ -22,7 +22,7 @@ export function useDedupeOldNodes() {
       key.endsWith('-unsavedNode')
     );
     staleNodeKeys.forEach((key) => {
-      const staleNode = controller.getNodeById(key);
+      const staleNode = controller.getElementById(key);
       if (staleNode) {
         action(() => {
           staleNode.setId(key);

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -15,6 +15,7 @@ import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
 import { Organization } from '../../../../interfaces/Organization';
 import { Label } from '../../../../interfaces/Label';
 import { START_NODE_ID, RESOURCE_TYPE } from '../constants';
+import { useAwxGetAllPages } from '../../../../common/useAwxGetAllPages';
 
 interface WorkflowApprovalNode {
   name: string;
@@ -42,7 +43,7 @@ interface CreateWorkflowNodePayload {
 }
 type CreatePayloadProperty = keyof CreateWorkflowNodePayload;
 
-export function useSaveVisualizer() {
+export function useSaveVisualizer(templateId: string) {
   const controller = useVisualizationController();
   const abortController = useAbortController();
   const deleteRequest = useDeleteRequest();
@@ -55,6 +56,10 @@ export function useSaveVisualizer() {
   const processCredentials = useProcessCredentials();
   const processInstanceGroups = useProcessInstanceGroups();
   const processLabels = useProcessLabels();
+
+  const { refresh: workflowNodeRefresh } = useAwxGetAllPages<WorkflowNode>(
+    awxAPI`/workflow_job_templates/${templateId ?? ''}/workflow_nodes/`
+  );
 
   return useCallback(async () => {
     const graphNodes = controller
@@ -519,7 +524,9 @@ export function useSaveVisualizer() {
         )
       )
     );
+
     action(() => {
+      workflowNodeRefresh();
       controller.setState({ ...state, modified: false });
       controller
         .getElements()
@@ -538,6 +545,7 @@ export function useSaveVisualizer() {
     processCredentials,
     processInstanceGroups,
     processLabels,
+    workflowNodeRefresh,
   ]);
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-21873

Instead of only removing unused nodes, remove all elements (including edges) with the temporary "unused" id. 