### PR TITLE
Add Team Access tab to credential, dec. env., project and rulebook activation

### DIFF
--- a/frontend/eda/access/common/TeamAccess.cy.tsx
+++ b/frontend/eda/access/common/TeamAccess.cy.tsx
@@ -1,0 +1,89 @@
+import { TeamAccess } from './TeamAccess';
+import { edaAPI } from '../../common/eda-utils';
+
+describe('TeamAccess.cy.ts', () => {
+  beforeEach(() => {
+    cy.intercept(
+      { method: 'GET', url: edaAPI`/role_team_assignments/*` },
+      {
+        count: 1,
+        next: null,
+        previous: null,
+        page_size: 10,
+        page: 1,
+        results: [
+          {
+            id: 1,
+            summary_fields: {
+              object_role: {
+                id: 1,
+              },
+              role_definition: {
+                id: 13,
+                name: 'Activation Admin',
+                description:
+                  'Has all permissions to a single activation and its child resources - rulebook process, audit rule',
+                managed: true,
+              },
+              team: {
+                id: 4,
+                name: 'Team Assignment 1',
+              },
+            },
+            object_role: 1,
+            role_definition: 13,
+            team: 4,
+          },
+        ],
+      }
+    );
+  });
+
+  it('Renders the correct teamAccess columns', () => {
+    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.get('.pf-v5-c-table__th').should('have.length', 5);
+    cy.contains('Team');
+    cy.contains('Role');
+    cy.contains('Role description');
+  });
+
+  it('can remove teamAccess', () => {
+    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.intercept(
+      { method: 'DELETE', url: edaAPI`/role_team_assignments/1/` },
+      {
+        statusCode: 204,
+      }
+    );
+    cy.get('input[id="select-all"]').first().click();
+    cy.get('[data-cy="actions-dropdown"]').first().click();
+    cy.get('[data-cy="delete-selected-roles"]').click();
+    cy.get('div[role="dialog"]').within(() => {
+      cy.contains('Team Assignment 1');
+      cy.get('input[id="confirm"]').click();
+      cy.get('button').contains('Remove team assignment').click();
+    });
+    cy.get('[data-cy="status-column-cell"] > span').contains('Success');
+    cy.clickButton(/^Close$/);
+  });
+});
+
+describe('Empty list', () => {
+  beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/eda/v1/role_team_assignments/*',
+      },
+      {
+        fixture: 'emptyList.json',
+      }
+    ).as('emptyList');
+  });
+  it('Empty state is displayed correctly', () => {
+    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.contains(/^There are currently no roles assigned to this object.$/);
+    cy.contains(/^Please add a role by using the button below.$/);
+    // cy.contains('button', /^Add role$/).should('be.visible'); TODO to be added later
+  });
+});

--- a/frontend/eda/access/common/TeamAccess.tsx
+++ b/frontend/eda/access/common/TeamAccess.tsx
@@ -8,34 +8,16 @@ import {
   PageTable,
   IToolbarFilter,
   ToolbarFilterType,
-} from '../../../framework';
-import { edaAPI } from './eda-utils';
+} from '../../../../framework';
+import { edaAPI } from '../../common/eda-utils';
 import { useCallback, useMemo } from 'react';
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon } from '@patternfly/react-icons';
-import { useEdaView } from './useEventDrivenView';
-import { useEdaBulkConfirmation } from './useEdaBulkConfirmation';
-import { idKeyFn } from '../../common/utils/nameKeyFn';
-import { requestDelete } from '../../common/crud/Data';
-
-export type TeamAssignment = {
-  id: number;
-  summary_fields: {
-    object_role: {
-      id: number;
-    };
-    role_definition: {
-      id: number;
-      name: string;
-      description: string;
-      managed: boolean;
-    };
-    team: {
-      id: number;
-      name: string;
-    };
-  };
-};
+import { MinusCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { useEdaView } from '../../common/useEventDrivenView';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
+import { idKeyFn } from '../../../common/utils/nameKeyFn';
+import { requestDelete } from '../../../common/crud/Data';
+import { TeamAssignment } from '../interfaces/TeamAssignment';
 
 function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   const { t } = useTranslation();
@@ -56,11 +38,11 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   return useCallback(
     (items: TeamAssignment[]) => {
       bulkAction({
-        title: t('Remove team assignmnent'),
+        title: t('Remove team assignment'),
         confirmText: t('Yes, I confirm that I want to remove these {{count}} team assignment.', {
           count: items.length,
         }),
-        actionButtonText: t('Remove team assignmnent'),
+        actionButtonText: t('Remove team assignment'),
         items: items.sort((l, r) =>
           compareStrings(l.summary_fields.team.name, r.summary_fields.team.name)
         ),
@@ -71,7 +53,6 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
         onComplete,
         actionFn: (item: TeamAssignment, signal: AbortSignal) =>
           requestDelete(edaAPI`/role_team_assignments/${item.id.toString()}/`, signal),
-        alertPrompts: [t('Note: This will not delete any running activations in these projects.')],
       });
     },
     [actionColumns, bulkAction, confirmationColumns, onComplete, t]
@@ -157,13 +138,21 @@ export function TeamAccess(id: string, type: string) {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         variant: ButtonVariant.primary,
-        icon: MinusCircleIcon,
+        icon: PlusCircleIcon,
         isPinned: true,
         label: t('Add role'),
         onClick: () => {},
       },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: TrashIcon,
+        label: t('Delete selected projects'),
+        onClick: (items: TeamAssignment[]) => removeRoles(items),
+        isDanger: true,
+      },
     ],
-    [t]
+    [t, removeRoles]
   );
   return (
     <PageTable

--- a/frontend/eda/access/common/TeamAccess.tsx
+++ b/frontend/eda/access/common/TeamAccess.tsx
@@ -59,8 +59,9 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   );
 }
 
-export function TeamAccess(id: string, type: string) {
+export function TeamAccess(props: { id: string; type: string }) {
   const { t } = useTranslation();
+  const { id, type } = props;
   const tableColumns = useMemo<ITableColumn<TeamAssignment>[]>(
     () => [
       {
@@ -147,7 +148,7 @@ export function TeamAccess(id: string, type: string) {
         type: PageActionType.Button,
         selection: PageActionSelection.Multiple,
         icon: TrashIcon,
-        label: t('Delete selected projects'),
+        label: t('Delete selected roles'),
         onClick: (items: TeamAssignment[]) => removeRoles(items),
         isDanger: true,
       },
@@ -168,7 +169,7 @@ export function TeamAccess(id: string, type: string) {
       // TODO navigate to add roles
       //emptyStateButtonClick={() => console.log('TODO')}
       {...view}
-      defaultSubtitle={t('Project')}
+      defaultSubtitle={t('Team access')}
     />
   );
 }

--- a/frontend/eda/access/credentials/CredentialPage/CredentialPage.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialPage.tsx
@@ -84,7 +84,10 @@ export function CredentialPage() {
           page: EdaRoute.Credentials,
           persistentFilterKey: 'credentials',
         }}
-        tabs={[{ label: t('Details'), page: EdaRoute.CredentialDetails }]}
+        tabs={[
+          { label: t('Details'), page: EdaRoute.CredentialDetails },
+          { label: t('Team Access'), page: EdaRoute.CredentialTeamAccess },
+        ]}
         params={{ id: credential?.id }}
       />
     </PageLayout>

--- a/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+import { TeamAccess } from '../../../common/TeamAccess';
+
+export function CredentialTeamAccess() {
+  const params = useParams<{ id: string }>();
+  return TeamAccess(params.id || '', 'credential');
+}

--- a/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { TeamAccess } from '../../../common/TeamAccess';
+import { TeamAccess } from '../../common/TeamAccess';
 
 export function CredentialTeamAccess() {
   const params = useParams<{ id: string }>();

--- a/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
@@ -3,5 +3,5 @@ import { TeamAccess } from '../../common/TeamAccess';
 
 export function CredentialTeamAccess() {
   const params = useParams<{ id: string }>();
-  return TeamAccess(params.id || '', 'credential');
+  return <TeamAccess id={params.id || ''} type={'credential'} />;
 }

--- a/frontend/eda/access/interfaces/TeamAssignment.ts
+++ b/frontend/eda/access/interfaces/TeamAssignment.ts
@@ -1,0 +1,18 @@
+export type TeamAssignment = {
+  id: number;
+  summary_fields: {
+    object_role: {
+      id: number;
+    };
+    role_definition: {
+      id: number;
+      name: string;
+      description: string;
+      managed: boolean;
+    };
+    team: {
+      id: number;
+      name: string;
+    };
+  };
+};

--- a/frontend/eda/common/TeamAccess.tsx
+++ b/frontend/eda/common/TeamAccess.tsx
@@ -56,11 +56,11 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   return useCallback(
     (items: TeamAssignment[]) => {
       bulkAction({
-        title: t('Remove team assignmnent', { count: items.length }),
+        title: t('Remove team assignmnent'),
         confirmText: t('Yes, I confirm that I want to remove these {{count}} team assignment.', {
           count: items.length,
         }),
-        actionButtonText: t('Remove team assignmnent', { count: items.length }),
+        actionButtonText: t('Remove team assignmnent'),
         items: items.sort((l, r) =>
           compareStrings(l.summary_fields.team.name, r.summary_fields.team.name)
         ),

--- a/frontend/eda/common/TeamAccess.tsx
+++ b/frontend/eda/common/TeamAccess.tsx
@@ -1,0 +1,185 @@
+import { useTranslation } from 'react-i18next';
+import {
+  compareStrings,
+  IPageAction,
+  ITableColumn,
+  PageActionSelection,
+  PageActionType,
+  PageTable,
+  IToolbarFilter,
+  ToolbarFilterType,
+} from '../../../framework';
+import { edaAPI } from './eda-utils';
+import { useCallback, useMemo } from 'react';
+import { ButtonVariant } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import { useEdaView } from './useEventDrivenView';
+import { useEdaBulkConfirmation } from './useEdaBulkConfirmation';
+import { idKeyFn } from '../../common/utils/nameKeyFn';
+import { requestDelete } from '../../common/crud/Data';
+
+export type TeamAssignment = {
+  id: number;
+  summary_fields: {
+    object_role: {
+      id: number;
+    };
+    role_definition: {
+      id: number;
+      name: string;
+      description: string;
+      managed: boolean;
+    };
+    team: {
+      id: number;
+      name: string;
+    };
+  };
+};
+
+function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
+  const { t } = useTranslation();
+  const confirmationColumns = useMemo<ITableColumn<TeamAssignment>[]>(
+    () => [
+      {
+        header: t('Team'),
+        type: 'description',
+        value: (teamAccess: TeamAssignment) => teamAccess.summary_fields.team.name,
+        card: 'description',
+        list: 'description',
+      },
+    ],
+    [t]
+  );
+  const actionColumns = useMemo(() => [confirmationColumns[0]], [confirmationColumns]);
+  const bulkAction = useEdaBulkConfirmation<TeamAssignment>();
+  return useCallback(
+    (items: TeamAssignment[]) => {
+      bulkAction({
+        title: t('Remove team assignmnent', { count: items.length }),
+        confirmText: t('Yes, I confirm that I want to remove these {{count}} team assignment.', {
+          count: items.length,
+        }),
+        actionButtonText: t('Remove team assignmnent', { count: items.length }),
+        items: items.sort((l, r) =>
+          compareStrings(l.summary_fields.team.name, r.summary_fields.team.name)
+        ),
+        keyFn: idKeyFn,
+        isDanger: true,
+        confirmationColumns,
+        actionColumns,
+        onComplete,
+        actionFn: (item: TeamAssignment, signal: AbortSignal) =>
+          requestDelete(edaAPI`/role_team_assignments/${item.id.toString()}/`, signal),
+        alertPrompts: [t('Note: This will not delete any running activations in these projects.')],
+      });
+    },
+    [actionColumns, bulkAction, confirmationColumns, onComplete, t]
+  );
+}
+
+export function TeamAccess(id: string, type: string) {
+  const { t } = useTranslation();
+  const tableColumns = useMemo<ITableColumn<TeamAssignment>[]>(
+    () => [
+      {
+        header: t('Team'),
+        type: 'description',
+        sort: 'team__name',
+        value: (teamAccess: TeamAssignment) => teamAccess.summary_fields.team.name,
+        card: 'description',
+        list: 'description',
+      },
+      {
+        header: t('Role'),
+        type: 'description',
+        value: (teamAccess: TeamAssignment) => teamAccess.summary_fields.role_definition.name,
+        sort: 'role_definition__name',
+        card: 'description',
+        list: 'description',
+      },
+      {
+        header: t('Role description'),
+        type: 'description',
+
+        value: (teamAccess: TeamAssignment) =>
+          teamAccess.summary_fields.role_definition.description,
+        card: 'description',
+        list: 'description',
+      },
+    ],
+    [t]
+  );
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'team__name',
+        label: t('Team name'),
+        type: ToolbarFilterType.SingleText,
+        query: 'team__name',
+        comparison: 'equals',
+      },
+      {
+        key: 'role_definition__name',
+        label: t('Role name'),
+        type: ToolbarFilterType.SingleText,
+        query: 'role_definition__name',
+        comparison: 'equals',
+      },
+    ],
+    [t]
+  );
+  const view = useEdaView<TeamAssignment>({
+    url: edaAPI`/role_team_assignments/`,
+    tableColumns,
+    toolbarFilters,
+    queryParams: { object_id: id, content_type__model: type },
+  });
+  const removeRoles = useRemoveRoles(view.unselectItemsAndRefresh);
+
+  const rowActions = useMemo<IPageAction<TeamAssignment>[]>(
+    () => [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        icon: MinusCircleIcon,
+        isPinned: true,
+        label: t('Remove role'),
+        onClick: (item: TeamAssignment) => removeRoles([item]),
+      },
+    ],
+    [t, removeRoles]
+  );
+  const toolbarActions = useMemo<IPageAction<TeamAssignment>[]>(
+    () => [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        icon: MinusCircleIcon,
+        isPinned: true,
+        label: t('Add role'),
+        onClick: () => {},
+      },
+    ],
+    [t]
+  );
+  return (
+    <PageTable
+      id="eda-team-access-table"
+      tableColumns={tableColumns}
+      toolbarActions={toolbarActions}
+      toolbarFilters={toolbarFilters}
+      rowActions={rowActions}
+      errorStateTitle={t('Error loading role access data.')}
+      emptyStateTitle={t('There are currently no roles assigned to this object.')}
+      emptyStateDescription={t('Please add a role by using the button below.')}
+      emptyStateButtonText={t('Add role')}
+      // TODO navigate to add roles
+      //emptyStateButtonClick={() => console.log('TODO')}
+      {...view}
+      defaultSubtitle={t('Project')}
+    />
+  );
+}

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentPage.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentPage.tsx
@@ -90,7 +90,10 @@ export function DecisionEnvironmentPage() {
           page: EdaRoute.DecisionEnvironments,
           persistentFilterKey: 'decision_environments',
         }}
-        tabs={[{ label: t('Details'), page: EdaRoute.DecisionEnvironmentDetails }]}
+        tabs={[
+          { label: t('Details'), page: EdaRoute.DecisionEnvironmentDetails },
+          { label: t('Team Access'), page: EdaRoute.DecisionEnvironmentTeamAccess },
+        ]}
         params={{ id: decisionEnvironment?.id }}
       />
     </PageLayout>

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { TeamAccess } from '../../common/TeamAccess';
+import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function DecisionEnvironmentTeamAccess() {
   const params = useParams<{ id: string }>();

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
@@ -3,5 +3,5 @@ import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function DecisionEnvironmentTeamAccess() {
   const params = useParams<{ id: string }>();
-  return TeamAccess(params.id || '', 'decisionenvironment');
+  return <TeamAccess id={params.id || ''} type={'decisionenvironment'} />;
 }

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+import { TeamAccess } from '../../common/TeamAccess';
+
+export function DecisionEnvironmentTeamAccess() {
+  const params = useParams<{ id: string }>();
+  return TeamAccess(params.id || '', 'decisionenvironment');
+}

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -16,24 +16,28 @@ export enum EdaRoute {
   RulebookActivationHistory = 'eda-rulebook-activation-history',
   RulebookActivationInstancePage = 'eda-rulebook-activation-instance-page',
   RulebookActivationInstanceDetails = 'eda-rulebook-activation-instance-details',
+  RulebookActivationTeamAccess = 'eda-rulebook-activation-team-access',
 
   Projects = 'eda-projects',
   CreateProject = 'eda-create-project',
   EditProject = 'eda-edit-project',
   ProjectPage = 'eda-project-page',
   ProjectDetails = 'eda-project-details',
+  ProjectTeamAccess = 'eda-project-project-team-access',
 
   DecisionEnvironments = 'eda-decision-environments',
   CreateDecisionEnvironment = 'eda-create-decision-environment',
   EditDecisionEnvironment = 'eda-edit-decision-environment',
   DecisionEnvironmentPage = 'eda-decision-environment-page',
   DecisionEnvironmentDetails = 'eda-decision-environment-details',
+  DecisionEnvironmentTeamAccess = 'eda-decision-environments-team-access',
 
   Credentials = 'eda-credentials',
   CreateCredential = 'eda-create-credential',
   EditCredential = 'eda-edit-credential',
   CredentialPage = 'eda-credential-page',
   CredentialDetails = 'eda-credential-details',
+  CredentialTeamAccess = 'eda-credential-team=access',
 
   CredentialTypes = 'eda-credential-types',
   CreateCredentialType = 'eda-create-credential-type',

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -24,11 +24,13 @@ import {
 } from '../decision-environments/DecisionEnvironmentForm';
 import { DecisionEnvironmentDetails } from '../decision-environments/DecisionEnvironmentPage/DecisionEnvironmentDetails';
 import { DecisionEnvironmentPage } from '../decision-environments/DecisionEnvironmentPage/DecisionEnvironmentPage';
+import { DecisionEnvironmentTeamAccess } from '../decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess';
 import { DecisionEnvironments } from '../decision-environments/DecisionEnvironments';
 import { EdaOverview } from '../overview/EdaOverview';
 import { CreateProject, EditProject } from '../projects/EditProject';
 import { ProjectDetails } from '../projects/ProjectPage/ProjectDetails';
 import { ProjectPage } from '../projects/ProjectPage/ProjectPage';
+import { ProjectTeamAccess } from '../projects/ProjectPage/ProjectTeamAccess';
 import { Projects } from '../projects/Projects';
 import { RuleAudit } from '../rule-audit/RuleAudit';
 import { RuleAuditActions } from '../rule-audit/RuleAuditPage/RuleAuditActions';
@@ -41,6 +43,7 @@ import { CreateRulebookActivation } from '../rulebook-activations/RulebookActiva
 import { RulebookActivationDetails } from '../rulebook-activations/RulebookActivationPage/RulebookActivationDetails';
 import { RulebookActivationHistory } from '../rulebook-activations/RulebookActivationPage/RulebookActivationHistory';
 import { RulebookActivationPage } from '../rulebook-activations/RulebookActivationPage/RulebookActivationPage';
+import { RulebookActivationTeamAccess } from '../rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess';
 import { RulebookActivations } from '../rulebook-activations/RulebookActivations';
 import { CreateWebhook, EditWebhook } from '../webhooks/EditWebhook';
 import { WebhookDetails } from '../webhooks/WebhookPage/WebhookDetails';
@@ -49,6 +52,7 @@ import { Webhooks } from '../webhooks/Webhooks';
 import { CredentialTypes } from '../access/credential-types/CredentialTypes';
 import { CredentialTypeDetails } from '../access/credential-types/CredentialTypePage/CredentialTypeDetails';
 import { CredentialTypePage } from '../access/credential-types/CredentialTypePage/CredentialTypePage';
+import { CredentialTeamAccess } from '../access/credentials/CredentialPage/CredentialTeamAccess';
 import {
   CreateCredentialType,
   EditCredentialType,
@@ -143,6 +147,11 @@ export function useEdaNavigation() {
               element: <RulebookActivationHistory />,
             },
             {
+              id: EdaRoute.RulebookActivationTeamAccess,
+              path: 'team-access',
+              element: <RulebookActivationTeamAccess />,
+            },
+            {
               path: '',
               element: <Navigate to="details" />,
             },
@@ -180,6 +189,11 @@ export function useEdaNavigation() {
               element: <ProjectDetails />,
             },
             {
+              id: EdaRoute.ProjectTeamAccess,
+              path: 'team-access',
+              element: <ProjectTeamAccess />,
+            },
+            {
               path: '',
               element: <Navigate to="details" />,
             },
@@ -215,6 +229,11 @@ export function useEdaNavigation() {
               id: EdaRoute.DecisionEnvironmentDetails,
               path: 'details',
               element: <DecisionEnvironmentDetails />,
+            },
+            {
+              id: EdaRoute.DecisionEnvironmentTeamAccess,
+              path: 'team-access',
+              element: <DecisionEnvironmentTeamAccess />,
             },
             {
               path: '',
@@ -409,6 +428,11 @@ export function useEdaNavigation() {
                   id: EdaRoute.CredentialDetails,
                   path: 'details',
                   element: <CredentialDetails />,
+                },
+                {
+                  id: EdaRoute.CredentialTeamAccess,
+                  path: 'team-access',
+                  element: <CredentialTeamAccess />,
                 },
                 {
                   path: '',

--- a/frontend/eda/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectPage.tsx
@@ -116,7 +116,10 @@ export function ProjectPage() {
           page: EdaRoute.Projects,
           persistentFilterKey: 'projects',
         }}
-        tabs={[{ label: t('Details'), page: EdaRoute.ProjectDetails }]}
+        tabs={[
+          { label: t('Details'), page: EdaRoute.ProjectDetails },
+          { label: t('Team Access'), page: EdaRoute.ProjectTeamAccess },
+        ]}
         params={{ id: project?.id }}
       />
     </PageLayout>

--- a/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
@@ -3,5 +3,5 @@ import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function ProjectTeamAccess() {
   const params = useParams<{ id: string }>();
-  return TeamAccess(params.id || '', 'project');
+  return <TeamAccess id={params.id || ''} type={'project'} />;
 }

--- a/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+import { TeamAccess } from '../../common/TeamAccess';
+
+export function ProjectTeamAccess() {
+  const params = useParams<{ id: string }>();
+  return TeamAccess(params.id || '', 'project');
+}

--- a/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { TeamAccess } from '../../common/TeamAccess';
+import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function ProjectTeamAccess() {
   const params = useParams<{ id: string }>();

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+import { TeamAccess } from '../../common/TeamAccess';
+
+export function RulebookActivationTeamAccess() {
+  const params = useParams<{ id: string }>();
+  return TeamAccess(params.id || '', 'activation');
+}

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { TeamAccess } from '../../common/TeamAccess';
+import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function RulebookActivationTeamAccess() {
   const params = useParams<{ id: string }>();

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
@@ -3,5 +3,5 @@ import { TeamAccess } from '../../access/common/TeamAccess';
 
 export function RulebookActivationTeamAccess() {
   const params = useParams<{ id: string }>();
-  return TeamAccess(params.id || '', 'activation');
+  return <TeamAccess id={params.id || ''} type={'activation'} />;
 }

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.cy.tsx
@@ -66,11 +66,16 @@ describe('RulebookActivationPage', () => {
   });
 
   it('Should render all the tabs', () => {
-    const tabNames: string[] = ['Back to Rulebook Activations', 'Details', 'History'];
+    const tabNames: string[] = [
+      'Back to Rulebook Activations',
+      'Details',
+      'History',
+      'Team Access',
+    ];
     cy.mount(<RulebookActivationPage />);
 
     cy.get('.pf-v5-c-tabs__list').within(() => {
-      cy.get('.pf-v5-c-tabs__item').should('have.length', 3);
+      cy.get('.pf-v5-c-tabs__item').should('have.length', 4);
       cy.get('.pf-v5-c-tabs__item').each((tab, index) => {
         cy.wrap(tab).should('contain', tabNames[index]);
       });

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -161,6 +161,7 @@ export function RulebookActivationPage() {
         tabs={[
           { label: t('Details'), page: EdaRoute.RulebookActivationDetails },
           { label: t('History'), page: EdaRoute.RulebookActivationHistory },
+          { label: t('Team Access'), page: EdaRoute.RulebookActivationTeamAccess },
         ]}
         params={{ id: params.id }}
       />


### PR DESCRIPTION

<img width="1712" alt="Screenshot 2024-04-02 at 15 31 18" src="https://github.com/ansible/ansible-ui/assets/9210860/9bc89c0d-c427-470c-8579-329033fa15e2">
<img width="1722" alt="Screenshot 2024-04-02 at 15 31 30" src="https://github.com/ansible/ansible-ui/assets/9210860/c0921729-970e-4526-ad65-c125e688f85c">
<img width="1715" alt="Screenshot 2024-04-02 at 15 33 35" src="https://github.com/ansible/ansible-ui/assets/9210860/b548b632-4436-4fa7-8a5d-2d23a892a0fd">


Implemented:
- tab with table
- sort by team and role name
- filter vy team and role name (must equal -> limited by API)
- remove team assignment
- component test of common component

Not implemented:
- Add role

Related Jira issues:
[Common component for Team Access tab](https://issues.redhat.com/browse/AAP-21529)
[Access tabs for Rulebook Activation](https://issues.redhat.com/browse/AAP-21700)
[Access tabs for Credential](https://issues.redhat.com/browse/AAP-21701)
[Access tabs for DecisionEnvironment](https://issues.redhat.com/browse/AAP-22183)
[Access tabs for Project](https://issues.redhat.com/browse/AAP-22185)