### PR TITLE
PageNavigationItem fix default expanded state

### DIFF
--- a/framework/PageNavigation/PageNavigation.tsx
+++ b/framework/PageNavigation/PageNavigation.tsx
@@ -43,7 +43,11 @@ function PageNavigationItems(props: { items: PageNavigationItem[]; baseRoute: st
           return true;
         })
         .map((item, index) => (
-          <PageNavigationItemComponent key={index} item={item} baseRoute={props.baseRoute} />
+          <PageNavigationItemComponent
+            key={item.id ?? item.label ?? index}
+            item={item}
+            baseRoute={props.baseRoute}
+          />
         ))}
     </>
   );

--- a/framework/PageNavigation/PageNavigationItem.tsx
+++ b/framework/PageNavigation/PageNavigationItem.tsx
@@ -27,7 +27,7 @@ export type PageNavigationItem = PageNavigationGroup | PageNavigationComponent;
 
 /**
  * Function to remove the leading slash from a path
- * Needed bacause routes caannot have slashes in the beginning
+ * Needed bacause routes cannot have slashes in the beginning
  */
 export function removeLeadingSlash(path: string): string {
   return path.replace(/^\//, '');


### PR DESCRIPTION
Recent changes to the navigation items broke loading the default expanded state if items. This fixes it.