### PR TITLE
ActiveUserProviders Fix and Streamline Providers and Hooks

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -1,6 +1,6 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 import { randomE2Ename } from '../../../support/utils';
 
@@ -43,7 +43,7 @@ describe('organizations', () => {
 
 describe('organizations edit and delete', function () {
   let organization: Organization;
-  let user: User;
+  let user: AwxUser;
 
   before(function () {
     cy.awxLogin();

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -3,13 +3,13 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Team } from '../../../../frontend/awx/interfaces/Team';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
 describe('teams', function () {
   let team: Team;
-  let user1: User;
-  let user2: User;
+  let user1: AwxUser;
+  let user2: AwxUser;
 
   before(function () {
     cy.awxLogin();
@@ -62,10 +62,10 @@ describe('teams', function () {
   });
 
   it('can remove users from the team via the teams list row item', function () {
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
-    cy.requestPost<User>(awxAPI`/users/${user2.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
 
@@ -133,11 +133,11 @@ describe('teams', function () {
     });
     cy.getTableRowByText(user1.username).should('be.visible');
     cy.getTableRowByText(user2.username).should('be.visible');
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
       disassociate: true,
     });
-    cy.requestPost<User>(awxAPI`/users/${user2.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
       disassociate: true,
     });
@@ -145,10 +145,10 @@ describe('teams', function () {
   });
 
   it('can remove users from the team via the team access tab toolbar', function () {
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
-    cy.requestPost<User>(awxAPI`/users/${user2.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
     cy.navigateTo('awx', 'teams');
@@ -169,7 +169,7 @@ describe('teams', function () {
   });
 
   it('can remove a single user from the team via the team access tab row action', function () {
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
     cy.navigateTo('awx', 'teams');
@@ -187,10 +187,10 @@ describe('teams', function () {
   });
 
   it('can remove a role from a user via the team access tab row action', function () {
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.read_role.id,
     });
     cy.navigateTo('awx', 'teams');
@@ -211,7 +211,7 @@ describe('teams', function () {
         `div[data-ouia-component-id="Read-${team.summary_fields.object_roles.read_role.id}"]`
       ).should('not.exist');
     });
-    cy.requestPost<User>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
       disassociate: true,
     });

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -3,11 +3,11 @@
 
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 
 describe('Users List Actions', () => {
   let organization: Organization;
-  let user: User;
+  let user: AwxUser;
 
   before(() => {
     cy.awxLogin();
@@ -78,7 +78,7 @@ describe('Users List Actions', () => {
 
 describe('Users Delete Actions', () => {
   let organization: Organization;
-  let user: User;
+  let user: AwxUser;
 
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/administration/activity-stream.cy.ts
+++ b/cypress/e2e/awx/administration/activity-stream.cy.ts
@@ -2,18 +2,18 @@ import { AwxItemsResponse } from '../../../../frontend/awx/common/AwxItemsRespon
 import { awxAPI } from '../../../../frontend/awx/common/api/awx-utils';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Team } from '../../../../frontend/awx/interfaces/Team';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 
 describe('activity-stream', () => {
   let team: Team;
-  let activeUser: User;
+  let activeUser: AwxUser;
 
   before(function () {
     cy.awxLogin();
     cy.createAwxTeam(this.globalOrganization as Organization).then((createdTeam) => {
       team = createdTeam;
     });
-    cy.requestGet<AwxItemsResponse<User>>(awxAPI`/me/`)
+    cy.requestGet<AwxItemsResponse<AwxUser>>(awxAPI`/me/`)
       .its('results')
       .then((results) => {
         activeUser = results[0];

--- a/cypress/e2e/awx/administration/workflowApproval.cy.ts
+++ b/cypress/e2e/awx/administration/workflowApproval.cy.ts
@@ -3,10 +3,10 @@ import { InventorySource } from '../../../../frontend/awx/interfaces/InventorySo
 import { JobTemplate } from '../../../../frontend/awx/interfaces/JobTemplate';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
+import { WorkflowJob } from '../../../../frontend/awx/interfaces/WorkflowJob';
 import { WorkflowJobTemplate } from '../../../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../../../frontend/awx/interfaces/WorkflowNode';
-import { WorkflowJob } from '../../../../frontend/awx/interfaces/WorkflowJob';
 
 /* Shared functions across test cases */
 const wfaURL = '/administration/workflow-approvals/';
@@ -80,10 +80,10 @@ function actAssertAndDeleteWorkflowApproval(
 describe('Workflow Approvals - List View', () => {
   let organization: Organization;
   let project: Project;
-  let user: User;
-  let userWFApprove: User;
-  let userWFDeny: User;
-  let userWFCancel: User;
+  let user: AwxUser;
+  let userWFApprove: AwxUser;
+  let userWFDeny: AwxUser;
+  let userWFCancel: AwxUser;
   let inventory: Inventory;
   let inventorySource: InventorySource;
   let jobTemplate: JobTemplate;

--- a/cypress/e2e/awx/cleanup/awx-cleanup.cy.ts
+++ b/cypress/e2e/awx/cleanup/awx-cleanup.cy.ts
@@ -4,7 +4,7 @@ import { Job } from '../../../../frontend/awx/interfaces/Job';
 import { JobTemplate } from '../../../../frontend/awx/interfaces/JobTemplate';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { WorkflowApproval } from '../../../../frontend/awx/interfaces/WorkflowApproval';
 import { getJobsAPIUrl } from '../../../../frontend/awx/views/jobs/jobUtils';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
@@ -43,7 +43,7 @@ describe('AWX Cleanup', () => {
   });
 
   it('cleanup users', () => {
-    cy.awxRequestGet<AwxItemsResponse<User>>(
+    cy.awxRequestGet<AwxItemsResponse<AwxUser>>(
       awxAPI`/users?username__startswith=e2e-&page=1&page_size=200&created__lt=${tenMinutesAgo}`
     ).then((result) => {
       for (const resource of result.results ?? []) {

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -3,13 +3,13 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Credential } from '../../../../frontend/awx/interfaces/Credential';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
 describe('credentials', () => {
   let organization: Organization;
   let credential: Credential;
-  let user: User;
+  let user: AwxUser;
 
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/resources/hosts.cy.ts
+++ b/cypress/e2e/awx/resources/hosts.cy.ts
@@ -1,12 +1,12 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 
 describe('host and inventory host', () => {
   let organization: Organization;
   let inventory: Inventory;
-  let user: User;
+  let user: AwxUser;
 
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -4,14 +4,14 @@ import { InstanceGroup } from '../../../../frontend/awx/interfaces/InstanceGroup
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Label } from '../../../../frontend/awx/interfaces/Label';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 
 describe('Inventories Tests', () => {
   let organization: Organization;
   let inventory: Inventory;
   let instanceGroup: InstanceGroup;
   let label: Label;
-  let user: User;
+  let user: AwxUser;
 
   before(() => {
     cy.awxLogin();

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -4,7 +4,7 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
-import { User } from '../../../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
 // These tests do not modify the project, thus can use the globalProject
@@ -93,7 +93,7 @@ describe('projects', () => {
 describe('project edit and delete tests', () => {
   let project: Project;
   let organization: Organization;
-  let user: User;
+  let user: AwxUser;
 
   before(function () {
     cy.awxLogin();

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -17,16 +17,16 @@ import { Job } from '../../frontend/awx/interfaces/Job';
 import { JobEvent } from '../../frontend/awx/interfaces/JobEvent';
 import { JobTemplate } from '../../frontend/awx/interfaces/JobTemplate';
 import { Label } from '../../frontend/awx/interfaces/Label';
+import { NotificationTemplate } from '../../frontend/awx/interfaces/NotificationTemplate';
 import { Organization } from '../../frontend/awx/interfaces/Organization';
 import { Project } from '../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../frontend/awx/interfaces/Schedule';
 import { Team } from '../../frontend/awx/interfaces/Team';
-import { User } from '../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../frontend/awx/interfaces/User';
+import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowJobNode, WorkflowNode } from '../../frontend/awx/interfaces/WorkflowNode';
 import { awxAPI } from './formatApiPathForAwx';
-import { NotificationTemplate } from '../../frontend/awx/interfaces/NotificationTemplate';
-import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 
 //  AWX related custom command implementation
 
@@ -746,7 +746,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('createAwxUser', (organization: Organization) => {
-  cy.awxRequestPost<Omit<User, 'id' | 'auth' | 'summary_fields'>, User>(
+  cy.awxRequestPost<Omit<AwxUser, 'id' | 'auth' | 'summary_fields'>, AwxUser>(
     awxAPI`/organizations/${organization.id.toString()}/users/`,
     {
       username: 'e2e-user-' + randomString(4),
@@ -761,7 +761,7 @@ Cypress.Commands.add('createAwxUser', (organization: Organization) => {
 Cypress.Commands.add(
   'deleteAwxUser',
   (
-    user: User,
+    user: AwxUser,
     options?: {
       /** Whether to fail on response codes other than 2xx and 3xx */
       failOnStatusCode?: boolean;

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -2,6 +2,7 @@
 import { SetOptional, SetRequired } from 'type-fest';
 import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
 import { Application } from '../../frontend/awx/interfaces/Application';
+import { AwxHost } from '../../frontend/awx/interfaces/AwxHost';
 import { AwxToken } from '../../frontend/awx/interfaces/AwxToken';
 import { Credential } from '../../frontend/awx/interfaces/Credential';
 import { CredentialType } from '../../frontend/awx/interfaces/CredentialType';
@@ -9,21 +10,22 @@ import { ExecutionEnvironment } from '../../frontend/awx/interfaces/ExecutionEnv
 import { Instance } from '../../frontend/awx/interfaces/Instance';
 import { InstanceGroup } from '../../frontend/awx/interfaces/InstanceGroup';
 import { Inventory } from '../../frontend/awx/interfaces/Inventory';
+import { InventoryGroup } from '../../frontend/awx/interfaces/InventoryGroup';
 import { InventorySource } from '../../frontend/awx/interfaces/InventorySource';
 import { Job } from '../../frontend/awx/interfaces/Job';
 import { JobEvent } from '../../frontend/awx/interfaces/JobEvent';
 import { JobTemplate } from '../../frontend/awx/interfaces/JobTemplate';
 import { Label } from '../../frontend/awx/interfaces/Label';
+import { NotificationTemplate } from '../../frontend/awx/interfaces/NotificationTemplate';
 import { Organization } from '../../frontend/awx/interfaces/Organization';
 import { Project } from '../../frontend/awx/interfaces/Project';
 import { Role } from '../../frontend/awx/interfaces/Role';
 import { Schedule } from '../../frontend/awx/interfaces/Schedule';
 import { Team } from '../../frontend/awx/interfaces/Team';
-import { User } from '../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../frontend/awx/interfaces/User';
+import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../frontend/awx/interfaces/WorkflowNode';
-import { InventoryGroup } from '../../frontend/awx/interfaces/InventoryGroup';
-import { AwxHost } from '../../frontend/awx/interfaces/AwxHost';
 import { EdaControllerToken } from '../../frontend/eda/interfaces/EdaControllerToken';
 import { EdaCredential } from '../../frontend/eda/interfaces/EdaCredential';
 import { EdaDecisionEnvironment } from '../../frontend/eda/interfaces/EdaDecisionEnvironment';
@@ -74,8 +76,6 @@ import {
   HubQueryRolesOptions,
   HubRequestOptions,
 } from './hub-commands';
-import { NotificationTemplate } from '../../frontend/awx/interfaces/NotificationTemplate';
-import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 
 declare global {
   namespace Cypress {
@@ -844,7 +844,7 @@ declare global {
 
       getAwxJobTemplateByName(awxJobTemplateName: string): Chainable<JobTemplate>;
       createAwxTeam(organization: Organization): Chainable<Team>;
-      createAwxUser(organization: Organization): Chainable<User>;
+      createAwxUser(organization: Organization): Chainable<AwxUser>;
       createAwxInstanceGroup(
         instanceGroup?: Partial<Omit<InstanceGroup, 'id'>>
       ): Chainable<InstanceGroup>;
@@ -941,7 +941,7 @@ declare global {
         }
       ): Chainable<void>;
       deleteAwxUser(
-        user: User,
+        user: AwxUser,
         options?: {
           /** Whether to fail on response codes other than 2xx and 3xx */
           failOnStatusCode?: boolean;

--- a/cypress/support/component.tsx
+++ b/cypress/support/component.tsx
@@ -26,11 +26,9 @@ import 'cypress-react-selector';
 import type { MountReturn } from 'cypress/react';
 import { mount } from 'cypress/react18';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRResponse } from 'swr';
 import { PageFramework } from '../../framework';
-import { AwxItemsResponse } from '../../frontend/awx/common/AwxItemsResponse';
 import { AwxActiveUserContext } from '../../frontend/awx/common/useAwxActiveUser';
-import { User } from '../../frontend/awx/interfaces/User';
+import { AwxUser } from '../../frontend/awx/interfaces/User';
 import '../../frontend/common/i18n';
 import './auth';
 import './awx-commands';
@@ -76,20 +74,16 @@ declare global {
 }
 
 Cypress.Commands.add('mount', (component, route, activeUserFixture) => {
-  cy.fixture(activeUserFixture || 'activeUser.json').then((activeUser: User) => {
+  cy.fixture(activeUserFixture || 'activeUser.json').then((activeAwxUser: AwxUser) => {
     return mount(
       <MemoryRouter initialEntries={route?.initialEntries || ['/1']}>
         <PageFramework defaultRefreshInterval={60}>
           <AwxActiveUserContext.Provider
-            value={
-              {
-                data: { count: 1, results: [activeUser] },
-                error: undefined,
-                mutate: () => Promise.resolve(),
-                isLoading: false,
-                isValidating: false,
-              } as SWRResponse<AwxItemsResponse<User>>
-            }
+            value={{
+              activeAwxUser,
+              refreshActiveAwxUser: () => null,
+              activeAwxUserIsLoading: false,
+            }}
           >
             <Page>
               <Routes>

--- a/frontend/awx/access/common/DeleteRoleConfirmation.tsx
+++ b/frontend/awx/access/common/DeleteRoleConfirmation.tsx
@@ -2,7 +2,7 @@ import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePageDialog } from '../../../../framework';
-import { AccessRole, User } from '../../interfaces/User';
+import { AccessRole, AwxUser } from '../../interfaces/User';
 
 export interface DeleteRoleConfirmationProps {
   /** Title for the modal */
@@ -10,9 +10,9 @@ export interface DeleteRoleConfirmationProps {
   /** Role to be deleted */
   role: AccessRole;
   /** User initiating the deletion request */
-  user: User;
+  user: AwxUser;
   /** Callback called when the user confirms. */
-  onConfirm: (role: AccessRole, user: User) => Promise<void>;
+  onConfirm: (role: AccessRole, user: AwxUser) => Promise<void>;
 
   /** Callback called when the dialog closes. */
   onClose?: () => void;

--- a/frontend/awx/access/common/ResourceAccessList.tsx
+++ b/frontend/awx/access/common/ResourceAccessList.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../../framework';
 import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 import { useAwxView } from '../../common/useAwxView';
-import { AccessRole, User } from '../../interfaces/User';
+import { AccessRole, AwxUser } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { useSelectUsersAddTeams } from '../users/hooks/useSelectUsersAddTeams';
 import { useUsersFilters } from '../users/hooks/useUsersFilters';
@@ -39,17 +39,17 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
   const { t } = useTranslation();
   const { url, resource } = props;
 
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const canAddAndRemoveUsers: boolean = useMemo(
-    () => activeUser?.is_superuser || resource?.summary_fields?.user_capabilities?.edit,
-    [activeUser?.is_superuser, resource?.summary_fields?.user_capabilities?.edit]
+    () => activeAwxUser?.is_superuser || resource?.summary_fields?.user_capabilities?.edit,
+    [activeAwxUser?.is_superuser, resource?.summary_fields?.user_capabilities?.edit]
   );
 
   const toolbarFilters = useUsersFilters();
 
   const openDeleteRoleConfirmationDialog = useDeleteRoleConfirmationDialog();
   const deleteAccessRole = useDeleteAccessRole(() => void view.refresh());
-  const deleteRole = (role: AccessRole, user: User) => {
+  const deleteRole = (role: AccessRole, user: AwxUser) => {
     openDeleteRoleConfirmationDialog({
       role,
       user: user,
@@ -59,7 +59,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
 
   const tableColumns = useAccessColumns(undefined, deleteRole);
 
-  const view = useAwxView<User>({
+  const view = useAwxView<AwxUser>({
     url: url,
     queryParams: {
       order_by: 'first_name',
@@ -70,7 +70,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
   });
 
   // Build the user and team roles lists for a user
-  useUserAndTeamRolesLists(view.pageItems as User[]);
+  useUserAndTeamRolesLists(view.pageItems as AwxUser[]);
 
   /**
    * TODO: Add users is currently specific to teams and does not handle role selection
@@ -81,7 +81,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
 
   const removeUsersFromResource = useRemoveUsersFromResource();
 
-  const toolbarActions = useMemo<IPageAction<User>[]>(
+  const toolbarActions = useMemo<IPageAction<AwxUser>[]>(
     () => [
       {
         type: PageActionType.Button,
@@ -123,7 +123,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
     ]
   );
 
-  const rowActions = useMemo<IPageAction<User>[]>(
+  const rowActions = useMemo<IPageAction<AwxUser>[]>(
     () => [
       {
         type: PageActionType.Button,
@@ -131,7 +131,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
         icon: MinusCircleIcon,
         label: t('Remove user'),
         onClick: (user) => removeUsersFromResource([user], resource, view.unselectItemsAndRefresh),
-        isDisabled: (user: User) => {
+        isDisabled: (user: AwxUser) => {
           if (user.is_superuser) {
             return t('System administrators have unrestricted access to all resources.');
           }
@@ -157,7 +157,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
   const pageNavigate = usePageNavigate();
 
   return (
-    <PageTable<User>
+    <PageTable<AwxUser>
       toolbarFilters={toolbarFilters}
       toolbarActions={toolbarActions}
       tableColumns={tableColumns}

--- a/frontend/awx/access/common/useAccessColumns.tsx
+++ b/frontend/awx/access/common/useAccessColumns.tsx
@@ -9,16 +9,16 @@ import {
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ITableColumn, TextCell, useGetPageUrl } from '../../../../framework';
-import { AccessRole, User } from '../../interfaces/User';
+import { AccessRole, AwxUser } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 
 export function useAccessColumns(
   _options?: { disableLinks?: boolean; disableSort?: boolean },
-  deleteRole?: (role: AccessRole, user: User) => void
+  deleteRole?: (role: AccessRole, user: AwxUser) => void
 ) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
-  const tableColumns = useMemo<ITableColumn<User>[]>(
+  const tableColumns = useMemo<ITableColumn<AwxUser>[]>(
     () => [
       {
         header: t('Username'),

--- a/frontend/awx/access/common/useDeleteAccessRole.tsx
+++ b/frontend/awx/access/common/useDeleteAccessRole.tsx
@@ -3,14 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { usePageAlertToaster } from '../../../../framework';
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { awxAPI } from '../../common/api/awx-utils';
-import { AccessRole, User } from '../../interfaces/User';
+import { AccessRole, AwxUser } from '../../interfaces/User';
 
 export function useDeleteAccessRole(onComplete?: () => void) {
   const { t } = useTranslation();
   const alertToaster = usePageAlertToaster();
   const postRequest = usePostRequest();
   const onDeleteRole = useCallback(
-    async (role: AccessRole, user: User) => {
+    async (role: AccessRole, user: AwxUser) => {
       try {
         if (typeof role.team_id !== 'undefined') {
           await postRequest(awxAPI`/teams/${role.team_id.toString()}/roles/`, {

--- a/frontend/awx/access/common/useRemoveUserFromResource.tsx
+++ b/frontend/awx/access/common/useRemoveUserFromResource.tsx
@@ -5,23 +5,23 @@ import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 import { useAwxBulkConfirmation } from '../../common/useAwxBulkConfirmation';
-import { User } from '../../interfaces/User';
+import { AwxUser } from '../../interfaces/User';
 import { useUsersColumns } from '../users/hooks/useUsersColumns';
 import { ResourceType } from './ResourceAccessList';
 
 export function useRemoveUsersFromResource() {
   const { t } = useTranslation();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const confirmationColumns = useUsersColumns();
-  const removeUserConfirmationDialog = useAwxBulkConfirmation<User>();
+  const removeUserConfirmationDialog = useAwxBulkConfirmation<AwxUser>();
 
   const postRequest = usePostRequest();
 
   const removeUsersFromResource = useCallback(
-    (users: User[], resource: ResourceType, onComplete?: (users: User[]) => void) => {
+    (users: AwxUser[], resource: ResourceType, onComplete?: (users: AwxUser[]) => void) => {
       const canRemoveUsers: boolean =
-        activeUser?.is_superuser || resource?.summary_fields?.user_capabilities?.edit;
-      const cannotRemoveUser = (user: User) => {
+        activeAwxUser?.is_superuser || resource?.summary_fields?.user_capabilities?.edit;
+      const cannotRemoveUser = (user: AwxUser) => {
         if (user.is_superuser) {
           return t('System administrators have unrestricted access to all resources.');
         }
@@ -48,7 +48,7 @@ export function useRemoveUsersFromResource() {
         }),
         actionButtonText: t('Remove user', { count: users.length }),
         items: users.sort((l, r) => compareStrings(l.username, r.username)),
-        keyFn: (user: User) => user.id,
+        keyFn: (user: AwxUser) => user.id,
         alertPrompts:
           undeletableUsers.length > 0
             ? [
@@ -63,9 +63,9 @@ export function useRemoveUsersFromResource() {
         isItemNonActionable: cannotRemoveUser,
         isDanger: true,
         confirmationColumns,
-        actionColumns: [{ header: 'User', cell: (user: User) => user.username }],
+        actionColumns: [{ header: 'User', cell: (user: AwxUser) => user.username }],
         onComplete,
-        actionFn: async (user: User, signal: AbortSignal) => {
+        actionFn: async (user: AwxUser, signal: AbortSignal) => {
           if (user.user_roles) {
             for (const role of user.user_roles) {
               await postRequest(
@@ -81,7 +81,7 @@ export function useRemoveUsersFromResource() {
         },
       });
     },
-    [activeUser?.is_superuser, confirmationColumns, removeUserConfirmationDialog, postRequest, t]
+    [activeAwxUser?.is_superuser, confirmationColumns, removeUserConfirmationDialog, postRequest, t]
   );
   return removeUsersFromResource;
 }

--- a/frontend/awx/access/common/useUserAndTeamRolesLists.tsx
+++ b/frontend/awx/access/common/useUserAndTeamRolesLists.tsx
@@ -1,4 +1,4 @@
-import { AccessRole, User } from '../../interfaces/User';
+import { AccessRole, AwxUser } from '../../interfaces/User';
 
 type Access = {
   descendant_roles: string[];
@@ -8,8 +8,8 @@ type Access = {
 /**
  * Contruct the user_roles and team_roles lists for a user based on their access
  */
-export function useUserAndTeamRolesLists(users: User[]) {
-  function sortRoles(access: Access, user: User) {
+export function useUserAndTeamRolesLists(users: AwxUser[]) {
+  function sortRoles(access: Access, user: AwxUser) {
     const { role } = access;
     if (role.team_id) {
       user.team_roles?.push(role);

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -32,13 +32,13 @@ export function CreateCredential() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const navigate = useNavigate();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const postRequest = usePostRequest<Credential>();
   const getPageUrl = useGetPageUrl();
   const onSubmit: PageFormSubmitHandler<CredentialForm> = async (credential) => {
     // can send only one of org, user, team
     if (!credential.organization) {
-      credential.user = activeUser?.id;
+      credential.user = activeAwxUser?.id;
     }
     const newCredential = await postRequest(awxAPI`/credentials/`, credential);
     pageNavigate(AwxRoute.CredentialDetails, { params: { id: newCredential.id } });
@@ -69,14 +69,14 @@ export function EditCredential() {
   const params = useParams<{ id?: string }>();
   const id = Number(params.id);
   const { data: credential } = useGet<Credential>(awxAPI`/credentials/${id.toString()}/`);
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const getPageUrl = useGetPageUrl();
   const patch = usePatchRequest();
 
   const onSubmit: PageFormSubmitHandler<CredentialForm> = async (editedCredential) => {
     // can send only one of org, user, team
     if (!editedCredential.organization) {
-      editedCredential.user = activeUser?.id;
+      editedCredential.user = activeAwxUser?.id;
     }
     await patch(awxAPI`/credentials/${id.toString()}/`, editedCredential);
     navigate(-1);

--- a/frontend/awx/access/organizations/hooks/useAddOrganizationsToUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useAddOrganizationsToUsers.tsx
@@ -4,7 +4,7 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
 export function useAddOrganizationsToUsers() {
   const { t } = useTranslation();
@@ -13,7 +13,7 @@ export function useAddOrganizationsToUsers() {
 
   const addUserToOrganizations = useCallback(
     (
-      users: User[],
+      users: AwxUser[],
       organizations: Organization[],
       onComplete?: (organizations: Organization[]) => void
     ) => {

--- a/frontend/awx/access/organizations/hooks/useRemoveOrganizationsFromUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useRemoveOrganizationsFromUsers.tsx
@@ -4,7 +4,7 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
 export function useRemoveOrganizationsFromUsers() {
   const { t } = useTranslation();
@@ -12,7 +12,7 @@ export function useRemoveOrganizationsFromUsers() {
   const postRequest = usePostRequest<{ id: number; disassociate: boolean }, Organization>();
   const removeUserToOrganizations = useCallback(
     (
-      users: User[],
+      users: AwxUser[],
       organizations: Organization[],
       onComplete?: (organizations: Organization[]) => void
     ) => {

--- a/frontend/awx/access/organizations/hooks/useSelectOrganizationsAddUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useSelectOrganizationsAddUsers.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useAddOrganizationsToUsers } from './useAddOrganizationsToUsers';
 import { useSelectOrganizations } from './useSelectOrganizations';
 
@@ -10,7 +10,7 @@ export function useSelectOrganizationsAddUsers(onClose?: (organizations: Organiz
   const selectOrganizations = useSelectOrganizations();
   const addOrganizationsToUsers = useAddOrganizationsToUsers();
   const selectOrganizationsAddUsers = useCallback(
-    (users: User[]) => {
+    (users: AwxUser[]) => {
       selectOrganizations(
         t('Add users to organizations', { count: users.length }),
         (organizations: Organization[]) => {

--- a/frontend/awx/access/organizations/hooks/useSelectOrganizationsRemoveUsers.tsx
+++ b/frontend/awx/access/organizations/hooks/useSelectOrganizationsRemoveUsers.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveOrganizationsFromUsers } from './useRemoveOrganizationsFromUsers';
 import { useSelectOrganizations } from './useSelectOrganizations';
 
@@ -12,7 +12,7 @@ export function useSelectOrganizationsRemoveUsers(
   const selectOrganizations = useSelectOrganizations();
   const removeOrganizationsFromUsers = useRemoveOrganizationsFromUsers();
   const selectOrganizationsRemoveUsers = useCallback(
-    (users: User[]) => {
+    (users: AwxUser[]) => {
       selectOrganizations(
         t('Remove users from organizations', { count: users.length }),
         (organizations: Organization[]) => {

--- a/frontend/awx/access/roles/AddRolesForm.tsx
+++ b/frontend/awx/access/roles/AddRolesForm.tsx
@@ -10,7 +10,7 @@ import { AwxPageForm } from '../../common/AwxPageForm';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../common/useAwxBulkActionDialog';
 import { Team } from '../../interfaces/Team';
-import { User } from '../../interfaces/User';
+import { AwxUser } from '../../interfaces/User';
 import { PageFormInventorySelect } from '../../resources/inventories/components/PageFormInventorySelect';
 import { PageFormProjectSelect } from '../../resources/projects/components/PageFormProjectSelect';
 import { PageFormJobTemplateSelect } from '../../resources/templates/components/PageFormJobTemplateSelect';
@@ -21,7 +21,7 @@ import { AwxResourceTypeRoles, useAwxRoles } from './useAwxRoles';
 
 interface UserRole {
   index: number;
-  user: User;
+  user: AwxUser;
   resource: { name: string };
   roleId: number;
   roleName: string;
@@ -37,7 +37,7 @@ interface TeamRole {
 
 type AddRole = UserRole | TeamRole;
 
-export function AddRolesForm(props: { users?: User[]; teams?: Team[]; onClose?: () => void }) {
+export function AddRolesForm(props: { users?: AwxUser[]; teams?: Team[]; onClose?: () => void }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const openBulkActionDialog = useAwxBulkActionDialog<AddRole>();

--- a/frontend/awx/access/teams/hooks/useAddTeamsToUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useAddTeamsToUsers.tsx
@@ -4,14 +4,14 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
 export function useAddTeamsToUsers() {
   const { t } = useTranslation();
   const teamProgressDialog = useAwxBulkActionDialog<Team>();
   const postRequest = usePostRequest();
   const addTeamsToUser = useCallback(
-    (teams: Team[], users: User[], onComplete?: (teams: Team[]) => void) => {
+    (teams: Team[], users: AwxUser[], onComplete?: (teams: Team[]) => void) => {
       teamProgressDialog({
         title: t('Adding user to teams', { count: teams.length }),
         keyFn: (team: Team) => team.id,

--- a/frontend/awx/access/teams/hooks/useRemoveTeamsFromUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useRemoveTeamsFromUsers.tsx
@@ -4,14 +4,14 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
 export function useRemoveTeamsFromUsers(onComplete?: (team: Team[]) => void) {
   const { t } = useTranslation();
   const bulkProgressDialog = useAwxBulkActionDialog<Team>();
   const postRequest = usePostRequest();
   const removeUserToTeams = useCallback(
-    (users: User[], teams: Team[]) => {
+    (users: AwxUser[], teams: Team[]) => {
       bulkProgressDialog({
         title: t('Removing user from teams', {
           count: teams.length,

--- a/frontend/awx/access/teams/hooks/useSelectTeamsAddUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useSelectTeamsAddUsers.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useAddTeamsToUsers } from './useAddTeamsToUsers';
 import { useSelectTeams } from './useSelectTeams';
 
@@ -10,7 +10,7 @@ export function useSelectTeamsAddUsers(onClose?: (teams: Team[]) => void) {
   const selectTeams = useSelectTeams();
   const addTeamsToUsers = useAddTeamsToUsers();
   const selectTeamsAddUsers = useCallback(
-    (users: User[]) => {
+    (users: AwxUser[]) => {
       selectTeams(t('Add users to teams', { count: users.length }), (teams: Team[]) => {
         addTeamsToUsers(teams, users, onClose);
       });

--- a/frontend/awx/access/teams/hooks/useSelectTeamsRemoveUsers.tsx
+++ b/frontend/awx/access/teams/hooks/useSelectTeamsRemoveUsers.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveTeamsFromUsers } from './useRemoveTeamsFromUsers';
 import { useSelectTeams } from './useSelectTeams';
 
@@ -10,7 +10,7 @@ export function useSelectTeamsRemoveUsers(onClose?: (teams: Team[]) => void) {
   const selectTeams = useSelectTeams();
   const removeTeamsFromUsers = useRemoveTeamsFromUsers(onClose);
   const selectTeamsRemoveUsers = useCallback(
-    (users: User[]) => {
+    (users: AwxUser[]) => {
       selectTeams(t('Remove users from teams', { count: users.length }), (teams: Team[]) => {
         removeTeamsFromUsers(users, teams);
       });

--- a/frontend/awx/access/teams/hooks/useTeamActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamActions.tsx
@@ -25,7 +25,7 @@ export function useTeamActions(options: {
   const deleteTeams = useDeleteTeams(onTeamsDeleted);
   const selectUsersAddTeams = useSelectUsersAddTeams();
   const selectAndRemoveUsersFromTeam = useSelectAndRemoveUsersFromTeam();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
 
   return useMemo(() => {
     const cannotDeleteTeam = (team: Team) =>
@@ -37,13 +37,13 @@ export function useTeamActions(options: {
         ? ''
         : t(`The team cannot be edited due to insufficient permissions.`);
     const cannotRemoveUsers = (team: Team) =>
-      activeUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
+      activeAwxUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
         ? ''
         : t(
             `You do not have permission to remove users. Please contact your organization administrator if there is an issue with your access.`
           );
     const cannotAddUsers = (team: Team) =>
-      activeUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
+      activeAwxUser?.is_superuser || team?.summary_fields?.user_capabilities?.edit
         ? ''
         : t(
             `You do not have permission to add users. Please contact your organization administrator if there is an issue with your access.`
@@ -90,7 +90,7 @@ export function useTeamActions(options: {
     ];
     return actions;
   }, [
-    activeUser?.is_superuser,
+    activeAwxUser?.is_superuser,
     deleteTeams,
     pageNavigate,
     selectAndRemoveUsersFromTeam,

--- a/frontend/awx/access/users/UserForm.tsx
+++ b/frontend/awx/access/users/UserForm.tsx
@@ -16,7 +16,7 @@ import { requestGet, requestPatch, swrOptions } from '../../../common/crud/Data'
 import { usePostRequest } from '../../../common/crud/usePostRequest';
 import { AwxPageForm } from '../../common/AwxPageForm';
 import { awxAPI } from '../../common/api/awx-utils';
-import { User } from '../../interfaces/User';
+import { AwxUser } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
 
@@ -30,7 +30,7 @@ export function CreateUser() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const navigate = useNavigate();
-  const postRequest = usePostRequest<User, User>();
+  const postRequest = usePostRequest<AwxUser, AwxUser>();
   const onSubmit: PageFormSubmitHandler<IUserInput> = async (
     userInput,
     setError,
@@ -81,7 +81,7 @@ export function EditUser() {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id?: string }>();
   const id = Number(params.id);
-  const { data: user } = useSWR<User>(awxAPI`/users/${id.toString()}/`, requestGet, swrOptions);
+  const { data: user } = useSWR<AwxUser>(awxAPI`/users/${id.toString()}/`, requestGet, swrOptions);
 
   const onSubmit: PageFormSubmitHandler<IUserInput> = async (
     userInput: IUserInput,
@@ -97,7 +97,7 @@ export function EditUser() {
         return false;
       }
     }
-    const newUser = await requestPatch<User>(awxAPI`/users/${id.toString()}/`, user);
+    const newUser = await requestPatch<AwxUser>(awxAPI`/users/${id.toString()}/`, user);
     pageNavigate(AwxRoute.UserDetails, { params: { id: newUser.id } });
   };
 
@@ -149,7 +149,7 @@ export function EditUser() {
   );
 }
 
-type IUserInput = User & { userType: string; confirmPassword: string };
+type IUserInput = AwxUser & { userType: string; confirmPassword: string };
 
 function UserInputs(props: { mode: 'create' | 'edit' }) {
   const { mode } = props;

--- a/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
@@ -7,13 +7,13 @@ import { useGet, useGetItem } from '../../../../common/crud/useGet';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
 export function AwxUserDetails() {
   const params = useParams<{ id: string }>();
   const getPageUrl = useGetPageUrl();
-  const { data: user } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { data: user } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
   const itemsResponse = useGet<AwxItemsResponse<Organization>>(
     user?.related?.organizations as string
   );

--- a/frontend/awx/access/users/UserPage/UserOrganizations.tsx
+++ b/frontend/awx/access/users/UserPage/UserOrganizations.tsx
@@ -15,7 +15,7 @@ import { useGetItem } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import {
   useOrganizationsColumns,
   useOrganizationsFilters,
@@ -25,7 +25,7 @@ import { useSelectOrganizationsAddUsers } from '../../organizations/hooks/useSel
 
 export function UserOrganizations() {
   const params = useParams<{ id: string }>();
-  const { data: user } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { data: user } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
 
   if (!user) {
     return null;
@@ -33,7 +33,7 @@ export function UserOrganizations() {
   return <UserOrganizationsInternal user={user} />;
 }
 
-function UserOrganizationsInternal(props: { user: User }) {
+function UserOrganizationsInternal(props: { user: AwxUser }) {
   const { t } = useTranslation();
   const { user } = props;
   const toolbarFilters = useOrganizationsFilters();

--- a/frontend/awx/access/users/UserPage/UserPage.tsx
+++ b/frontend/awx/access/users/UserPage/UserPage.tsx
@@ -19,24 +19,24 @@ import { LoadingPage } from '../../../../../framework/components/LoadingPage';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { AwxError } from '../../../common/AwxError';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useDeleteUsers } from '../hooks/useDeleteUsers';
 
 export function UserPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { error, data: user, refresh } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { error, data: user, refresh } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
   const pageNavigate = usePageNavigate();
 
-  const deleteUsers = useDeleteUsers((deleted: User[]) => {
+  const deleteUsers = useDeleteUsers((deleted: AwxUser[]) => {
     if (deleted.length > 0) {
       pageNavigate(AwxRoute.Users);
     }
   });
 
-  const itemActions: IPageAction<User>[] = useMemo(() => {
-    const itemActions: IPageAction<User>[] = [
+  const itemActions: IPageAction<AwxUser>[] = useMemo(() => {
+    const itemActions: IPageAction<AwxUser>[] = [
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -73,7 +73,7 @@ export function UserPage() {
           { label: user.username },
         ]}
         headerActions={
-          <PageActions<User>
+          <PageActions<AwxUser>
             actions={itemActions}
             position={DropdownPosition.right}
             selectedItem={user}

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
 } from '@patternfly/react-core';
-import { CubesIcon, PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -21,14 +21,14 @@ import { useGetItem } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { Role } from '../../../interfaces/Role';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useRolesColumns } from '../../roles/useRolesColumns';
 import { useRolesFilters } from '../../roles/useRolesFilters';
 
 export function UserRoles() {
   const params = useParams<{ id: string }>();
-  const { data: user } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { data: user } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
 
   if (!user) {
     return null;
@@ -36,7 +36,7 @@ export function UserRoles() {
   return <UserRolesInternal user={user} />;
 }
 
-function UserRolesInternal(props: { user: User }) {
+function UserRolesInternal(props: { user: AwxUser }) {
   const { user } = props;
   const { t } = useTranslation();
   const toolbarFilters = useRolesFilters();

--- a/frontend/awx/access/users/UserPage/UserTeams.tsx
+++ b/frontend/awx/access/users/UserPage/UserTeams.tsx
@@ -17,7 +17,7 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveTeamsFromUsers } from '../../teams/hooks/useRemoveTeamsFromUsers';
 import { useSelectTeamsAddUsers } from '../../teams/hooks/useSelectTeamsAddUsers';
 import { useTeamsColumns } from '../../teams/hooks/useTeamsColumns';
@@ -25,7 +25,7 @@ import { useTeamsFilters } from '../../teams/hooks/useTeamsFilters';
 
 export function UserTeams() {
   const params = useParams<{ id: string }>();
-  const { data: user } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { data: user } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
 
   if (!user) {
     return null;
@@ -33,7 +33,7 @@ export function UserTeams() {
   return <UserTeamsInternal user={user} />;
 }
 
-function UserTeamsInternal(props: { user: User }) {
+function UserTeamsInternal(props: { user: AwxUser }) {
   const { user } = props;
   const { t } = useTranslation();
   const toolbarFilters = useTeamsFilters();

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -20,12 +20,13 @@ import {
 } from '../../../../framework';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { useOptions } from '../../../common/crud/useOptions';
+import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxConfig } from '../../common/useAwxConfig';
 import { useAwxView } from '../../common/useAwxView';
 import { getDocsBaseUrl } from '../../common/util/getDocsBaseUrl';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
-import { User } from '../../interfaces/User';
+import { AwxUser } from '../../interfaces/User';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { useSelectOrganizationsAddUsers } from '../organizations/hooks/useSelectOrganizationsAddUsers';
 import { useSelectOrganizationsRemoveUsers } from '../organizations/hooks/useSelectOrganizationsRemoveUsers';
@@ -34,7 +35,6 @@ import { useSelectTeamsRemoveUsers } from '../teams/hooks/useSelectTeamsRemoveUs
 import { useDeleteUsers } from './hooks/useDeleteUsers';
 import { useUsersColumns } from './hooks/useUsersColumns';
 import { useUsersFilters } from './hooks/useUsersFilters';
-import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 
 export function Users() {
   const { t } = useTranslation();
@@ -48,7 +48,7 @@ export function Users() {
 
   const tableColumns = useUsersColumns();
 
-  const view = useAwxView<User>({ url: awxAPI`/users/`, toolbarFilters, tableColumns });
+  const view = useAwxView<AwxUser>({ url: awxAPI`/users/`, toolbarFilters, tableColumns });
 
   const deleteUsers = useDeleteUsers(view.unselectItemsAndRefresh);
 
@@ -60,7 +60,7 @@ export function Users() {
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/users/`);
   const canCreateUser = Boolean(data && data.actions && data.actions['POST']);
 
-  const toolbarActions = useMemo<IPageAction<User>[]>(
+  const toolbarActions = useMemo<IPageAction<AwxUser>[]>(
     () => [
       {
         type: PageActionType.Link,
@@ -129,12 +129,12 @@ export function Users() {
     ]
   );
 
-  const rowActions = useMemo<IPageAction<User>[]>(() => {
-    const cannotDeleteUser = (user: User) =>
+  const rowActions = useMemo<IPageAction<AwxUser>[]>(() => {
+    const cannotDeleteUser = (user: AwxUser) =>
       user?.summary_fields?.user_capabilities?.delete
         ? ''
         : t(`The user cannot be deleted due to insufficient permissions.`);
-    const cannotEditUser = (user: User) =>
+    const cannotEditUser = (user: AwxUser) =>
       user?.summary_fields?.user_capabilities?.edit
         ? ''
         : t(`The user cannot be edited due to insufficient permissions.`);
@@ -147,7 +147,7 @@ export function Users() {
         isPinned: true,
         icon: PencilAltIcon,
         label: t('Edit user'),
-        isDisabled: (user: User) => cannotEditUser(user),
+        isDisabled: (user: AwxUser) => cannotEditUser(user),
         onClick: (user) => pageNavigate(AwxRoute.EditUser, { params: { id: user.id } }),
       },
       { type: PageActionType.Seperator },
@@ -186,7 +186,7 @@ export function Users() {
         selection: PageActionSelection.Single,
         icon: TrashIcon,
         label: t('Delete user'),
-        isDisabled: (user: User) => cannotDeleteUser(user),
+        isDisabled: (user: AwxUser) => cannotDeleteUser(user),
         onClick: (user) => deleteUsers([user]),
         isDanger: true,
       },
@@ -217,7 +217,7 @@ export function Users() {
         )}
         headerActions={<ActivityStreamIcon type={'user'} />}
       />
-      <PageTable<User>
+      <PageTable<AwxUser>
         id="awx-users-table"
         toolbarFilters={toolbarFilters}
         toolbarActions={toolbarActions}
@@ -251,14 +251,14 @@ export function AccessTable(props: { url: string }) {
   const toolbarFilters = useUsersFilters();
   const tableColumns = useUsersColumns();
   const getPageUrl = useGetPageUrl();
-  const view = useAwxView<User>({
+  const view = useAwxView<AwxUser>({
     url: props.url,
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
 
-  const toolbarActions = useMemo<IPageAction<User>[]>(
+  const toolbarActions = useMemo<IPageAction<AwxUser>[]>(
     () => [
       {
         type: PageActionType.Link,
@@ -285,7 +285,7 @@ export function AccessTable(props: { url: string }) {
     [getPageUrl, t]
   );
 
-  const rowActions = useMemo<IPageAction<User>[]>(
+  const rowActions = useMemo<IPageAction<AwxUser>[]>(
     () => [
       {
         type: PageActionType.Button,
@@ -301,7 +301,7 @@ export function AccessTable(props: { url: string }) {
   const pageNavigate = usePageNavigate();
 
   return (
-    <PageTable<User>
+    <PageTable<AwxUser>
       id="awx-users-table"
       toolbarFilters={toolbarFilters}
       toolbarActions={toolbarActions}

--- a/frontend/awx/access/users/components/AddRolesToUser.tsx
+++ b/frontend/awx/access/users/components/AddRolesToUser.tsx
@@ -5,13 +5,13 @@ import { LoadingPage } from '../../../../../framework/components/LoadingPage';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { AwxError } from '../../../common/AwxError';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { AddRolesForm } from '../../roles/AddRolesForm';
 
 export function AddRolesToUser() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const { error, data: user, refresh } = useGetItem<User>(awxAPI`/users`, params.id);
+  const { error, data: user, refresh } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
   const navigate = useNavigate();
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;

--- a/frontend/awx/access/users/components/UserRoles.tsx
+++ b/frontend/awx/access/users/components/UserRoles.tsx
@@ -1,8 +1,8 @@
 import { Chip, ChipGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
-export function UserRoles(props: { user: User }) {
+export function UserRoles(props: { user: AwxUser }) {
   const { user } = props;
   const { t } = useTranslation();
   return (

--- a/frontend/awx/access/users/hooks/useAddUsersToResources.tsx
+++ b/frontend/awx/access/users/hooks/useAddUsersToResources.tsx
@@ -3,21 +3,21 @@ import { useTranslation } from 'react-i18next';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { ResourceType } from '../../common/ResourceAccessList';
 
 export function useAddUsersToResources() {
   const { t } = useTranslation();
-  const userProgressDialog = useAwxBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<AwxUser>();
   const postRequest = usePostRequest();
   const addUserToTeams = useCallback(
-    (users: User[], resources: ResourceType[], onComplete?: (users: User[]) => void) => {
+    (users: AwxUser[], resources: ResourceType[], onComplete?: (users: AwxUser[]) => void) => {
       userProgressDialog({
         title: t('Adding users', { count: resources.length }),
-        keyFn: (user: User) => user.id,
+        keyFn: (user: AwxUser) => user.id,
         items: users,
-        actionColumns: [{ header: 'User', cell: (user: User) => user.username }],
-        actionFn: async (user: User, signal: AbortSignal) => {
+        actionColumns: [{ header: 'User', cell: (user: AwxUser) => user.username }],
+        actionFn: async (user: AwxUser, signal: AbortSignal) => {
           for (const resource of resources) {
             await postRequest(
               awxAPI`/users/${user.id.toString()}/roles/`,

--- a/frontend/awx/access/users/hooks/useDeleteUsers.tsx
+++ b/frontend/awx/access/users/hooks/useDeleteUsers.tsx
@@ -4,29 +4,29 @@ import { compareStrings, TextCell } from '../../../../../framework';
 import { getItemKey, requestDelete } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useUsersColumns } from './useUsersColumns';
 
-export function useDeleteUsers(onComplete: (users: User[]) => void) {
+export function useDeleteUsers(onComplete: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useUsersColumns({ disableLinks: true, disableSort: true });
   const deleteActionNameColumn = useMemo(
     () => ({
       header: t('Username'),
-      cell: (user: User) => <TextCell text={user.username} />,
+      cell: (user: AwxUser) => <TextCell text={user.username} />,
       sort: 'username',
       maxWidth: 200,
     }),
     [t]
   );
   const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const cannotDeleteUser = (user: User) => {
+  const cannotDeleteUser = (user: AwxUser) => {
     return user?.summary_fields?.user_capabilities?.delete
       ? undefined
       : t('The user cannot be deleted due to insufficient permissions.');
   };
-  const bulkAction = useAwxBulkConfirmation<User>();
-  const deleteUsers = (users: User[]) => {
+  const bulkAction = useAwxBulkConfirmation<AwxUser>();
+  const deleteUsers = (users: AwxUser[]) => {
     const undeletableUsers = users.filter(cannotDeleteUser);
 
     bulkAction({
@@ -53,7 +53,7 @@ export function useDeleteUsers(onComplete: (users: User[]) => void) {
       confirmationColumns,
       actionColumns,
       onComplete,
-      actionFn: (user: User, signal) =>
+      actionFn: (user: AwxUser, signal) =>
         requestDelete(awxAPI`/users/${user.id.toString()}/`, signal),
     });
   };

--- a/frontend/awx/access/users/hooks/useRemoveUsersFromOrganizations.tsx
+++ b/frontend/awx/access/users/hooks/useRemoveUsersFromOrganizations.tsx
@@ -4,22 +4,22 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
-export function useRemoveUsersFromOrganizations(onComplete?: (users: User[]) => void) {
+export function useRemoveUsersFromOrganizations(onComplete?: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
-  const userProgressDialog = useAwxBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<AwxUser>();
   const postRequest = usePostRequest();
   const removeUserToOrganizations = useCallback(
-    (users: User[], organizations: Organization[]) => {
+    (users: AwxUser[], organizations: Organization[]) => {
       userProgressDialog({
         title: t('Removing users from organizations', {
           count: organizations.length,
         }),
-        keyFn: (user: User) => user.id,
+        keyFn: (user: AwxUser) => user.id,
         items: users,
-        actionColumns: [{ header: t('User'), cell: (user: User) => user.username }],
-        actionFn: async (user: User, signal: AbortSignal) => {
+        actionColumns: [{ header: t('User'), cell: (user: AwxUser) => user.username }],
+        actionFn: async (user: AwxUser, signal: AbortSignal) => {
           for (const organization of organizations) {
             await postRequest(
               awxAPI`/users/${user.id.toString()}/roles/`,

--- a/frontend/awx/access/users/hooks/useRemoveUsersFromTeams.tsx
+++ b/frontend/awx/access/users/hooks/useRemoveUsersFromTeams.tsx
@@ -4,22 +4,22 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxBulkActionDialog } from '../../../common/useAwxBulkActionDialog';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 
 export function useRemoveUsersFromTeams() {
   const { t } = useTranslation();
-  const userProgressDialog = useAwxBulkActionDialog<User>();
+  const userProgressDialog = useAwxBulkActionDialog<AwxUser>();
   const postRequest = usePostRequest();
   const removeUserToTeams = useCallback(
-    (users: User[], teams: Team[], onComplete?: (users: User[]) => void) => {
+    (users: AwxUser[], teams: Team[], onComplete?: (users: AwxUser[]) => void) => {
       userProgressDialog({
         title: t('Removing users from teams', {
           count: teams.length,
         }),
-        keyFn: (user: User) => user.id,
+        keyFn: (user: AwxUser) => user.id,
         items: users,
-        actionColumns: [{ header: t('User'), cell: (user: User) => user.username }],
-        actionFn: async (user: User, signal: AbortSignal) => {
+        actionColumns: [{ header: t('User'), cell: (user: AwxUser) => user.username }],
+        actionFn: async (user: AwxUser, signal: AbortSignal) => {
           for (const team of teams) {
             await postRequest(
               awxAPI`/users/${user.id.toString()}/roles/`,

--- a/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
+++ b/frontend/awx/access/users/hooks/useSelectAndRemoveUsersFromTeam.tsx
@@ -2,11 +2,11 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveUsersFromResource } from '../../common/useRemoveUserFromResource';
 import { useSelectUsers } from './useSelectUsers';
 
-export function useSelectAndRemoveUsersFromTeam(onClose?: (users: User[]) => void) {
+export function useSelectAndRemoveUsersFromTeam(onClose?: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
   const selectUsers = useSelectUsers();
   const removeUsersFromTeams = useRemoveUsersFromResource();
@@ -15,7 +15,7 @@ export function useSelectAndRemoveUsersFromTeam(onClose?: (users: User[]) => voi
     (team: Team) => {
       selectUsers(
         t('Remove users from team'),
-        (users: User[]) => {
+        (users: AwxUser[]) => {
           removeUsersFromTeams(users, team, onClose);
         },
         t('Remove user(s)'),

--- a/frontend/awx/access/users/hooks/useSelectUsers.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsers.tsx
@@ -4,7 +4,7 @@ import { usePageDialog } from '../../../../../framework';
 import { MultiSelectDialog } from '../../../../../framework/PageDialogs/MultiSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useUserAndTeamRolesLists } from '../../common/useUserAndTeamRolesLists';
 import { useUsersColumns } from './useUsersColumns';
 import { useUsersFilters } from './useUsersFilters';
@@ -12,19 +12,19 @@ import { useUsersFilters } from './useUsersFilters';
 function SelectUsers(props: {
   accessUrl?: string;
   title: string;
-  onSelect: (users: User[]) => void;
+  onSelect: (users: AwxUser[]) => void;
   confirmText?: string;
 }) {
   const { t } = useTranslation();
   const toolbarFilters = useUsersFilters();
   const tableColumns = useUsersColumns({ disableLinks: true });
-  const view = useAwxView<User>({
+  const view = useAwxView<AwxUser>({
     url: props.accessUrl ?? awxAPI`/users/`,
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
   });
-  useUserAndTeamRolesLists(view.pageItems as User[]);
+  useUserAndTeamRolesLists(view.pageItems as AwxUser[]);
 
   return (
     <MultiSelectDialog
@@ -43,7 +43,7 @@ export function useSelectUsers() {
   const openSelectUsers = useCallback(
     (
       title: string,
-      onSelect: (users: User[]) => void,
+      onSelect: (users: AwxUser[]) => void,
       confirmText?: string,
       accessUrl?: string
     ) => {

--- a/frontend/awx/access/users/hooks/useSelectUsersAddOrganizations.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsersAddOrganizations.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useAddUsersToResources } from './useAddUsersToResources';
 import { useSelectUsers } from './useSelectUsers';
 
@@ -13,7 +13,7 @@ export function useSelectUsersAddOrganizations() {
     (organizations: Organization[]) => {
       selectUsers(
         t('Add users to organizations', { count: organizations.length }),
-        (users: User[]) => {
+        (users: AwxUser[]) => {
           addUsersToResources(users, organizations);
         }
       );

--- a/frontend/awx/access/users/hooks/useSelectUsersAddTeams.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsersAddTeams.tsx
@@ -1,17 +1,17 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { ResourceType } from '../../common/ResourceAccessList';
 import { useAddUsersToResources } from './useAddUsersToResources';
 import { useSelectUsers } from './useSelectUsers';
 
-export function useSelectUsersAddTeams(onClose?: (users: User[]) => void) {
+export function useSelectUsersAddTeams(onClose?: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
   const selectUsers = useSelectUsers();
   const addUsersToResources = useAddUsersToResources();
   const selectUsersAddTeams = useCallback(
     (teams: ResourceType[]) => {
-      selectUsers(t('Add users to teams', { count: teams.length }), (users: User[]) => {
+      selectUsers(t('Add users to teams', { count: teams.length }), (users: AwxUser[]) => {
         addUsersToResources(users, teams, onClose);
       });
     },

--- a/frontend/awx/access/users/hooks/useSelectUsersRemoveOrganizations.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsersRemoveOrganizations.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Organization } from '../../../interfaces/Organization';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveUsersFromOrganizations } from './useRemoveUsersFromOrganizations';
 import { useSelectUsers } from './useSelectUsers';
 
-export function useSelectUsersRemoveOrganizations(onClose?: (users: User[]) => void) {
+export function useSelectUsersRemoveOrganizations(onClose?: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
   const selectUsers = useSelectUsers();
   const removeUsersFromOrganizations = useRemoveUsersFromOrganizations(onClose);
@@ -13,7 +13,7 @@ export function useSelectUsersRemoveOrganizations(onClose?: (users: User[]) => v
     (organizations: Organization[]) => {
       selectUsers(
         t('Remove users from organizations', { count: organizations.length }),
-        (users: User[]) => {
+        (users: AwxUser[]) => {
           removeUsersFromOrganizations(users, organizations);
         },
         t('Remove user(s)')

--- a/frontend/awx/access/users/hooks/useSelectUsersRemoveTeams.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsersRemoveTeams.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Team } from '../../../interfaces/Team';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { useRemoveUsersFromTeams } from './useRemoveUsersFromTeams';
 import { useSelectUsers } from './useSelectUsers';
 
-export function useSelectUsersRemoveTeams(onClose?: (users: User[]) => void) {
+export function useSelectUsersRemoveTeams(onClose?: (users: AwxUser[]) => void) {
   const { t } = useTranslation();
   const selectUsers = useSelectUsers();
   const removeUsersFromTeams = useRemoveUsersFromTeams();
@@ -13,7 +13,7 @@ export function useSelectUsersRemoveTeams(onClose?: (users: User[]) => void) {
     (teams: Team[]) => {
       selectUsers(
         t('Remove users from teams', { count: teams.length }),
-        (users: User[]) => {
+        (users: AwxUser[]) => {
           removeUsersFromTeams(users, teams, onClose);
         },
         t('Remove user(s)')

--- a/frontend/awx/access/users/hooks/useUsersColumns.tsx
+++ b/frontend/awx/access/users/hooks/useUsersColumns.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ITableColumn, TextCell, useGetPageUrl } from '../../../../../framework';
 import { useCreatedColumn } from '../../../../common/columns';
-import { User } from '../../../interfaces/User';
+import { AwxUser } from '../../../interfaces/User';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { UserType } from '../components/UserType';
 
@@ -12,7 +12,7 @@ export function useUsersColumns(options?: { disableLinks?: boolean; disableSort?
   const disableLinks = options?.disableLinks || false;
 
   const createdColumn = useCreatedColumn(options);
-  const tableColumns = useMemo<ITableColumn<User>[]>(
+  const tableColumns = useMemo<ITableColumn<AwxUser>[]>(
     () => [
       {
         header: t('Username'),

--- a/frontend/awx/administration/applications/hooks/useApplicationActions.tsx
+++ b/frontend/awx/administration/applications/hooks/useApplicationActions.tsx
@@ -15,7 +15,7 @@ import { useDeleteApplications } from '../hooks/useDeleteApplications';
 export function useApplicationActions(options: {
   onApplicationsDeleted: (applications: Application[]) => void;
 }) {
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { onApplicationsDeleted } = options;
   const { t } = useTranslation();
   const deleteApplications = useDeleteApplications(onApplicationsDeleted);
@@ -40,7 +40,7 @@ export function useApplicationActions(options: {
         selection: PageActionSelection.Single,
         icon: TrashIcon,
         isHidden: (application) =>
-          !application?.summary_fields.user_capabilities.delete || activeUser?.is_system_auditor
+          !application?.summary_fields.user_capabilities.delete || activeAwxUser?.is_system_auditor
             ? true
             : false,
         label: t('Delete application'),
@@ -54,5 +54,5 @@ export function useApplicationActions(options: {
       },
     ];
     return itemActions;
-  }, [t, pageNavigate, activeUser?.is_system_auditor, deleteApplications]);
+  }, [t, pageNavigate, activeAwxUser?.is_system_auditor, deleteApplications]);
 }

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -72,7 +72,7 @@ export function InstanceDetailsTab(props: {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { instance, instanceGroups, instanceForks, handleInstanceForksSlider } = props;
   const toolTipMap: { [item: string]: string } = useNodeTypeTooltip();
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
@@ -174,7 +174,7 @@ export function InstanceDetailsTab(props: {
               onChange={(_event: SliderOnChangeEvent, value: number) =>
                 void handleInstanceForksSlider(instance, value)
               }
-              isDisabled={!activeUser?.is_superuser || !instance.enabled || !capacityAvailable}
+              isDisabled={!activeAwxUser?.is_superuser || !instance.enabled || !capacityAvailable}
             />
           ) : undefined}
         </PageDetail>

--- a/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
+++ b/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
@@ -1,15 +1,15 @@
 import { Slider, SliderOnChangeEvent, Tooltip } from '@patternfly/react-core';
 import { t } from 'i18next';
 import { Dotted } from '../../../../../framework/components/Dotted';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { Instance } from '../../../interfaces/Instance';
 import { useInstanceActions } from '../hooks/useInstanceActions';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 
 export function InstanceForksSlider(props: { instance: Instance }) {
   const { instance } = props;
   const { instanceForks, handleInstanceForksSlider } = useInstanceActions(String(instance.id));
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
 
   if (instanceForks > 0) {
     return (
@@ -23,7 +23,7 @@ export function InstanceForksSlider(props: { instance: Instance }) {
           onChange={(_event: SliderOnChangeEvent, value: number) =>
             void handleInstanceForksSlider(instance, value)
           }
-          isDisabled={!activeUser?.is_superuser || !instance.enabled || !capacityAvailable}
+          isDisabled={!activeAwxUser?.is_superuser || !instance.enabled || !capacityAvailable}
         />
       </>
     );

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -1,27 +1,27 @@
+import { AlertProps, ButtonVariant } from '@patternfly/react-core';
+import { HeartbeatIcon, MinusCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
+import { TFunction } from 'i18next';
 import pDebounce from 'p-debounce';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  IPageAction,
+  PageActionSelection,
+  PageActionType,
+  usePageAlertToaster,
+  usePageNavigate,
+} from '../../../../../framework';
 import { postRequest, requestGet, requestPatch } from '../../../../common/crud/Data';
+import { useGet, useGetItem } from '../../../../common/crud/useGet';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { Instance } from '../../../interfaces/Instance';
 import { InstanceGroup } from '../../../interfaces/InstanceGroup';
-import { HeartbeatIcon, PencilAltIcon, MinusCircleIcon } from '@patternfly/react-icons';
-import { useTranslation } from 'react-i18next';
-import {
-  usePageNavigate,
-  IPageAction,
-  PageActionType,
-  PageActionSelection,
-  usePageAlertToaster,
-} from '../../../../../framework';
+import { Settings } from '../../../interfaces/Settings';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useRemoveInstances } from './useRemoveInstances';
-import { AlertProps, ButtonVariant } from '@patternfly/react-core';
-import { useGet, useGetItem } from '../../../../common/crud/useGet';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
-import { Settings } from '../../../interfaces/Settings';
-import { useParams } from 'react-router-dom';
-import { TFunction } from 'i18next';
 
 export function useInstanceActions(instanceId: string) {
   const [instance, setInstance] = useState<Instance>();
@@ -112,10 +112,10 @@ export function useInstanceDetailsActions(options: {
   const { data: instance } = useGetItem<Instance>(awxAPI`/instances`, params.id);
 
   const removeInstances = useRemoveInstances(onInstancesRemoved);
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { data } = useGet<Settings>(awxAPI`/settings/system/`);
   const instancesType = instance?.node_type === 'execution' || instance?.node_type === 'hop';
-  const userAccess = activeUser?.is_superuser || activeUser?.is_system_auditor;
+  const userAccess = activeAwxUser?.is_superuser || activeAwxUser?.is_system_auditor;
   const isK8s = data?.IS_K8S;
   const canEditAndRemoveInstances = instancesType && isK8s && userAccess;
   const alertToaster = usePageAlertToaster();

--- a/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
@@ -10,17 +10,17 @@ import {
   usePageNavigate,
 } from '../../../../../framework';
 import { postRequest, requestPatch } from '../../../../common/crud/Data';
-import { awxAPI } from '../../../common/api/awx-utils';
-import { Instance } from '../../../interfaces/Instance';
-import { AwxRoute } from '../../../main/AwxRoutes';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { useGet } from '../../../../common/crud/useGet';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { Instance } from '../../../interfaces/Instance';
 import { Settings } from '../../../interfaces/Settings';
+import { AwxRoute } from '../../../main/AwxRoutes';
 
 export function useInstanceRowActions(onComplete: (instances: Instance[]) => void) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { data } = useGet<Settings>(awxAPI`/settings/system/`);
 
   const alertToaster = usePageAlertToaster();
@@ -31,7 +31,7 @@ export function useInstanceRowActions(onComplete: (instances: Instance[]) => voi
     },
     [onComplete]
   );
-  const userAccess = activeUser?.is_superuser || activeUser?.is_system_auditor;
+  const userAccess = activeAwxUser?.is_superuser || activeAwxUser?.is_system_auditor;
   const isK8s = data?.IS_K8S;
 
   return useMemo<IPageAction<Instance>[]>(

--- a/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
@@ -1,31 +1,35 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { HeartbeatIcon, PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { HeartbeatIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
-import { IAwxView } from '../../../common/useAwxView';
-import { Instance } from '../../../interfaces/Instance';
-import { useRunHealthCheck } from './useRunHealthCheck';
-import { AwxRoute } from '../../../main/AwxRoutes';
-import { usePageNavigate } from '../../../../../framework';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import {
+  IPageAction,
+  PageActionSelection,
+  PageActionType,
+  usePageNavigate,
+} from '../../../../../framework';
 import { useGet } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { IAwxView } from '../../../common/useAwxView';
+import { Instance } from '../../../interfaces/Instance';
 import { Settings } from '../../../interfaces/Settings';
-import { useRemoveInstances } from './useRemoveInstances';
+import { AwxRoute } from '../../../main/AwxRoutes';
 import { cannotRemoveInstances } from './useInstanceActions';
+import { useRemoveInstances } from './useRemoveInstances';
+import { useRunHealthCheck } from './useRunHealthCheck';
 
 export function useInstanceToolbarActions(view: IAwxView<Instance>) {
   const { t } = useTranslation();
   const runHealthCheck = useRunHealthCheck(view.unselectItemsAndRefresh);
   const removeInstances = useRemoveInstances(view.unselectItemsAndRefresh);
   const pageNavigate = usePageNavigate();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { data } = useGet<Settings>(awxAPI`/settings/system/`);
   const isK8s = data?.IS_K8S;
 
   const canAddAndEditInstances =
-    (activeUser?.is_superuser || activeUser?.is_system_auditor) && data?.IS_K8S;
+    (activeAwxUser?.is_superuser || activeAwxUser?.is_system_auditor) && data?.IS_K8S;
 
   const cannotRunHealthCheckDueToPending = useCallback(
     (instance: Instance) => {

--- a/frontend/awx/analytics/Reports/ErrorStates.tsx
+++ b/frontend/awx/analytics/Reports/ErrorStates.tsx
@@ -3,12 +3,12 @@ import { KeyIcon, MonitoringIcon } from '@patternfly/react-icons';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EmptyStateCustom } from '../../../../framework/components/EmptyStateCustom';
-import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 import { EmptyStateError } from '../../../../framework/components/EmptyStateError';
+import { useAwxActiveUser } from '../../common/useAwxActiveUser';
 
 export function AnalyticsErrorState(props: { error?: string }) {
   const { t } = useTranslation();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { error } = props;
 
   interface errorTextsType {
@@ -80,7 +80,7 @@ export function AnalyticsErrorState(props: { error?: string }) {
         <EmptyStateCustom
           title={t('Automation Analytics is currently not enabled to send data.')}
           description={
-            activeUser?.is_superuser
+            activeAwxUser?.is_superuser
               ? t(
                   'Please click the button below to visit the settings page to set your credentials.'
                 )
@@ -88,7 +88,7 @@ export function AnalyticsErrorState(props: { error?: string }) {
           }
           icon={MonitoringIcon}
           button={
-            activeUser?.is_superuser ? (
+            activeAwxUser?.is_superuser ? (
               <Button onClick={() => null}>{t('Go to settings')}</Button>
             ) : undefined
           }
@@ -100,7 +100,7 @@ export function AnalyticsErrorState(props: { error?: string }) {
     );
   }
 
-  return (activeUser?.is_superuser || activeUser?.is_system_auditor) && !!error ? (
+  return (activeAwxUser?.is_superuser || activeAwxUser?.is_system_auditor) && !!error ? (
     <ErrorState error={error} />
   ) : (
     <DisabledState />

--- a/frontend/awx/analytics/Reports/Reports.tsx
+++ b/frontend/awx/analytics/Reports/Reports.tsx
@@ -23,7 +23,7 @@ export interface ReportItemsResponse {
 }
 
 export function Reports() {
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const { data, error } = useSWR<ReportItemsResponse, Error>(
     awxAPI`/analytics/report/automation_calculator/`,
     requestGet
@@ -77,7 +77,11 @@ export function Reports() {
           description={data?.report?.description || ''}
           controls={data ? reportTags : undefined}
         />
-        {activeUser && !activeUser?.is_superuser ? <AnalyticsErrorState /> : <ReportsInternal />}
+        {activeAwxUser && !activeAwxUser?.is_superuser ? (
+          <AnalyticsErrorState />
+        ) : (
+          <ReportsInternal />
+        )}
       </PageLayout>
     </Page>
   );

--- a/frontend/awx/common/useAwxActiveUser.tsx
+++ b/frontend/awx/common/useAwxActiveUser.tsx
@@ -1,33 +1,45 @@
-import { ReactNode, createContext, useContext } from 'react';
-import useSWR, { SWRResponse } from 'swr';
+import { ReactNode, createContext, useContext, useMemo } from 'react';
+import useSWR from 'swr';
 import { requestGet } from '../../common/crud/Data';
-import { User } from '../interfaces/User';
+import { AwxUser } from '../interfaces/User';
 import { AwxItemsResponse } from './AwxItemsResponse';
 import { awxAPI } from './api/awx-utils';
 
-export const AwxActiveUserContext = createContext<SWRResponse<AwxItemsResponse<User>> | undefined>(
-  undefined
-);
-
-export function useAwxActiveUser() {
-  const context = useContext(AwxActiveUserContext);
-  const itemsResponse = context?.data;
-  if (!itemsResponse) return undefined;
-  if (!itemsResponse.results) return undefined;
-  if (!itemsResponse.results.length) return undefined;
-  return itemsResponse.results[0];
+interface ActiveUserState {
+  activeAwxUser?: AwxUser;
+  refreshActiveAwxUser?: () => void;
+  activeAwxUserIsLoading?: boolean;
 }
 
-export function useAwxActiveUserContext() {
+export const AwxActiveUserContext = createContext<ActiveUserState>({});
+
+export function useAwxActiveUser() {
   return useContext(AwxActiveUserContext);
 }
 
 export function AwxActiveUserProvider(props: { children: ReactNode }) {
-  const response = useSWR<AwxItemsResponse<User>>(awxAPI`/me/`, requestGet, {
+  const response = useSWR<AwxItemsResponse<AwxUser>>(awxAPI`/me/`, requestGet, {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,
   });
+  const { mutate } = response;
+  const activeAwxUser = useMemo<AwxUser | undefined>(() => {
+    return !response.error && response.data?.results && response.data.results.length > 0
+      ? response.data.results[0]
+      : undefined;
+  }, [response]);
+  const activeAwxUserIsLoading = useMemo<boolean>(
+    () => !response.error && response.isLoading,
+    [response]
+  );
+  const state = useMemo<ActiveUserState>(() => {
+    return {
+      activeAwxUser,
+      refreshActiveAwxUser: () => void mutate(),
+      activeAwxUserIsLoading,
+    };
+  }, [activeAwxUser, activeAwxUserIsLoading, mutate]);
   return (
-    <AwxActiveUserContext.Provider value={response}>{props.children}</AwxActiveUserContext.Provider>
+    <AwxActiveUserContext.Provider value={state}>{props.children}</AwxActiveUserContext.Provider>
   );
 }

--- a/frontend/awx/interfaces/User.ts
+++ b/frontend/awx/interfaces/User.ts
@@ -17,7 +17,8 @@ export type AccessRole = {
     unattach: boolean;
   };
 };
-export interface User extends Omit<SwaggerUser, 'id' | 'username' | 'summary_fields' | 'related'> {
+export interface AwxUser
+  extends Omit<SwaggerUser, 'id' | 'username' | 'summary_fields' | 'related'> {
   id: number;
   username: string;
   user_type?: 'normal' | 'administrator' | 'auditor';

--- a/frontend/awx/main/AwxLogin.tsx
+++ b/frontend/awx/main/AwxLogin.tsx
@@ -5,7 +5,7 @@ import { Login } from '../../common/Login';
 import type { AuthOption } from '../../common/SocialAuthLogin';
 import { requestGet } from '../../common/crud/Data';
 import { awxAPI } from '../common/api/awx-utils';
-import { useAwxActiveUser, useAwxActiveUserContext } from '../common/useAwxActiveUser';
+import { useAwxActiveUser } from '../common/useAwxActiveUser';
 import { AwxConfigProvider } from '../common/useAwxConfig';
 import { WebSocketProvider } from '../common/useAwxWebSocket';
 
@@ -27,10 +27,9 @@ export function AwxLogin(props: { children: React.ReactNode }) {
     });
   }
 
-  const awxActiveUserContext = useAwxActiveUserContext();
-  const awxActiveUser = useAwxActiveUser();
+  const { activeAwxUser, activeAwxUserIsLoading, refreshActiveAwxUser } = useAwxActiveUser();
 
-  if (awxActiveUserContext?.isLoading) {
+  if (activeAwxUserIsLoading) {
     return (
       <Page>
         <LoadingState />
@@ -38,12 +37,12 @@ export function AwxLogin(props: { children: React.ReactNode }) {
     );
   }
 
-  if (!awxActiveUser) {
+  if (!activeAwxUser) {
     return (
       <Login
         authOptions={authOptions}
         apiUrl="/api/login/"
-        onSuccess={() => void awxActiveUserContext?.mutate()}
+        onSuccess={() => refreshActiveAwxUser?.()}
       />
     );
   }

--- a/frontend/awx/main/AwxMasthead.tsx
+++ b/frontend/awx/main/AwxMasthead.tsx
@@ -14,7 +14,7 @@ import { useGet } from '../../common/crud/useGet';
 import { useClearCache } from '../../common/useInvalidateCache';
 import { AwxItemsResponse } from '../common/AwxItemsResponse';
 import { awxAPI } from '../common/api/awx-utils';
-import { useAwxActiveUser, useAwxActiveUserContext } from '../common/useAwxActiveUser';
+import { useAwxActiveUser } from '../common/useAwxActiveUser';
 import { useAwxConfig } from '../common/useAwxConfig';
 import { useAwxWebSocketSubscription } from '../common/useAwxWebSocket';
 import { getDocsBaseUrl } from '../common/util/getDocsBaseUrl';
@@ -28,15 +28,13 @@ export function AwxMasthead() {
   const { clearAllCache } = useClearCache();
   const config = useAwxConfig();
   const pageNavigate = usePageNavigate();
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser, refreshActiveAwxUser } = useAwxActiveUser();
   useAwxNotifications();
-  const activeUserContext = useAwxActiveUserContext();
   const logout = useCallback(async () => {
     await fetch('/api/logout/');
     clearAllCache();
-    void activeUserContext?.mutate();
-  }, [activeUserContext, clearAllCache]);
-
+    refreshActiveAwxUser?.();
+  }, [clearAllCache, refreshActiveAwxUser]);
   return (
     <PageMasthead brand={<AwxBrand style={{ height: 60 }} />}>
       <ToolbarGroup variant="icon-button-group" style={{ flexGrow: 1 }}>
@@ -78,12 +76,12 @@ export function AwxMasthead() {
                 <UserCircleIcon />
               </Icon>
             }
-            label={activeUser?.username}
+            label={activeAwxUser?.username}
           >
             <DropdownItem
               id="user-details"
               label={t('User details')}
-              onClick={() => pageNavigate(AwxRoute.UserPage, { params: { id: activeUser?.id } })}
+              onClick={() => pageNavigate(AwxRoute.UserPage, { params: { id: activeAwxUser?.id } })}
             >
               {t('User details')}
             </DropdownItem>

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -2,6 +2,7 @@ import { ButtonVariant } from '@patternfly/react-core';
 import { PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import {
   IPageAction,
   PageActionSelection,
@@ -15,7 +16,6 @@ import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { InventorySource } from '../../../interfaces/InventorySource';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useDeleteInventorySources } from './useDeleteInventorySources';
-import { useParams } from 'react-router-dom';
 
 type InventorySourceActionOptions = {
   onInventorySourcesDeleted: (inventorySources: InventorySource[]) => void;
@@ -29,7 +29,7 @@ export function useInventorySourceActions({
   const deleteInventorySources = useDeleteInventorySources(onInventorySourcesDeleted);
   const params = useParams<{ inventory_type: string }>();
 
-  const activeUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const alertToaster = usePageAlertToaster();
 
   const postRequest = usePostRequest();
@@ -57,7 +57,7 @@ export function useInventorySourceActions({
 
       if (
         !inventorySource?.summary_fields?.user_capabilities?.delete &&
-        !activeUser?.is_system_auditor
+        !activeAwxUser?.is_system_auditor
       ) {
         return t(`The inventory source cannot be deleted due to insufficient permission`);
       }
@@ -65,12 +65,12 @@ export function useInventorySourceActions({
       return '';
     };
     const cannotEditInventorySource = (inventorySource: InventorySource): string =>
-      inventorySource?.summary_fields?.user_capabilities?.edit && !activeUser?.is_system_auditor
+      inventorySource?.summary_fields?.user_capabilities?.edit && !activeAwxUser?.is_system_auditor
         ? ''
         : t(`The inventory source cannot be edited due to insufficient permission`);
     const cannotLaunchInventorySourceUpdate = (inventorySource: InventorySource): string => {
       return inventorySource.summary_fields.user_capabilities.start &&
-        !activeUser?.is_system_auditor
+        !activeAwxUser?.is_system_auditor
         ? ''
         : t(`The inventory source cannot be updated due to insufficient permission`);
     };
@@ -119,5 +119,5 @@ export function useInventorySourceActions({
       },
     ];
     return itemActions;
-  }, [deleteInventorySources, pageNavigate, handleUpdate, activeUser, t, params.inventory_type]);
+  }, [deleteInventorySources, pageNavigate, handleUpdate, activeAwxUser, t, params.inventory_type]);
 }

--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
@@ -33,7 +33,7 @@ export function ProjectPage() {
   } = useGet<Project>(awxAPI`/projects/${params.id ?? ''}/`);
   const pageNavigate = usePageNavigate();
   const itemActions = useProjectActions(() => pageNavigate(AwxRoute.Projects));
-  const currentUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const {
     data: isNotifAdmin,
     error: isNotifAdminError,
@@ -51,11 +51,11 @@ export function ProjectPage() {
       { label: t('Schedules'), page: AwxRoute.ProjectSchedules },
       { label: t('Job templates'), page: AwxRoute.ProjectJobTemplates },
     ];
-    if (currentUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
+    if (activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
       tabs.push({ label: t('Notifications'), page: AwxRoute.ProjectNotifications });
     }
     return tabs;
-  }, [t, currentUser, isNotifAdmin]);
+  }, [t, activeAwxUser, isNotifAdmin]);
   if (error) return <AwxError error={error} handleRefresh={projectRefresh || refreshNotifAdmin} />;
   if (!project || isProjectLoading || isNotifAdminLoading) return <LoadingPage breadcrumbs tabs />;
 

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -24,7 +24,7 @@ import { useTemplateActions } from '../hooks/useTemplateActions';
 
 export function TemplatePage() {
   const { t } = useTranslation();
-  const currentUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const params = useParams<{ id: string }>();
   const {
     error: templateError,
@@ -55,11 +55,11 @@ export function TemplatePage() {
       { label: t('Jobs'), page: AwxRoute.JobTemplateJobs },
       { label: t('Survey'), page: AwxRoute.JobTemplateSurvey },
     ];
-    if (currentUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
+    if (activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
       tabs.push({ label: t('Notifications'), page: AwxRoute.JobTemplateNotifications });
     }
     return tabs;
-  }, [t, currentUser, isNotifAdmin]);
+  }, [t, activeAwxUser, isNotifAdmin]);
   if (error) return <AwxError error={error} handleRefresh={refresh || refreshNotifAdmin} />;
   if (isTemplateLoading || isNotifAdminLoading) return <LoadingPage breadcrumbs tabs />;
 

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -25,7 +25,7 @@ import { useTemplateActions } from '../hooks/useTemplateActions';
 export function WorkflowJobTemplatePage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  const currentUser = useAwxActiveUser();
+  const { activeAwxUser } = useAwxActiveUser();
   const {
     error: templateError,
     data: template,
@@ -55,12 +55,12 @@ export function WorkflowJobTemplatePage() {
       { label: t('Schedules'), page: AwxRoute.WorkflowJobTemplateSchedules },
       { label: t('Jobs'), page: AwxRoute.WorkflowJobTemplateJobs },
       { label: t('Survey'), page: AwxRoute.WorkflowJobTemplateSurvey },
-      currentUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)
+      activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)
         ? { label: t('Notifications'), page: AwxRoute.WorkflowJobTemplateNotifications }
         : false,
     ],
 
-    [t, currentUser, isNotifAdmin]
+    [t, activeAwxUser, isNotifAdmin]
   );
 
   if (error) return <AwxError error={error} handleRefresh={refresh || refreshNotifAdmin} />;

--- a/frontend/eda/access/users/CreateControllerToken.tsx
+++ b/frontend/eda/access/users/CreateControllerToken.tsx
@@ -48,7 +48,7 @@ export function CreateControllerToken() {
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
   const postRequest = usePostRequest<EdaControllerTokenCreate, EdaControllerToken>();
-  const user = useEdaActiveUser();
+  const { activeEdaUser } = useEdaActiveUser();
 
   const onSubmit: PageFormSubmitHandler<EdaControllerTokenCreate> = async (token) => {
     await postRequest(edaAPI`/users/me/awx-tokens/`, token);
@@ -58,22 +58,24 @@ export function CreateControllerToken() {
 
   const getPageUrl = useGetPageUrl();
 
-  const canViewUsers = user?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
+  const canViewUsers = activeEdaUser?.roles.some(
+    (role) => role.name === 'Admin' || role.name === 'Auditor'
+  );
   const breadcrumbs = [
     ...(canViewUsers ? [{ label: t('Users'), to: getPageUrl(EdaRoute.Users) }] : []),
     {
-      label: user?.username ?? '',
+      label: activeEdaUser?.username ?? '',
       to: canViewUsers
-        ? getPageUrl(EdaRoute.UserPage, { params: { id: user?.id } })
+        ? getPageUrl(EdaRoute.UserPage, { params: { id: activeEdaUser?.id } })
         : getPageUrl(EdaRoute.MyPage),
     },
     {
       label: t('Controller tokens'),
       to: canViewUsers
-        ? getPageUrl(EdaRoute.UserTokens, { params: { id: user?.id } })
+        ? getPageUrl(EdaRoute.UserTokens, { params: { id: activeEdaUser?.id } })
         : getPageUrl(EdaRoute.MyTokens),
     },
-    { label: user?.username ?? '' },
+    { label: activeEdaUser?.username ?? '' },
   ];
 
   return (

--- a/frontend/eda/access/users/UserPage/MyPage.tsx
+++ b/frontend/eda/access/users/UserPage/MyPage.tsx
@@ -29,12 +29,12 @@ export function MyPage() {
 
   const getPageUrl = useGetPageUrl();
 
-  const activeUser = useEdaActiveUser();
+  const { activeEdaUser } = useEdaActiveUser();
   const canEditUser =
-    !!activeUser?.is_superuser || !!activeUser?.roles.some((role) => role.name === 'Admin');
+    !!activeEdaUser?.is_superuser || !!activeEdaUser?.roles.some((role) => role.name === 'Admin');
   const canViewUsers =
-    !!activeUser?.is_superuser ||
-    !!activeUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
+    !!activeEdaUser?.is_superuser ||
+    !!activeEdaUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
 
   const isActionTab = location.pathname === `/eda/access/users/me/details`;
   const itemActions = useMemo<IPageAction<EdaUser>[]>(() => {
@@ -68,7 +68,7 @@ export function MyPage() {
       : [];
     return actions;
   }, [canEditUser, pageNavigate, isActionTab, t]);
-  if (!activeUser) return <LoadingPage breadcrumbs tabs />;
+  if (!activeEdaUser) return <LoadingPage breadcrumbs tabs />;
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/eda/access/users/UserPage/UserPage.tsx
+++ b/frontend/eda/access/users/UserPage/UserPage.tsx
@@ -37,13 +37,13 @@ export function UserPage() {
 
   const getPageUrl = useGetPageUrl();
 
-  const activeUser = useEdaActiveUser();
-  const isViewingSelf = Number(user?.id) === Number(activeUser?.id);
+  const { activeEdaUser } = useEdaActiveUser();
+  const isViewingSelf = Number(user?.id) === Number(activeEdaUser?.id);
   const canEditUser =
-    activeUser?.is_superuser || activeUser?.roles.some((role) => role.name === 'Admin');
+    activeEdaUser?.is_superuser || activeEdaUser?.roles.some((role) => role.name === 'Admin');
   const canViewUsers =
-    activeUser?.is_superuser ||
-    activeUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
+    activeEdaUser?.is_superuser ||
+    activeEdaUser?.roles.some((role) => role.name === 'Admin' || role.name === 'Auditor');
 
   const isActionTab =
     location.pathname === getPageUrl(EdaRoute.UserDetails, { params: { id: user?.id } });
@@ -90,7 +90,7 @@ export function UserPage() {
     return actions;
   }, [canEditUser, deleteUsers, isViewingSelf, pageNavigate, isActionTab, t]);
 
-  if (!activeUser) return <LoadingPage breadcrumbs tabs />;
+  if (!activeEdaUser) return <LoadingPage breadcrumbs tabs />;
   const tabs = isViewingSelf
     ? [
         { label: t('Details'), page: EdaRoute.UserDetails },

--- a/frontend/eda/access/users/hooks/useUserActions.tsx
+++ b/frontend/eda/access/users/hooks/useUserActions.tsx
@@ -18,7 +18,7 @@ export function useUserActions(view: IEdaView<EdaUser>) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const deleteUsers = useDeleteUsers(view.unselectItemsAndRefresh);
-  const activeUser = useEdaActiveUser();
+  const { activeEdaUser } = useEdaActiveUser();
 
   return useMemo<IPageAction<EdaUser>[]>(
     () => [
@@ -41,12 +41,12 @@ export function useUserActions(view: IEdaView<EdaUser>) {
         label: t('Delete user'),
         onClick: (user: EdaUser) => deleteUsers([user]),
         isDisabled: (user) =>
-          !activeUser || Number(user.id) === Number(activeUser.id)
+          !activeEdaUser || Number(user.id) === Number(activeEdaUser.id)
             ? t('Current user cannot be deleted')
             : undefined,
         isDanger: true,
       },
     ],
-    [activeUser, deleteUsers, pageNavigate, t]
+    [activeEdaUser, deleteUsers, pageNavigate, t]
   );
 }

--- a/frontend/eda/access/users/hooks/useUsersActions.tsx
+++ b/frontend/eda/access/users/hooks/useUsersActions.tsx
@@ -18,9 +18,9 @@ export function useUsersActions(view: IEdaView<EdaUser>) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const deleteUsers = useDeleteUsers(view.unselectItemsAndRefresh);
-  const activeUser = useEdaActiveUser();
+  const { activeEdaUser } = useEdaActiveUser();
   const isCurrentUserSelected =
-    activeUser && view.selectedItems.length > 0 && view.isSelected(activeUser);
+    activeEdaUser && view.selectedItems.length > 0 && view.isSelected(activeEdaUser);
 
   return useMemo<IPageAction<EdaUser>[]>(
     () => [
@@ -32,7 +32,8 @@ export function useUsersActions(view: IEdaView<EdaUser>) {
         icon: PlusCircleIcon,
         label: t('Create user'),
         isHidden: () =>
-          !activeUser?.is_superuser && !activeUser?.roles.find((role) => role.name === 'Admin'),
+          !activeEdaUser?.is_superuser &&
+          !activeEdaUser?.roles.find((role) => role.name === 'Admin'),
         onClick: () => pageNavigate(EdaRoute.CreateUser),
       },
       {
@@ -45,6 +46,6 @@ export function useUsersActions(view: IEdaView<EdaUser>) {
         isDanger: true,
       },
     ],
-    [deleteUsers, isCurrentUserSelected, activeUser, pageNavigate, t]
+    [deleteUsers, isCurrentUserSelected, activeEdaUser, pageNavigate, t]
   );
 }

--- a/frontend/eda/common/useEdaActiveUser.tsx
+++ b/frontend/eda/common/useEdaActiveUser.tsx
@@ -1,16 +1,18 @@
-import { ReactNode, createContext, useContext } from 'react';
-import useSWR, { SWRResponse } from 'swr';
+import { ReactNode, createContext, useContext, useMemo } from 'react';
+import useSWR from 'swr';
 import { requestGet } from '../../common/crud/Data';
 import { EdaUser } from '../interfaces/EdaUser';
 import { edaAPI } from './eda-utils';
 
-export const EdaActiveUserContext = createContext<SWRResponse<EdaUser> | undefined>(undefined);
-
-export function useEdaActiveUser() {
-  return useContext(EdaActiveUserContext)?.data;
+interface EdaActiveUserState {
+  activeEdaUser?: EdaUser;
+  refreshActiveEdaUser?: () => void;
+  activeEdaUserIsLoading?: boolean;
 }
 
-export function useEdaActiveUserContext() {
+export const EdaActiveUserContext = createContext<EdaActiveUserState>({});
+
+export function useEdaActiveUser() {
   return useContext(EdaActiveUserContext);
 }
 
@@ -19,7 +21,23 @@ export function EdaActiveUserProvider(props: { children: ReactNode }) {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,
   });
+  const { mutate } = response;
+  const activeEdaUser = useMemo<EdaUser | undefined>(
+    () => (response.error ? undefined : response.data),
+    [response]
+  );
+  const activeEdaUserIsLoading = useMemo<boolean>(
+    () => !response.error && response.isLoading,
+    [response]
+  );
+  const state = useMemo<EdaActiveUserState>(() => {
+    return {
+      activeEdaUser,
+      refreshActiveEdaUser: () => void mutate(),
+      activeEdaUserIsLoading,
+    };
+  }, [activeEdaUser, activeEdaUserIsLoading, mutate]);
   return (
-    <EdaActiveUserContext.Provider value={response}>{props.children}</EdaActiveUserContext.Provider>
+    <EdaActiveUserContext.Provider value={state}>{props.children}</EdaActiveUserContext.Provider>
   );
 }

--- a/frontend/eda/main/EdaLogin.tsx
+++ b/frontend/eda/main/EdaLogin.tsx
@@ -2,13 +2,12 @@ import { Page } from '@patternfly/react-core';
 import { LoadingState } from '../../../framework/components/LoadingState';
 import { Login } from '../../common/Login';
 import { edaAPI } from '../common/eda-utils';
-import { useEdaActiveUser, useEdaActiveUserContext } from '../common/useEdaActiveUser';
+import { useEdaActiveUser } from '../common/useEdaActiveUser';
 
 export function EdaLogin(props: { children: React.ReactNode }) {
-  const edaActiveUserContext = useEdaActiveUserContext();
-  const edaActiveUser = useEdaActiveUser();
+  const { activeEdaUser, activeEdaUserIsLoading, refreshActiveEdaUser } = useEdaActiveUser();
 
-  if (edaActiveUserContext?.isLoading) {
+  if (activeEdaUserIsLoading) {
     return (
       <Page>
         <LoadingState />
@@ -16,12 +15,9 @@ export function EdaLogin(props: { children: React.ReactNode }) {
     );
   }
 
-  if (!edaActiveUser) {
+  if (!activeEdaUser) {
     return (
-      <Login
-        apiUrl={edaAPI`/auth/session/login/`}
-        onSuccess={() => void edaActiveUserContext?.mutate()}
-      />
+      <Login apiUrl={edaAPI`/auth/session/login/`} onSuccess={() => refreshActiveEdaUser?.()} />
     );
   }
 

--- a/frontend/eda/main/EdaMasthead.tsx
+++ b/frontend/eda/main/EdaMasthead.tsx
@@ -11,7 +11,7 @@ import { PageRefreshIcon } from '../../common/PageRefreshIcon';
 import { postRequest } from '../../common/crud/Data';
 import { useClearCache } from '../../common/useInvalidateCache';
 import { edaAPI } from '../common/eda-utils';
-import { useEdaActiveUser, useEdaActiveUserContext } from '../common/useEdaActiveUser';
+import { useEdaActiveUser } from '../common/useEdaActiveUser';
 import { EdaRoute } from './EdaRoutes';
 import EdaBrand from './eda-logo.svg';
 
@@ -20,13 +20,12 @@ export function EdaMasthead() {
   const openAnsibleAboutModal = useAnsibleAboutModal();
   const { clearAllCache } = useClearCache();
   const pageNavigate = usePageNavigate();
-  const activeUser = useEdaActiveUser();
-  const userContext = useEdaActiveUserContext();
+  const { activeEdaUser, refreshActiveEdaUser } = useEdaActiveUser();
   const logout = useCallback(async () => {
     await postRequest(edaAPI`/auth/session/logout/`, {});
     clearAllCache();
-    void userContext?.mutate();
-  }, [clearAllCache, userContext]);
+    refreshActiveEdaUser?.();
+  }, [clearAllCache, refreshActiveEdaUser]);
   return (
     <PageMasthead brand={<EdaBrand style={{ height: 45, width: 45 }} />}>
       <ToolbarGroup variant="icon-button-group" style={{ flexGrow: 1 }}>
@@ -64,7 +63,7 @@ export function EdaMasthead() {
           <PageMastheadDropdown
             id="account-menu"
             icon={<UserCircleIcon />}
-            label={activeUser?.username}
+            label={activeEdaUser?.username}
           >
             <DropdownItem
               id="user-details"

--- a/frontend/hub/common/useHubContext.tsx
+++ b/frontend/hub/common/useHubContext.tsx
@@ -26,16 +26,16 @@ export function useHubContext() {
 export const HubContextProvider = ({ children }: { children: ReactNode }) => {
   const getFeatureFlags = useSWR<HubFeatureFlags>(hubAPI`/_ui/v1/feature-flags/`, requestGet);
   const getSettings = useSWR<HubSettings>(hubAPI`/_ui/v1/settings/`, requestGet);
-  const hubUser = useHubActiveUser();
+  const { activeHubUser } = useHubActiveUser();
 
   const context = useMemo<HubContext>(
     () => ({
       featureFlags: getFeatureFlags.data as HubFeatureFlags,
       settings: getSettings.data as HubSettings,
-      user: hubUser,
-      hasPermission: (permission) => hasPermission(permission, hubUser!),
+      user: activeHubUser,
+      hasPermission: (permission) => hasPermission(permission, activeHubUser!),
     }),
-    [getFeatureFlags, getSettings, hubUser]
+    [getFeatureFlags, getSettings, activeHubUser]
   );
 
   if (getFeatureFlags.isLoading || getSettings.isLoading) {

--- a/frontend/hub/main/HubLogin.tsx
+++ b/frontend/hub/main/HubLogin.tsx
@@ -1,15 +1,14 @@
 import { Page } from '@patternfly/react-core';
 import { LoadingState } from '../../../framework/components/LoadingState';
 import { Login } from '../../common/Login';
-import { useHubActiveUser, useHubActiveUserContext } from '../../hub/common/useHubActiveUser';
+import { useHubActiveUser } from '../../hub/common/useHubActiveUser';
 import { hubAPI } from '../common/api/formatPath';
 import { HubContextProvider } from '../common/useHubContext';
 
 export function HubLogin(props: { children: React.ReactNode }) {
-  const hubActiveUserContext = useHubActiveUserContext();
-  const hubActiveUser = useHubActiveUser();
+  const { activeHubUser, refreshActiveHubUser, activeHubUserIsLoading } = useHubActiveUser();
 
-  if (hubActiveUserContext?.isLoading) {
+  if (activeHubUserIsLoading) {
     return (
       <Page>
         <LoadingState />
@@ -17,12 +16,9 @@ export function HubLogin(props: { children: React.ReactNode }) {
     );
   }
 
-  if (!hubActiveUser) {
+  if (!activeHubUser) {
     return (
-      <Login
-        apiUrl={hubAPI`/_ui/v1/auth/login/`}
-        onSuccess={() => void hubActiveUserContext?.mutate()}
-      />
+      <Login apiUrl={hubAPI`/_ui/v1/auth/login/`} onSuccess={() => refreshActiveHubUser?.()} />
     );
   }
 

--- a/frontend/hub/main/HubMasthead.tsx
+++ b/frontend/hub/main/HubMasthead.tsx
@@ -15,7 +15,7 @@ import { useGet } from '../../common/crud/useGet';
 import { useClearCache } from '../../common/useInvalidateCache';
 import { CollectionVersionSearch } from '../collections/Collection';
 import { hubAPI } from '../common/api/formatPath';
-import { useHubActiveUser, useHubActiveUserContext } from '../common/useHubActiveUser';
+import { useHubActiveUser } from '../common/useHubActiveUser';
 import { useHubContext } from '../common/useHubContext';
 import { HubItemsResponse } from '../common/useHubView';
 import { HubRoute } from './HubRoutes';
@@ -25,14 +25,13 @@ export function HubMasthead() {
   const { t } = useTranslation();
   const openAnsibleAboutModal = useAnsibleAboutModal();
   const { clearAllCache } = useClearCache();
-  const hubUser = useHubActiveUser();
   useHubNotifications();
-  const userContext = useHubActiveUserContext();
+  const { activeHubUser, refreshActiveHubUser } = useHubActiveUser();
   const logout = useCallback(async () => {
     await postRequest(hubAPI`/_ui/v1/auth/logout/`, {});
     clearAllCache();
-    void userContext?.mutate();
-  }, [clearAllCache, userContext]);
+    refreshActiveHubUser?.();
+  }, [clearAllCache, refreshActiveHubUser]);
   return (
     <PageMasthead brand={<GalaxyBrand style={{ height: 48, marginTop: -8 }} />}>
       <ToolbarGroup variant="icon-button-group" style={{ flexGrow: 1 }}>
@@ -71,7 +70,7 @@ export function HubMasthead() {
           <PageMastheadDropdown
             id="account-menu"
             icon={<UserCircleIcon />}
-            label={hubUser?.username}
+            label={activeHubUser?.username}
           >
             {/* <DropdownItem
               id="user-details"

--- a/frontend/hub/overview/CollectionCategories.cy.tsx
+++ b/frontend/hub/overview/CollectionCategories.cy.tsx
@@ -1,4 +1,3 @@
-import { SWRResponse } from 'swr';
 import { CollectionVersionSearch } from '../administration/collection-approvals/Approval';
 import { HubActiveUserContext } from '../common/useHubActiveUser';
 import { HubContextProvider } from '../common/useHubContext';
@@ -58,12 +57,12 @@ describe('CollectionCategories.cy.tsx', () => {
   it('renders Manage Content button for platform admin', () => {
     cy.intercept('**/_ui/v1/settings/', { fixture: 'hub_settings.json' });
     cy.intercept('**/_ui/v1/feature-flags/', { fixture: 'hub_feature_flags.json' });
-    cy.fixture('hub_admin').then((user: HubUser) => {
+    cy.fixture('hub_admin').then((activeHubUser: HubUser) => {
       cy.fixture('collection_versions_eda').then(
         (collectionVersionsResponse: HubItemsResponse<CollectionVersionSearch>) => {
           const collections = collectionVersionsResponse.data;
           cy.mount(
-            <HubActiveUserContext.Provider value={{ data: user } as SWRResponse}>
+            <HubActiveUserContext.Provider value={{ activeHubUser }}>
               <HubContextProvider>
                 <CollectionCategoryCarousel
                   collections={collections}
@@ -83,13 +82,13 @@ describe('CollectionCategories.cy.tsx', () => {
   it('Manage Content button should not be shown for non-admin user', () => {
     cy.intercept('**/_ui/v1/settings/', { fixture: 'hub_settings.json' });
     cy.intercept('**/_ui/v1/feature-flags/', { fixture: 'hub_feature_flags.json' });
-    cy.fixture('hub_admin').then((user: HubUser) => {
-      user.is_superuser = false;
+    cy.fixture('hub_admin').then((activeHubUser: HubUser) => {
+      activeHubUser.is_superuser = false;
       cy.fixture('collection_versions_eda').then(
         (collectionVersionsResponse: HubItemsResponse<CollectionVersionSearch>) => {
           const collections = collectionVersionsResponse.data;
           cy.mount(
-            <HubActiveUserContext.Provider value={{ data: user } as SWRResponse}>
+            <HubActiveUserContext.Provider value={{ activeHubUser }}>
               <HubContextProvider>
                 <CollectionCategoryCarousel
                   collections={collections}


### PR DESCRIPTION
Cleaned up the AWX, EDA, and HUB active user contexts and hooks.
Added better state management that keeps the login page from refreshing when a user is trying to type in credentials.
Reduced the number of hooks and made the naming in the hooks clearer.
Renamed User to AwxUser to match EdaUser and HubUser.
These changes will make the login more stable and make the code more consistent.