### PR TITLE
Component tests for adding users/teams to an EDA project

### DIFF
--- a/cypress/fixtures/edaProjectRoles.json
+++ b/cypress/fixtures/edaProjectRoles.json
@@ -1,0 +1,69 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "page_size": 10,
+  "page": 1,
+  "results": [
+    {
+      "id": 14,
+      "url": "/api/eda/v1/role_definitions/14/",
+      "related": {
+        "team_assignments": "/api/eda/v1/role_definitions/14/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/14/user_assignments/"
+      },
+      "summary_fields": {},
+      "permissions": [
+        "eda.change_project",
+        "eda.delete_project",
+        "eda.view_project",
+        "eda.view_rulebook"
+      ],
+      "content_type": "eda.project",
+      "modified": "2024-04-04T16:38:50.059713Z",
+      "created": "2024-04-04T16:38:50.059752Z",
+      "name": "Project Admin",
+      "description": "Has all permissions to a single project and its child resources - rulebook",
+      "managed": true,
+      "modified_by": null,
+      "created_by": null
+    },
+    {
+      "id": 16,
+      "url": "/api/eda/v1/role_definitions/16/",
+      "related": {
+        "created_by": "/api/eda/v1/users/1/",
+        "modified_by": "/api/eda/v1/users/1/",
+        "team_assignments": "/api/eda/v1/role_definitions/16/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/16/user_assignments/"
+      },
+      "summary_fields": {
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "test@example.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        },
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "test@example.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        }
+      },
+      "permissions": ["eda.view_project"],
+      "content_type": "eda.project",
+      "modified": "2024-04-05T13:42:27.344054Z",
+      "created": "2024-04-05T13:19:30.781599Z",
+      "name": "View project",
+      "description": "Has permissions to view project",
+      "managed": false,
+      "modified_by": 1,
+      "created_by": 1
+    }
+  ]
+}

--- a/cypress/fixtures/edaTeams.json
+++ b/cypress/fixtures/edaTeams.json
@@ -1,0 +1,49 @@
+{
+  "count": 4,
+  "next": null,
+  "previous": null,
+  "page_size": 10,
+  "page": 1,
+  "results": [
+    {
+      "id": 2,
+      "name": "Test",
+      "description": "",
+      "organization_id": 1,
+      "created": "2024-04-04T19:07:59.894304Z",
+      "created_by": 1,
+      "modified": "2024-04-04T19:07:59.894269Z",
+      "modified_by": 1
+    },
+    {
+      "id": 3,
+      "name": "Demo",
+      "description": "",
+      "organization_id": 1,
+      "created": "2024-04-04T19:08:08.928387Z",
+      "created_by": 1,
+      "modified": "2024-04-04T19:08:08.928338Z",
+      "modified_by": 1
+    },
+    {
+      "id": 4,
+      "name": "Platform",
+      "description": "",
+      "organization_id": 1,
+      "created": "2024-04-04T19:08:21.825944Z",
+      "created_by": 1,
+      "modified": "2024-04-04T19:08:21.825887Z",
+      "modified_by": 1
+    },
+    {
+      "id": 5,
+      "name": "Galaxy",
+      "description": "",
+      "organization_id": 1,
+      "created": "2024-04-04T19:08:27.308818Z",
+      "created_by": 1,
+      "modified": "2024-04-04T19:08:27.308767Z",
+      "modified_by": 1
+    }
+  ]
+}

--- a/cypress/fixtures/edaUsers.json
+++ b/cypress/fixtures/edaUsers.json
@@ -1,0 +1,57 @@
+{
+  "count": 6,
+  "next": null,
+  "previous": null,
+  "page_size": 10,
+  "page": 1,
+  "results": [
+    {
+      "id": 1,
+      "username": "admin",
+      "first_name": "",
+      "last_name": "",
+      "is_superuser": true,
+      "roles": []
+    },
+    {
+      "id": 2,
+      "username": "ci-sa-user",
+      "first_name": "",
+      "last_name": "",
+      "is_superuser": true,
+      "roles": []
+    },
+    {
+      "id": 3,
+      "username": "dev",
+      "first_name": "",
+      "last_name": "",
+      "is_superuser": true,
+      "roles": []
+    },
+    {
+      "id": 4,
+      "username": "e2e",
+      "first_name": "",
+      "last_name": "",
+      "is_superuser": true,
+      "roles": []
+    },
+    {
+      "id": 5,
+      "username": "demo-user",
+      "first_name": "Demo",
+      "last_name": "User",
+      "is_superuser": false,
+      "roles": []
+    },
+    {
+      "id": 6,
+      "username": "demo-user2",
+      "first_name": "Demo",
+      "last_name": "User2",
+      "is_superuser": false,
+      "roles": []
+    }
+  ]
+}

