### PR TITLE
Fix Hosts detail inventory link

### DIFF
--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.cy.tsx
@@ -14,12 +14,7 @@ describe('InventoryHostDetails', () => {
   const kinds = ['constructed', 'smart', ''];
 
   kinds.forEach((kind) => {
-    const path =
-      kind === ''
-        ? '/inventories/:inventory_type/:id/hosts/:host_id/details'
-        : kind === 'smart'
-          ? '/inventories/:inventory_type/:id/hosts/:host_id/details'
-          : '/inventories/:inventory_type/:id/hosts/:host_id/details';
+    const path = '/inventories/:inventory_type/:id/hosts/:host_id/details';
 
     const initialEntries =
       kind === ''

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
@@ -43,10 +43,9 @@ export function InventoryHostDetails() {
 }
 
 function inventoryKindToType(kind: string) {
-  if (kind === '') return 'inventory';
   if (kind === 'smart') return 'smart_inventory';
   if (kind === 'constructed') return 'constructed_inventory';
-  return '';
+  return 'inventory';
 }
 
 export function InventoryHostDetailsInner(props: { host: AwxHost }) {
@@ -77,7 +76,7 @@ export function InventoryHostDetailsInner(props: { host: AwxHost }) {
           to={getPageUrl(AwxRoute.InventoryDetails, {
             params: {
               id: host.summary_fields?.inventory?.id,
-              inventory_type: inventoryKindToType(host.summary_fields?.inventory.kind),
+              inventory_type: inventoryKindToType(host.summary_fields?.inventory?.kind),
             },
           })}
         />

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostDetails.tsx
@@ -42,6 +42,13 @@ export function InventoryHostDetails() {
   return <InventoryHostDetailsInner host={host} />;
 }
 
+function inventoryKindToType(kind: string) {
+  if (kind === '') return 'inventory';
+  if (kind === 'smart') return 'smart_inventory';
+  if (kind === 'constructed') return 'constructed_inventory';
+  return '';
+}
+
 export function InventoryHostDetailsInner(props: { host: AwxHost }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
@@ -68,7 +75,10 @@ export function InventoryHostDetailsInner(props: { host: AwxHost }) {
         <TextCell
           text={host.summary_fields?.inventory?.name}
           to={getPageUrl(AwxRoute.InventoryDetails, {
-            params: { id: host.summary_fields?.inventory?.id },
+            params: {
+              id: host.summary_fields?.inventory?.id,
+              inventory_type: inventoryKindToType(host.summary_fields?.inventory.kind),
+            },
           })}
         />
       </PageDetail>


### PR DESCRIPTION
Inventory link in host detail did not filled the :inventory_type props, so it then failed to load the hosts and groups in tabs.