### PR TITLE
[AAP-21052] Inventories page dynamic filters update

### DIFF
--- a/cypress/e2e/awx/resources/hosts.cy.ts
+++ b/cypress/e2e/awx/resources/hosts.cy.ts
@@ -59,7 +59,7 @@ function createAndCheckHost(inventory_host: boolean, inventory: string) {
     cy.contains('button', 'Browse').click();
     cy.contains('Select Inventory');
     cy.get(`[aria-label="Select Inventory"]`).within(() => {
-      cy.searchAndDisplayResource(inventory);
+      cy.filterTableBySingleSelect('name', inventory);
       cy.get(`[data-cy="checkbox-column-cell"] input`).click();
       cy.contains('button', 'Confirm').click();
     });

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { randomString } from '../../../../framework/utils/random-string';
 import { InstanceGroup } from '../../../../frontend/awx/interfaces/InstanceGroup';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
@@ -74,7 +73,7 @@ describe('Inventories Tests', () => {
       //Refactor this test to match the updated test case and improve the assertions
 
       cy.navigateTo('awx', 'inventories');
-      cy.searchAndDisplayResource(inventory.name);
+      cy.filterTableBySingleSelect('name', inventory.name);
       cy.get(`[data-cy="row-id-${inventory.id}"]`).within(() => {
         cy.get('[data-cy="edit-inventory"]').click();
       });
@@ -96,7 +95,8 @@ describe('Inventories Tests', () => {
       //Refactor this test to match the updated test case and improve the assertions
 
       cy.navigateTo('awx', 'inventories');
-      cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
       cy.verifyPageTitle(inventory.name);
       //Add more assertions to verify that the user is now on the details screen and to assert the inventory's original info
       cy.clickButton(/^Edit inventory/);
@@ -113,7 +113,8 @@ describe('Inventories Tests', () => {
       //Refactor this test to match the updated test case and improve the assertions
 
       cy.navigateTo('awx', 'inventories');
-      cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
       cy.verifyPageTitle(inventory.name); //Add more assertions to verify that the user is now on the details screen
       cy.clickPageAction('copy-inventory');
       cy.hasAlert(`${inventory.name} copied`);
@@ -124,14 +125,16 @@ describe('Inventories Tests', () => {
       //Refactor this test to match the updated test case and improve the assertions
 
       cy.navigateTo('awx', 'inventories'); //Add assertion to verify the user is on the inventories list view
-      cy.clickTableRowKebabAction(inventory.name, 'copy-inventory', true);
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowKebabAction(inventory.name, 'copy-inventory', false);
       cy.hasAlert(`${inventory.name.toString()} copied`);
       //Assert the presence of the original and the copy by performing a search on the list of inventories
     });
 
     it('can delete an inventory from the inventory list row item', () => {
       cy.navigateTo('awx', 'inventories');
-      cy.clickTableRowKebabAction(inventory.name, 'delete-inventory', true);
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowKebabAction(inventory.name, 'delete-inventory', false);
       //Add assertion to show the presence of the expected inventory
       cy.get('#confirm').click();
       cy.clickButton(/^Delete inventory/);
@@ -146,7 +149,8 @@ describe('Inventories Tests', () => {
       //Improve the assertions in this test
 
       cy.navigateTo('awx', 'inventories');
-      cy.selectTableRow(inventory.name, true);
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.selectTableRowByCheckbox('name', inventory.name, { disableFilter: true });
       //Add an assertion that the expected inventory name appears where it should
       cy.clickToolbarKebabAction('delete-selected-inventories');
       cy.get('#confirm').click();

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -70,7 +70,8 @@ describe('Inventory Groups', () => {
         const { inventory, host, group } = result;
 
         cy.navigateTo('awx', 'inventories');
-        cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+        cy.filterTableBySingleSelect('name', inventory.name);
+        cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.verifyPageTitle(inventory.name);
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
@@ -141,7 +142,8 @@ describe('Inventory Groups', () => {
         const { inventory, host, group } = result;
 
         cy.navigateTo('awx', 'inventories');
-        cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+        cy.filterTableBySingleSelect('name', inventory.name);
+        cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.verifyPageTitle(inventory.name);
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
@@ -193,7 +195,8 @@ describe('Inventory Groups', () => {
         const newRelatedGroup = 'New test group' + randomString(4);
 
         cy.navigateTo('awx', 'inventories');
-        cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+        cy.filterTableBySingleSelect('name', inventory.name);
+        cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.verifyPageTitle(inventory.name);
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
@@ -224,7 +227,8 @@ describe('Inventory Groups', () => {
         const newGroup = 'New test group' + randomString(4);
 
         cy.navigateTo('awx', 'inventories');
-        cy.clickTableRow(inventory.name); //Refactor this line to use the updated custom command
+        cy.filterTableBySingleSelect('name', inventory.name);
+        cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
         cy.clickLink(/^Groups$/);

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -54,7 +54,8 @@ describe('Inventory Sources', () => {
   describe('Inventory Source List', () => {
     it('can navigate to the Create Source form, create new Source, and verify all expected info shows on the details page', () => {
       cy.navigateTo('awx', 'inventories');
-      cy.clickTableRow(inventory.name);
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
       cy.verifyPageTitle(inventory.name);
       cy.clickLink(/^Sources$/);
       cy.clickButton(/^Add source/);
@@ -90,7 +91,8 @@ describe('Inventory Sources', () => {
 
     it('can create an Amazon EC2 Inventory Source and edit the form', () => {
       cy.navigateTo('awx', 'inventories');
-      cy.clickTableRow(inventory.name);
+      cy.filterTableBySingleSelect('name', inventory.name);
+      cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
       cy.verifyPageTitle(inventory.name);
       cy.clickLink(/^Sources$/);
       cy.getBy('#add-source').click();

--- a/frontend/awx/resources/inventories/Inventories.cy.tsx
+++ b/frontend/awx/resources/inventories/Inventories.cy.tsx
@@ -31,23 +31,23 @@ describe('Inventories', () => {
       cy.get('table').find('tr').should('have.length', 10);
     });
 
-    it('should have filters for Name, Description, Type, Organization, Created By and Modified By', () => {
-      cy.mount(<Inventories />);
-      cy.intercept('/api/v2/inventories/?organization__name__icontains=Organization%200*').as(
-        'orgFilterRequest'
+    it('should have filters for Name, Description, Created By and Modified By', () => {
+      cy.intercept(
+        { method: 'OPTIONS', url: '/api/v2/inventories/' },
+        { fixture: 'mock_options.json' }
       );
+      cy.mount(<Inventories />);
       cy.verifyPageTitle('Inventories');
       cy.openToolbarFilterTypeSelect().within(() => {
         cy.contains(/^Name$/).should('be.visible');
         cy.contains(/^Description$/).should('be.visible');
-        cy.contains(/^Inventory type$/).should('be.visible');
-        cy.contains(/^Organization$/).should('be.visible');
         cy.contains(/^Created by$/).should('be.visible');
         cy.contains(/^Modified by$/).should('be.visible');
-        cy.contains('button', /^Organization$/).click();
+        cy.contains('button', /^Name$/).click();
       });
-      cy.filterTableByText('Organization 0');
-      cy.wait('@orgFilterRequest');
+      cy.filterTableBySingleSelect('name', 'Demo Inventory');
+      cy.get('tr').should('have.length.greaterThan', 0);
+      cy.getByDataCy('filter-input').click();
       cy.clickButton(/^Clear all filters$/);
     });
 

--- a/frontend/awx/resources/inventories/hooks/useInventoriesFilters.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesFilters.tsx
@@ -1,38 +1,18 @@
-import { useMemo } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
 import {
   useCreatedByToolbarFilter,
-  useDescriptionToolbarFilter,
-  useInventoryTypeToolbarFilter,
   useModifiedByToolbarFilter,
-  useNameToolbarFilter,
-  useOrganizationToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
+import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
 export function useInventoriesFilters() {
   const createdByToolbarFilter = useCreatedByToolbarFilter();
-  const descriptionToolbarFilter = useDescriptionToolbarFilter();
-  const inventoryTypeToolbarFilter = useInventoryTypeToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
-  const nameToolbarFilter = useNameToolbarFilter();
-  const organizationToolbarFilter = useOrganizationToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [
-      nameToolbarFilter,
-      createdByToolbarFilter,
-      descriptionToolbarFilter,
-      inventoryTypeToolbarFilter,
-      modifiedByToolbarFilter,
-      organizationToolbarFilter,
-    ],
-    [
-      nameToolbarFilter,
-      createdByToolbarFilter,
-      descriptionToolbarFilter,
-      inventoryTypeToolbarFilter,
-      modifiedByToolbarFilter,
-      organizationToolbarFilter,
-    ]
-  );
+
+  const toolbarFilters = useDynamicToolbarFilters({
+    optionsPath: 'inventories',
+    preSortedKeys: ['name', 'id', 'created-by', 'modified-by'],
+    preFilledValueKeys: { name: { apiPath: 'inventories' }, id: { apiPath: 'inventories' } },
+    additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
+  });
   return toolbarFilters;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostForm.cy.tsx
@@ -156,14 +156,14 @@ describe('Create Edit Inventory/Standalone Host Form', () => {
         cy.get('[data-cy="name"]').clear();
         cy.get('[data-cy="name"]').type('Edited Host');
         cy.get('[data-cy="description"]').clear();
-        cy.get('[data-cy="description"]').type('Edited Description');
+        cy.get('[data-cy="description"]').type('Edited Descriptions');
         cy.getBy('[data-cy="variables"]').type('s');
         cy.clickButton(/^Save host$/);
         cy.wait('@editHost')
           .its('request.body')
           .then((editedHost: IHostInput) => {
             expect(editedHost.name).to.equal('Edited Host');
-            expect(editedHost.description).to.equal('Edited Description');
+            expect(editedHost.description).to.equal('Edited Descriptions');
             expect(editedHost.variables).to.equal(`${payload.variables}s`);
           });
       });


### PR DESCRIPTION
This PR updates the inventories page to use dynamic filters and fixes tests affected by this change. 

Jira issue: https://issues.redhat.com/browse/AAP-21052

Before:
![Screenshot 2024-04-05 at 1 55 53 PM](https://github.com/ansible/ansible-ui/assets/89094075/c04d8296-a4a3-4e7d-90a1-3007a0ad55f2)

After: 
![Screenshot 2024-04-05 at 1 50 42 PM](https://github.com/ansible/ansible-ui/assets/89094075/1afe6a18-01ab-4aaf-9f8a-b2f2a7f324a6)