### PR TITLE
uxd_aap_9321_updates_to_repositories_landingpage

### DIFF
--- a/cypress/e2e/hub/constants.ts
+++ b/cypress/e2e/hub/constants.ts
@@ -73,7 +73,7 @@ export const SignatureKeys = {
 };
 
 export const Repositories = {
-  title: 'Repositories',
+  title: 'Repository Management',
   url: 'repositories',
   urlCreate: '/repositories/create',
 };

--- a/cypress/e2e/hub/constants.ts
+++ b/cypress/e2e/hub/constants.ts
@@ -73,7 +73,7 @@ export const SignatureKeys = {
 };
 
 export const Repositories = {
-  title: 'Repository Management',
+  title: 'Repositories',
   url: 'repositories',
   urlCreate: '/repositories/create',
 };

--- a/cypress/e2e/hub/repositories.cy.ts
+++ b/cypress/e2e/hub/repositories.cy.ts
@@ -29,7 +29,7 @@ describe('Repositories', () => {
 
   beforeEach(() => {
     cy.navigateTo('hub', Repositories.url);
-    cy.verifyPageTitle(Repositories.title);
+    cy.verifyPageTitle('Repositories');
 
     // Create remote and repository before each test
     // Note: Some tests like create and delete do not use this shared remote and repository
@@ -92,7 +92,7 @@ describe('Repositories', () => {
       cy.get('button').contains('Delete repositories').click();
 
       // Repositories Page
-      cy.verifyPageTitle(Repositories.title);
+      cy.verifyPageTitle('Repositories');
       cy.filterTableByTextFilter('name', repositoryToDelete.name);
       cy.get('.pf-v5-c-empty-state').should('be.visible');
       cy.get('.pf-v5-c-empty-state').contains('No results found');

--- a/frontend/hub/administration/repositories/Repositories.tsx
+++ b/frontend/hub/administration/repositories/Repositories.tsx
@@ -31,7 +31,7 @@ export function Repositories() {
   return (
     <PageLayout>
       <PageHeader
-        title={t('Repository Management')}
+        title={t('Repositories')}
         description={t(
           'Repositories are online storage locations where Ansible content, such as roles and collections, can be published, shared, and accessed by the community.'
         )}


### PR DESCRIPTION
Updating "Repositories" landing page from "Repository Management" to "Repositories" to match the navigation.
<img width="1326" alt="Screenshot 2024-04-09 at 2 16 20 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/12d992c4-e06d-40d1-94c8-d181687460ab">

https://issues.redhat.com/browse/AAP-9321