### PR TITLE
Contructed inventory add edit form

### DIFF
--- a/framework/PageForm/Inputs/PageFormDataEditor.tsx
+++ b/framework/PageForm/Inputs/PageFormDataEditor.tsx
@@ -310,7 +310,10 @@ export function DataEditorActions(props: {
   );
 }
 
-function valueToObject(value: string | object | undefined | null, isArray?: boolean): object {
+export function valueToObject(
+  value: string | object | undefined | null,
+  isArray?: boolean
+): object {
   if (value === undefined || value === null) {
     return isArray ? [] : {};
   }

--- a/frontend/awx/administration/instance-groups/components/PageFormInstanceGroupSelect.tsx
+++ b/frontend/awx/administration/instance-groups/components/PageFormInstanceGroupSelect.tsx
@@ -25,7 +25,7 @@ export function PageFormInstanceGroupSelect<
       placeholder={t('Add instance groups')}
       labelHelpTitle={t('Instance groups')}
       labelHelp={props.labelHelp}
-      label={t('Instance group')}
+      label={t('Instance Groups')}
       selectTitle={t('Select an instance group')}
       selectOpen={selectInstanceGroup}
       validate={(instanceGroups: InstanceGroup[]) => {

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -34,23 +34,10 @@ export function PageFormMultiSelectAwxResource<
 }) {
   const id = useID(props);
 
-  function constructQueryParams() {
-    let queryString = '&';
-    if (props.queryParams) {
-      Object.keys(props.queryParams).forEach((key) => {
-        queryString += key + '=' + props.queryParams?.[key];
-      });
-    } else {
-      return '';
-    }
-
-    return queryString;
-  }
-
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
     async (options) => {
       try {
-        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams();
+        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -159,3 +146,16 @@ function SelectResource<
     />
   );
 }
+
+export function constructQueryParams(queryParams : QueryParams) {
+    let queryString = '&';
+    if (queryParams) {
+      Object.keys(queryParams).forEach((key) => {
+        queryString += key + '=' + queryParams?.[key];
+      });
+    } else {
+      return '';
+    }
+
+    return queryString;
+  }

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -34,10 +34,23 @@ export function PageFormMultiSelectAwxResource<
 }) {
   const id = useID(props);
 
+  function constructQueryParams() {
+    let queryString = '&';
+    if (props.queryParams) {
+      Object.keys(props.queryParams).forEach((key) => {
+        queryString += key + '=' + props.queryParams?.[key];
+      });
+    } else {
+      return '';
+    }
+
+    return queryString;
+  }
+
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
     async (options) => {
       try {
-        let url = props.url + `?page_size=10&order_by=name`;
+        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams();
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -134,7 +147,7 @@ function SelectResource<
     tableColumns: props.tableColumns,
     disableQueryString: true,
     defaultSelection: props.defaultSelection as Resource[],
-    queryParams : props.queryParams,
+    queryParams: props.queryParams,
   });
   return (
     <MultiSelectDialog<Resource>

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -1,0 +1,148 @@
+import { useCallback } from 'react';
+import { FieldPath, FieldValues, PathValue, useFormContext, useWatch } from 'react-hook-form';
+import { ITableColumn, IToolbarFilter, usePageDialog } from '../../../framework';
+import { MultiSelectDialog } from '../../../framework';
+import { PageAsyncSelectOptionsFn } from '../../../framework/PageInputs/PageAsyncSelectOptions';
+import { useID } from '../../../framework/hooks/useID';
+import { requestGet } from '../../common/crud/Data';
+import { AwxItemsResponse } from './AwxItemsResponse';
+import { useAwxView } from './useAwxView';
+import { AwxAsyncName } from './PageFormSingleSelectAwxResource';
+import { PageFormAsyncMultiSelect } from '../../../framework/PageForm/Inputs/PageFormAsyncMultiSelect';
+import { QueryParams } from './useAwxView';
+
+export function PageFormMultiSelectAwxResource<
+  Resource extends { id: number; name: string; description?: string | null | undefined },
+  FormData extends FieldValues = FieldValues,
+  Name extends FieldPath<FormData> = FieldPath<FormData>,
+  Value extends number = PathValue<FormData, Name>,
+>(props: {
+  id?: string;
+  name: Name;
+  label: string;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  url: string;
+  toolbarFilters?: IToolbarFilter[];
+  tableColumns: ITableColumn<Resource>[];
+  defaultSelection?: Value[];
+  placeholder: string;
+  queryPlaceholder: string;
+  queryErrorText: string;
+  helperText?: string;
+  queryParams?: QueryParams;
+}) {
+  const id = useID(props);
+
+  const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
+    async (options) => {
+      try {
+        let url = props.url + `?page_size=10&order_by=name`;
+        if (options.next) url = url + `&name__gt=${options.next}`;
+        if (options.search) url = url + `&name__icontains=${options.search}`;
+        const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
+        return {
+          remaining: response.count - response.results.length,
+          options:
+            response.results?.map((resource) => ({
+              label: resource.name,
+              value: resource.id as PathValue<FormData, Name>,
+              description: resource.description,
+            })) ?? [],
+          next: response.results[response.results.length - 1]?.name,
+        };
+      } catch (error) {
+        return {
+          remaining: 0,
+          options: [],
+          next: 0,
+        };
+      }
+    },
+    [props.url]
+  );
+
+  const [_, setDialog] = usePageDialog();
+  const { setValue } = useFormContext<FormData>();
+  const value = useWatch<FormData>({ name: props.name }) as number[];
+  const openSelectDialog = useCallback(
+    (onSelect: (resource: Resource[]) => void) => {
+      setDialog(
+        <SelectResource<Resource>
+          title={props.label}
+          url={props.url}
+          onSelect={onSelect}
+          toolbarFilters={props.toolbarFilters}
+          tableColumns={props.tableColumns}
+          queryParams={props.queryParams}
+          defaultSelection={
+            value && Array.isArray(value)
+              ? value.map((item: number) => {
+                  return { id: item };
+                })
+              : []
+          }
+        />
+      );
+    },
+    [props.label, props.tableColumns, props.toolbarFilters, props.url, setDialog, value]
+  );
+
+  const queryLabel = useCallback(
+    (value: Value) => <AwxAsyncName url={props.url} id={value as unknown as number} />,
+    [props.url]
+  );
+
+  return (
+    <PageFormAsyncMultiSelect<FormData, Name>
+      id={id}
+      name={props.name}
+      label={props.label}
+      queryOptions={queryOptions}
+      placeholder={props.placeholder}
+      queryPlaceholder={props.queryPlaceholder}
+      queryErrorText={props.queryErrorText}
+      isRequired={props.isRequired}
+      isDisabled={props.isDisabled}
+      helperText={props.helperText}
+      onBrowse={() =>
+        openSelectDialog((resources: Resource[]) => {
+          if (resources) {
+            setValue(props.name, resources.map((res) => res.id) as PathValue<FormData, Name>);
+          }
+        })
+      }
+      queryLabel={queryLabel}
+    />
+  );
+}
+
+function SelectResource<
+  Resource extends { id: number; name: string; description?: string | null | undefined },
+>(props: {
+  title: string;
+  url: string;
+  onSelect: (resource: Resource[]) => void;
+  defaultSelection?: { id: number }[];
+  toolbarFilters?: IToolbarFilter[];
+  tableColumns: ITableColumn<Resource>[];
+  queryParams?: QueryParams;
+}) {
+  const view = useAwxView<Resource>({
+    url: props.url,
+    toolbarFilters: props.toolbarFilters,
+    tableColumns: props.tableColumns,
+    disableQueryString: true,
+    defaultSelection: props.defaultSelection as Resource[],
+    queryParams : props.queryParams,
+  });
+  return (
+    <MultiSelectDialog<Resource>
+      title={props.title}
+      onSelect={props.onSelect}
+      toolbarFilters={props.toolbarFilters ?? []}
+      tableColumns={props.tableColumns}
+      view={view}
+    />
+  );
+}

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -37,7 +37,8 @@ export function PageFormMultiSelectAwxResource<
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
     async (options) => {
       try {
-        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
+        let url =
+          props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -59,7 +60,7 @@ export function PageFormMultiSelectAwxResource<
         };
       }
     },
-    [props.url]
+    [props.url, props.queryParams]
   );
 
   const [_, setDialog] = usePageDialog();
@@ -85,7 +86,15 @@ export function PageFormMultiSelectAwxResource<
         />
       );
     },
-    [props.label, props.tableColumns, props.toolbarFilters, props.url, setDialog, value]
+    [
+      props.label,
+      props.tableColumns,
+      props.toolbarFilters,
+      props.url,
+      setDialog,
+      value,
+      props.queryParams,
+    ]
   );
 
   const queryLabel = useCallback(
@@ -147,15 +156,15 @@ function SelectResource<
   );
 }
 
