### PR TITLE
Set credential input fields defaults. Other small updates.

### DIFF
--- a/frontend/eda/access/credentials/CredentialForm.tsx
+++ b/frontend/eda/access/credentials/CredentialForm.tsx
@@ -52,6 +52,10 @@ function CredentialInputs(props: { editMode: boolean }) {
     fields?.map((field) => {
       if (field?.default !== undefined) {
         setValue(`inputs.${field.id}`, field.default);
+      } else if (field.type === 'boolean') {
+        setValue(`inputs.${field.id}`, false);
+      } else if (field.type === 'string') {
+        setValue(`inputs.${field.id}`, '');
       }
     });
   }, [credentialType, setValue]);

--- a/frontend/eda/access/credentials/CredentialFormTypes.tsx
+++ b/frontend/eda/access/credentials/CredentialFormTypes.tsx
@@ -32,6 +32,7 @@ interface IFieldTypeString extends IFieldTypeBase {
 interface IFieldTypeBoolean extends IFieldTypeBase {
   type: 'boolean';
   default?: boolean;
+  secret: boolean;
 }
 
 export function CredentialFormInputs(props: { credentialType: EdaCredentialType | undefined }) {

--- a/frontend/eda/access/credentials/CredentialPage/CredentialDetailFields.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialDetailFields.tsx
@@ -1,27 +1,37 @@
-import { LoadingPage, PageDetail } from '../../../../../framework';
-import { useGet } from '../../../../common/crud/useGet';
-import { edaAPI } from '../../../common/eda-utils';
+import { PageDetail } from '../../../../../framework';
 import { EdaCredential } from '../../../interfaces/EdaCredential';
-import { EdaCredentialType } from '../../../interfaces/EdaCredentialType';
+import { useTranslation } from 'react-i18next';
+import { capitalizeFirstLetter } from '../../../../../framework/utils/strings';
 
 export function CredentialDetailFields(props: { credential: EdaCredential }) {
-  const { data: credentialType } = useGet<EdaCredentialType>(
-    edaAPI`/credential-types/` + `${props.credential.credential_type?.id ?? ''}/`
-  );
+  const { t } = useTranslation();
+  if (!props?.credential?.inputs) return <></>;
+  const enabledOptions: string[] = [];
+  Object.keys(props?.credential?.inputs).map((label, idx) => {
+    if (
+      typeof Object.values(props?.credential?.inputs || {}).at(idx) === 'boolean' &&
+      Object.values(props?.credential?.inputs || {}).at(idx) === true
+    ) {
+      enabledOptions.push(capitalizeFirstLetter(label));
+    }
+  });
 
-  if (!credentialType) {
-    return <LoadingPage />;
-  }
   return (
     <>
-      {props?.credential?.inputs &&
-        Object.keys(props?.credential?.inputs).map((value, idx) => {
-          return (
-            <PageDetail key={value} label={value}>
-              {Object.values(props?.credential?.inputs || {}).at(idx) as string}
-            </PageDetail>
-          );
-        })}
+      {Object.keys(props?.credential?.inputs).map((label, idx) => {
+        return typeof Object.values(props?.credential?.inputs || {}).at(idx) !== 'boolean' ? (
+          <PageDetail key={label} label={label}>
+            {Object.values(props?.credential?.inputs || {}).at(idx) as string}
+          </PageDetail>
+        ) : (
+          <></>
+        );
+      })}
+      {enabledOptions.length > 0 && (
+        <PageDetail key={'enabled_options'} label={t('Enabled options')}>
+          {enabledOptions.join(', ')}
+        </PageDetail>
+      )}
     </>
   );
 }

--- a/frontend/eda/access/credentials/CredentialPage/CredentialDetailFields.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialDetailFields.tsx
@@ -20,7 +20,7 @@ export function CredentialDetailFields(props: { credential: EdaCredential }) {
     <>
       {Object.keys(props?.credential?.inputs).map((label, idx) => {
         return typeof Object.values(props?.credential?.inputs || {}).at(idx) !== 'boolean' ? (
-          <PageDetail key={label} label={label}>
+          <PageDetail key={label} label={capitalizeFirstLetter(label)}>
             {Object.values(props?.credential?.inputs || {}).at(idx) as string}
           </PageDetail>
         ) : (

--- a/frontend/eda/access/credentials/CredentialPage/CredentialDetails.tsx
+++ b/frontend/eda/access/credentials/CredentialPage/CredentialDetails.tsx
@@ -34,7 +34,9 @@ export function CredentialDetails() {
           credential?.organization?.name || ''
         )}
       </PageDetail>
-
+      <PageDetail label={t('Credential type')}>
+        {credential.credential_type?.name || credential.credential_type?.id || ''}
+      </PageDetail>
       <CredentialDetailFields credential={credential} />
       <PageDetail label={t('Created')}>
         {credential?.created_at ? formatDateString(credential.created_at) : ''}

--- a/frontend/eda/interfaces/generated/eda-api.ts
+++ b/frontend/eda/interfaces/generated/eda-api.ts
@@ -314,6 +314,7 @@ export interface CredentialType {
       id: string;
       label: string;
       type: string;
+      secret: boolean;
       help_text: string;
       ask_at_runtime?: boolean;
       default?: number | string | boolean;

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -271,6 +271,7 @@ export function useEdaNavigation() {
       id: EdaRoute.Webhooks,
       label: t('Webhooks'),
       path: 'webhooks',
+      hidden: true,
       children: [
         {
           id: EdaRoute.CreateWebhook,

--- a/frontend/eda/projects/EditProject.tsx
+++ b/frontend/eda/projects/EditProject.tsx
@@ -180,7 +180,7 @@ function ProjectEditInputs() {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const { data: credentials } = useGet<EdaResult<EdaCredential>>(
-    edaAPI`/credentials/` + `?credential_type__kind=scm&page_size=300`
+    edaAPI`/eda-credentials/` + `?credential_type__kind=scm&page_size=300`
   );
   const { data: verifyCredentials } = useGet<EdaResult<EdaCredential>>(
     edaAPI`/eda-credentials/` + `?credential_type__kind=cryptography&page_size=300`


### PR DESCRIPTION
Changes to the Left-hand navigation menu - removes the Webhooks entry

Changes to the Credentials pages:
- Add default values for the credential input fields when none specifically provided.
- Updated the display values for the boolean credential input fields to be under 'Enabled options' 
- Add Credential type to the credential details page.
- Capitalize input fields labels

![Screenshot from 2024-04-09 15-47-32](https://github.com/ansible/ansible-ui/assets/12769982/ada0f451-1565-452c-96eb-e497ce42386f)
 

- Update the credential api on the Project Edit Page to eda-credentials

![Screenshot from 2024-04-09 12-17-56](https://github.com/ansible/ansible-ui/assets/12769982/4eb22c36-9fd1-4818-96d0-f92b76176dc6)


