### PR TITLE
Support job deletion through job header

### DIFF
--- a/frontend/awx/views/jobs/JobHeader.cy.tsx
+++ b/frontend/awx/views/jobs/JobHeader.cy.tsx
@@ -12,9 +12,54 @@ describe('Job Page', () => {
       }
     );
   });
-  it('job header should have relaunch and cancel buttons on a running job', () => {
+  it('Relaunch and cancel buttons are visible on a running job', () => {
     cy.mount(<JobHeader />, { path: ':job_type/:id', initialEntries: ['/workflow/1'] });
     cy.get('[data-cy="relaunch-job"]').should('contain', 'Relaunch job');
     cy.get('[data-cy="cancel-job"]').should('contain', 'Cancel job');
+  });
+  it('Delete button is disabled on a running job', () => {
+    cy.mount(<JobHeader />, { path: ':job_type/:id', initialEntries: ['/workflow/1'] });
+    cy.getByDataCy('actions-dropdown').click();
+    cy.contains('[data-cy="delete-job"]', 'Delete job').should(
+      'have.attr',
+      'aria-disabled',
+      'true'
+    );
+  });
+  it('Delete button is enabled on a finished job', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/v2/workflow_jobs/*',
+      },
+      {
+        fixture: 'workflow_job.json',
+      }
+    );
+    cy.mount(<JobHeader />, { path: ':job_type/:id', initialEntries: ['/workflow/1'] });
+    cy.getByDataCy('actions-dropdown').click();
+    cy.contains('[data-cy="delete-job"]', 'Delete job').should(
+      'have.attr',
+      'aria-disabled',
+      'true'
+    );
+  });
+  it('Cancel button is disabled on a finished job', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/v2/workflow_jobs/*',
+      },
+      {
+        fixture: 'workflow_job.json',
+      }
+    );
+    cy.mount(<JobHeader />, { path: ':job_type/:id', initialEntries: ['/workflow/1'] });
+    cy.getByDataCy('actions-dropdown').click();
+    cy.contains('[data-cy="cancel-job"]', 'Cancel job').should(
+      'have.attr',
+      'aria-disabled',
+      'true'
+    );
   });
 });

--- a/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
@@ -1,11 +1,12 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, RocketIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
 import { isJobRunning } from '../jobUtils';
 import { useCancelJobs } from './useCancelJobs';
+import { useDeleteJobs } from './useDeleteJobs';
 import { useRelaunchJob } from './useRelaunchJob';
 import { TFunction } from 'i18next';
 
@@ -19,9 +20,18 @@ export const cannotCancelJob = (job: UnifiedJob, t: TFunction<'translation', und
 export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
   const { t } = useTranslation();
   const cancelJobs = useCancelJobs(onComplete);
+  const deleteJobs = useDeleteJobs(onComplete);
   const relaunchJob = useRelaunchJob();
 
   return useMemo<IPageAction<UnifiedJob>[]>(() => {
+    const cannotDeleteJob = (job: UnifiedJob) => {
+      if (!job.summary_fields.user_capabilities.delete)
+        return t(`The job cannot be deleted due to insufficient permission`);
+      else if (isJobRunning(job.status))
+        return t(`The job cannot be deleted due to a running job status`);
+      return '';
+    };
+
     const actions: IPageAction<UnifiedJob>[] = [
       {
         type: PageActionType.Button,
@@ -42,10 +52,25 @@ export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
         isPinned: true,
         icon: MinusCircleIcon,
         label: t(`Cancel job`),
-        isHidden: (job: UnifiedJob) => Boolean(cannotCancelJob(job, t)),
+        isDisabled: (job: UnifiedJob) => cannotCancelJob(job, t),
         onClick: (job: UnifiedJob) => cancelJobs([job]),
+      },
+      { type: PageActionType.Seperator },
+
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TrashIcon,
+        label: t(`Delete job`),
+        isDisabled: (job: UnifiedJob) => cannotDeleteJob(job),
+        onClick: (job: UnifiedJob) => {
+          if (!job) return;
+          deleteJobs([job]);
+        },
+        ouiaId: 'job-detail-delete-button',
+        isDanger: true,
       },
     ];
     return actions;
-  }, [cancelJobs, relaunchJob, t]);
+  }, [cancelJobs, deleteJobs, relaunchJob, t]);
 }


### PR DESCRIPTION
**Summary**
Add job delete support to job header and component tests. 

When a job is running, we should enable the cancel button and disable the delete button. 
When a job is finished, we should disable the cancel button and enable the delete button. 


![Screenshot 2024-03-28 at 2 02 28 PM](https://github.com/ansible/ansible-ui/assets/15881645/77ac2207-b479-4668-9355-87c5c5bf5ea2)
