### PR TITLE
Roles step for EDA project

### DIFF
--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -1,7 +1,7 @@
 import { PageSection } from '@patternfly/react-core';
 import { useCallback, useEffect } from 'react';
 import { useFormState } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageForm } from '../PageForm/PageForm';
 import { PageWizardFooter } from './PageWizardFooter';
 import { usePageWizard, isStepVisible } from './PageWizardProvider';
@@ -27,6 +27,7 @@ export function PageWizardBody<T>({
     visibleSteps,
     wizardData,
   } = usePageWizard();
+  const [_, setSearchParams] = useSearchParams();
 
   const onClose = useCallback((): void => {
     if (onCancel) {
@@ -58,6 +59,8 @@ export function PageWizardBody<T>({
       const activeStepIndex = filteredSteps.findIndex((step) => step.id === activeStep?.id);
       const nextStep = filteredSteps[activeStepIndex + 1];
 
+      // Clear search params
+      setSearchParams(new URLSearchParams(''));
       setWizardData((prev: object) => ({ ...prev, ...formData }));
       setStepData((prev) => ({ ...prev, [activeStep?.id]: formData }));
       setVisibleSteps(filteredSteps);
@@ -69,6 +72,7 @@ export function PageWizardBody<T>({
       allSteps,
       onSubmit,
       setActiveStep,
+      setSearchParams,
       setStepData,
       setVisibleSteps,
       setWizardData,
@@ -79,8 +83,10 @@ export function PageWizardBody<T>({
   const onBack = useCallback(() => {
     const activeStepIndex = visibleSteps.findIndex((step) => step.id === activeStep?.id);
     const previousStep = visibleSteps[activeStepIndex - 1];
+    // Clear search params
+    setSearchParams(new URLSearchParams(''));
     setActiveStep(previousStep);
-  }, [activeStep, visibleSteps, setActiveStep]);
+  }, [visibleSteps, setSearchParams, setActiveStep, activeStep?.id]);
 
   return (
     <>

--- a/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
@@ -2,6 +2,9 @@ import { useFormContext } from 'react-hook-form';
 import { ISelected, ITableColumn, IToolbarFilter, IView } from '../../../../../framework';
 import { useEffect } from 'react';
 import { PageMultiSelectList } from '../../../../../framework/PageTable/PageMultiSelectList';
+import { Title } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 interface SelectRolesStepProps<T extends object> {
   view: IView & ISelected<T> & { itemCount?: number; pageItems: T[] | undefined };
@@ -9,8 +12,13 @@ interface SelectRolesStepProps<T extends object> {
   toolbarFilters: IToolbarFilter[];
 }
 
+const StyledTitle = styled(Title)`
+  margin-bottom: 4vh;
+`;
+
 export function SelectRolesStep<T extends object>(props: SelectRolesStepProps<T>) {
   const { setValue } = useFormContext();
+  const { t } = useTranslation();
 
   useEffect(() => {
     setValue('roles', props.view.selectedItems);
@@ -18,10 +26,12 @@ export function SelectRolesStep<T extends object>(props: SelectRolesStepProps<T>
 
   return (
     <>
+      <StyledTitle headingLevel="h1">{t('Select roles to apply')}</StyledTitle>
       <PageMultiSelectList
         view={props.view}
         tableColumns={props.tableColumns}
         toolbarFilters={props.toolbarFilters}
+        labelForSelectedItems={t('Selected roles')}
       />
     </>
   );

--- a/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
@@ -1,0 +1,28 @@
+import { useFormContext } from 'react-hook-form';
+import { ISelected, ITableColumn, IToolbarFilter, IView } from '../../../../../framework';
+import { useEffect } from 'react';
+import { PageMultiSelectList } from '../../../../../framework/PageTable/PageMultiSelectList';
+
+interface SelectRolesStepProps<T extends object> {
+  view: IView & ISelected<T> & { itemCount?: number; pageItems: T[] | undefined };
+  tableColumns: ITableColumn<T>[];
+  toolbarFilters: IToolbarFilter[];
+}
+
+export function SelectRolesStep<T extends object>(props: SelectRolesStepProps<T>) {
+  const { setValue } = useFormContext();
+
+  useEffect(() => {
+    setValue('roles', props.view.selectedItems);
+  }, [setValue, props.view.selectedItems]);
+
+  return (
+    <>
+      <PageMultiSelectList
+        view={props.view}
+        tableColumns={props.tableColumns}
+        toolbarFilters={props.toolbarFilters}
+      />
+    </>
+  );
+}

--- a/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
@@ -13,7 +13,7 @@ interface SelectRolesStepProps<T extends object> {
 }
 
 const StyledTitle = styled(Title)`
-  margin-bottom: 4vh;
+  margin-bottom: 1rem;
 `;
 
 export function SelectRolesStep<T extends object>(props: SelectRolesStepProps<T>) {

--- a/frontend/eda/access/roles/components/EdaSelectRolesStep.tsx
+++ b/frontend/eda/access/roles/components/EdaSelectRolesStep.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import { EdaRbacRole } from '../../../interfaces/EdaRBACRole';
 import { ITableColumn, TextCell } from '../../../../../framework';
 import { useTranslation } from 'react-i18next';
 import { useEdaRolesFilters } from '../hooks/useEdaRolesFilters';
 import { useEdaView } from '../../../common/useEventDrivenView';
 import { edaAPI } from '../../../common/eda-utils';
 import { SelectRolesStep } from '../../../../common/access/RolesWizard/steps/SelectRolesStep';
+import { EdaRbacRole } from '../../../interfaces/EdaRbacRole';
 
 export function EdaSelectRolesStep(props: { contentType: string }) {
   const toolbarFilters = useEdaRolesFilters();

--- a/frontend/eda/access/roles/components/EdaSelectRolesStep.tsx
+++ b/frontend/eda/access/roles/components/EdaSelectRolesStep.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { EdaRbacRole } from '../../../interfaces/EdaRBACRole';
+import { ITableColumn, TextCell } from '../../../../../framework';
+import { useTranslation } from 'react-i18next';
+import { useEdaRolesFilters } from '../hooks/useEdaRolesFilters';
+import { useEdaView } from '../../../common/useEventDrivenView';
+import { edaAPI } from '../../../common/eda-utils';
+import { SelectRolesStep } from '../../../../common/access/RolesWizard/steps/SelectRolesStep';
+
+export function EdaSelectRolesStep(props: { contentType: string }) {
+  const toolbarFilters = useEdaRolesFilters();
+  const { t } = useTranslation();
+  const { contentType } = props;
+
+  const tableColumns: ITableColumn<EdaRbacRole>[] = useMemo(() => {
+    return [
+      {
+        header: t('Name'),
+        cell: (role) => <TextCell text={role.name} />,
+        card: 'name',
+        list: 'name',
+        sort: 'name',
+      },
+      {
+        header: t('Description'),
+        cell: (role) => role.description && <TextCell text={role.description} />,
+        card: 'description',
+        list: 'description',
+      },
+    ];
+  }, [t]);
+
+  const view = useEdaView<EdaRbacRole>({
+    url: edaAPI`/role_definitions/`,
+    // toolbarFilters,
+    tableColumns,
+    queryParams: {
+      content_type__model: contentType,
+    },
+  });
+
+  return (
+    <SelectRolesStep view={view} tableColumns={tableColumns} toolbarFilters={toolbarFilters} />
+  );
+}

--- a/frontend/eda/access/roles/hooks/useEdaRolesFilters.tsx
+++ b/frontend/eda/access/roles/hooks/useEdaRolesFilters.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+import { IToolbarFilter, ToolbarFilterType } from '../../../../../framework';
+import { useMemo } from 'react';
+
+export function useEdaRolesFilters() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'name',
+        label: t('Name'),
+        type: ToolbarFilterType.MultiText,
+        query: 'name__contains',
+        comparison: 'contains',
+      },
+    ],
+    [t]
+  );
+}

--- a/frontend/eda/access/users/components/EdaSelectUsersStep.tsx
+++ b/frontend/eda/access/users/components/EdaSelectUsersStep.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { useUserFilters } from '../hooks/useUserFilters';
+import { useMemo } from 'react';
+import { EdaUser } from '../../../interfaces/EdaUser';
+import { ITableColumn, TextCell } from '../../../../../framework';
+import { useEdaView } from '../../../common/useEventDrivenView';
+import { edaAPI } from '../../../common/eda-utils';
+import { SelectUsersStep } from '../../../../common/access/RolesWizard/steps/SelectUsersStep';
+
+export function EdaSelectUsersStep() {
+  const toolbarFilters = useUserFilters();
+  const { t } = useTranslation();
+
+  const tableColumns: ITableColumn<EdaUser>[] = useMemo(() => {
+    return [
+      {
+        header: t('Username'),
+        cell: (user: EdaUser) => <TextCell text={user.username} />,
+        card: 'name',
+        list: 'name',
+        sort: 'username',
+        maxWidth: 200,
+      },
+      {
+        header: t('First name'),
+        type: 'text',
+        value: (user: EdaUser) => user.first_name,
+        sort: 'first_name',
+      },
+      {
+        header: t('Last name'),
+        type: 'text',
+        value: (user: EdaUser) => user.last_name,
+        sort: 'last_name',
+      },
+    ];
+  }, [t]);
+
+  const view = useEdaView<EdaUser>({
+    url: edaAPI`/users/`,
+    toolbarFilters,
+    tableColumns,
+  });
+
+  return (
+    <SelectUsersStep view={view} tableColumns={tableColumns} toolbarFilters={toolbarFilters} />
+  );
+}

--- a/frontend/eda/interfaces/EdaRbacRole.ts
+++ b/frontend/eda/interfaces/EdaRbacRole.ts
@@ -1,0 +1,20 @@
+export interface EdaRbacRole {
+  id: number;
+  url: string;
+  related: {
+    team_assignments: string;
+    user_assignments: string;
+  };
+  summary_fields: {
+    [key: string]: Record<string, string>[] | undefined;
+  };
+  permissions: string[];
+  content_type: string;
+  created: string;
+  modified: string;
+  name: string;
+  description: string;
+  managed: boolean;
+  created_by: string | null;
+  modified_by: string | null;
+}

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -22,6 +22,8 @@ export enum EdaRoute {
   EditProject = 'eda-edit-project',
   ProjectPage = 'eda-project-page',
   ProjectDetails = 'eda-project-details',
+  ProjectUsers = 'eda-project-users',
+  ProjectAddUsers = 'eda-project-add-users',
 
   DecisionEnvironments = 'eda-decision-environments',
   CreateDecisionEnvironment = 'eda-create-decision-environment',

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -46,6 +46,8 @@ import { CreateWebhook, EditWebhook } from '../webhooks/EditWebhook';
 import { WebhookPage } from '../webhooks/WebhookPage/WebhookPage';
 import { WebhookDetails } from '../webhooks/WebhookPage/WebhookDetails';
 import { Webhooks } from '../webhooks/Webhooks';
+import { EdaProjectAddUsers } from '../projects/components/EdaProjectAddUsers';
+import { PageNotImplemented } from '../../../framework';
 
 export function useEdaNavigation() {
   const { t } = useTranslation();
@@ -175,7 +177,17 @@ export function useEdaNavigation() {
               path: '',
               element: <Navigate to="details" />,
             },
+            {
+              id: EdaRoute.ProjectUsers,
+              path: 'users',
+              element: <PageNotImplemented />,
+            },
           ],
+        },
+        {
+          id: EdaRoute.ProjectAddUsers,
+          path: ':id/users/add-users',
+          element: <EdaProjectAddUsers />,
         },
         {
           path: '',

--- a/frontend/eda/projects/components/EdaProjectAddUsers.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import {
+  PageHeader,
+  PageLayout,
+  PageWizard,
+  PageWizardStep,
+  useGetPageUrl,
+} from '../../../../framework';
+import { EdaSelectRolesStep } from '../../access/roles/components/EdaSelectRolesStep';
+import { EdaSelectUsersStep } from '../../access/users/components/EdaSelectUsersStep';
+import { EdaRoute } from '../../main/EdaRoutes';
+import { EdaProject } from '../../interfaces/EdaProject';
+import { useParams } from 'react-router-dom';
+import { useGet } from '../../../common/crud/useGet';
+import { edaAPI } from '../../common/eda-utils';
+
+export function EdaProjectAddUsers() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const params = useParams<{ id: string }>();
+  const { data: project } = useGet<EdaProject>(edaAPI`/projects/${params.id ?? ''}/`);
+
+  const steps: PageWizardStep[] = [
+    {
+      id: 'user',
+      label: 'Select User',
+      inputs: <EdaSelectUsersStep />,
+    },
+    {
+      id: 'roles',
+      label: 'Select Roles',
+      inputs: <EdaSelectRolesStep contentType="project" />,
+    },
+    { id: 'review', label: 'Review', element: <div>TODO</div> },
+  ];
+
+  const onSubmit = async (/* data */) => {
+    // console.log(data);
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Add roles')}
+        breadcrumbs={[
+          { label: t('Projects'), to: getPageUrl(EdaRoute.Projects) },
+          { label: project?.name, to: getPageUrl(EdaRoute.ProjectDetails) },
+          { label: t('User Access'), to: getPageUrl(EdaRoute.ProjectUsers) },
+          { label: t('Add roles') },
+        ]}
+      />
+      <PageWizard steps={steps} onSubmit={onSubmit} disableGrid />
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
The sample wizard can be tested on `https://localhost:4103/projects/:id/users/add-users` for an EDA project. (using EDA's feature/rbac server)

Includes a framework change to rest all search params in the URL in the onNext and onBack callbacks of the PageWizard.

<img width="1347" alt="image" src="https://github.com/ansible/ansible-ui/assets/43621546/700833a2-2f71-4386-bc25-df20393be663">

### TODOs:

- fix filter in roles step
- indicate selected users in the roles step
- run e2e tests manually against the feature/rbac server