### PR TITLE
Fix workflow output error status indicator bug and hover styles

### DIFF
--- a/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputGraph.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputGraph.tsx
@@ -54,13 +54,37 @@ export const WorkflowOutputGraph = observer(
         });
         return;
       };
+
       if (!message?.workflow_node_id || !message?.status || !nodes?.length) {
         return;
+      }
+
+      if (message?.unified_job_id && message.unified_job_id !== props.job?.id) {
+        if (node) {
+          const { resource } = node.getData() as { resource: WorkflowNode };
+          action(() => {
+            node.setData({
+              ...node.getData(),
+              resource: {
+                ...resource,
+                summary_fields: {
+                  ...resource.summary_fields,
+                  job: {
+                    ...resource.summary_fields.job,
+                    id: message.unified_job_id,
+                    type: message.type,
+                  },
+                },
+              },
+            });
+          })();
+        }
       }
 
       if (message.finished) {
         void getElapsedTime(message.workflow_node_id);
       }
+
       action(() => {
         node?.setNodeStatus(message.status as NodeStatus);
       })();
@@ -69,6 +93,7 @@ export const WorkflowOutputGraph = observer(
     useEffect(() => {
       refreshNodeStatus();
     }, [node, refreshNodeStatus]);
+
     return (
       <ViewOptionsProvider>
         <ViewOptionsContext.Consumer>

--- a/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputNode.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutput/WorkflowOutputNode.tsx
@@ -12,9 +12,12 @@ import {
 import {
   DefaultNode,
   ElementModel,
+  Layer,
+  TOP_LAYER,
   GraphElement,
-  observer,
+  NodeStatus,
   WithSelectionProps,
+  observer,
   useHover,
 } from '@patternfly/react-topology';
 import { usePageNavigate } from '../../../../../framework';
@@ -24,14 +27,18 @@ import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import type { WorkflowNode } from '../../../interfaces/WorkflowNode';
 
 const StyledNode = styled(DefaultNode)`
-  cursor: pointer;
+  &.pf-m-hover {
+    cursor: pointer;
+  }
   &.unexecuted-job {
+    &:hover {
+      cursor: default;
+    }
     .pf-topology__node__background {
       fill: var(--pf-v5-chart-color-black-300);
       stroke: var(--pf-v5-global--Color--200);
     }
   }
-  ${({ hover }) => (hover === true ? `cursor: pointer;` : `cursor: default;`)}
 `;
 
 const jobPaths: { [key: string]: string } = {
@@ -72,10 +79,10 @@ export const WorkflowOutputNode = observer(({ element, selected }: WorkflowOutpu
   const [hover, hoverRef] = useHover();
   const pageNavigate = usePageNavigate();
   const statusDecorator = useStatusDecorator();
-  const { job, unified_job_template } = element?.getData()?.resource?.summary_fields || {};
-  const { unified_job_type: templateType } = unified_job_template || {};
+  const status = element.getController().getNodeById(element.getId())?.getNodeStatus();
   const data = element.getData();
-
+  const { job, unified_job_template } = data?.resource?.summary_fields || {};
+  const { unified_job_type: templateType } = unified_job_template || {};
   const Icon = NodeIcon[templateType ?? 'deleted_resource'];
 
   function handleSelect() {
@@ -93,25 +100,28 @@ export const WorkflowOutputNode = observer(({ element, selected }: WorkflowOutpu
   }
 
   return (
-    <StyledNode
-      showLabel
-      element={element}
-      hover={job?.type ? hover : false}
-      labelClassName={`${element.getId()}-node-label`}
-      onSelect={handleSelect}
-      secondaryLabel={data?.secondaryLabel}
-      selected={job?.type ? selected : false}
-      truncateLength={20}
-      badge={data?.badge}
-      badgeColor={data?.badgeColor}
-      badgeTextColor={data?.badgeTextColor}
-      badgeBorderColor={data?.badgeBorderColor}
-      className={job ? '' : 'unexecuted-job'}
-    >
-      <g transform={`translate(13, 13)`} ref={hoverRef as LegacyRef<SVGGElement>}>
-        <Icon style={{ color: '#393F44' }} width={25} height={25} />
+    <Layer id={hover ? TOP_LAYER : undefined}>
+      <g ref={hoverRef as LegacyRef<SVGGElement>}>
+        <StyledNode
+          showLabel
+          element={element}
+          labelClassName={`${element.getId()}-node-label`}
+          onSelect={handleSelect}
+          secondaryLabel={data?.secondaryLabel}
+          selected={job?.type ? selected : false}
+          truncateLength={20}
+          badge={data?.badge}
+          badgeColor={data?.badgeColor}
+          badgeTextColor={data?.badgeTextColor}
+          badgeBorderColor={data?.badgeBorderColor}
+          className={status === NodeStatus.default && !job ? 'unexecuted-job' : ''}
+        >
+          <g transform={`translate(13, 13)`}>
+            <Icon style={{ color: '#393F44' }} width={25} height={25} />
+          </g>
+          {statusDecorator(element)}
+        </StyledNode>
       </g>
-      {statusDecorator(element)}
-    </StyledNode>
+    </Layer>
   );
 });

--- a/frontend/awx/views/jobs/WorkflowOutput/hooks/useStatusDecorator.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutput/hooks/useStatusDecorator.tsx
@@ -73,6 +73,7 @@ function getStatusIcon(nodeType: string, centerPoint: { x: number; y: number }) 
       );
     case 'fail':
     case 'failed':
+    case 'error':
       return <ExclamationCircleIcon data-cy="failed-icon" style={{ fill: pfDanger }} />;
     case 'pending':
     case 'waiting':


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-22021

* Fix bug where unexecuted job styles were showing up on finished jobs 
* Show failed job status indicator on output node
* Move cursor hover styles boundary from the icon wrapper to the node wrapper
* Add ability to click and navigate to a job's output while it is currently running 


_Bug fix demo_
![output_error_status_bug](https://github.com/ansible/ansible-ui/assets/15881645/22cc7c4f-13bc-4cf4-af2e-b162a54230ad)
