### PR TITLE
Hosts groups empty button

### DIFF
--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
@@ -223,7 +223,7 @@ describe('Inventory Host Groups List', () => {
         });
         cy.contains(/^There are currently no groups associated with this host$/);
         cy.contains(/^Please add a group by using the button below.$/);
-        cy.contains('button', /^Add group$/).should('be.visible');
+        cy.contains('button', /^Associate groups$/).should('be.visible');
       });
       it(`Empty state is displayed correctly for user without permission to create group  (${type})`, () => {
         cy.stub(useOptions, 'useOptions').callsFake(() => ({

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -68,7 +68,7 @@ export function InventoryHostGroups(props: { page: string }) {
               )
         }
         emptyStateIcon={canCreateGroup ? undefined : CubesIcon}
-        emptyStateButtonText={canCreateGroup ? t('Add group') : undefined}
+        emptyStateButtonText={canCreateGroup ? t('Associate groups') : undefined}
         emptyStateButtonClick={
           canCreateGroup
             ? () =>


### PR DESCRIPTION
Changes the text of the hosts groups empty state button from Add group to Associate group.