-export function constructQueryParams(queryParams : QueryParams) {
-    let queryString = '&';
-    if (queryParams) {
-      Object.keys(queryParams).forEach((key) => {
-        queryString += key + '=' + queryParams?.[key];
-      });
-    } else {
-      return '';
-    }
-
-    return queryString;
+export function constructQueryParams(queryParams: QueryParams) {
+  let queryString = '&';
+  if (queryParams) {
+    Object.keys(queryParams).forEach((key) => {
+      queryString += key + '=' + queryParams?.[key];
+    });
+  } else {
+    return '';
   }
+
+  return queryString;
+}

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -30,7 +30,7 @@ export function PageFormMultiSelectAwxResource<
   queryPlaceholder: string;
   queryErrorText: string;
   helperText?: string;
-  labelHelp? : string;
+  labelHelp?: string;
   queryParams?: QueryParams;
 }) {
   const id = useID(props);

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -10,6 +10,7 @@ import { useAwxView } from './useAwxView';
 import { AwxAsyncName } from './PageFormSingleSelectAwxResource';
 import { PageFormAsyncMultiSelect } from '../../../framework/PageForm/Inputs/PageFormAsyncMultiSelect';
 import { QueryParams } from './useAwxView';
+import { getQueryString } from './useAwxView';
 
 export function PageFormMultiSelectAwxResource<
   Resource extends { id: number; name: string; description?: string | null | undefined },
@@ -39,7 +40,7 @@ export function PageFormMultiSelectAwxResource<
     async (options) => {
       try {
         let url =
-          props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
+          props.url + `?page_size=10&order_by=name` + getQueryString(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -156,17 +157,4 @@ function SelectResource<
       view={view}
     />
   );
-}
-
-export function constructQueryParams(queryParams: QueryParams) {
-  let queryString = '&';
-  if (queryParams) {
-    Object.keys(queryParams).forEach((key) => {
-      queryString += key + '=' + queryParams?.[key];
-    });
-  } else {
-    return '';
-  }
-
-  return queryString;
 }

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -30,6 +30,7 @@ export function PageFormMultiSelectAwxResource<
   queryPlaceholder: string;
   queryErrorText: string;
   helperText?: string;
+  labelHelp? : string;
   queryParams?: QueryParams;
 }) {
   const id = useID(props);
@@ -114,6 +115,7 @@ export function PageFormMultiSelectAwxResource<
       isRequired={props.isRequired}
       isDisabled={props.isDisabled}
       helperText={props.helperText}
+      labelHelp={props.labelHelp}
       onBrowse={() =>
         openSelectDialog((resources: Resource[]) => {
           if (resources) {

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -40,7 +40,7 @@ export function PageFormMultiSelectAwxResource<
     async (options) => {
       try {
         let url =
-          props.url + `?page_size=10&order_by=name` + getQueryString(props.queryParams || {});
+          props.url + `?page_size=10&order_by=name&` + getQueryString(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -11,6 +11,8 @@ import { requestGet } from '../../common/crud/Data';
 import { useGetItem } from '../../common/crud/useGet';
 import { AwxItemsResponse } from './AwxItemsResponse';
 import { useAwxView } from './useAwxView';
+import { QueryParams } from './useAwxView';
+import { constructQueryParams } from './PageFormMultiSelectAwxResource';
 
 export function PageFormSingleSelectAwxResource<
   Resource extends { id: number; name: string; description?: string | null | undefined },
@@ -31,13 +33,14 @@ export function PageFormSingleSelectAwxResource<
   queryPlaceholder: string;
   queryErrorText: string;
   helperText?: string;
+  queryParams?: QueryParams;
 }) {
   const id = useID(props);
 
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
     async (options) => {
       try {
-        let url = props.url + `?page_size=10&order_by=name`;
+        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -75,6 +78,7 @@ export function PageFormSingleSelectAwxResource<
           toolbarFilters={props.toolbarFilters}
           tableColumns={props.tableColumns}
           defaultSelection={value ? [{ id: value }] : []}
+          queryParams={props.queryParams}
         />
       );
     },
@@ -117,6 +121,7 @@ function SelectResource<
   defaultSelection?: { id: number }[];
   toolbarFilters?: IToolbarFilter[];
   tableColumns: ITableColumn<Resource>[];
+  queryParams?: QueryParams;
 }) {
   const view = useAwxView<Resource>({
     url: props.url,
@@ -124,6 +129,7 @@ function SelectResource<
     tableColumns: props.tableColumns,
     disableQueryString: true,
     defaultSelection: props.defaultSelection as Resource[],
+    queryParams : props.queryParams,
   });
   return (
     <SingleSelectDialog<Resource>

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -40,7 +40,8 @@ export function PageFormSingleSelectAwxResource<
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
     async (options) => {
       try {
-        let url = props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
+        let url =
+          props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);
@@ -62,7 +63,7 @@ export function PageFormSingleSelectAwxResource<
         };
       }
     },
-    [props.url]
+    [props.url, props.queryParams]
   );
 
   const [_, setDialog] = usePageDialog();
@@ -82,7 +83,15 @@ export function PageFormSingleSelectAwxResource<
         />
       );
     },
-    [props.label, props.tableColumns, props.toolbarFilters, props.url, setDialog, value]
+    [
+      props.label,
+      props.tableColumns,
+      props.toolbarFilters,
+      props.url,
+      setDialog,
+      value,
+      props.queryParams,
+    ]
   );
 
   const queryLabel = useCallback(
@@ -129,7 +138,7 @@ function SelectResource<
     tableColumns: props.tableColumns,
     disableQueryString: true,
     defaultSelection: props.defaultSelection as Resource[],
-    queryParams : props.queryParams,
+    queryParams: props.queryParams,
   });
   return (
     <SingleSelectDialog<Resource>

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -33,7 +33,7 @@ export function PageFormSingleSelectAwxResource<
   queryPlaceholder: string;
   queryErrorText: string;
   helperText?: string;
-  labelHelp? : string;
+  labelHelp?: string;
   queryParams?: QueryParams;
 }) {
   const id = useID(props);

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -12,7 +12,7 @@ import { useGetItem } from '../../common/crud/useGet';
 import { AwxItemsResponse } from './AwxItemsResponse';
 import { useAwxView } from './useAwxView';
 import { QueryParams } from './useAwxView';
-import { constructQueryParams } from './PageFormMultiSelectAwxResource';
+import { getQueryString } from './useAwxView';
 
 export function PageFormSingleSelectAwxResource<
   Resource extends { id: number; name: string; description?: string | null | undefined },
@@ -42,7 +42,7 @@ export function PageFormSingleSelectAwxResource<
     async (options) => {
       try {
         let url =
-          props.url + `?page_size=10&order_by=name` + constructQueryParams(props.queryParams || {});
+          props.url + `?page_size=10&order_by=name` + getQueryString(props.queryParams || {});
         if (options.next) url = url + `&name__gt=${options.next}`;
         if (options.search) url = url + `&name__icontains=${options.search}`;
         const response = await requestGet<AwxItemsResponse<Resource>>(url, options.signal);

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -33,6 +33,7 @@ export function PageFormSingleSelectAwxResource<
   queryPlaceholder: string;
   queryErrorText: string;
   helperText?: string;
+  labelHelp? : string;
   queryParams?: QueryParams;
 }) {
   const id = useID(props);
@@ -111,6 +112,7 @@ export function PageFormSingleSelectAwxResource<
       isRequired={props.isRequired}
       isDisabled={props.isDisabled}
       helperText={props.helperText}
+      labelHelp={props.labelHelp}
       onBrowse={() =>
         openSelectDialog((resource) =>
           setValue(props.name, resource.id as PathValue<FormData, Name>)

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -136,7 +136,7 @@ function SelectResource<
   );
 }
 
-function AwxAsyncName(props: { url: string; id: number; nameProp?: string }) {
+export function AwxAsyncName(props: { url: string; id: number; nameProp?: string }) {
   const { t } = useTranslation();
   const { data, isLoading, error } = useGetItem<Record<string, string>>(props.url, props.id);
   if (isLoading) return <Spinner size="md" />;

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -28,7 +28,7 @@ export type QueryParams = {
   [key: string]: string;
 };
 
-function getQueryString(queryParams: QueryParams) {
+export function getQueryString(queryParams: QueryParams) {
   return Object.entries(queryParams)
     .map(([key, value = '']) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join('&');

--- a/frontend/awx/main/ansibleDocsUrls.ts
+++ b/frontend/awx/main/ansibleDocsUrls.ts
@@ -1,0 +1,18 @@
+export const ansibleDocUrls: { [key: string]: string } = {
+  ec2: 'https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html',
+  azure_rm:
+    'https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_inventory.html',
+  controller: 'https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_inventory.html',
+  gce: 'https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_inventory.html',
+  insights:
+    'https://docs.ansible.com/ansible/latest/collections/redhatinsights/insights/insights_inventory.html',
+  openstack:
+    'https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html',
+  satellite6:
+    'https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/foreman_inventory.html',
+  rhv: 'https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_inventory.html',
+  vmware:
+    'https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_inventory_inventory.html',
+  constructed:
+    'https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html',
+};

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -256,6 +256,11 @@ export function useAwxInventoryRoutes() {
           element: <CreateInventory inventoryKind="smart" />,
         },
         {
+          id: AwxRoute.CreateConstructedInventory,
+          path: 'constructed_inventory/create',
+          element: <CreateInventory inventoryKind="constructed" />,
+        },
+        {
           path: '',
           element: <Inventories />,
         },

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -37,6 +37,7 @@ import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { ansibleDocUrls } from '../../main/ansibleDocsUrls';
 
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
@@ -321,7 +322,14 @@ function InventoryInputs(props: { inventoryKind: string }) {
   somepassword: magic
 `;
 
-  const labelHelpVarsInventory: React.ReactNode = (
+  const yamlExampleConstructed = `
+      ---
+      plugin: constructed
+      strict: true
+      use_vars_plugins: true
+    `;
+
+  const labelHelpVarsInventory = (
     <>
       <Trans>
         Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
@@ -343,12 +351,53 @@ function InventoryInputs(props: { inventoryKind: string }) {
       <br />
       <Trans>
         View YAML examples at{' '}
-        <Link to="http://docs.ansible.com/YAMLSyntax.html" target="_blank" rel="noopener noreferrer">
+        <Link
+          to="http://docs.ansible.com/YAMLSyntax.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           docs.ansible.com
         </Link>
       </Trans>
     </>
   );
+
+  const labelHelpVarsSmartInventory =
+    t(`Enter inventory variables using either JSON or YAML syntax. 
+  Use the radio button to toggle between the two. 
+  Refer to the Ansible Controller documentation for example syntax.
+  `);
+
+  const labelHelpVarsConstructedInventory = (
+    <>
+      <Trans>
+        Variables used to configure the constructed inventory plugin. For a detailed description of
+        how to configure this plugin, see{' '}
+        <a href={ansibleDocUrls.constructed} target="_blank" rel="noopener noreferrer">
+          constructed inventory
+        </a>{' '}
+        plugin configuration guide.
+      </Trans>
+      <br />
+      <br />
+      <hr />
+      <br />
+      <Trans>
+        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
+      </Trans>
+      <br />
+      <br />
+      <Trans>YAML:</Trans>
+      <pre>{yamlExampleConstructed}</pre>
+    </>
+  );
+
+  const labelHelp =
+    inventoryKind === ''
+      ? labelHelpVarsInventory
+      : inventoryKind === 'smart'
+        ? labelHelpVarsSmartInventory
+        : labelHelpVarsConstructedInventory;
 
   return (
     <>
@@ -441,7 +490,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
           label={inventoryKind === 'constructed' ? t('Source vars') : t('Variables')}
           format="yaml"
           isRequired={inventoryKind === 'constructed' ? true : false}
-          labelHelp={labelHelpVarsInventory}
+          labelHelp={labelHelp}
         />
       </PageFormSection>
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -309,7 +309,21 @@ function InventoryInputs(props: { inventoryKind: string }) {
         name="instanceGroups"
         labelHelp={t(`Select the instance groups for this inventory to run on.`)}
       />
-      {inventoryKind === 'constructed' && <PageFormMultiSelectInventories />}
+      {inventoryKind === 'constructed' && 
+        <>
+          <PageFormMultiSelectInventories />
+          <PageFormTextInput 
+            name='update_cache_timeout'
+            id='update_cache_timeout'
+            type='number'
+            label={t(`Cache timeout (seconds)`)}
+            labelHelp={t(`The cache timeout for the related auto-created inventory source, special to constructed inventory`)}
+            validate={ (item) => 
+              (Number.parseFloat(item) >= 0) ? undefined : t('This field must be a number and have a value between 0 and 2147483647')
+            }
+          />
+        </>
+      }
       {inventoryKind === '' && (
         <PageFormLabelSelect<InventoryCreate>
           labelHelpTitle={t('Labels')}

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -30,6 +30,7 @@ import { requestGet } from '../../../common/crud/Data';
 import { PageFormMultiSelectAwxResource } from '../../common/PageFormMultiSelectAwxResource';
 import { useInventoriesColumns } from './hooks/useInventoriesColumns';
 import { useInventoriesFilters } from './hooks/useInventoriesFilters';
+import { TFunction } from 'i18next';
 
 
 export type InventoryCreate = Inventory & {
@@ -57,13 +58,10 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
     let inputInventories : InputInventory[] = [];
     if (props.inventoryKind == 'constructed')
     {
-        inputInventories = await loadInstances(data.inventories || []);
+        inputInventories = await loadInputInventories(data.inventories || [], t);
         data.inputInventories = inputInventories;
-        debugger;
     }
-    return;
 
-    // load input inventories
     const urlType = props.inventoryKind == 'constructed' ? 'constructed_inventories' : 'inventories';
     const newInventory = await postRequest(awxAPI`/${urlType}/`, inventory);
 
@@ -316,7 +314,7 @@ async function submitLabels(inventory: Inventory, labels: Label[]) {
 
 type InputInventory = { id : number; url : string, type : string};
 
-async function loadInstances(inventories : number[])
+async function loadInputInventories(inventories : number[], t: TFunction<"translation", undefined> )
 {
   const promises : unknown[] = [];
   const inventoriesData : InputInventory[] = inventories.map ( (inv) => { return { id : inv, url : '', type : ''} })
@@ -329,6 +327,9 @@ async function loadInstances(inventories : number[])
           const inv = inventoriesData.find( (inv) => inv.id === id);
           if (inv) { inv.url = result.results[0].url || ''; inv.type = result.results[0].type || '' }
         }
+      }).catch( () =>
+      {
+        throw new Error(t(`Error loading input inventory with id {{id}}.`, { id : id}));
       });
 
     promises.push(promise);

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -31,7 +31,6 @@ import { PageFormMultiSelectAwxResource } from '../../common/PageFormMultiSelect
 import { useInventoriesColumns } from './hooks/useInventoriesColumns';
 import { useInventoriesFilters } from './hooks/useInventoriesFilters';
 import { TFunction } from 'i18next';
-import { QueryParams } from '../../common/useAwxView';
 
 // TODO - filter for query string not__kind=smart&not__kind=constructed
 
@@ -58,13 +57,13 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
     const { instanceGroups, ...inventory } = data;
 
     let inputInventories: InputInventory[] = [];
-    if (props.inventoryKind == 'constructed') {
+    if (props.inventoryKind === 'constructed') {
       inputInventories = await loadInputInventories(data.inventories || [], t);
       data.inputInventories = inputInventories;
     }
 
     const urlType =
-      props.inventoryKind == 'constructed' ? 'constructed_inventories' : 'inventories';
+      props.inventoryKind === 'constructed' ? 'constructed_inventories' : 'inventories';
     const newInventory = await postRequest(awxAPI`/${urlType}/`, inventory);
 
     // Update new inventory with selected instance groups

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -35,9 +35,7 @@ import { TFunction } from 'i18next';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
-import { Trans } from 'react-i18next';
-import { Link } from 'react-router-dom';
-import { ansibleDocUrls } from '../../main/ansibleDocsUrls';
+import { LabelHelp } from './components/LabelHelp';
 
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
@@ -310,95 +308,6 @@ function InventoryInputs(props: { inventoryKind: string }) {
   const { t } = useTranslation();
   const { inventoryKind } = props;
 
-  const jsonExample = `
-  {
-    "somevar": "somevalue"
-    "somepassword": "Magic"
-  }
-`;
-  const yamlExample = `
-  ---
-  somevar: somevalue
-  somepassword: magic
-`;
-
-  const yamlExampleConstructed = `
-      ---
-      plugin: constructed
-      strict: true
-      use_vars_plugins: true
-    `;
-
-  const labelHelpVarsInventory = (
-    <>
-      <Trans>
-        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
-      </Trans>
-      <br />
-      <br />
-      <Trans>JSON:</Trans>
-      <pre>{jsonExample}</pre>
-      <br />
-      <Trans>YAML:</Trans>
-      <pre>{yamlExample}</pre>
-      <br />
-      <Trans>
-        View JSON examples at{' '}
-        <Link to="http://www.json.org" target="_blank" rel="noopener noreferrer">
-          www.json.org
-        </Link>
-      </Trans>
-      <br />
-      <Trans>
-        View YAML examples at{' '}
-        <Link
-          to="http://docs.ansible.com/YAMLSyntax.html"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          docs.ansible.com
-        </Link>
-      </Trans>
-    </>
-  );
-
-  const labelHelpVarsSmartInventory =
-    t(`Enter inventory variables using either JSON or YAML syntax. 
-  Use the radio button to toggle between the two. 
-  Refer to the Ansible Controller documentation for example syntax.
-  `);
-
-  const labelHelpVarsConstructedInventory = (
-    <>
-      <Trans>
-        Variables used to configure the constructed inventory plugin. For a detailed description of
-        how to configure this plugin, see{' '}
-        <a href={ansibleDocUrls.constructed} target="_blank" rel="noopener noreferrer">
-          constructed inventory
-        </a>{' '}
-        plugin configuration guide.
-      </Trans>
-      <br />
-      <br />
-      <hr />
-      <br />
-      <Trans>
-        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
-      </Trans>
-      <br />
-      <br />
-      <Trans>YAML:</Trans>
-      <pre>{yamlExampleConstructed}</pre>
-    </>
-  );
-
-  const labelHelp =
-    inventoryKind === ''
-      ? labelHelpVarsInventory
-      : inventoryKind === 'smart'
-        ? labelHelpVarsSmartInventory
-        : labelHelpVarsConstructedInventory;
-
   return (
     <>
       <PageFormTextInput<InventoryCreate>
@@ -490,7 +399,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
           label={inventoryKind === 'constructed' ? t('Source vars') : t('Variables')}
           format="yaml"
           isRequired={inventoryKind === 'constructed' ? true : false}
-          labelHelp={labelHelp}
+          labelHelp={<LabelHelp inventoryKind={inventoryKind} />}
         />
       </PageFormSection>
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -34,6 +34,7 @@ import { useInventoriesFilters } from './hooks/useInventoriesFilters';
 import { TFunction } from 'i18next';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { AwxError } from '../../common/AwxError';
+import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
 
 
 // TODO - filter for query string not__kind=smart&not__kind=constructed
@@ -117,6 +118,7 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
             inputInventories: [],
             verbosity: 0,
             update_cache_timeout: 0,
+            limit: '',
           }
         : {
             kind: inventoryKind,
@@ -357,6 +359,17 @@ function InventoryInputs(props: { inventoryKind: string }) {
               { value: 5, label: t('5 (WinRM Debug)') },
             ]}
           />
+          <PageFormSection singleColumn>
+            <ConstructedInventoryHint/>
+          </PageFormSection>
+          <PageFormTextInput
+            name="limit"
+            id="limit"
+            label={t(`Limit`)}
+            labelHelp={t(
+              `The limit to restrict the returned hosts for the related auto-created inventory source, special to constructed inventory.`
+            )}
+          />        
         </>
       )}
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -36,7 +36,6 @@ import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/Page
 import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
 
-
 // TODO - filter for query string not__kind=smart&not__kind=constructed
 
 export type InventoryCreate = Inventory & {
@@ -360,7 +359,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
             ]}
           />
           <PageFormSection singleColumn>
-            <ConstructedInventoryHint/>
+            <ConstructedInventoryHint />
           </PageFormSection>
           <PageFormTextInput
             name="limit"
@@ -369,7 +368,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
             labelHelp={t(
               `The limit to restrict the returned hosts for the related auto-created inventory source, special to constructed inventory.`
             )}
-          />        
+          />
         </>
       )}
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -35,6 +35,7 @@ import { TFunction } from 'i18next';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { AwxError } from '../../common/AwxError';
 
+
 // TODO - filter for query string not__kind=smart&not__kind=constructed
 
 export type InventoryCreate = Inventory & {

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -201,7 +201,7 @@ export function EditInventory() {
       submitInstanceGroups(updatedInventory, instanceGroups ?? [], originalInstanceGroups ?? [])
     );
 
-    if (params.inventory_type === 'smart_inventory') {
+    if (params.inventory_type === 'inventory') {
       promises.push(submitLabels(inventory as Inventory, labels || []));
     }
 

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -143,12 +143,22 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
 export function EditInventory() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const params = useParams<{ id?: string }>();
+  const params = useParams<{ id?: string, inventory_type : string }>();
   const id = Number(params.id);
-  const { data: inventory } = useGet<Inventory>(awxAPI`/inventories/${id.toString()}/`);
+
+  const urlType =
+      params.inventory_type === 'constructedconstructed_inventory' ? 'constructed_inventories' : 'inventories';
+
+  const { data: inventory } = useGet<Inventory>(awxAPI`/${urlType}/${id.toString()}/`);
   const { data: igResponse } = useGet<AwxItemsResponse<InstanceGroup>>(
-    awxAPI`/inventories/${id.toString()}/instance_groups/`
+    awxAPI`/${urlType}/${id.toString()}/instance_groups/`
   );
+
+  const { data: inputInventoriesResponse } = useGet<AwxItemsResponse<InputInventory>>(
+    awxAPI`/${urlType}/${id.toString()}/inputInventories/`
+  );
+
+  debugger;
   // Fetch instance groups associated with the inventory
   const originalInstanceGroups = igResponse?.results;
   const onSubmit: PageFormSubmitHandler<InventoryCreate> = async (data) => {
@@ -156,7 +166,7 @@ export function EditInventory() {
 
     // Update the inventory
     const updatedInventory = await requestPatch<Inventory>(
-      awxAPI`/inventories/${id.toString()}/`,
+      awxAPI`/${urlType}/${id.toString()}/`,
       editedInventory
     );
     const promises = [];
@@ -197,7 +207,9 @@ export function EditInventory() {
     inventory.kind === 'smart'
       ? { ...inventory, instanceGroups: originalInstanceGroups }
       : inventory.kind === 'constructed'
-        ? {}
+        ? {
+          ...inventory, instanceGrous : originalInstanceGroups, inventories : inputInventoriesResponse 
+        }
         : {
             ...inventory,
             instanceGroups: originalInstanceGroups,

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -36,6 +36,7 @@ import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/Page
 import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
 import { LabelHelp } from './components/LabelHelp';
+import { valueToObject } from '../../../../framework';
 
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
@@ -400,6 +401,14 @@ function InventoryInputs(props: { inventoryKind: string }) {
           format="yaml"
           isRequired={inventoryKind === 'constructed' ? true : false}
           labelHelp={<LabelHelp inventoryKind={inventoryKind} />}
+          validate={(item) => {
+            const obj = valueToObject(item) as { plugin?: unknown };
+            if (obj.plugin) {
+              return undefined;
+            } else {
+              return t(`The plugin parameter is required.`);
+            }
+          }}
         />
       </PageFormSection>
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -471,7 +471,7 @@ function PageFormMultiSelectInventories() {
       queryPlaceholder={t('Loading inventories...')}
       queryErrorText={t('Error loading inventories')}
       isRequired={true}
-      helperText={''}
+      labelHelp={t(`Select Input Inventories for the constructed inventory plugin.`)}
       url={awxAPI`/inventories/`}
       tableColumns={columns}
       toolbarFilters={filters}

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -36,8 +36,6 @@ import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/Page
 import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
 
-// TODO - filter for query string not__kind=smart&not__kind=constructed
-
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
   labels: Label[];
@@ -76,7 +74,11 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
       promises.push(submitInstanceGroups(newInventory, instanceGroups ?? [], []));
 
     // Update new inventory with selected input inventories
-    if (data?.inventories?.length && data.inventories.length > 0) {
+    if (
+      props.inventoryKind === 'constructed' &&
+      data?.inventories?.length &&
+      data.inventories.length > 0
+    ) {
       promises.push(submitInputInventories(newInventory, inputInventories || [], []));
     }
 
@@ -141,6 +143,7 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
       <AwxPageForm
         submitText={t('Create inventory')}
         onSubmit={onSubmit}
+        disableSubmitOnEnter={true}
         onCancel={() => pageNavigate(AwxRoute.Inventories)}
         defaultValue={defaultValue}
       >
@@ -177,6 +180,7 @@ export function EditInventory() {
 
   // Fetch instance groups associated with the inventory
   const originalInstanceGroups = igResponse?.results;
+
   const onSubmit: PageFormSubmitHandler<InventoryCreate> = async (data) => {
     const { organization, labels, instanceGroups, ...editedInventory } = data;
 
@@ -197,10 +201,16 @@ export function EditInventory() {
       submitInstanceGroups(updatedInventory, instanceGroups ?? [], originalInstanceGroups ?? [])
     );
 
-    promises.push(submitLabels(inventory as Inventory, labels || []));
+    if (params.inventory_type === 'smart_inventory') {
+      promises.push(submitLabels(inventory as Inventory, labels || []));
+    }
 
     // Update new inventory with selected input inventories
-    if (data?.inventories?.length && data.inventories.length > 0) {
+    if (
+      params.inventory_type === 'constructed_inventory' &&
+      data?.inventories?.length &&
+      data.inventories.length > 0
+    ) {
       promises.push(
         submitInputInventories(
           data,
@@ -279,6 +289,7 @@ export function EditInventory() {
       <AwxPageForm<InventoryCreate>
         submitText={t('Save inventory')}
         onSubmit={onSubmit}
+        disableSubmitOnEnter={true}
         onCancel={() =>
           pageNavigate(AwxRoute.InventoryDetails, {
             params: { id, inventory_type: kinds[inventory.kind] },

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -35,6 +35,8 @@ import { TFunction } from 'i18next';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { AwxError } from '../../common/AwxError';
 import { ConstructedInventoryHint } from './components/ConstructedInventoryHint';
+import { Trans } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
@@ -306,6 +308,48 @@ export function EditInventory() {
 function InventoryInputs(props: { inventoryKind: string }) {
   const { t } = useTranslation();
   const { inventoryKind } = props;
+
+  const jsonExample = `
+  {
+    "somevar": "somevalue"
+    "somepassword": "Magic"
+  }
+`;
+  const yamlExample = `
+  ---
+  somevar: somevalue
+  somepassword: magic
+`;
+
+  const labelHelpVarsInventory: React.ReactNode = (
+    <>
+      <Trans>
+        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
+      </Trans>
+      <br />
+      <br />
+      <Trans>JSON:</Trans>
+      <pre>{jsonExample}</pre>
+      <br />
+      <Trans>YAML:</Trans>
+      <pre>{yamlExample}</pre>
+      <br />
+      <Trans>
+        View JSON examples at{' '}
+        <Link to="http://www.json.org" target="_blank" rel="noopener noreferrer">
+          www.json.org
+        </Link>
+      </Trans>
+      <br />
+      <Trans>
+        View YAML examples at{' '}
+        <Link to="http://docs.ansible.com/YAMLSyntax.html" target="_blank" rel="noopener noreferrer">
+          docs.ansible.com
+        </Link>
+      </Trans>
+    </>
+  );
+
   return (
     <>
       <PageFormTextInput<InventoryCreate>
@@ -394,8 +438,10 @@ function InventoryInputs(props: { inventoryKind: string }) {
       <PageFormSection singleColumn>
         <PageFormDataEditor<InventoryCreate>
           name="variables"
-          label={t('Variables')}
+          label={inventoryKind === 'constructed' ? t('Source vars') : t('Variables')}
           format="yaml"
+          isRequired={inventoryKind === 'constructed' ? true : false}
+          labelHelp={labelHelpVarsInventory}
         />
       </PageFormSection>
       {inventoryKind === '' && (

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -32,6 +32,7 @@ import { PageFormMultiSelectAwxResource } from '../../common/PageFormMultiSelect
 import { useInventoriesColumns } from './hooks/useInventoriesColumns';
 import { useInventoriesFilters } from './hooks/useInventoriesFilters';
 import { TFunction } from 'i18next';
+import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 
 // TODO - filter for query string not__kind=smart&not__kind=constructed
 
@@ -112,6 +113,8 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
             description: '',
             instanceGroups: [],
             inputInventories: [],
+            verbosity: 0,
+            update_cache_timeout: 0,
           }
         : {
             kind: inventoryKind,
@@ -309,21 +312,42 @@ function InventoryInputs(props: { inventoryKind: string }) {
         name="instanceGroups"
         labelHelp={t(`Select the instance groups for this inventory to run on.`)}
       />
-      {inventoryKind === 'constructed' && 
+      {inventoryKind === 'constructed' && (
         <>
           <PageFormMultiSelectInventories />
-          <PageFormTextInput 
-            name='update_cache_timeout'
-            id='update_cache_timeout'
-            type='number'
+          <PageFormTextInput
+            name="update_cache_timeout"
+            id="update_cache_timeout"
+            type="number"
             label={t(`Cache timeout (seconds)`)}
-            labelHelp={t(`The cache timeout for the related auto-created inventory source, special to constructed inventory`)}
-            validate={ (item) => 
-              (Number.parseFloat(item) >= 0) ? undefined : t('This field must be a number and have a value between 0 and 2147483647')
+            labelHelp={t(
+              `The cache timeout for the related auto-created inventory source, special to constructed inventory`
+            )}
+            validate={(item) =>
+              Number.parseFloat(item) >= 0
+                ? undefined
+                : t('This field must be a number and have a value between 0 and 2147483647')
             }
           />
+          <PageFormSingleSelect
+            name="verbosity"
+            id="verbosity"
+            label={t(`Verbosity`)}
+            placeholder={''}
+            labelHelp={t(
+              'The verbosity level for the related auto-created inventory source, special to constructed inventory'
+            )}
+            options={[
+              { value: 0, label: t('0 (Normal)') },
+              { value: 1, label: t('1 (Verbose)') },
+              { value: 2, label: t('2 (More Verbose)') },
+              { value: 3, label: t('3 (Debug)') },
+              { value: 4, label: t('4 (Connection Debug)') },
+              { value: 5, label: t('5 (WinRM Debug)') },
+            ]}
+          />
         </>
-      }
+      )}
       {inventoryKind === '' && (
         <PageFormLabelSelect<InventoryCreate>
           labelHelpTitle={t('Labels')}

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -538,7 +538,7 @@ function PageFormMultiSelectInventories() {
     <PageFormMultiSelectAwxResource<Inventory>
       name={'inventories'}
       id={'inventories'}
-      label={t('Inventories')}
+      label={t('Input Inventories')}
       placeholder={t('Select inventories')}
       queryPlaceholder={t('Loading inventories...')}
       queryErrorText={t('Error loading inventories')}

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -27,6 +27,10 @@ import { Inventory } from '../../interfaces/Inventory';
 import { Label } from '../../interfaces/Label';
 import { AwxRoute } from '../../main/AwxRoutes';
 
+import { PageFormMultiSelectAwxResource } from '../../common/PageFormMultiSelectAwxResource';
+import { useInventoriesColumns } from './hooks/useInventoriesColumns';
+import { useInventoriesFilters } from './hooks/useInventoriesFilters';
+
 export type InventoryCreate = Inventory & {
   instanceGroups: InstanceGroup[];
   labels: Label[];
@@ -82,6 +86,10 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
       : inventoryKind === 'constructed'
         ? {
             kind: inventoryKind,
+            name: '',
+            description: '',
+            instanceGroups: [],
+            inputInventories: [],
           }
         : {
             kind: inventoryKind,
@@ -235,6 +243,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
         name="instanceGroups"
         labelHelp={t(`Select the instance groups for this inventory to run on.`)}
       />
+      {inventoryKind === 'constructed' && <PageFormMultiSelectInventories />}
       {inventoryKind === '' && (
         <PageFormLabelSelect<InventoryCreate>
           labelHelpTitle={t('Labels')}
@@ -319,4 +328,25 @@ async function submitInstanceGroups(
 
   const results = await Promise.all([...disassociationPromises, ...associationPromises]);
   return results;
+}
+
+function PageFormMultiSelectInventories() {
+  const filters = useInventoriesFilters();
+  const columns = useInventoriesColumns();
+  const { t } = useTranslation();
+  return (
+    <PageFormMultiSelectAwxResource<Inventory>
+      name={'inputInventories'}
+      id={'inputInventories'}
+      label={t('Inventories')}
+      placeholder={t('Select inventories')}
+      queryPlaceholder={t('Loading inventories...')}
+      queryErrorText={t('Error loading inventories')}
+      isRequired={true}
+      helperText={''}
+      url={awxAPI`/inventories/`}
+      tableColumns={columns}
+      toolbarFilters={filters}
+    />
+  );
 }

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -402,6 +402,9 @@ function InventoryInputs(props: { inventoryKind: string }) {
           isRequired={inventoryKind === 'constructed' ? true : false}
           labelHelp={<LabelHelp inventoryKind={inventoryKind} />}
           validate={(item) => {
+            if (inventoryKind !== 'constructed') {
+              return undefined;
+            }
             const obj = valueToObject(item) as { plugin?: unknown };
             if (obj.plugin) {
               return undefined;

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
@@ -57,7 +57,7 @@ export function InventoryDetailsInner(props: { inventory: Inventory }) {
   const { data: inputInventories, error: inputInventoriesError } = useGet<{ results: Inventory[] }>(
     inventory.kind === 'constructed'
       ? awxAPI`/inventories/${inventory.id.toString()}/input_inventories/`
-      : undefined
+      : ''
   );
 
   const inventoryTypes: { [key: string]: string } = {

--- a/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
+++ b/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { t } from '@lingui/macro';
+import { useTranslation } from 'react-i18next';
 import {
   Alert,
   AlertActionLink,
@@ -16,7 +16,7 @@ import {
   CardBody,
 } from '@patternfly/react-core';
 import {
-  TableComposable,
+  Table,
   Thead,
   Tr,
   Th,
@@ -24,10 +24,10 @@ import {
   Td,
 } from '@patternfly/react-table';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { useConfig } from 'contexts/Config';
 
 export function ConstructedInventoryHint() {
-  const config = useConfig();
+  //const config = useConfig();
+  const {t} = useTranslation();
 
   return (
     <Alert
@@ -37,9 +37,9 @@ export function ConstructedInventoryHint() {
       title={t`How to use constructed inventory plugin`}
       actionLinks={
         <AlertActionLink
-          href={`${getDocsBaseUrl(
+          href={`${/*getDocsBaseUrl(
             config
-          )}/html/userguide/inventories.html#constructed-inventories`}
+          )*/''}/html/userguide/inventories.html#constructed-inventories`}
           component="a"
           target="_blank"
           rel="noopener noreferrer"
@@ -58,7 +58,7 @@ export function ConstructedInventoryHint() {
       </span>
       <br />
       <br />
-      <TableComposable
+      <Table
         aria-label={t`Constructed inventory parameters table`}
         variant="compact"
       >
@@ -116,7 +116,7 @@ export function ConstructedInventoryHint() {
             </Td>
           </Tr>
         </Tbody>
-      </TableComposable>
+      </Table>
       <br />
       <br />
       <Panel>
@@ -134,12 +134,13 @@ export function ConstructedInventoryHint() {
 }
 
 function LimitToIntersectionExample() {
+  const {t} = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event, text) => {
+  const clipboardCopyFunc = (event : unknown, text : string) => {
     navigator.clipboard.writeText(text.toString());
   };
 
-  const onClick = (event, text) => {
+  const onClick = (event : unknown, text : string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -203,12 +204,13 @@ groups:
   );
 }
 function FilterOnNestedGroupExample() {
+  const {t} = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event, text) => {
+  const clipboardCopyFunc = (event : unknown, text : string) => {
     navigator.clipboard.writeText(text.toString());
   };
 
-  const onClick = (event, text) => {
+  const onClick = (event : unknown, text : string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -289,12 +291,13 @@ function FilterOnNestedGroupExample() {
   );
 }
 function HostsByProcessorTypeExample() {
+  const {t} = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event, text) => {
+  const clipboardCopyFunc = (event : unknown, text : string) => {
     navigator.clipboard.writeText(text.toString());
   };
 
-  const onClick = (event, text) => {
+  const onClick = (event : unknown, text : string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -356,7 +359,7 @@ groups:
   );
 }
 
-export default function getDocsBaseUrl(config) {
+export default function getDocsBaseUrl(config : any) {
   let version = 'latest';
   const licenseType = config?.license_info?.license_type;
 

--- a/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
+++ b/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
@@ -1,0 +1,370 @@
+import React from 'react';
+import { t } from '@lingui/macro';
+import {
+  Alert,
+  AlertActionLink,
+  ClipboardCopyButton,
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  ClipboardCopy,
+  Form,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  FormGroup,
+  Panel,
+  CardBody,
+} from '@patternfly/react-core';
+import {
+  TableComposable,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from '@patternfly/react-table';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useConfig } from 'contexts/Config';
+
+export function ConstructedInventoryHint() {
+  const config = useConfig();
+
+  return (
+    <Alert
+      isExpandable
+      isInline
+      variant="info"
+      title={t`How to use constructed inventory plugin`}
+      actionLinks={
+        <AlertActionLink
+          href={`${getDocsBaseUrl(
+            config
+          )}/html/userguide/inventories.html#constructed-inventories`}
+          component="a"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t`View constructed inventory documentation here`}{' '}
+          <ExternalLinkAltIcon />
+        </AlertActionLink>
+      }
+    >
+      <span>
+        {t`This table gives a few useful parameters of the constructed
+               inventory plugin. For the full list of parameters `}{' '}
+        <a
+          href={t`https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html`}
+        >{t`view the constructed inventory plugin docs here.`}</a>
+      </span>
+      <br />
+      <br />
+      <TableComposable
+        aria-label={t`Constructed inventory parameters table`}
+        variant="compact"
+      >
+        <Thead>
+          <Tr>
+            <Th>{t`Parameter`}</Th>
+            <Th>{t`Description`}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr ouiaId="plugin-row">
+            <Td dataLabel={t`name`}>
+              <code>plugin</code>
+              <p style={{ color: 'blue' }}>{t`string`}</p>
+              <p style={{ color: 'red' }}>{t`required`}</p>
+            </Td>
+            <Td dataLabel={t`description`}>
+              {t`Token that ensures this is a source file
+              for the ‘constructed’ plugin.`}
+            </Td>
+          </Tr>
+          <Tr key="strict">
+            <Td dataLabel={t`name`}>
+              <code>strict</code>
+              <p style={{ color: 'blue' }}>{t`boolean`}</p>
+            </Td>
+            <Td dataLabel={t`description`}>
+              {t`If yes make invalid entries a fatal error, otherwise skip and
+              continue.`}{' '}
+              <br />
+              {t`If users need feedback about the correctness
+              of their constructed groups, it is highly recommended
+              to use strict: true in the plugin configuration.`}
+            </Td>
+          </Tr>
+          <Tr key="groups">
+            <Td dataLabel={t`name`}>
+              <code>groups</code>
+              <p style={{ color: 'blue' }}>{t`dictionary`}</p>
+            </Td>
+            <Td dataLabel={t`description`}>
+              {t`Add hosts to group based on Jinja2 conditionals.`}
+            </Td>
+          </Tr>
+          <Tr key="compose">
+            <Td dataLabel={t`name`}>
+              <code>compose</code>
+              <p style={{ color: 'blue' }}>{t`dictionary`}</p>
+            </Td>
+            <Td dataLabel={t`description`}>
+              {t`Create vars from jinja2 expressions. This can be useful
+              if the constructed groups you define do not contain the expected
+              hosts. This can be used to add hostvars from expressions so
+              that you know what the resultant values of those expressions are.`}
+            </Td>
+          </Tr>
+        </Tbody>
+      </TableComposable>
+      <br />
+      <br />
+      <Panel>
+        <CardBody>
+          <Form autoComplete="off">
+            <b>{t`Constructed inventory examples`}</b>
+            <LimitToIntersectionExample />
+            <FilterOnNestedGroupExample />
+            <HostsByProcessorTypeExample />
+          </Form>
+        </CardBody>
+      </Panel>
+    </Alert>
+  );
+}
+
+function LimitToIntersectionExample() {
+  const [copied, setCopied] = React.useState(false);
+  const clipboardCopyFunc = (event, text) => {
+    navigator.clipboard.writeText(text.toString());
+  };
+
+  const onClick = (event, text) => {
+    clipboardCopyFunc(event, text);
+    setCopied(true);
+  };
+
+  const limitToIntersectionLimit = `is_shutdown:&product_dev`;
+  const limitToIntersectionCode = `plugin: constructed
+strict: true
+groups:
+  shutdown_in_product_dev: state | default("running") == "shutdown" and account_alias == "product_dev"`;
+
+  return (
+    <FormFieldGroupExpandable
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: t`Construct 2 groups, limit to intersection`,
+            id: 'intersection-example',
+          }}
+          titleDescription={t`This constructed inventory input 
+            creates a group for both of the categories and uses 
+            the limit (host pattern) to only return hosts that 
+            are in the intersection of those two groups.`}
+        />
+      }
+    >
+      <FormGroup label={t`Limit`} fieldId="intersection-example-limit">
+        <ClipboardCopy isReadOnly hoverTip={t`Copy`} clickTip={t`Copied`}>
+          {limitToIntersectionLimit}
+        </ClipboardCopy>
+      </FormGroup>
+      <FormGroup
+        label={t`Source vars`}
+        fieldId="intersection-example-source-vars"
+      >
+        <CodeBlock
+          actions={
+            <CodeBlockAction>
+              <ClipboardCopyButton
+                id="intersection-example-source-vars"
+                textId="intersection-example-source-vars"
+                aria-label={t`Copy to clipboard`}
+                onClick={(e) => onClick(e, limitToIntersectionCode)}
+                exitDelay={copied ? 1500 : 600}
+                maxWidth="110px"
+                variant="plain"
+                onTooltipHidden={() => setCopied(false)}
+              >
+                {copied
+                  ? t`Successfully copied to clipboard!`
+                  : t`Copy to clipboard`}
+              </ClipboardCopyButton>
+            </CodeBlockAction>
+          }
+        >
+          <CodeBlockCode id="intersection-example-source-vars">
+            {limitToIntersectionCode}
+          </CodeBlockCode>
+        </CodeBlock>
+      </FormGroup>
+    </FormFieldGroupExpandable>
+  );
+}
+function FilterOnNestedGroupExample() {
+  const [copied, setCopied] = React.useState(false);
+  const clipboardCopyFunc = (event, text) => {
+    navigator.clipboard.writeText(text.toString());
+  };
+
+  const onClick = (event, text) => {
+    clipboardCopyFunc(event, text);
+    setCopied(true);
+  };
+
+  const nestedGroupsInventoryLimit = `groupA`;
+  const nestedGroupsInventorySourceVars = `plugin: constructed`;
+  const nestedGroupsInventory = `all:
+  children:
+    groupA:
+      children:
+        groupB:
+          hosts:
+            host1: {}
+      vars:
+        filter_var: filter_val
+    ungrouped:
+      hosts:
+        host2: {}`;
+
+  return (
+    <FormFieldGroupExpandable
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: t`Filter on nested group name`,
+            id: 'nested-groups-example',
+          }}
+          titleDescription={t`This constructed inventory input
+            creates a group for both of the categories and uses
+            the limit (host pattern) to only return hosts that
+            are in the intersection of those two groups.`}
+        />
+      }
+    >
+      <FormGroup>
+        <p>{t`Nested groups inventory definition:`}</p>
+        <CodeBlock>
+          <CodeBlockCode id="nested-groups-example-inventory">
+            {nestedGroupsInventory}
+          </CodeBlockCode>
+        </CodeBlock>
+      </FormGroup>
+      <FormGroup label={t`Limit`} fieldId="nested-groups-example-limit">
+        <ClipboardCopy isReadOnly hoverTip={t`Copy`} clickTip={t`Copied`}>
+          {nestedGroupsInventoryLimit}
+        </ClipboardCopy>
+      </FormGroup>
+      <FormGroup
+        label={t`Source vars`}
+        fieldId="nested-groups-example-source-vars"
+      >
+        <CodeBlock
+          actions={
+            <CodeBlockAction>
+              <ClipboardCopyButton
+                id="nested-groups-example-source-vars"
+                textId="nested-groups-example-source-vars"
+                aria-label={t`Copy to clipboard`}
+                onClick={(e) => onClick(e, nestedGroupsInventorySourceVars)}
+                exitDelay={copied ? 1500 : 600}
+                maxWidth="110px"
+                variant="plain"
+                onTooltipHidden={() => setCopied(false)}
+              >
+                {copied
+                  ? t`Successfully copied to clipboard!`
+                  : t`Copy to clipboard`}
+              </ClipboardCopyButton>
+            </CodeBlockAction>
+          }
+        >
+          <CodeBlockCode id="nested-groups-example-source-vars">
+            {nestedGroupsInventorySourceVars}
+          </CodeBlockCode>
+        </CodeBlock>
+      </FormGroup>
+    </FormFieldGroupExpandable>
+  );
+}
+function HostsByProcessorTypeExample() {
+  const [copied, setCopied] = React.useState(false);
+  const clipboardCopyFunc = (event, text) => {
+    navigator.clipboard.writeText(text.toString());
+  };
+
+  const onClick = (event, text) => {
+    clipboardCopyFunc(event, text);
+    setCopied(true);
+  };
+
+  const hostsByProcessorLimit = `intel_hosts`;
+  const hostsByProcessorSourceVars = `plugin: constructed
+strict: true
+groups:
+  intel_hosts: "'GenuineIntel' in ansible_processor"`;
+
+  return (
+    <FormFieldGroupExpandable
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: t`Hosts by processor type`,
+            id: 'processor-example',
+          }}
+          titleDescription="It is hard to give a specification for
+            the inventory for Ansible facts, because to populate
+            the system facts you need to run a playbook against
+            the inventory that has `gather_facts: true`. The
+            actual facts will differ system-to-system."
+        />
+      }
+    >
+      <FormGroup label={t`Limit`} fieldId="processor-example-limit">
+        <ClipboardCopy isReadOnly hoverTip={t`Copy`} clickTip={t`Copied`}>
+          {hostsByProcessorLimit}
+        </ClipboardCopy>
+      </FormGroup>
+      <FormGroup label={t`Source vars`} fieldId="processor-example-source-vars">
+        <CodeBlock
+          actions={
+            <CodeBlockAction>
+              <ClipboardCopyButton
+                id="processor-example-source-vars"
+                textId="processor-example-source-vars"
+                aria-label={t`Copy to clipboard`}
+                onClick={(e) => onClick(e, hostsByProcessorSourceVars)}
+                exitDelay={copied ? 1500 : 600}
+                maxWidth="110px"
+                variant="plain"
+                onTooltipHidden={() => setCopied(false)}
+              >
+                {copied
+                  ? t`Successfully copied to clipboard!`
+                  : t`Copy to clipboard`}
+              </ClipboardCopyButton>
+            </CodeBlockAction>
+          }
+        >
+          <CodeBlockCode id="processor-example-source-vars">
+            {hostsByProcessorSourceVars}
+          </CodeBlockCode>
+        </CodeBlock>
+      </FormGroup>
+    </FormFieldGroupExpandable>
+  );
+}
+
+export default function getDocsBaseUrl(config) {
+  let version = 'latest';
+  const licenseType = config?.license_info?.license_type;
+
+  if (licenseType && licenseType !== 'open' && config?.version) {
+    version = parseFloat(config?.version.split('-')[0]).toFixed(1);
+  }
+
+  return `https://docs.ansible.com/automation-controller/${version}`;
+}
+
+

--- a/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
+++ b/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
@@ -15,21 +15,14 @@ import {
   Panel,
   CardBody,
 } from '@patternfly/react-core';
-import {
-  Table,
-  Thead,
-  Tr,
-  Th,
-  Tbody,
-  Td,
-} from '@patternfly/react-table';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useAwxConfig } from '../../../common/useAwxConfig';
 import { getDocsBaseUrl } from '../../../common/util/getDocsBaseUrl';
 
 export function ConstructedInventoryHint() {
   const config = useAwxConfig();
-  const {t} = useTranslation();
+  const { t } = useTranslation();
 
   return (
     <Alert
@@ -39,15 +32,12 @@ export function ConstructedInventoryHint() {
       title={t`How to use constructed inventory plugin`}
       actionLinks={
         <AlertActionLink
-          href={`${getDocsBaseUrl(
-            config
-          )}/html/userguide/inventories.html#constructed-inventories`}
+          href={`${getDocsBaseUrl(config)}/html/userguide/inventories.html#constructed-inventories`}
           component="a"
           target="_blank"
           rel="noopener noreferrer"
         >
-          {t`View constructed inventory documentation here`}{' '}
-          <ExternalLinkAltIcon />
+          {t`View constructed inventory documentation here`} <ExternalLinkAltIcon />
         </AlertActionLink>
       }
     >
@@ -60,10 +50,7 @@ export function ConstructedInventoryHint() {
       </span>
       <br />
       <br />
-      <Table
-        aria-label={t`Constructed inventory parameters table`}
-        variant="compact"
-      >
+      <Table aria-label={t`Constructed inventory parameters table`} variant="compact">
         <Thead>
           <Tr>
             <Th>{t`Parameter`}</Th>
@@ -73,7 +60,7 @@ export function ConstructedInventoryHint() {
         <Tbody>
           <Tr ouiaId="plugin-row">
             <Td dataLabel={t`name`}>
-              <code>plugin</code>
+              <code>{t`plugin`}</code>
               <p style={{ color: 'blue' }}>{t`string`}</p>
               <p style={{ color: 'red' }}>{t`required`}</p>
             </Td>
@@ -84,7 +71,7 @@ export function ConstructedInventoryHint() {
           </Tr>
           <Tr key="strict">
             <Td dataLabel={t`name`}>
-              <code>strict</code>
+              <code>{t('strict')}</code>
               <p style={{ color: 'blue' }}>{t`boolean`}</p>
             </Td>
             <Td dataLabel={t`description`}>
@@ -98,7 +85,7 @@ export function ConstructedInventoryHint() {
           </Tr>
           <Tr key="groups">
             <Td dataLabel={t`name`}>
-              <code>groups</code>
+              <code>{t(`groups`)}</code>
               <p style={{ color: 'blue' }}>{t`dictionary`}</p>
             </Td>
             <Td dataLabel={t`description`}>
@@ -107,7 +94,7 @@ export function ConstructedInventoryHint() {
           </Tr>
           <Tr key="compose">
             <Td dataLabel={t`name`}>
-              <code>compose</code>
+              <code>{t('compose')}</code>
               <p style={{ color: 'blue' }}>{t`dictionary`}</p>
             </Td>
             <Td dataLabel={t`description`}>
@@ -124,11 +111,13 @@ export function ConstructedInventoryHint() {
       <Panel>
         <CardBody>
           <Form autoComplete="off">
-          <div style={{ 
-                paddingTop : 25,
-                paddingLeft : 20,
-            }}>
-                <b>{t`Constructed inventory examples`}</b>
+            <div
+              style={{
+                paddingTop: 25,
+                paddingLeft: 20,
+              }}
+            >
+              <b>{t`Constructed inventory examples`}</b>
             </div>
             <LimitToIntersectionExample />
             <FilterOnNestedGroupExample />
@@ -141,13 +130,13 @@ export function ConstructedInventoryHint() {
 }
 
 function LimitToIntersectionExample() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event : unknown, text : string) => {
-    navigator.clipboard.writeText(text.toString());
+  const clipboardCopyFunc = (event: unknown, text: string) => {
+    clipboardCopy(text);
   };
 
-  const onClick = (event : unknown, text : string) => {
+  const onClick = (event: unknown, text: string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -178,10 +167,7 @@ groups:
           {limitToIntersectionLimit}
         </ClipboardCopy>
       </FormGroup>
-      <FormGroup
-        label={t`Source vars`}
-        fieldId="intersection-example-source-vars"
-      >
+      <FormGroup label={t`Source vars`} fieldId="intersection-example-source-vars">
         <CodeBlock
           actions={
             <CodeBlockAction>
@@ -195,9 +181,7 @@ groups:
                 variant="plain"
                 onTooltipHidden={() => setCopied(false)}
               >
-                {copied
-                  ? t`Successfully copied to clipboard!`
-                  : t`Copy to clipboard`}
+                {copied ? t`Successfully copied to clipboard!` : t`Copy to clipboard`}
               </ClipboardCopyButton>
             </CodeBlockAction>
           }
@@ -211,13 +195,13 @@ groups:
   );
 }
 function FilterOnNestedGroupExample() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event : unknown, text : string) => {
-    navigator.clipboard.writeText(text.toString());
+  const clipboardCopyFunc = (event: unknown, text: string) => {
+    clipboardCopy(text);
   };
 
-  const onClick = (event : unknown, text : string) => {
+  const onClick = (event: unknown, text: string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -265,10 +249,7 @@ function FilterOnNestedGroupExample() {
           {nestedGroupsInventoryLimit}
         </ClipboardCopy>
       </FormGroup>
-      <FormGroup
-        label={t`Source vars`}
-        fieldId="nested-groups-example-source-vars"
-      >
+      <FormGroup label={t`Source vars`} fieldId="nested-groups-example-source-vars">
         <CodeBlock
           actions={
             <CodeBlockAction>
@@ -282,9 +263,7 @@ function FilterOnNestedGroupExample() {
                 variant="plain"
                 onTooltipHidden={() => setCopied(false)}
               >
-                {copied
-                  ? t`Successfully copied to clipboard!`
-                  : t`Copy to clipboard`}
+                {copied ? t`Successfully copied to clipboard!` : t`Copy to clipboard`}
               </ClipboardCopyButton>
             </CodeBlockAction>
           }
@@ -297,14 +276,19 @@ function FilterOnNestedGroupExample() {
     </FormFieldGroupExpandable>
   );
 }
+
+function clipboardCopy(text: string) {
+  void navigator.clipboard.writeText(text);
+}
+
 function HostsByProcessorTypeExample() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const [copied, setCopied] = React.useState(false);
-  const clipboardCopyFunc = (event : unknown, text : string) => {
-    navigator.clipboard.writeText(text.toString());
+  const clipboardCopyFunc = (event: unknown, text: string) => {
+    clipboardCopy(text);
   };
 
-  const onClick = (event : unknown, text : string) => {
+  const onClick = (event: unknown, text: string) => {
     clipboardCopyFunc(event, text);
     setCopied(true);
   };
@@ -350,9 +334,7 @@ groups:
                 variant="plain"
                 onTooltipHidden={() => setCopied(false)}
               >
-                {copied
-                  ? t`Successfully copied to clipboard!`
-                  : t`Copy to clipboard`}
+                {copied ? t`Successfully copied to clipboard!` : t`Copy to clipboard`}
               </ClipboardCopyButton>
             </CodeBlockAction>
           }
@@ -365,5 +347,3 @@ groups:
     </FormFieldGroupExpandable>
   );
 }
-
-

--- a/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
+++ b/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
@@ -24,9 +24,11 @@ import {
   Td,
 } from '@patternfly/react-table';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useAwxConfig } from '../../../common/useAwxConfig';
+import { getDocsBaseUrl } from '../../../common/util/getDocsBaseUrl';
 
 export function ConstructedInventoryHint() {
-  //const config = useConfig();
+  const config = useAwxConfig();
   const {t} = useTranslation();
 
   return (
@@ -37,9 +39,9 @@ export function ConstructedInventoryHint() {
       title={t`How to use constructed inventory plugin`}
       actionLinks={
         <AlertActionLink
-          href={`${/*getDocsBaseUrl(
+          href={`${getDocsBaseUrl(
             config
-          )*/''}/html/userguide/inventories.html#constructed-inventories`}
+          )}/html/userguide/inventories.html#constructed-inventories`}
           component="a"
           target="_blank"
           rel="noopener noreferrer"
@@ -122,7 +124,12 @@ export function ConstructedInventoryHint() {
       <Panel>
         <CardBody>
           <Form autoComplete="off">
-            <b>{t`Constructed inventory examples`}</b>
+          <div style={{ 
+                paddingTop : 25,
+                paddingLeft : 20,
+            }}>
+                <b>{t`Constructed inventory examples`}</b>
+            </div>
             <LimitToIntersectionExample />
             <FilterOnNestedGroupExample />
             <HostsByProcessorTypeExample />
@@ -357,17 +364,6 @@ groups:
       </FormGroup>
     </FormFieldGroupExpandable>
   );
-}
-
-export default function getDocsBaseUrl(config : any) {
-  let version = 'latest';
-  const licenseType = config?.license_info?.license_type;
-
-  if (licenseType && licenseType !== 'open' && config?.version) {
-    version = parseFloat(config?.version.split('-')[0]).toFixed(1);
-  }
-
-  return `https://docs.ansible.com/automation-controller/${version}`;
 }
 
 

--- a/frontend/awx/resources/inventories/components/LabelHelp.tsx
+++ b/frontend/awx/resources/inventories/components/LabelHelp.tsx
@@ -1,0 +1,99 @@
+import { Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { ansibleDocUrls } from '../../../main/ansibleDocsUrls';
+
+export function LabelHelp(props: { inventoryKind: string }) {
+  const { t } = useTranslation();
+  const inventoryKind = props.inventoryKind;
+  const jsonExample = `
+  {
+    "somevar": "somevalue"
+    "somepassword": "Magic"
+  }
+`;
+  const yamlExample = `
+  ---
+  somevar: somevalue
+  somepassword: magic
+`;
+
+  const yamlExampleConstructed = `
+      ---
+      plugin: constructed
+      strict: true
+      use_vars_plugins: true
+    `;
+
+  const labelHelpVarsInventory = (
+    <>
+      <Trans>
+        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
+      </Trans>
+      <br />
+      <br />
+      <Trans>JSON:</Trans>
+      <pre>{jsonExample}</pre>
+      <br />
+      <Trans>YAML:</Trans>
+      <pre>{yamlExample}</pre>
+      <br />
+      <Trans>
+        View JSON examples at{' '}
+        <Link to="http://www.json.org" target="_blank" rel="noopener noreferrer">
+          www.json.org
+        </Link>
+      </Trans>
+      <br />
+      <Trans>
+        View YAML examples at{' '}
+        <Link
+          to="http://docs.ansible.com/YAMLSyntax.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          docs.ansible.com
+        </Link>
+      </Trans>
+    </>
+  );
+
+  const labelHelpVarsSmartInventory = (
+    <>
+      {t(`Enter inventory variables using either JSON or YAML syntax. 
+  Use the radio button to toggle between the two. 
+  Refer to the Ansible Controller documentation for example syntax.
+  `)}
+    </>
+  );
+
+  const labelHelpVarsConstructedInventory = (
+    <>
+      <Trans>
+        Variables used to configure the constructed inventory plugin. For a detailed description of
+        how to configure this plugin, see{' '}
+        <a href={ansibleDocUrls.constructed} target="_blank" rel="noopener noreferrer">
+          constructed inventory
+        </a>{' '}
+        plugin configuration guide.
+      </Trans>
+      <br />
+      <br />
+      <hr />
+      <br />
+      <Trans>
+        Variables must be in JSON or YAML syntax. Use the radio button to toggle between the two.
+      </Trans>
+      <br />
+      <br />
+      <Trans>YAML:</Trans>
+      <pre>{yamlExampleConstructed}</pre>
+    </>
+  );
+
+  return inventoryKind === ''
+    ? labelHelpVarsInventory
+    : inventoryKind === 'smart'
+      ? labelHelpVarsSmartInventory
+      : labelHelpVarsConstructedInventory;
+}

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
@@ -33,6 +33,7 @@ import { useVerbosityString } from '../../../common/useVerbosityString';
 import { InventorySource } from '../../../interfaces/InventorySource';
 import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { ansibleDocUrls } from '../../../main/ansibleDocsUrls';
 
 export type WebsocketInventorySource = {
   status: string;
@@ -143,25 +144,6 @@ export function InventorySourceDetails(props: {
       )}
     </>
   );
-
-  const ansibleDocUrls: { [key: string]: string } = {
-    ec2: 'https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html',
-    azure_rm:
-      'https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_inventory.html',
-    controller: 'https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_inventory.html',
-    gce: 'https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_inventory.html',
-    insights:
-      'https://docs.ansible.com/ansible/latest/collections/redhatinsights/insights/insights_inventory.html',
-    openstack:
-      'https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html',
-    satellite6:
-      'https://docs.ansible.com/ansible/latest/collections/theforeman/foreman/foreman_inventory.html',
-    rhv: 'https://docs.ansible.com/ansible/latest/collections/ovirt/ovirt/ovirt_inventory.html',
-    vmware:
-      'https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vm_inventory_inventory.html',
-    constructed:
-      'https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html',
-  };
 
   const getSourceVarsHelpText = (source: string) => {
     let sourceType = '';


### PR DESCRIPTION
Create and Edit constructed inventory. Enhance the InventoryForm, which is used for all 3 types - inventory, smart and constructed.

Also:
- created Multi selector for AWX resources
- added QueryParams and LabelHelp to both single and multi AWX resources
- disabled Inventory form create and edit submit on enter, so labels can be added by typing and pressing enter
(without that, the user will type and possibly press enter and he dont want the form to be submitted).
- added error handling for edit form data loading and loading spinner     
- component and e2e tests will come in follow ups PRs

![image](https://github.com/ansible/ansible-ui/assets/23277791/e5508ffa-6372-450c-ba51-2c8a772f294c)
