### PR TITLE
[AAP-19507] Constructed Inventory Group Hosts

### DIFF
--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -67,7 +67,6 @@ describe('Inventory Groups', () => {
     });
   });
 
-
   it('can add and remove new related groups', () => {
     cy.createInventoryHostGroup(organization).then((result) => {
       const { inventory, group } = result;

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -67,22 +67,6 @@ describe('Inventory Groups', () => {
     });
   });
 
-  it('test inventory group can be edited from groups details', () => {
-    cy.createInventoryHostGroup(organization).then((result) => {
-      const { inventory, group } = result;
-      cy.navigateTo('awx', 'inventories');
-      cy.clickTableRow(inventory.name);
-      cy.verifyPageTitle(inventory.name);
-      cy.clickLink(/^Groups$/);
-      cy.clickTableRow(group.name as string);
-      cy.verifyPageTitle(group.name as string);
-      cy.get('[data-cy="edit-group"]').click();
-      cy.verifyPageTitle('Edit group');
-      cy.get('[data-cy="name-form-group"]').type('-changed');
-      cy.get('[data-cy="Submit"]').click();
-      cy.verifyPageTitle(group.name + '-changed');
-    });
-  });
 
   it('can add and remove new related groups', () => {
     cy.createInventoryHostGroup(organization).then((result) => {
@@ -175,10 +159,12 @@ describe('Inventory Groups', () => {
       cy.hasDetail(/^Name$/, groupName);
       cy.hasDetail(/^Description$/, 'This is a description');
       cy.hasDetail(/^Variables$/, 'test: true');
-      cy.get('[data-cy="actions-dropdown"]').click();
-      cy.get('[data-cy="delete-group"]').click();
+      cy.clickLink(/^Back to Groups$/);
+      cy.selectTableRow(groupName);
+      cy.clickToolbarKebabAction('delete-selected-groups');
       cy.get('[data-cy="delete-groups-dialog-radio-delete"]').click();
       cy.get('[data-cy="delete-group-modal-delete-button"]').click();
+      cy.clickButton(/^Clear all filters$/);
       cy.get('[data-cy="empty-state-title"]').contains(
         /^There are currently no groups added to this inventory./
       );

--- a/frontend/awx/resources/groups/GroupHosts.cy.tsx
+++ b/frontend/awx/resources/groups/GroupHosts.cy.tsx
@@ -35,29 +35,60 @@ describe('GroupHosts', () => {
     );
   });
 
-  it('renders group hosts', () => {
-    cy.mount(<GroupHosts />, {
-      path: '/inventories/:inventory_type/:id/groups/:group_id/nested_hosts',
-      initialEntries: ['/inventories/inventory/1/groups/176/nested_hosts'],
-    });
-    cy.fixture('hosts.json')
-      .its('results')
-      .should('be.an', 'array')
-      .then((results: AwxHost[]) => {
-        const host = results[0];
-        cy.contains(host.name);
-      });
-  });
+  const kinds = ['', 'constructed'];
 
-  it('disassociate group host from toolbar menu', () => {
-    cy.mount(<GroupHosts />);
-    cy.fixture('hosts.json')
-      .its('results')
-      .should('be.an', 'array')
-      .then(() => {
-        cy.get('[data-cy="checkbox-column-cell"] > label > input').click();
-        cy.get('[data-cy="disassociate-selected-hosts"]').click();
-        cy.contains('Disassociate host from group?');
+  kinds.forEach((kind) => {
+    const path = '/inventories/:inventory_type/:id/groups/:group_id/nested_hosts';
+    const initialEntries =
+      kind === ''
+        ? ['/inventories/inventory/1/groups/176/nested_hosts']
+        : ['/inventories/constructed_inventory/1/groups/176/nested_hosts'];
+
+    it(`renders group hosts (${kind === '' ? 'inventory' : kind})`, () => {
+      cy.mount(<GroupHosts />, {
+        path,
+        initialEntries,
       });
+      cy.fixture('hosts.json')
+        .its('results')
+        .should('be.an', 'array')
+        .then((results: AwxHost[]) => {
+          const host = results[0];
+          cy.contains(host.name);
+          if (kind === '') {
+            cy.get('[data-cy="actions-column-cell"]').should(
+              'have.descendants',
+              '[data-cy="edit-host"]'
+            );
+          } else {
+            cy.get('[data-cy="actions-column-cell"]').should(
+              'not.have.descendants',
+              '[data-cy="edit-host"]'
+            );
+          }
+        });
+    });
+
+    it(`try disassociate group host from toolbar menu (${kind === '' ? 'inventory' : kind})`, () => {
+      cy.mount(<GroupHosts />, {
+        path,
+        initialEntries,
+      });
+      cy.fixture('hosts.json')
+        .its('results')
+        .should('be.an', 'array')
+        .then(() => {
+          if (kind === '') {
+            cy.get('[data-cy="checkbox-column-cell"] > label > input').click();
+            cy.get('[data-cy="disassociate-selected-hosts"]').click();
+            cy.contains('Disassociate host from group?');
+          } else {
+            cy.get('body').should(
+              'not.have.descendants',
+              '[data-cy="disassociate-selected-hosts"]'
+            );
+          }
+        });
+    });
   });
 });

--- a/frontend/awx/resources/groups/GroupHosts.tsx
+++ b/frontend/awx/resources/groups/GroupHosts.tsx
@@ -25,7 +25,7 @@ export function GroupHosts() {
     tableColumns,
   });
   const toolbarActions = useInventoriesGroupsHostsToolbarActions(view);
-  const rowActions = useInventoriesGroupsHostsActions(view.unselectItemsAndRefresh, view.refresh);
+  const rowActions = useInventoriesGroupsHostsActions(view.refresh);
   const emptyStateActions = useHostsEmptyStateActions(view);
 
   const hostOptions = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/hosts/`).data;

--- a/frontend/awx/resources/groups/GroupPage.tsx
+++ b/frontend/awx/resources/groups/GroupPage.tsx
@@ -58,13 +58,6 @@ export function GroupPage() {
           },
           { label: inventoryGroup?.name },
         ]}
-        headerActions={
-          <PageActions<InventoryGroup>
-            actions={actions}
-            position={DropdownPosition.right}
-            selectedItem={inventoryGroup}
-          />
-        }
       />
       <PageRoutedTabs
         backTab={{

--- a/frontend/awx/resources/groups/GroupPage.tsx
+++ b/frontend/awx/resources/groups/GroupPage.tsx
@@ -3,18 +3,10 @@ import { useParams } from 'react-router-dom';
 import { useGetItem } from '../../../common/crud/useGet';
 import { InventoryGroup } from '../../interfaces/InventoryGroup';
 import { awxAPI } from '../../common/api/awx-utils';
-import {
-  LoadingPage,
-  PageActions,
-  PageHeader,
-  PageLayout,
-  useGetPageUrl,
-} from '../../../../framework';
+import { LoadingPage, PageHeader, PageLayout, useGetPageUrl } from '../../../../framework';
 import { AwxError } from '../../common/AwxError';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageRoutedTabs } from '../../../../framework/PageTabs/PageRoutedTabs';
-import { DropdownPosition } from '@patternfly/react-core/deprecated';
-import { useInventoriesGroupActions } from '../inventories/hooks/useInventoriesGroupActions';
 
 export function GroupPage() {
   const { t } = useTranslation();
@@ -26,8 +18,6 @@ export function GroupPage() {
   } = useGetItem<InventoryGroup>(awxAPI`/groups/`, params.group_id);
 
   const getPageUrl = useGetPageUrl();
-
-  const actions = useInventoriesGroupActions();
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!inventoryGroup) return <LoadingPage breadcrumbs tabs />;

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsActions.tsx
@@ -60,7 +60,7 @@ export function useInventoriesGroupsHostsActions(onToggle: (() => Promise<void>)
             params: { id: params.id, inventory_type: params.inventory_type, host_id: host.id },
           }),
         isDisabled: (host) => cannotEditResource(host, t),
-        isHidden: (host) => params.inventory_type === 'constructed_inventory',
+        isHidden: (_host) => params.inventory_type === 'constructed_inventory',
       },
     ],
     [t, handleToggleHost, pageNavigate, params.id, params.inventory_type]

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsActions.tsx
@@ -14,10 +14,7 @@ import { AwxHost } from '../../../interfaces/AwxHost';
 import { usePatchRequest } from '../../../../common/crud/usePatchRequest';
 import { useParams } from 'react-router-dom';
 
-export function useInventoriesGroupsHostsActions(
-  onDisassociate: (host: AwxHost[]) => void,
-  onToggle: (() => Promise<void>) | (() => void)
-) {
+export function useInventoriesGroupsHostsActions(onToggle: (() => Promise<void>) | (() => void)) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
 
@@ -63,6 +60,7 @@ export function useInventoriesGroupsHostsActions(
             params: { id: params.id, inventory_type: params.inventory_type, host_id: host.id },
           }),
         isDisabled: (host) => cannotEditResource(host, t),
+        isHidden: (host) => params.inventory_type === 'constructed_inventory',
       },
     ],
     [t, handleToggleHost, pageNavigate, params.id, params.inventory_type]

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
@@ -59,13 +59,14 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
     [setDialog, params.group_id, view, alertToaster, t]
   );
 
-  return useMemo<IPageAction<AwxHost>[]>(
-    () => [
+  return useMemo<IPageAction<AwxHost>[]>(() => {
+    const toolbarActions: IPageAction<AwxHost>[] = [
       {
         type: PageActionType.Dropdown,
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
         isPinned: true,
+        isHidden: () => params.inventory_type === 'constructed_inventory',
         icon: PlusCircleIcon,
         label: t('Add host'),
         actions: [
@@ -111,37 +112,39 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
         label: t('Run Command'),
         onClick: () => pageNavigate(AwxRoute.Inventories),
         isDisabled: () =>
-          view.selectedItems.length === 0
-            ? t('Select at least one item from the list')
-            : canRunAdHocCommand
-              ? undefined
-              : t(
-                  'You do not have permission to run an ad hoc command. Please contact your organization administrator if there is an issue with your access.'
-                ),
+          canRunAdHocCommand
+            ? undefined
+            : t(
+                'You do not have permission to run an ad hoc command. Please contact your organization administrator if there is an issue with your access.'
+              ),
       },
-      { type: PageActionType.Seperator },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Multiple,
-        isPinned: true,
-        label: t('Disassociate selected hosts'),
-        onClick: disassociateHosts,
-        isDisabled:
-          view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
-      },
-    ],
-    [
-      t,
-      disassociateHosts,
-      view.selectedItems.length,
-      setDialog,
-      params.id,
-      params.group_id,
-      params.inventory_type,
-      onSelectedHosts,
-      pageNavigate,
-      canCreateHost,
-      canRunAdHocCommand,
-    ]
-  );
+    ];
+
+    const disassociateAction: IPageAction<AwxHost> = {
+      type: PageActionType.Button,
+      selection: PageActionSelection.Multiple,
+      isPinned: true,
+      label: t('Disassociate selected hosts'),
+      onClick: disassociateHosts,
+      isDisabled:
+        view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
+    };
+
+    if (params.inventory_type === 'inventory') {
+      toolbarActions.push(disassociateAction);
+    }
+    return toolbarActions;
+  }, [
+    t,
+    disassociateHosts,
+    view.selectedItems.length,
+    setDialog,
+    params.id,
+    params.group_id,
+    params.inventory_type,
+    onSelectedHosts,
+    pageNavigate,
+    canCreateHost,
+    canRunAdHocCommand,
+  ]);
 }


### PR DESCRIPTION
This PR contains updates to the inventory -> group -> hosts section of the new UI which now accounts for the constructed inventory type. 

The `GroupHosts` list component now dynamically hides toolbar and row actions depending on the inventory type (either constructed or regular inventory in this case as smart inventories will not be able to route to this page). 

In addition this, small changes include updating the `Run Command` button so it is enabled regardless of a host being selected on the page and as long as the user has the correct permissions to run a command against an inventory. 

Another small change includes removing the page actions from the `GroupPage` component to be in parity with the old UI.

***Updating component tests will move out of draft once that is done***