### PR TITLE
[AAP-9121] workflow visualizer is primary

### DIFF
--- a/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ButtonVariant } from '@patternfly/react-core';
 import {
   IPageAction,
   PageActionSelection,
@@ -45,6 +46,7 @@ export function useTemplateActions({
         isPinned: true,
         icon: ProjectDiagramIcon,
         label: t('View workflow visualizer'),
+        variant: ButtonVariant.primary,
         ouiaId: 'job-template-detail-edit-button',
         href: (template) =>
           getPageUrl(AwxRoute.WorkflowVisualizer, { params: { id: template.id } }),


### PR DESCRIPTION
Workflow visualizer should be first, and primary.
<img width="823" alt="Screenshot 2024-03-26 at 3 02 39 PM" src="https://github.com/ansible/ansible-ui/assets/64337863/32ebc5d8-e55a-43cd-9c90-2f77cbbd1570">
