### PR TITLE
Controller > Schedules tests structure

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/// <reference types="cypress" />
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { InventorySource } from '../../../../frontend/awx/interfaces/InventorySource';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../../../frontend/awx/interfaces/Schedule';
 
-describe('schedules', () => {
+describe('Schedules', () => {
   let schedule: Schedule;
   let organization: Organization;
   let inventory: Inventory;
@@ -31,6 +29,7 @@ describe('schedules', () => {
         });
       });
     });
+    cy.navigateTo('awx', 'schedules');
   });
 
   afterEach(() => {
@@ -38,14 +37,12 @@ describe('schedules', () => {
   });
 
   it('renders schedules list', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.verifyPageTitle('Schedules');
-    cy.getTableRowByText(schedule.name);
+    cy.getTableRow('name', schedule.name);
     cy.deleteAWXSchedule(schedule);
   });
 
   it('renders the toolbar and row actions', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.get('.pf-v5-c-toolbar__group button.toggle-kebab').click();
     cy.get('.pf-v5-c-dropdown__menu').within(() => {
       cy.contains(/^Delete selected schedules$/).should('exist');
@@ -53,33 +50,7 @@ describe('schedules', () => {
     });
   });
 
-  it('deletes a schedule from the schedules list row', () => {
-    cy.navigateTo('awx', 'schedules');
-    cy.clickTableRowKebabAction(schedule.name, 'delete-schedule', true);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete schedule/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.filterTableByText(schedule.name);
-    cy.contains('No results found');
-  });
-
-  it('deletes a schedule from the schedules list toolbar', () => {
-    cy.navigateTo('awx', 'schedules');
-    cy.getTableRowByText(schedule.name).within(() => {
-      cy.get('input[aria-label="Select all rows"]').click();
-    });
-    cy.clickToolbarKebabAction('delete-selected-schedules');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete schedule/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.contains('tr', schedule.name).should('not.exist');
-    cy.clickButton(/^Clear all filters$/);
-  });
-
   it('loads the correct options for the schedule wizard', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.get('.pf-v5-c-form__label-text').contains(/Resource type/);
   });
@@ -91,7 +62,6 @@ describe('schedules', () => {
       inventory: inventory.id,
       ask_variables_on_launch: true,
     }).then((jobTemplate) => {
-      cy.navigateTo('awx', 'schedules');
       cy.getBy('[data-cy="create-schedule"]').click();
       cy.selectDropdownOptionByResourceName('node_type', 'Job template');
       cy.selectDropdownOptionByResourceName('job-template-select', jobTemplate.name);
@@ -105,7 +75,6 @@ describe('schedules', () => {
       inventory: inventory.id,
       ask_variables_on_launch: true,
     }).then((workflowJobTemplate) => {
-      cy.navigateTo('awx', 'schedules');
       cy.getBy('[data-cy="create-schedule"]').click();
       cy.selectDropdownOptionByResourceName('node_type', 'Workflow job template');
       cy.selectDropdownOptionByResourceName('job-template-select', workflowJobTemplate.name);
@@ -114,7 +83,6 @@ describe('schedules', () => {
   });
 
   it('project does not renders prompt step', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.getBy('[data-cy="node_type-form-group"]').click();
     cy.getBy('[data-cy="project"]').click();
@@ -123,7 +91,6 @@ describe('schedules', () => {
   });
 
   it('management jobs does not renders prompt step', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.selectDropdownOptionByResourceName('node_type', 'Management job template');
     cy.selectDropdownOptionByResourceName(
@@ -134,11 +101,98 @@ describe('schedules', () => {
   });
 
   it('inventory source does not renders prompt step', () => {
-    cy.navigateTo('awx', 'schedules');
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.selectDropdownOptionByResourceName('node_type', 'Inventory source');
     cy.selectDropdownOptionByResourceName('inventory', inventory.name);
     cy.selectDropdownOptionByResourceName('inventory-source-select', inventorySource.name);
     cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Rules');
   });
+});
+
+describe('Schedules - Create', () => {
+  it.skip('can create a simple schedule and navigate to the schedule details page', () => {
+    //Make sure to assert schedule summary, rules preview, exceptions preview
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+  it.skip('can create a simple schedule of resource type Job template', () => {
+    //Make sure to assert the input data in the review step
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+
+  it.skip('can create a simple schedule of resource type Workflow job template', () => {
+    //Make sure to assert the input data in the review step
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+
+  it.skip('can create a simple schedule of resource type Inventory source', () => {
+    //Make sure to assert the input data in the review step
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+
+  it.skip('can create a simple schedule of resource type Project', () => {
+    //Make sure to assert the input data in the review step
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+
+  it.skip('can create a simple schedule of resource type Management job template', () => {
+    //Make sure to assert the input data in the review step
+    //Survey, prompts, rules and exceptions are not needed for this test
+  });
+
+  it.skip('can create a complex schedule and navigate to details page', () => {
+    //Survey, prompts, rules and exceptions should be included
+  });
+});
+
+describe('Schedules - Delete', () => {
+  let schedule: Schedule;
+
+  before(() => {
+    cy.awxLogin();
+  });
+
+  beforeEach(() => {
+    cy.createAWXSchedule().then((sched: Schedule) => (schedule = sched));
+    cy.navigateTo('awx', 'schedules');
+  });
+
+  it('deletes a schedule from the schedules list row', () => {
+    cy.clickTableRowKebabAction(schedule.name, 'delete-schedule', true);
+    cy.get('#confirm').click();
+    cy.clickButton(/^Delete schedule/);
+    cy.contains(/^Success$/);
+    cy.clickButton(/^Close$/);
+    cy.filterTableByTextFilter('name', schedule.name);
+    cy.contains('No results found');
+  });
+
+  it('deletes a schedule from the schedules list toolbar', () => {
+    cy.getTableRow('name', schedule.name).within(() => {
+      cy.get('input[aria-label="Select all rows"]').click();
+    });
+    cy.clickToolbarKebabAction('delete-selected-schedules');
+    cy.get('#confirm').click();
+    cy.clickButton(/^Delete schedule/);
+    cy.contains(/^Success$/);
+    cy.clickButton(/^Close$/);
+    cy.contains('tr', schedule.name).should('not.exist');
+    cy.clickButton(/^Clear all filters$/);
+  });
+
+  it.skip('user can bulk delete schedules from the Schedules list page ', () => {
+    //Make sure to assert the deletion by intercepting the Delete request
+  });
+});
+
+describe('Schedules - Edit', () => {
+  //Make sure to assert the deletion by intercepting the Patch request
+
+  it.skip('can edit a simple schedule from details page', () => {});
+  it.skip('can edit a simple schedule from the schedules list row', () => {});
+  it.skip('can edit a schedule to add rules', () => {});
+  it.skip('can edit a schedule to exceptions', () => {});
+  it.skip('can edit a schedule to remove rules', () => {});
+  it.skip('can edit a schedule remove exceptions', () => {});
+  it.skip('can enable a schedule', () => {});
+  it.skip('can disable a schedule', () => {});
 });


### PR DESCRIPTION
This PR closes [AAP-21388](https://issues.redhat.com/browse/AAP-21388)

- Test stubs added
- Refactor the existing tests
- Replace deprecated  `cy.filterTableByText` with `cy.filterTableByTextFilter`
- Replace deprecated `cy.getTableRowByText` with `cy.getTableRow`