### PR TITLE
Adds functionality to the discard button

### DIFF
--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { PageFormSection } from '../../../../../framework/PageForm/Utils/PageFormSection';
 import { PageFormSelect, PageFormTextInput } from '../../../../../framework';
-import { RuleFields, RuleListItemType, ScheduleFormWizard } from '../types';
+import { RuleFields, RuleListItemType, RuleType, ScheduleFormWizard } from '../types';
 import { useTranslation } from 'react-i18next';
 import { RRule, datetime } from 'rrule';
 import {
@@ -34,6 +34,7 @@ export function RuleForm(props: {
     getValues,
     reset,
     formState: { defaultValues },
+    setValue,
   } = useFormContext();
   const { activeStep, wizardData } = usePageWizard();
   const ruleId = typeof props.isOpen === 'number' && props.isOpen;
@@ -125,10 +126,14 @@ export function RuleForm(props: {
         : exceptions.length + 1 || 1;
     const ruleObject = { rule, id: itemId };
     if (isRulesStep) {
-      ruleId ? rules.splice(index, 1, ruleObject) : rules.push(ruleObject);
+      ruleId
+        ? setValue('rules', rules.splice(index, 1, ruleObject))
+        : setValue('rules', rules.push(ruleObject));
     }
     if (!isRulesStep) {
-      ruleId ? exceptions.splice(index, 1, ruleObject) : exceptions.push(ruleObject);
+      ruleId
+        ? setValue('exceptions', exceptions.splice(index, 1, ruleObject))
+        : setValue('exceptions', exceptions.push(ruleObject));
     }
 
     reset({
@@ -259,7 +264,11 @@ export function RuleForm(props: {
           variant="secondary"
           isDanger
           onClick={() => {
-            reset({ keepDefaultValues: true });
+            const { rules = [], exceptions = [] } = getValues() as RuleFields;
+            const ruleType: RuleType =
+              props.title === t('Define rules') ? RuleType.Rules : RuleType.Exceptions;
+            const ruleArray = ruleType === RuleType.Rules ? [...rules] : [...exceptions];
+            reset({ ...defaultValues, [`${ruleType}`]: ruleArray });
             props.setIsOpen(false);
           }}
         >

--- a/frontend/awx/views/schedules/hooks/useRuleRowActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useRuleRowActions.tsx
@@ -41,6 +41,7 @@ export function useRuleRowActions(
         selection: PageActionSelection.Single,
         icon: TrashIcon,
         label: t('Delete rule'),
+        isPinned: true,
         onClick: (rule) => deleteRule(rule),
         isDanger: true,
       },

--- a/frontend/awx/views/schedules/types.ts
+++ b/frontend/awx/views/schedules/types.ts
@@ -65,3 +65,8 @@ export interface PreviewSchedule {
   utc?: string[];
   rrule: string;
 }
+
+export enum RuleType {
+  Rules = 'rules',
+  Exceptions = 'exceptions',
+}

--- a/frontend/awx/views/schedules/wizard/RulesStep.tsx
+++ b/frontend/awx/views/schedules/wizard/RulesStep.tsx
@@ -5,14 +5,13 @@ import { useState } from 'react';
 import { RuleForm } from '../components/RuleForm';
 import { RulesList } from '../components/RulesList';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { RuleListItemType } from '../types';
 
 export function RulesStep() {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState<boolean | number>(false);
-  const { getValues } = useFormContext();
-  const rules = getValues('rules') as RuleListItemType[];
+  const rules = useWatch({ name: 'rules' }) as RuleListItemType[];
   const hasRules = rules?.length > 0;
   return (
     <PageFormSection title={t('Rules')} singleColumn>

--- a/frontend/awx/views/schedules/wizard/ScheduleAddWizard.cy.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleAddWizard.cy.tsx
@@ -171,5 +171,45 @@ describe('ScheduleAddWizard', () => {
       cy.get('[data-cy="update-rule-button"]').click();
       cy.get('tr[data-cy="row-id-1"]').should('contain.text', 'INTERVAL=44400');
     });
+    it('Should be able to discard editing a rule without adding 1 to the list', () => {
+      cy.get('[data-cy="interval"]').clear().type('100');
+      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+      cy.get('[data-cy="count-form-group"]').type('17');
+      cy.get('[data-cy="add-rule-button"]').click();
+      cy.get('tr[data-cy="row-id-1"]').within(() => {
+        cy.get('td[data-cy="rrule-column-cell"]').should(
+          'contains.text',
+          'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+        );
+      });
+
+      cy.get('[data-cy="page-title"]').should('contain.text', 'Schedule Rules');
+      cy.get('tr[data-cy="row-id-1"]').within(() => {
+        cy.get('button[data-cy="edit-rule"]').click();
+      });
+      cy.get('[data-cy="interval"]').should('have.value', '100');
+      cy.get('[data-cy="interval"]').clear().type('44400');
+      cy.get('[data-cy="discard-rule-button"]').click();
+      cy.get('tr[data-cy="row-id-1"]').should('not.contain.text', 'INTERVAL=44400');
+      cy.get('tr[data-cy="row-id-1"]').should('contain.text', 'INTERVAL=100');
+      cy.get('tbody').within(() => {
+        cy.get('tr').should('have.length', 1);
+      });
+    });
+
+    it('Should be able to discard adding a rule without adding 1 to the list', () => {
+      cy.get('[data-cy="interval"]').clear().type('100');
+      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+      cy.get('[data-cy="count-form-group"]').type('17');
+      cy.get('[data-cy="add-rule-button"]').click();
+      cy.clickButton(/^Add rule$/);
+      cy.get('[data-cy="interval"]').clear().type('200');
+      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+      cy.get('[data-cy="discard-rule-button"]').click();
+
+      cy.get('tbody').within(() => {
+        cy.get('tr').should('have.length', 1);
+      });
+    });
   });
 });


### PR DESCRIPTION
Addresses AAP-21982
Adds functionality to discard a rule.  Should function as a normal cancel button except should not navigate away from the wizard, or from the wizard step.

Note** If no rules exist and a user clicks discard rule, the form should just reset but should not disappear.