### PR TITLE
[AAP-19501] Constructed Inventory Host Details

### DIFF
--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.cy.tsx
@@ -4,24 +4,47 @@ import { AwxHost } from '../../../interfaces/AwxHost';
 import { InventoryHostDetailsInner as InventoryHostDetails } from './InventoryHostDetails';
 
 describe('InventoryHostDetails', () => {
-  it('Component renders and displays Application', () => {
-    cy.mount(<InventoryHostDetails host={mockAwxHost as unknown as AwxHost} />);
-  });
-  it('Render inventory host detail fields', () => {
-    cy.mount(<InventoryHostDetails host={mockAwxHost as unknown as AwxHost} />);
-    cy.get('[data-cy="name"]').should('have.text', 'test');
-    cy.get('[data-cy="code-block-value"]').should('have.text', '---\ntest: test');
-    cy.get('[data-cy="activity"] > .pf-v5-c-description-list__text').find(
-      'a[href="/jobs/command/1/output"]'
-    );
-    cy.get('[data-cy="activity"] > .pf-v5-c-description-list__text').find(
-      'a[href="/jobs/playbook/2/output"]'
-    );
-    cy.get('[data-cy="code-block-value"]');
-    cy.get('[data-cy="created"]').should('contain.text', formatDateString(mockAwxHost.created));
-    cy.get('[data-cy="last-modified"]').should(
-      'contain.text',
-      formatDateString(mockAwxHost.modified)
-    );
+  const kinds = ['constructed', 'smart', ''];
+
+  kinds.forEach((kind) => {
+    const path =
+      kind === ''
+        ? '/inventories/:inventory_type/:id/hosts/:host_id/details'
+        : kind === 'smart'
+          ? '/inventories/:inventory_type/:id/hosts/:host_id/details'
+          : '/inventories/:inventory_type/:id/hosts/:host_id/details';
+
+    const initialEntries =
+      kind === ''
+        ? ['/inventories/inventory/1/hosts/1/details']
+        : kind === 'smart'
+          ? ['/inventories/smart_inventory/1/hosts/1/details']
+          : ['/inventories/constructed_inventory/1/hosts/1/details'];
+
+    it(`Render inventory host detail fields (${kind === '' ? 'inventory' : kind})`, () => {
+      cy.mount(<InventoryHostDetails host={mockAwxHost as unknown as AwxHost} />, {
+        path,
+        initialEntries,
+      });
+      cy.get('[data-cy="name"]').should('have.text', 'test');
+      cy.get('[data-cy="code-block-value"]').should('have.text', '---\ntest: test');
+      cy.get('[data-cy="activity"] > .pf-v5-c-description-list__text').find(
+        'a[href="/jobs/command/1/output"]'
+      );
+      cy.get('[data-cy="activity"] > .pf-v5-c-description-list__text').find(
+        'a[href="/jobs/playbook/2/output"]'
+      );
+      cy.get('[data-cy="code-block-value"]');
+      cy.get('[data-cy="created"]').should('contain.text', formatDateString(mockAwxHost.created));
+      cy.get('[data-cy="last-modified"]').should(
+        'contain.text',
+        formatDateString(mockAwxHost.modified)
+      );
+      if (kind === 'constructed' || kind === 'smart') {
+        cy.get('[data-cy="enabled"]').should('exist');
+      } else {
+        cy.get('[data-cy="enabled"]').should('not.exist');
+      }
+    });
   });
 });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
@@ -46,6 +46,7 @@ export function InventoryHostDetailsInner(props: { host: AwxHost }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
+  const params = useHostDetailParams();
 
   const host = props.host;
 
@@ -57,9 +58,11 @@ export function InventoryHostDetailsInner(props: { host: AwxHost }) {
   return (
     <PageDetails>
       <PageDetail label={t('Name')}>{host.name}</PageDetail>
-      <PageDetail label={t('Activity')}>
-        <Sparkline jobs={recentPlaybookJobs} />
-      </PageDetail>
+      {recentPlaybookJobs.length > 0 && (
+        <PageDetail label={t('Activity')}>
+          <Sparkline jobs={recentPlaybookJobs} />
+        </PageDetail>
+      )}
       <PageDetail label={t('Description')}>{host.description}</PageDetail>
       <PageDetail label={t('Inventory')} helpText={t(`The inventory that this host belongs to.`)}>
         <TextCell
@@ -69,6 +72,12 @@ export function InventoryHostDetailsInner(props: { host: AwxHost }) {
           })}
         />
       </PageDetail>
+      {(params.inventory_type === 'constructed_inventory' ||
+        params.inventory_type === 'smart_inventory') && (
+        <PageDetail label={t('Enabled')}>
+          <TextCell text={host.enabled ? 'On' : 'Off'} />
+        </PageDetail>
+      )}
       <PageDetail label={t('Created')}>
         <DateTimeCell
           value={host.created}

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.tsx
@@ -36,6 +36,19 @@ export function InventoryHostPage() {
 
   const getPageUrl = useGetPageUrl();
 
+  let tabs: Array<{ label: string; page: string }> = [];
+
+  if (params.inventory_type === 'inventory') {
+    tabs = [
+      { label: t('Details'), page: AwxRoute.InventoryHostDetails },
+      { label: t('Facts'), page: AwxRoute.InventoryHostFacts },
+      { label: t('Groups'), page: AwxRoute.InventoryHostGroups },
+      { label: t('Jobs'), page: AwxRoute.InventoryHostJobs },
+    ];
+  } else {
+    tabs = [{ label: t('Details'), page: AwxRoute.InventoryHostDetails }];
+  }
+
   return (
     <PageLayout>
       <PageHeader
@@ -75,12 +88,7 @@ export function InventoryHostPage() {
           page: AwxRoute.InventoryHosts,
           persistentFilterKey: 'inventories',
         }}
-        tabs={[
-          { label: t('Details'), page: AwxRoute.InventoryHostDetails },
-          { label: t('Facts'), page: AwxRoute.InventoryHostFacts },
-          { label: t('Groups'), page: AwxRoute.InventoryHostGroups },
-          { label: t('Jobs'), page: AwxRoute.InventoryHostJobs },
-        ]}
+        tabs={tabs}
         params={params}
       />
     </PageLayout>


### PR DESCRIPTION
This PR updates the inventory host details section tabs and fields. Smart and constructed inventories display an extra `enabled` field on the details page. In addition, the tabs in the inventory hosts section are different. Only the details tab is shown for smart and constructed inventories; all other tabs are hidden and only shown for regular inventories. 