### PR TITLE
[AAP-8292] Smart Inventory Details

### DIFF
--- a/cypress/fixtures/inventory.json
+++ b/cypress/fixtures/inventory.json
@@ -100,5 +100,7 @@
   "total_inventory_sources": 0,
   "inventory_sources_with_failures": 0,
   "pending_deletion": false,
-  "prevent_instance_group_fallback": false
+  "prevent_instance_group_fallback": false,
+  "update_cache_timeout": 0,
+  "verbosity": 0
 }

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
@@ -3,21 +3,84 @@ import { Inventory } from '../../../interfaces/Inventory';
 import { InventoryDetailsInner as InventoryDetails } from './InventoryDetails';
 
 describe('InventoryDetails', () => {
-  it('Component renders and displays inventory', () => {
-    cy.fixture('inventory').then((inventory: Inventory) => {
-      cy.mount(<InventoryDetails inventory={inventory} />);
-      cy.get('#name').should('have.text', 'test inventory');
-      cy.get('#type').should('have.text', 'Inventory');
-      cy.get('#organization').should('have.text', 'Default');
-      cy.get('#total-hosts').should('have.text', '1');
-      cy.get('#labels').should('have.text', 'test label');
-      cy.get('#created > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button').should(
-        'have.text',
-        'awx'
+  const kinds: Array<'' | 'smart' | 'constructed'> = ['', 'smart', 'constructed'];
+
+  kinds.forEach((kind) => {
+    it(`Component renders and displays inventory (${kind === '' ? 'regular' : kind})`, () => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/inventories/*/instance_groups*',
+        },
+        {
+          fixture: 'instance_groups.json',
+        }
       );
-      cy.get(
-        '#last-modified > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button'
-      ).should('have.text', 'awx');
+      cy.fixture('inventory')
+        .then((inventory: Inventory) => {
+          inventory.kind = kind;
+
+          if (inventory.kind === 'smart') {
+            inventory.host_filter = 'name__icontains=test';
+          }
+          if (inventory.kind === 'constructed') {
+            inventory.hosts_with_active_failures = 1;
+          }
+        })
+        .then((inventory: Inventory) => {
+          cy.mount(<InventoryDetails inventory={inventory} />);
+          cy.get('#name').should('have.text', 'test inventory');
+          cy.get('#organization').should('have.text', 'Default');
+          cy.get('#total-hosts').should('have.text', '1');
+          cy.get('#labels').should('have.text', 'test label');
+          cy.get(
+            '#created > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button'
+          ).should('have.text', 'awx');
+          cy.get(
+            '#last-modified > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button'
+          ).should('have.text', 'awx');
+          cy.get('[data-cy="instance-groups"]').should('contain.text', 'controlplane');
+          cy.get('[data-cy="instance-groups"]').should('contain.text', 'default');
+          cy.get('[data-cy="instance-groups"]').should('contain.text', 'Container Group 01');
+          if (inventory.kind === '') {
+            cy.get('#type').should('have.text', 'Inventory');
+            cy.get('body').should('not.have.descendants', '[data-cy="hosts-with-active-failures"]');
+            cy.get('body').should('not.have.descendants', '[data-cy="total-groups"]');
+            cy.get('body').should('not.have.descendants', '[data-cy="total-inventory-sources"]');
+            cy.get('body').should(
+              'not.have.descendants',
+              '[data-cy="inventory-sources-with-active-failures"]'
+            );
+          }
+          if (inventory.kind === 'smart') {
+            cy.get('#type').should('have.text', 'Smart inventory');
+            cy.get('body').should('not.have.descendants', '[data-cy="hosts-with-active-failures"]');
+            cy.get('body').should('not.have.descendants', '[data-cy="total-groups"]');
+            cy.get('body').should('not.have.descendants', '[data-cy="total-inventory-sources"]');
+            cy.get('body').should(
+              'not.have.descendants',
+              '[data-cy="inventory-sources-with-active-failures"]'
+            );
+          }
+          if (inventory.kind === 'constructed') {
+            cy.get('#type').should('have.text', 'Constructed inventory');
+            cy.get('body').should('have.descendants', '[data-cy="hosts-with-active-failures"]');
+            cy.get('[data-cy="hosts-with-active-failures"]').should('have.text', 1);
+            cy.get('body').should('have.descendants', '[data-cy="total-groups"]');
+            cy.get('[data-cy="total-groups"]').should('have.text', 0);
+            cy.get('body').should('have.descendants', '[data-cy="total-inventory-sources"]');
+            cy.get('[data-cy="total-inventory-sources"]').should('have.text', 0);
+            cy.get('body').should(
+              'have.descendants',
+              '[data-cy="inventory-sources-with-active-failures"]'
+            );
+            cy.get('[data-cy="inventory-sources-with-active-failures"]').should('have.text', 0);
+            cy.get('body').should('have.descendants', '[data-cy="update-cache-timeout"]');
+            cy.get('[data-cy="update-cache-timeout"]').should('have.text', 0);
+            cy.get('body').should('have.descendants', '[data-cy="verbosity"]');
+            cy.get('[data-cy="verbosity"]').should('have.text', `0 (Normal)`);
+          }
+        });
     });
   });
 });

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.cy.tsx
@@ -29,21 +29,17 @@ describe('InventoryDetails', () => {
         })
         .then((inventory: Inventory) => {
           cy.mount(<InventoryDetails inventory={inventory} />);
-          cy.get('#name').should('have.text', 'test inventory');
-          cy.get('#organization').should('have.text', 'Default');
-          cy.get('#total-hosts').should('have.text', '1');
-          cy.get('#labels').should('have.text', 'test label');
-          cy.get(
-            '#created > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button'
-          ).should('have.text', 'awx');
-          cy.get(
-            '#last-modified > .pf-v5-c-description-list__text > .date-time > .pf-v5-c-button'
-          ).should('have.text', 'awx');
+          cy.get('[data-cy="name"]').should('have.text', 'test inventory');
+          cy.get('[data-cy="organization"]').should('have.text', 'Default');
+          cy.get('[data-cy="total-hosts"]').should('have.text', '1');
+          cy.get('[data-cy="labels"]').should('have.text', 'test label');
+          cy.get('[data-cy="last-modified"]').should('contain.text', 'awx');
+          cy.get('[data-cy="created"]').should('contain.text', 'awx');
           cy.get('[data-cy="instance-groups"]').should('contain.text', 'controlplane');
           cy.get('[data-cy="instance-groups"]').should('contain.text', 'default');
           cy.get('[data-cy="instance-groups"]').should('contain.text', 'Container Group 01');
           if (inventory.kind === '') {
-            cy.get('#type').should('have.text', 'Inventory');
+            cy.get('[data-cy="type"]').should('have.text', 'Inventory');
             cy.get('body').should('not.have.descendants', '[data-cy="hosts-with-active-failures"]');
             cy.get('body').should('not.have.descendants', '[data-cy="total-groups"]');
             cy.get('body').should('not.have.descendants', '[data-cy="total-inventory-sources"]');
@@ -53,7 +49,7 @@ describe('InventoryDetails', () => {
             );
           }
           if (inventory.kind === 'smart') {
-            cy.get('#type').should('have.text', 'Smart inventory');
+            cy.get('[data-cy="type"]').should('have.text', 'Smart inventory');
             cy.get('body').should('not.have.descendants', '[data-cy="hosts-with-active-failures"]');
             cy.get('body').should('not.have.descendants', '[data-cy="total-groups"]');
             cy.get('body').should('not.have.descendants', '[data-cy="total-inventory-sources"]');
@@ -63,7 +59,7 @@ describe('InventoryDetails', () => {
             );
           }
           if (inventory.kind === 'constructed') {
-            cy.get('#type').should('have.text', 'Constructed inventory');
+            cy.get('[data-cy="type"]').should('have.text', 'Constructed inventory');
             cy.get('body').should('have.descendants', '[data-cy="hosts-with-active-failures"]');
             cy.get('[data-cy="hosts-with-active-failures"]').should('have.text', 1);
             cy.get('body').should('have.descendants', '[data-cy="total-groups"]');


### PR DESCRIPTION
This PR updates the inventory details section to account for smart inventories. The work involved hiding fields that were specific to constructed inventories, showing the smart host filter field for smart inventories and showing common fields for all types of inventories. In addition the inventory details component tests have been updated to account for the constructed and smart inventory views.