--- a/frontend/common/access/RolesWizard/steps/RoleAssignmentsReviewStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/RoleAssignmentsReviewStep.tsx
@@ -159,6 +159,7 @@ function ReviewExpandableList<
 
   return (
     <ExpandableSection
+      data-cy={`expandable-section-${fieldName}`}
       toggleContent={
         <div>
           <span>{labelForSelectedItems}</span>

--- a/frontend/eda/access/teams/components/steps/EdaSelectTeamsStep.tsx
+++ b/frontend/eda/access/teams/components/steps/EdaSelectTeamsStep.tsx
@@ -1,20 +1,20 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ITableColumn, TextCell } from '../../../../../../framework';
-// import { useTeamsFilters } from '../../hooks/useTeamsFilters';
 import { edaAPI } from '../../../../common/eda-utils';
 import { useMultiSelectListView } from '../../../../common/useMultiSelectListView';
 import { PageMultiSelectList } from '../../../../../../framework/PageTable/PageMultiSelectList';
 import { EdaTeam } from '../../../../interfaces/EdaTeam';
 import { Title } from '@patternfly/react-core';
 import styled from 'styled-components';
+import { useEdaTeamFilters } from '../../hooks/useEdaTeamFilters';
 
 const StyledTitle = styled(Title)`
   margin-bottom: 1rem;
 `;
 
 export function EdaSelectTeamsStep(props: { descriptionForTeamsSelection?: string }) {
-  // const toolbarFilters = useTeamsFilters();
+  const toolbarFilters = useEdaTeamFilters();
   const { descriptionForTeamsSelection } = props;
   const { t } = useTranslation();
 
@@ -25,7 +25,7 @@ export function EdaSelectTeamsStep(props: { descriptionForTeamsSelection?: strin
         cell: (team: EdaTeam) => <TextCell text={team.name} />,
         card: 'name',
         list: 'name',
-        sort: 'username',
+        sort: 'name',
         maxWidth: 200,
       },
     ];
@@ -34,7 +34,7 @@ export function EdaSelectTeamsStep(props: { descriptionForTeamsSelection?: strin
   const view = useMultiSelectListView<EdaTeam>(
     {
       url: edaAPI`/teams/`,
-      toolbarFilters: [],
+      toolbarFilters,
       tableColumns,
     },
     'teams'
@@ -47,7 +47,11 @@ export function EdaSelectTeamsStep(props: { descriptionForTeamsSelection?: strin
         {descriptionForTeamsSelection ??
           t('Select the team(s) that you want to apply new roles to.')}
       </h2>
-      <PageMultiSelectList view={view} tableColumns={tableColumns} toolbarFilters={[]} />
+      <PageMultiSelectList
+        view={view}
+        tableColumns={tableColumns}
+        toolbarFilters={toolbarFilters}
+      />
     </>
   );
 }

--- a/frontend/eda/access/teams/hooks/useEdaTeamFilters.tsx
+++ b/frontend/eda/access/teams/hooks/useEdaTeamFilters.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+import { IToolbarFilter, ToolbarFilterType } from '../../../../../framework';
+import { useMemo } from 'react';
+
+export function useEdaTeamFilters() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'name',
+        label: t('Name'),
+        type: ToolbarFilterType.MultiText,
+        query: 'name',
+        comparison: 'startsWith',
+      },
+    ],
+    [t]
+  );
+}

--- a/frontend/eda/access/users/hooks/useUserFilters.tsx
+++ b/frontend/eda/access/users/hooks/useUserFilters.tsx
@@ -8,7 +8,7 @@ export function useUserFilters() {
     () => [
       {
         key: 'name',
-        label: t('Name'),
+        label: t('Username'),
         type: ToolbarFilterType.MultiText,
         query: 'name',
         comparison: 'startsWith',

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -27,7 +27,6 @@ export enum EdaRoute {
   ProjectDetails = 'eda-project-details',
   ProjectTeamAccess = 'eda-project-project-team-access',
   ProjectUserAccess = 'eda-project-project-user-access',
-  ProjectUsers = 'eda-project-users',
   ProjectAddUsers = 'eda-project-add-users',
   ProjectAddTeams = 'eda-project-add-teams',
 

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -218,15 +218,15 @@ export function useEdaNavigation() {
               element: <Navigate to="details" />,
             },
             {
-              id: EdaRoute.ProjectUsers,
-              path: 'users',
+              id: EdaRoute.ProjectUserAccess,
+              path: 'user-access',
               element: <PageNotImplemented />,
             },
           ],
         },
         {
           id: EdaRoute.ProjectAddUsers,
-          path: ':id/users/add-users',
+          path: ':id/user-access/add-users',
           element: <EdaProjectAddUsers />,
         },
         {

--- a/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
@@ -1,0 +1,92 @@
+import { edaAPI } from '../../common/eda-utils';
+import { EdaProjectAddTeams } from './EdaProjectAddTeams';
+
+describe('EdaProjectAddTeams', () => {
+  const component = <EdaProjectAddTeams />;
+  const path = '/projects/:id/team-access/add-teams';
+  const initialEntries = [`/projects/1/team-access/add-teams`];
+  const params = {
+    path,
+    initialEntries,
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', edaAPI`/projects/*`, { fixture: 'edaProject.json' });
+    cy.intercept('GET', edaAPI`/teams/?order_by=name*`, { fixture: 'edaTeams.json' });
+    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=project*`, {
+      fixture: 'edaProjectRoles.json',
+    });
+    cy.mount(component, params);
+  });
+  it('should render with correct steps', () => {
+    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select team(s)');
+    cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select roles to apply');
+    cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Review');
+    cy.get('[data-cy="wizard-nav-item-teams"] button').should('have.class', 'pf-m-current');
+    cy.get('table tbody').find('tr').should('have.length', 4);
+  });
+  it('can filter teams by name', () => {
+    cy.intercept(edaAPI`/teams/?name=Gal*`).as('nameFilterRequest');
+    cy.get('[data-cy="text-input"]').within(() => {
+      cy.get('input').clear().type('Gal', { delay: 0 });
+    });
+    cy.getByDataCy('apply-filter').click();
+    cy.wait('@nameFilterRequest');
+  });
+  it('should validate that at least one team is selected for moving to next step', () => {
+    cy.get('table tbody').find('tr').should('have.length', 4);
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one team.');
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-teams"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+  });
+  it('should validate that at least one role is selected for moving to Review step', () => {
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
+    cy.selectTableRowByCheckbox('name', 'Project Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+  });
+  it('should display selected team and role in the Review step', () => {
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'Project Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Teams');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Demo');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Project Admin');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should(
+      'contain.text',
+      'Has all permissions to a single project and its child resources - rulebook'
+    );
+  });
+  it('should trigger bulk action dialog on submit', () => {
+    cy.intercept('POST', edaAPI`/role_team_assignments/`, {
+      statusCode: 201,
+      body: { team: 3, role_definition: 14, content_type: 'eda.project', object_id: 1 },
+    }).as('createRoleAssignment');
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'Project Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.clickButton(/^Finish$/);
+    // Bulks action modal is displayed with success
+    cy.get('.pf-v5-c-modal-box').within(() => {
+      cy.get('table tbody').find('tr').should('have.length', 1);
+      cy.get('table tbody').should('contain.text', 'Demo');
+      cy.get('table tbody').should('contain.text', 'Project Admin');
+      cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
+      cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');
+    });
+  });
+});

--- a/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
@@ -26,11 +26,8 @@ describe('EdaProjectAddTeams', () => {
     cy.get('table tbody').find('tr').should('have.length', 4);
   });
   it('can filter teams by name', () => {
-    cy.intercept(edaAPI`/teams/?name=Gal*`, { statusCode: 200 }).as('nameFilterRequest');
-    cy.get('[data-cy="text-input"]').within(() => {
-      cy.get('input').clear().type('Gal', { delay: 0 });
-    });
-    cy.getByDataCy('apply-filter').click();
+    cy.intercept(edaAPI`/teams/?name=Gal*`, { fixtures: 'edaTeams.json' }).as('nameFilterRequest');
+    cy.filterTableByText('Gal');
     cy.wait('@nameFilterRequest');
     cy.clearAllFilters();
   });

--- a/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.cy.tsx
@@ -26,7 +26,7 @@ describe('EdaProjectAddTeams', () => {
     cy.get('table tbody').find('tr').should('have.length', 4);
   });
   it('can filter teams by name', () => {
-    cy.intercept(edaAPI`/teams/?name=Gal*`).as('nameFilterRequest');
+    cy.intercept(edaAPI`/teams/?name=Gal*`, { statusCode: 200 }).as('nameFilterRequest');
     cy.get('[data-cy="text-input"]').within(() => {
       cy.get('input').clear().type('Gal', { delay: 0 });
     });

--- a/frontend/eda/projects/components/EdaProjectAddTeams.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddTeams.tsx
@@ -37,7 +37,7 @@ export function EdaProjectAddTeams() {
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
   const { data: project, isLoading } = useGet<EdaProject>(edaAPI`/projects/${params.id ?? ''}/`);
-  const userProgressDialog = useEdaBulkActionDialog<TeamRolePair>();
+  const teamRoleProgressDialog = useEdaBulkActionDialog<TeamRolePair>();
 
   if (isLoading || !project) return <LoadingPage />;
 
@@ -97,7 +97,7 @@ export function EdaProjectAddTeams() {
       }
     }
     return new Promise<void>((resolve) => {
-      userProgressDialog({
+      teamRoleProgressDialog({
         title: t('Add roles'),
         keyFn: ({ team, role }) => `${team.id}_${role.id}`,
         items,

--- a/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
@@ -26,7 +26,7 @@ describe('EdaProjectAddUsers', () => {
     cy.get('table tbody').find('tr').should('have.length', 6);
   });
   it('can filter users by username', () => {
-    cy.intercept(edaAPI`/users/?name=demo*`).as('nameFilterRequest');
+    cy.intercept(edaAPI`/users/?name=demo*`, { statusCode: 200 }).as('nameFilterRequest');
     cy.get('[data-cy="text-input"]').within(() => {
       cy.get('input').clear().type('demo', { delay: 0 });
     });

--- a/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
@@ -1,10 +1,10 @@
 import { edaAPI } from '../../common/eda-utils';
-import { EdaProjectAddTeams } from './EdaProjectAddTeams';
+import { EdaProjectAddUsers } from './EdaProjectAddUsers';
 
-describe('EdaProjectAddTeams', () => {
-  const component = <EdaProjectAddTeams />;
-  const path = '/projects/:id/team-access/add-teams';
-  const initialEntries = [`/projects/1/team-access/add-teams`];
+describe('EdaProjectAddUsers', () => {
+  const component = <EdaProjectAddUsers />;
+  const path = '/projects/:id/user-access/add-users';
+  const initialEntries = [`/projects/1/user-access/add-users`];
   const params = {
     path,
     initialEntries,
@@ -12,39 +12,39 @@ describe('EdaProjectAddTeams', () => {
 
   beforeEach(() => {
     cy.intercept('GET', edaAPI`/projects/*`, { fixture: 'edaProject.json' });
-    cy.intercept('GET', edaAPI`/teams/?order_by=name*`, { fixture: 'edaTeams.json' });
+    cy.intercept('GET', edaAPI`/users/?order_by=username*`, { fixture: 'edaUsers.json' });
     cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=project*`, {
       fixture: 'edaProjectRoles.json',
     });
     cy.mount(component, params);
   });
   it('should render with correct steps', () => {
-    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select team(s)');
+    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select user(s)');
     cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select roles to apply');
     cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Review');
-    cy.get('[data-cy="wizard-nav-item-teams"] button').should('have.class', 'pf-m-current');
-    cy.get('table tbody').find('tr').should('have.length', 4);
+    cy.get('[data-cy="wizard-nav-item-users"] button').should('have.class', 'pf-m-current');
+    cy.get('table tbody').find('tr').should('have.length', 6);
   });
-  it('can filter teams by name', () => {
-    cy.intercept(edaAPI`/teams/?name=Gal*`).as('nameFilterRequest');
+  it('can filter users by username', () => {
+    cy.intercept(edaAPI`/users/?name=demo*`).as('nameFilterRequest');
     cy.get('[data-cy="text-input"]').within(() => {
-      cy.get('input').clear().type('Gal', { delay: 0 });
+      cy.get('input').clear().type('demo', { delay: 0 });
     });
     cy.getByDataCy('apply-filter').click();
     cy.wait('@nameFilterRequest');
     cy.clearAllFilters();
   });
-  it('should validate that at least one team is selected for moving to next step', () => {
-    cy.get('table tbody').find('tr').should('have.length', 4);
+  it('should validate that at least one user is selected for moving to next step', () => {
+    cy.get('table tbody').find('tr').should('have.length', 6);
     cy.clickButton(/^Next$/);
-    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one team.');
-    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one user.');
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
-    cy.get('[data-cy="wizard-nav-item-teams"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-users"] button').should('not.have.class', 'pf-m-current');
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
   });
   it('should validate that at least one role is selected for moving to Review step', () => {
-    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
     cy.clickButton(/^Next$/);
@@ -54,15 +54,15 @@ describe('EdaProjectAddTeams', () => {
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
   });
-  it('should display selected team and role in the Review step', () => {
-    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+  it('should display selected user and role in the Review step', () => {
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.selectTableRowByCheckbox('name', 'Project Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
-    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Teams');
-    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', '1');
-    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Demo');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'Users');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'demo-user');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Project Admin');
@@ -72,11 +72,11 @@ describe('EdaProjectAddTeams', () => {
     );
   });
   it('should trigger bulk action dialog on submit', () => {
-    cy.intercept('POST', edaAPI`/role_team_assignments/`, {
+    cy.intercept('POST', edaAPI`/role_user_assignments/`, {
       statusCode: 201,
-      body: { team: 3, role_definition: 14, content_type: 'eda.project', object_id: 1 },
+      body: { user: 5, role_definition: 14, content_type: 'eda.project', object_id: 1 },
     }).as('createRoleAssignment');
-    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.selectTableRowByCheckbox('name', 'Project Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
@@ -85,7 +85,7 @@ describe('EdaProjectAddTeams', () => {
     // Bulk action modal is displayed with success
     cy.get('.pf-v5-c-modal-box').within(() => {
       cy.get('table tbody').find('tr').should('have.length', 1);
-      cy.get('table tbody').should('contain.text', 'Demo');
+      cy.get('table tbody').should('contain.text', 'demo-user');
       cy.get('table tbody').should('contain.text', 'Project Admin');
       cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
       cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');

--- a/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.cy.tsx
@@ -26,11 +26,8 @@ describe('EdaProjectAddUsers', () => {
     cy.get('table tbody').find('tr').should('have.length', 6);
   });
   it('can filter users by username', () => {
-    cy.intercept(edaAPI`/users/?name=demo*`, { statusCode: 200 }).as('nameFilterRequest');
-    cy.get('[data-cy="text-input"]').within(() => {
-      cy.get('input').clear().type('demo', { delay: 0 });
-    });
-    cy.getByDataCy('apply-filter').click();
+    cy.intercept(edaAPI`/users/?name=demo*`, { fixture: 'edaUsers.json' }).as('nameFilterRequest');
+    cy.filterTableByText('demo');
     cy.wait('@nameFilterRequest');
     cy.clearAllFilters();
   });

--- a/frontend/eda/projects/components/EdaProjectAddUsers.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.tsx
@@ -64,7 +64,7 @@ export function EdaProjectAddUsers() {
       },
     },
     {
-      id: 'edaRoles',
+      id: 'roles',
       label: t('Select roles to apply'),
       inputs: (
         <EdaSelectRolesStep

--- a/frontend/eda/projects/components/EdaProjectAddUsers.tsx
+++ b/frontend/eda/projects/components/EdaProjectAddUsers.tsx
@@ -137,7 +137,7 @@ export function EdaProjectAddUsers() {
           },
           {
             label: t('User Access'),
-            to: getPageUrl(EdaRoute.ProjectUsers, { params: { id: project?.id } }),
+            to: getPageUrl(EdaRoute.ProjectUserAccess, { params: { id: project?.id } }),
           },
           { label: t('Add roles') },
         ]}
@@ -147,7 +147,7 @@ export function EdaProjectAddUsers() {
         onSubmit={onSubmit}
         disableGrid
         onCancel={() => {
-          pageNavigate(EdaRoute.ProjectUsers, { params: { id: project?.id } });
+          pageNavigate(EdaRoute.ProjectUserAccess, { params: { id: project?.id } });
         }}
       />
     </PageLayout>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/AAP-22244

This PR includes a few small updates(filters, route names) and adds component tests for the "add roles" UI for EDA projects.
This can be tested with EDA's RBAC-enabled server
`EDA_SERVER=https://eda.dev-feature-rbac.gcp.testing.ansible.com/` (see canvas of `#wg-aap-unified-rbac` for credentials)

Test:
- "Add roles" for adding teams, can be tested from the `Team access` tab for a project
- "Add roles" for adding users, can be tested on the URL `https://localhost:4103/projects/:id/user-access/add-users` (The user access tab is under development)


cc: @appuk 