### PR TITLE
Refactor useTemplatesFilter to take in additional params.

### DIFF
--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -231,3 +231,21 @@ export function useAddressToolbarFilter() {
     [t]
   );
 }
+
+export function useTemplateTypeToolbarFilter() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter>(
+    () => ({
+      key: 'type-templates',
+      label: t('Type'),
+      type: ToolbarFilterType.MultiSelect,
+      query: 'type',
+      options: [
+        { label: t('Job template'), value: 'job_template' },
+        { label: t('Workflow job template'), value: 'workflow_job_template' },
+      ],
+      placeholder: t('Select types'),
+    }),
+    [t]
+  );
+}

--- a/frontend/awx/common/useDynamicFilters.tsx
+++ b/frontend/awx/common/useDynamicFilters.tsx
@@ -25,6 +25,9 @@ interface DynamicToolbarFiltersProps {
 
   /** Additional filters in addition to the dynamic filters */
   additionalFilters?: IToolbarFilter[];
+
+  /** Additional filters to remove */
+  removeFilters?: string[];
 }
 
 interface FilterableFields {
@@ -87,7 +90,8 @@ function craftRequestUrl(
 }
 
 export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
-  const { optionsPath, preSortedKeys, preFilledValueKeys, additionalFilters } = props;
+  const { optionsPath, preSortedKeys, preFilledValueKeys, additionalFilters, removeFilters } =
+    props;
   const { t } = useTranslation();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/${optionsPath}/`);
   const filterableFields = useFilters(data?.actions?.GET);
@@ -151,7 +155,8 @@ export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
       filterableFields: FilterableFields[],
       preSortedKeys?: string[],
       preFilledValueKeys?: Record<string, AsyncKeyOptions>,
-      additionalFilters?: IToolbarFilter[]
+      additionalFilters?: IToolbarFilter[],
+      removeFilters?: string[]
     ): IToolbarFilter[] => {
       const toolbarFilters: IToolbarFilter[] = [];
 
@@ -246,15 +251,26 @@ export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
           return indexA - indexB;
         });
       }
+      // remove filters if provided
+      if (removeFilters && toolbarFilters.length > 0) {
+        return toolbarFilters.filter((filter) => !removeFilters.includes(filter.key));
+      }
 
       return toolbarFilters;
     };
-    return getToolbars(filterableFields, preSortedKeys, preFilledValueKeys, additionalFilters);
+    return getToolbars(
+      filterableFields,
+      preSortedKeys,
+      preFilledValueKeys,
+      additionalFilters,
+      removeFilters
+    );
   }, [
     filterableFields,
     preSortedKeys,
     preFilledValueKeys,
     additionalFilters,
+    removeFilters,
     t,
     queryResource,
     queryResourceLabel,

--- a/frontend/awx/resources/templates/TemplatesList.tsx
+++ b/frontend/awx/resources/templates/TemplatesList.tsx
@@ -33,7 +33,13 @@ export function TemplatesList(props: {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
-  const toolbarFilters = useTemplateFilters();
+  const toolbarFilters = useTemplateFilters({
+    url: props.url,
+    projectId: props.projectId,
+    inventoryId: props.inventoryId,
+    credentialsId: props.credentialsId,
+    executionEnvironmentId: props.executionEnvironmentId,
+  });
   const tableColumns = useTemplateColumns();
   const getQueryParams = (
     projectId?: string,

--- a/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateActions.tsx
@@ -69,7 +69,7 @@ export function useTemplateActions({
         type: PageActionType.Link,
         selection: PageActionSelection.Single,
         isPinned: true,
-        isHidden: (template) => !template?.summary_fields.user_capabilities.edit,
+        isHidden: (template) => !template?.summary_fields?.user_capabilities?.edit,
         icon: PencilAltIcon,
         label: t('Edit template'),
         ouiaId: 'job-template-detail-edit-button',
@@ -100,7 +100,7 @@ export function useTemplateActions({
         selection: PageActionSelection.Single,
         icon: TrashIcon,
         isDisabled: (template) =>
-          !template?.summary_fields.user_capabilities.delete
+          !template?.summary_fields?.user_capabilities?.delete
             ? t('You do not have permission to delete this template')
             : undefined,
         label: t('Delete template'),

--- a/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
@@ -4,20 +4,58 @@ import {
 } from '../../../common/awx-toolbar-filters';
 import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
-export function useTemplateFilters() {
+export function useTemplateFilters({
+  url,
+  projectId,
+  inventoryId,
+  credentialsId,
+  executionEnvironmentId,
+}: {
+  url?: string;
+  projectId?: string;
+  inventoryId?: string;
+  credentialsId?: string;
+  executionEnvironmentId?: string;
+} = {}) {
+  const splitUrl = url ? url.split('/') : [];
+  const optionsPath = splitUrl[splitUrl.length - 2] || 'unified_job_templates';
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const getQueryParams = (
+    projectId?: string,
+    inventoryId?: string,
+    credentialsId?: string,
+    executionEnvironmentId?: string
+  ) => {
+    const templateQueryParams: { [key: string]: string } = {
+      type: 'job_template,workflow_job_template',
+    };
+    if (projectId) {
+      templateQueryParams.project__id = projectId;
+    }
+    if (inventoryId) {
+      templateQueryParams.inventory__id = inventoryId;
+    }
+    if (credentialsId) {
+      templateQueryParams.credentials__id = credentialsId;
+    }
+    if (executionEnvironmentId) {
+      templateQueryParams.execution_environment__id = executionEnvironmentId;
+    }
+    return templateQueryParams;
+  };
+  const queryParams = getQueryParams(projectId, inventoryId, credentialsId, executionEnvironmentId);
   const toolbarFilters = useDynamicToolbarFilters({
-    optionsPath: 'unified_job_templates',
+    optionsPath: optionsPath,
     preSortedKeys: ['name', 'description', 'status', 'created-by', 'modified-by'],
     preFilledValueKeys: {
       name: {
-        apiPath: 'unified_job_templates',
-        queryParams: { type: 'job_template,workflow_job_template' },
+        apiPath: optionsPath,
+        queryParams: queryParams,
       },
       id: {
-        apiPath: 'unified_job_templates',
-        queryParams: { type: 'job_template,workflow_job_template' },
+        apiPath: optionsPath,
+        queryParams: queryParams,
       },
     },
     additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],

--- a/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
+++ b/frontend/awx/resources/templates/hooks/useTemplateFilters.tsx
@@ -1,6 +1,7 @@
 import {
   useCreatedByToolbarFilter,
   useModifiedByToolbarFilter,
+  useTemplateTypeToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
 import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
@@ -21,6 +22,7 @@ export function useTemplateFilters({
   const optionsPath = splitUrl[splitUrl.length - 2] || 'unified_job_templates';
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const typeToolbarFilter = useTemplateTypeToolbarFilter();
   const getQueryParams = (
     projectId?: string,
     inventoryId?: string,
@@ -47,7 +49,7 @@ export function useTemplateFilters({
   const queryParams = getQueryParams(projectId, inventoryId, credentialsId, executionEnvironmentId);
   const toolbarFilters = useDynamicToolbarFilters({
     optionsPath: optionsPath,
-    preSortedKeys: ['name', 'description', 'status', 'created-by', 'modified-by'],
+    preSortedKeys: ['name', 'description', 'status', 'created-by', 'modified-by', 'type-templates'],
     preFilledValueKeys: {
       name: {
         apiPath: optionsPath,
@@ -58,7 +60,8 @@ export function useTemplateFilters({
         queryParams: queryParams,
       },
     },
-    additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
+    additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter, typeToolbarFilter],
+    removeFilters: ['type'], // Remove the default type filter provided by API as it gives additional types that are not applicable to the Templates list view
   });
   return toolbarFilters;
 }


### PR DESCRIPTION
This PR includes several changes:
1. Add resourceId to useTemplatesFilter to allow filtering by resource ID for tabbed views.
2. Add url to useTemplatesFilter to allow for filtering based on resource type (for example, Templates tab within Execution environments queries the job_templates endpoint, not unified_job_templates).
3. Add removeFilters prop to useDynamicToolbarFilters hook to allow for removing filters.
4. Updates useTemplatesFilter to include custom Type filter.