### PR TITLE
[AAP-21055] Add dynamic filters to execution environments page

### DIFF
--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -103,7 +103,16 @@ describe('Job templates form Create, Edit, Delete', function () {
         cy.clickButton(/^Next/);
         cy.selectItemFromLookupModal('credential-select', machineCredential.name);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('execution-environment-select', executionEnvironment);
+        cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
+          cy.get('button').eq(1).click();
+        });
+        cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+          cy.filterTableBySingleSelect('name', executionEnvironment);
+          cy.get('[data-ouia-component-id="simple-table"] tbody').within(() => {
+            cy.get('[data-cy="checkbox-column-cell"] input').click();
+          });
+          cy.clickButton(/^Confirm/);
+        });
         cy.clickButton(/^Next/);
         cy.get(`[data-cy*="instance-group-select-form-group"]`).within(() => {
           cy.get('button').eq(1).click();
@@ -167,7 +176,16 @@ describe('Job templates form Create, Edit, Delete', function () {
         cy.clickButton(/^Next/);
         cy.selectItemFromLookupModal('credential-select', machineCredential.name);
         cy.clickButton(/^Next/);
-        cy.selectItemFromLookupModal('execution-environment-select', executionEnvironment);
+        cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
+          cy.get('button').eq(1).click();
+        });
+        cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+          cy.filterTableBySingleSelect('name', executionEnvironment);
+          cy.get('[data-ouia-component-id="simple-table"] tbody').within(() => {
+            cy.get('[data-cy="checkbox-column-cell"] input').click();
+          });
+          cy.clickButton(/^Confirm/);
+        });
         cy.clickButton(/^Next/);
         cy.get(`[data-cy*="instance-group-select-form-group"]`).within(() => {
           cy.get('button').eq(1).click();

--- a/cypress/fixtures/mock_options.json
+++ b/cypress/fixtures/mock_options.json
@@ -202,6 +202,12 @@
           ["hybrid", "Controller and execution"],
           ["hop", "Message-passing node, no execution capability"]
         ]
+      },
+      "image_location": {
+        "type": "string",
+        "label": "Image location",
+        "help_text": "The location of the image being used in the execution environment.",
+        "filterable": true
       }
     }
   },

--- a/cypress/support/table-commands.ts
+++ b/cypress/support/table-commands.ts
@@ -39,6 +39,7 @@ Cypress.Commands.add('selectTableFilter', (dataCy: string) => {
   // We need to use document() to get the body of the page
   // and then find the filter-select within that body
   // This fixes the issue where this command would fail inside a within() block
+  cy.document().its('body').find('#filter-search').type(dataCy.replaceAll('-', ' '));
   cy.document()
     .its('body')
     .find('#filter-select')

--- a/frontend/awx/access/credential-types/hooks/useCredentialTypesFilters.cy.tsx
+++ b/frontend/awx/access/credential-types/hooks/useCredentialTypesFilters.cy.tsx
@@ -29,6 +29,6 @@ describe('useCredentialTypesFilters', () => {
     cy.mount(<Test />);
     cy.wait('@getOptions');
     cy.waitForReact(10000, '#root');
-    cy.getReact('TestInner').getProps('filters').should('have.length', 25);
+    cy.getReact('TestInner').getProps('filters').should('have.length', 26);
   });
 });

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.cy.tsx
@@ -32,22 +32,25 @@ describe('Execution Environments List', () => {
     });
 
     it('Filter execution environments by name', () => {
-      cy.mount(<ExecutionEnvironments />);
       cy.intercept(
-        'api/v2/execution_environments/?name__icontains=Control%20Plane%20Execution%20Environment*'
-      ).as('nameFilterRequest');
-      cy.filterTableByTypeAndText(/^Name$/, 'Control Plane Execution Environment');
-      cy.wait('@nameFilterRequest');
+        { method: 'OPTIONS', url: '/api/v2/execution_environments/' },
+        { fixture: 'mock_options.json' }
+      );
+      cy.mount(<ExecutionEnvironments />);
+      cy.filterTableByMultiSelect('name', ['Control Plane Execution Environment']);
+      cy.getByDataCy('filter-input').click();
+      cy.get('tr').should('have.length.greaterThan', 0);
       cy.clickButton(/^Clear all filters$/);
     });
 
     it('Filter execution environments by image', () => {
-      cy.mount(<ExecutionEnvironments />);
-      cy.intercept('api/v2/execution_environments/?image__icontains=quay*').as(
-        'imageFilterRequest'
+      cy.intercept(
+        { method: 'OPTIONS', url: '/api/v2/execution_environments/' },
+        { fixture: 'mock_options.json' }
       );
-      cy.filterTableByTypeAndText(/^Image$/, 'quay');
-      cy.wait('@imageFilterRequest');
+      cy.mount(<ExecutionEnvironments />);
+      cy.filterTableByTextFilter('image-location', 'quay', { disableFilterSelection: false });
+      cy.get('tr').should('have.length.greaterThan', 0);
       cy.clickButton(/^Clear all filters$/);
     });
 

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsFilters.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvironmentsFilters.tsx
@@ -1,18 +1,17 @@
-import { useMemo } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
-import {
-  useNameToolbarFilter,
-  useOrganizationToolbarFilter,
-  useImageToolbarFilter,
-} from '../../../common/awx-toolbar-filters';
+import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
 export function useExecutionEnvironmentsFilters() {
-  const nameToolbarFilter = useNameToolbarFilter();
-  const organizationToolbarFilter = useOrganizationToolbarFilter();
-  const imageToolbarFilter = useImageToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter],
-    [nameToolbarFilter, organizationToolbarFilter, imageToolbarFilter]
-  );
+  const toolbarFilters = useDynamicToolbarFilters({
+    optionsPath: 'execution_environments',
+    preSortedKeys: ['name', 'id'],
+    preFilledValueKeys: {
+      name: {
+        apiPath: 'execution_environments',
+      },
+      id: {
+        apiPath: 'execution_environments',
+      },
+    },
+  });
   return toolbarFilters;
 }

--- a/frontend/awx/administration/notifiers/Notifiers.cy.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.cy.tsx
@@ -52,7 +52,7 @@ describe('Notifiers.cy.tsx', () => {
       cy.mount(<Test />);
       cy.wait('@getOptions');
       cy.waitForReact(10000, '#root');
-      cy.getReact('TestInner').getProps('filters').should('have.length', 25);
+      cy.getReact('TestInner').getProps('filters').should('have.length', 26);
     });
 
     it('List has filter for Name', () => {

--- a/frontend/awx/views/jobs/hooks/useJobFilters.cy.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobFilters.cy.tsx
@@ -29,6 +29,6 @@ describe('useJobsFilters', () => {
     cy.mount(<Test />);
     cy.wait('@getOptions');
     cy.waitForReact(10000, '#root');
-    cy.getReact('TestInner').getProps('filters').should('have.length', 23);
+    cy.getReact('TestInner').getProps('filters').should('have.length', 24);
   });
 });


### PR DESCRIPTION
This PR updates the execution environments page to use dynamic filters and fixes affected tests.

Jira issue: https://issues.redhat.com/browse/AAP-21055

Before:
![Screenshot 2024-04-17 at 1 59 24 PM](https://github.com/ansible/ansible-ui/assets/89094075/f8286bc5-6626-476c-bd3f-4cf30842c2b3)

After:
![Screenshot 2024-04-17 at 1 58 44 PM](https://github.com/ansible/ansible-ui/assets/89094075/8fa16651-6796-4c32-9c0f-a50a690ff4fd)