### PR TITLE
uxd minor updates to awx overview page

### DIFF
--- a/frontend/awx/overview/cards/AwxRecentInventoriesCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentInventoriesCard.tsx
@@ -34,7 +34,7 @@ export function AwxRecentInventoriesCard() {
       subtitle={t('Recently updated inventories')}
       width="md"
       height="md"
-      linkText={t('Go to Inventories')}
+      linkText={t('View all Inventories')}
       to={getPageUrl(AwxRoute.Inventories)}
     >
       <PageTable<Inventory>

--- a/frontend/awx/overview/cards/AwxRecentJobsCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentJobsCard.tsx
@@ -29,7 +29,7 @@ export function AwxRecentJobsCard() {
       subtitle={t('Recently finished jobs')}
       width="md"
       height="md"
-      linkText={t('Go to Jobs')}
+      linkText={t('View all Jobs')}
       to={getPageUrl(AwxRoute.Jobs)}
     >
       <PageTable<Job>

--- a/frontend/awx/overview/cards/AwxRecentProjectsCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentProjectsCard.tsx
@@ -33,7 +33,7 @@ export function AwxRecentProjectsCard() {
       subtitle={t('Recently updated projects')}
       width="md"
       height="md"
-      linkText={t('Go to Projects')}
+      linkText={t('View all Projects')}
       to={getPageUrl(AwxRoute.Projects)}
     >
       <PageTable

--- a/frontend/awx/overview/charts/JobsChart.tsx
+++ b/frontend/awx/overview/charts/JobsChart.tsx
@@ -66,7 +66,7 @@ export function JobsChart(props: {
 
   return (
     <PageDashboardChart
-      yLabel={t('Job Count')}
+      yLabel={t('Job count')}
       variant="stackedAreaChart"
       groups={[
         {


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-21970

There are some casing errors and text updates that need to be made on the Overview page from the ansible-ui repo

[ x ]Update Job activity "Job count" text

![Screenshot 2024-03-21 at 9 14 30 AM](https://github.com/ansible/ansible-ui/assets/98424339/ec360ce0-8b4f-42fe-bca1-6935ff4cc8fb)

[ N/A ]Update Job activity missing key [looks like it there is a key on the AWX/Controller side]

[ x ]Update Jobs card text link

[ x ]Update Projects card text link

[ x ]Update Inventories card text link

![Screenshot 2024-03-21 at 9 14 46 AM](https://github.com/ansible/ansible-ui/assets/98424339/ef745974-733c-4045-b352-1a8a0d9aafb0)
