### PR TITLE
Fix failing Schedules e2e tests.

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -139,9 +139,7 @@ describe('organizations edit and delete', function () {
   it('deletes an organization from the organizations list toolbar', function () {
     cy.navigateTo('awx', 'organizations');
     cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.get('[data-cy="checkbox-column-cell"]').within(() => {
-      cy.get('input').click();
-    });
+    cy.selectTableRow(organization.name, false);
     cy.clickToolbarKebabAction('delete-selected-organizations');
     cy.getModal().within(() => {
       cy.get('#confirm').click();

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -198,7 +198,7 @@ describe('Job templates form Create, Edit, Delete', function () {
       const newName = (jobTemplate.name ?? '') + ' edited';
       cy.filterTableByMultiSelect('name', [jobTemplate.name]);
       cy.getTableRow('name', jobTemplate.name, { disableFilter: true }).should('be.visible');
-      cy.selectTableRowByCheckbox('name', jobTemplate.name, { disableFilter: true });
+      cy.selectTableRow(jobTemplate.name, false);
       cy.get('[data-cy="edit-template"]').click();
       cy.verifyPageTitle('Edit Job Template');
       cy.get('[data-cy="name"]').clear().type(newName);
@@ -291,8 +291,8 @@ describe('Job templates form Create, Edit, Delete', function () {
       }).then((jobTemplate2) => {
         cy.navigateTo('awx', 'templates');
         cy.filterTableByMultiSelect('name', [jobTemplate1.name, jobTemplate2.name]);
-        cy.selectTableRowByCheckbox('name', jobTemplate1.name, { disableFilter: true });
-        cy.selectTableRowByCheckbox('name', jobTemplate2.name, { disableFilter: true });
+        cy.selectTableRow(jobTemplate1.name, false);
+        cy.selectTableRow(jobTemplate2.name, false);
         cy.clickToolbarKebabAction('delete-selected-templates');
         cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate1.id.toString()}/`).as(
           'deleteJobTemplate1'

--- a/frontend/awx/resources/templates/components/PageFormWorkflowJobTemplateSelect.tsx
+++ b/frontend/awx/resources/templates/components/PageFormWorkflowJobTemplateSelect.tsx
@@ -43,9 +43,9 @@ export function PageFormWorkflowJobTemplateSelect<
         }
         return (value as WorkflowJobTemplate)?.name ?? '';
       }}
-      placeholder={t('Select job template')}
-      loadingPlaceholder={t('Loading job templates...')}
-      loadingErrorText={t('Error loading job templates')}
+      placeholder={t('Select workflow job template')}
+      loadingPlaceholder={t('Loading workflow job templates...')}
+      loadingErrorText={t('Error loading workflow job templates')}
       isRequired={props.isRequired}
       limit={200}
       openSelectDialog={openSelectDialog}

--- a/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
@@ -1,15 +1,32 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { IToolbarFilter, usePageDialog } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { useTemplateColumns } from './useTemplateColumns';
-import { useTemplateFilters } from './useTemplateFilters';
+import {
+  useCreatedByToolbarFilter,
+  useDescriptionToolbarFilter,
+  useModifiedByToolbarFilter,
+  useNameToolbarFilter,
+} from '../../../common/awx-toolbar-filters';
 
 function SelectJobTemplate(props: { title: string; onSelect: (template: JobTemplate) => void }) {
-  const toolbarFilters = useTemplateFilters();
+  const nameToolbarFilter = useNameToolbarFilter();
+  const descriptionToolbarFilter = useDescriptionToolbarFilter();
+  const createdByToolbarFilter = useCreatedByToolbarFilter();
+  const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      nameToolbarFilter,
+      descriptionToolbarFilter,
+      createdByToolbarFilter,
+      modifiedByToolbarFilter,
+    ],
+    [nameToolbarFilter, descriptionToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
+  );
   const tableColumns = useTemplateColumns({ disableLinks: true });
   const view = useAwxView<JobTemplate>({
     url: awxAPI`/job_templates/`,

--- a/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
@@ -1,21 +1,38 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { IToolbarFilter, usePageDialog } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { useTemplateColumns } from './useTemplateColumns';
-import { useTemplateFilters } from './useTemplateFilters';
+import {
+  useCreatedByToolbarFilter,
+  useDescriptionToolbarFilter,
+  useModifiedByToolbarFilter,
+  useNameToolbarFilter,
+} from '../../../common/awx-toolbar-filters';
 
 function SelectWorkflowJobTemplate(props: {
   title: string;
   onSelect: (template: WorkflowJobTemplate) => void;
 }) {
-  const toolbarFilters = useTemplateFilters();
+  const nameToolbarFilter = useNameToolbarFilter();
+  const descriptionToolbarFilter = useDescriptionToolbarFilter();
+  const createdByToolbarFilter = useCreatedByToolbarFilter();
+  const modifiedByToolbarFilter = useModifiedByToolbarFilter();
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      nameToolbarFilter,
+      descriptionToolbarFilter,
+      createdByToolbarFilter,
+      modifiedByToolbarFilter,
+    ],
+    [nameToolbarFilter, descriptionToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
+  );
   const tableColumns = useTemplateColumns({ disableLinks: true });
   const view = useAwxView<WorkflowJobTemplate>({
-    url: awxAPI`/job_templates/`,
+    url: awxAPI`/workflow_job_templates/`,
     toolbarFilters,
     tableColumns,
     disableQueryString: true,
@@ -35,7 +52,9 @@ export function useSelectWorkflowJobTemplate() {
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (template: WorkflowJobTemplate) => void) => {
-      setDialog(<SelectWorkflowJobTemplate title={t('Select job template')} onSelect={onSelect} />);
+      setDialog(
+        <SelectWorkflowJobTemplate title={t('Select workflow job template')} onSelect={onSelect} />
+      );
     },
     [setDialog, t]
   );


### PR DESCRIPTION
E2E tests were failing for Schedules at this test case: `workflow job template renders prompt step` and causing the other tests to subsequently fail.

This PR reverts the `Workflow job template` and `Job template` select modals to use a simple toolbar until `searchAndDisplayResource` can support text input and multi-select.