### PR TITLE
Pass queryParams to useJobsFilters hook.

### DIFF
--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -16,7 +16,7 @@ export function JobsList(props: {
   columns: ITableColumn<UnifiedJob>[];
 }) {
   const { t } = useTranslation();
-  const toolbarFilters = useJobsFilters();
+  const toolbarFilters = useJobsFilters(props.queryParams ?? {});
   const tableColumns = props.columns;
   const view = useAwxView<UnifiedJob>({
     url: awxAPI`/unified_jobs/`,

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -1,15 +1,18 @@
+import { QueryParams } from '../../../common/useAwxView';
 import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
-export function useJobsFilters() {
+export function useJobsFilters(queryParams: QueryParams = {}) {
   const toolBarFilters = useDynamicToolbarFilters({
     optionsPath: 'unified_jobs',
     preSortedKeys: ['name', 'description', 'status'],
     preFilledValueKeys: {
       name: {
         apiPath: 'unified_jobs',
+        queryParams: queryParams,
       },
       id: {
         apiPath: 'unified_jobs',
+        queryParams: queryParams,
       },
     },
   });


### PR DESCRIPTION
This PR fixes the Jobs tab filter by name within resource views by passing the query params down to the useJobsFilters hook.