### PR TITLE
Assert enabled delete button for finished jobs in job header

### DIFF
--- a/frontend/awx/views/jobs/JobHeader.cy.tsx
+++ b/frontend/awx/views/jobs/JobHeader.cy.tsx
@@ -26,7 +26,7 @@ describe('Job Page', () => {
       'true'
     );
   });
-  it.skip('Delete button is enabled on a finished job', () => {
+  it('Delete button is enabled on a finished job', () => {
     cy.intercept(
       {
         method: 'GET',
@@ -41,7 +41,7 @@ describe('Job Page', () => {
     cy.contains('[data-cy="delete-job"]', 'Delete job').should(
       'have.attr',
       'aria-disabled',
-      'true'
+      'false'
     );
   });
   it('Cancel button is disabled on a finished job', () => {


### PR DESCRIPTION
Fix and un-skip job header component test assertion - disabled value should have been false instead of true. 