### PR TITLE
Access roles wizard from Project Team Access page

### DIFF
--- a/frontend/eda/access/common/TeamAccess.cy.tsx
+++ b/frontend/eda/access/common/TeamAccess.cy.tsx
@@ -40,7 +40,7 @@ describe('TeamAccess.cy.ts', () => {
   });
 
   it('Renders the correct teamAccess columns', () => {
-    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.mount(<TeamAccess id={'1'} type={'activation'} addRolesRoute="xyz" />);
     cy.get('.pf-v5-c-table__th').should('have.length', 5);
     cy.contains('Team');
     cy.contains('Role');
@@ -48,7 +48,7 @@ describe('TeamAccess.cy.ts', () => {
   });
 
   it('can remove teamAccess', () => {
-    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.mount(<TeamAccess id={'1'} type={'activation'} addRolesRoute="xyz" />);
     cy.intercept(
       { method: 'DELETE', url: edaAPI`/role_team_assignments/1/` },
       {
@@ -81,7 +81,7 @@ describe('Empty list', () => {
     ).as('emptyList');
   });
   it('Empty state is displayed correctly', () => {
-    cy.mount(<TeamAccess id={'1'} type={'activation'} />);
+    cy.mount(<TeamAccess id={'1'} type={'activation'} addRolesRoute="xyz" />);
     cy.contains(/^There are currently no roles assigned to this object.$/);
     cy.contains(/^Please add a role by using the button below.$/);
     // cy.contains('button', /^Add role$/).should('be.visible'); TODO to be added later

--- a/frontend/eda/access/common/TeamAccess.tsx
+++ b/frontend/eda/access/common/TeamAccess.tsx
@@ -60,7 +60,7 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   );
 }
 
-export function TeamAccess(props: { id: string; type: string; addRolesRoute: string }) {
+export function TeamAccess(props: { id: string; type: string; addRolesRoute?: string }) {
   const { t } = useTranslation();
   const { id, type, addRolesRoute } = props;
   const getPageUrl = useGetPageUrl();
@@ -144,7 +144,7 @@ export function TeamAccess(props: { id: string; type: string; addRolesRoute: str
         isPinned: true,
         icon: PlusCircleIcon,
         label: t('Add roles'),
-        href: getPageUrl(addRolesRoute, { params: { id: id } }),
+        href: getPageUrl(addRolesRoute ?? '', { params: { id: id } }),
       },
       {
         type: PageActionType.Button,

--- a/frontend/eda/access/common/TeamAccess.tsx
+++ b/frontend/eda/access/common/TeamAccess.tsx
@@ -8,6 +8,7 @@ import {
   PageTable,
   IToolbarFilter,
   ToolbarFilterType,
+  useGetPageUrl,
 } from '../../../../framework';
 import { edaAPI } from '../../common/eda-utils';
 import { useCallback, useMemo } from 'react';
@@ -59,9 +60,10 @@ function useRemoveRoles(onComplete: (roles: TeamAssignment[]) => void) {
   );
 }
 
-export function TeamAccess(props: { id: string; type: string }) {
+export function TeamAccess(props: { id: string; type: string; addRolesRoute: string }) {
   const { t } = useTranslation();
-  const { id, type } = props;
+  const { id, type, addRolesRoute } = props;
+  const getPageUrl = useGetPageUrl();
   const tableColumns = useMemo<ITableColumn<TeamAssignment>[]>(
     () => [
       {
@@ -136,13 +138,13 @@ export function TeamAccess(props: { id: string; type: string }) {
   const toolbarActions = useMemo<IPageAction<TeamAssignment>[]>(
     () => [
       {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
+        type: PageActionType.Link,
+        selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
-        icon: PlusCircleIcon,
         isPinned: true,
-        label: t('Add role'),
-        onClick: () => {},
+        icon: PlusCircleIcon,
+        label: t('Add roles'),
+        href: getPageUrl(addRolesRoute, { params: { id: id } }),
       },
       {
         type: PageActionType.Button,
@@ -153,7 +155,7 @@ export function TeamAccess(props: { id: string; type: string }) {
         isDanger: true,
       },
     ],
-    [t, removeRoles]
+    [t, getPageUrl, addRolesRoute, id, removeRoles]
   );
   return (
     <PageTable
@@ -166,8 +168,7 @@ export function TeamAccess(props: { id: string; type: string }) {
       emptyStateTitle={t('There are currently no roles assigned to this object.')}
       emptyStateDescription={t('Please add a role by using the button below.')}
       emptyStateButtonText={t('Add role')}
-      // TODO navigate to add roles
-      //emptyStateButtonClick={() => console.log('TODO')}
+      emptyStateActions={toolbarActions.slice(0, 1)}
       {...view}
       defaultSubtitle={t('Team access')}
     />

--- a/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialTeamAccess.tsx
@@ -1,7 +1,14 @@
 import { useParams } from 'react-router-dom';
 import { TeamAccess } from '../../common/TeamAccess';
+import { EdaRoute } from '../../../main/EdaRoutes';
 
 export function CredentialTeamAccess() {
   const params = useParams<{ id: string }>();
-  return <TeamAccess id={params.id || ''} type={'credential'} />;
+  return (
+    <TeamAccess
+      id={params.id || ''}
+      type={'credential'}
+      addRolesRoute={EdaRoute.CredentialAddTeams}
+    />
+  );
 }

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentTeamAccess.tsx
@@ -1,7 +1,14 @@
 import { useParams } from 'react-router-dom';
 import { TeamAccess } from '../../access/common/TeamAccess';
+import { EdaRoute } from '../../main/EdaRoutes';
 
 export function DecisionEnvironmentTeamAccess() {
   const params = useParams<{ id: string }>();
-  return <TeamAccess id={params.id || ''} type={'decisionenvironment'} />;
+  return (
+    <TeamAccess
+      id={params.id || ''}
+      type={'decisionenvironment'}
+      addRolesRoute={EdaRoute.DecisionEnvironmentAddTeams}
+    />
+  );
 }

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -17,6 +17,7 @@ export enum EdaRoute {
   RulebookActivationInstancePage = 'eda-rulebook-activation-instance-page',
   RulebookActivationInstanceDetails = 'eda-rulebook-activation-instance-details',
   RulebookActivationTeamAccess = 'eda-rulebook-activation-team-access',
+  RulebookActivationAddTeams = 'eda-rulebook-activation-add-teams',
 
   Projects = 'eda-projects',
   CreateProject = 'eda-create-project',
@@ -34,6 +35,7 @@ export enum EdaRoute {
   DecisionEnvironmentPage = 'eda-decision-environment-page',
   DecisionEnvironmentDetails = 'eda-decision-environment-details',
   DecisionEnvironmentTeamAccess = 'eda-decision-environments-team-access',
+  DecisionEnvironmentAddTeams = 'eda-decision-environments-add-teams',
 
   Credentials = 'eda-credentials',
   CreateCredential = 'eda-create-credential',
@@ -41,6 +43,7 @@ export enum EdaRoute {
   CredentialPage = 'eda-credential-page',
   CredentialDetails = 'eda-credential-details',
   CredentialTeamAccess = 'eda-credential-team=access',
+  CredentialAddTeams = 'eda-credential-add-teams',
 
   CredentialTypes = 'eda-credential-types',
   CreateCredentialType = 'eda-create-credential-type',

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -25,7 +25,6 @@ export enum EdaRoute {
   ProjectDetails = 'eda-project-details',
   ProjectTeamAccess = 'eda-project-project-team-access',
   ProjectUsers = 'eda-project-users',
-  ProjectTeams = 'eda-project-teams',
   ProjectAddUsers = 'eda-project-add-users',
   ProjectAddTeams = 'eda-project-add-teams',
 

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -207,11 +207,6 @@ export function useEdaNavigation() {
               path: 'users',
               element: <PageNotImplemented />,
             },
-            {
-              id: EdaRoute.ProjectTeams,
-              path: 'teams',
-              element: <PageNotImplemented />,
-            },
           ],
         },
         {
@@ -221,7 +216,7 @@ export function useEdaNavigation() {
         },
         {
           id: EdaRoute.ProjectAddTeams,
-          path: ':id/teams/add-teams',
+          path: ':id/team-access/add-teams',
           element: <EdaProjectAddTeams />,
         },
         {

--- a/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
+++ b/frontend/eda/projects/ProjectPage/ProjectTeamAccess.tsx
@@ -1,7 +1,10 @@
 import { useParams } from 'react-router-dom';
 import { TeamAccess } from '../../access/common/TeamAccess';
+import { EdaRoute } from '../../main/EdaRoutes';
 
 export function ProjectTeamAccess() {
   const params = useParams<{ id: string }>();
-  return <TeamAccess id={params.id || ''} type={'project'} />;
+  return (
+    <TeamAccess id={params.id || ''} type={'project'} addRolesRoute={EdaRoute.ProjectAddTeams} />
+  );
 }

--- a/frontend/eda/projects/components/EdaProjectAddTeams.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.tsx
@@ -116,7 +116,7 @@ export function EdaProjectAddTeams() {
           resolve();
         },
         onClose: () => {
-          pageNavigate(EdaRoute.ProjectDetails, {
+          pageNavigate(EdaRoute.ProjectTeamAccess, {
             params: { id: project.id.toString() },
           });
         },
@@ -136,7 +136,7 @@ export function EdaProjectAddTeams() {
           },
           {
             label: t('Team Access'),
-            to: getPageUrl(EdaRoute.ProjectTeams, { params: { id: project?.id } }),
+            to: getPageUrl(EdaRoute.ProjectTeamAccess, { params: { id: project?.id } }),
           },
           { label: t('Add roles') },
         ]}

--- a/frontend/eda/projects/components/EdaProjectAddTeams.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.tsx
@@ -35,9 +35,9 @@ export function EdaProjectAddTeams() {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const params = useParams<{ id: string }>();
+  const pageNavigate = usePageNavigate();
   const { data: project, isLoading } = useGet<EdaProject>(edaAPI`/projects/${params.id ?? ''}/`);
   const userProgressDialog = useEdaBulkActionDialog<TeamRolePair>();
-  const pageNavigate = usePageNavigate();
 
   if (isLoading || !project) return <LoadingPage />;
 
@@ -141,7 +141,14 @@ export function EdaProjectAddTeams() {
           { label: t('Add roles') },
         ]}
       />
-      <PageWizard<WizardFormValues> steps={steps} onSubmit={onSubmit} disableGrid />
+      <PageWizard<WizardFormValues>
+        steps={steps}
+        onSubmit={onSubmit}
+        disableGrid
+        onCancel={() => {
+          pageNavigate(EdaRoute.ProjectTeamAccess, { params: { id: project?.id } });
+        }}
+      />
     </PageLayout>
   );
 }

--- a/frontend/eda/projects/components/EdaProjectAddUsers.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.tsx
@@ -142,7 +142,14 @@ export function EdaProjectAddUsers() {
           { label: t('Add roles') },
         ]}
       />
-      <PageWizard<WizardFormValues> steps={steps} onSubmit={onSubmit} disableGrid />
+      <PageWizard<WizardFormValues>
+        steps={steps}
+        onSubmit={onSubmit}
+        disableGrid
+        onCancel={() => {
+          pageNavigate(EdaRoute.ProjectUsers, { params: { id: project?.id } });
+        }}
+      />
     </PageLayout>
   );
 }

--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RuleBookActivationTeamAccess.tsx
@@ -1,7 +1,14 @@
 import { useParams } from 'react-router-dom';
 import { TeamAccess } from '../../access/common/TeamAccess';
+import { EdaRoute } from '../../main/EdaRoutes';
 
 export function RulebookActivationTeamAccess() {
   const params = useParams<{ id: string }>();
-  return <TeamAccess id={params.id || ''} type={'activation'} />;
+  return (
+    <TeamAccess
+      id={params.id || ''}
+      type={'activation'}
+      addRolesRoute={EdaRoute.RulebookActivationAddTeams}
+    />
+  );
 }


### PR DESCRIPTION
This PR adjusts route names to link the EDA Project Team Access UI with the Add Roles wizard for adding teams to a project.

cc: @keithjgrant @ZitaNemeckova 