### PR TITLE
Add fullWidth prop to PageDetail component

### DIFF
--- a/framework/PageDetails/PageDetail.tsx
+++ b/framework/PageDetails/PageDetail.tsx
@@ -13,6 +13,7 @@ export function PageDetail(props: {
   children?: ReactNode;
   helpText?: string | ReactNode;
   isEmpty?: boolean;
+  fullWidth?: boolean;
 }) {
   const id = useID(props);
   const { label, children, helpText, isEmpty } = props;
@@ -23,7 +24,7 @@ export function PageDetail(props: {
     return <></>;
   }
   return (
-    <DescriptionListGroup>
+    <DescriptionListGroup style={{ gridColumn: props.fullWidth ? 'span 3' : undefined }}>
       {label && (
         <DescriptionListTerm>
           {label}


### PR DESCRIPTION
This is useful for details that are really large and would wrap otherwise.
Examples:
 - Description
 - URL