### PR TITLE
Notifications add edit form

### DIFF
--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -29,8 +29,9 @@ import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/Page
 import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatch';
 import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGroup';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
+
 import { useOptions } from '../../../common/crud/useOptions';
-import { genericForm } from './NotifierFormGenerator';
+import { requestCommon } from '../../../common/crud/requestCommon';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -60,7 +61,8 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
   const navigate = useNavigate();
 
-  //const optionsRequest = useOptions<NotificationTemplateOptions>(awxAPI`/notification_templates/`);
+
+  const optionsRequest = useOptions<NotificationTemplateOptions>(awxAPI`/notification_templates/`);
 
   const breadcrumbs: ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
@@ -71,17 +73,17 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
     return <AwxError error={notifierRequest.error} />;
   }
 
-  /*if (optionsRequest.error) {
+  if (optionsRequest.error) {
     return <AwxError error={optionsRequest.error} />;
-  }*/
+  }
 
   if (!notifierRequest.data && mode === 'edit') {
     return <LoadingPage />;
   }
 
-  /*if (!optionsRequest.data) {
+  if (!optionsRequest.data) {
     return <LoadingPage />;
-  }*/
+  }
 
   const defaultValue = mode === 'add' ? {} : notifierRequest.data;
 
@@ -91,8 +93,12 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
 
   const onSubmit: PageFormSubmitHandler<NotificationTemplate> = async (data) => {
     stringToArrays(data);
-
-    console.log(data);
+    const id = mode === 'edit' ? data.id?.toString() : '';
+    return requestCommon({
+      url : awxAPI`/notification_templates/${id}`,
+      method : mode === 'edit' ? 'PATCH' : 'POST',
+      body : data,
+    });
   };
 
   return (

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   ICatalogBreadcrumb,
+  LoadingPage,
   PageFormDataEditor,
   PageFormSubmitHandler,
   PageFormTextInput,
@@ -17,6 +18,10 @@ import {
 import { AwxPageForm } from '../../common/AwxPageForm';
 import { NotificationTemplate } from '../../interfaces/NotificationTemplate';
 import { AwxRoute } from '../../main/AwxRoutes';
+
+import { awxAPI } from '../../common/api/awx-utils';
+import { useGet } from '../../../common/crud/useGet';
+import { AwxError } from '../../common/AwxError';
 
 export function EditNotifier()
 {
@@ -33,12 +38,25 @@ function NotifierForm(props : {mode : 'add' | 'edit'})
   const {t} = useTranslation();
   const getPageUrl = useGetPageUrl();
   const {mode } = props;
+  const params = useParams<{ id : string }>();
+  let getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
+  const notifierRequest = useGet<NotificationTemplate>(getUrl);
 
   const breadcrumbs : ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
     { label: mode === 'add' ? t('Add') : t('Edit') }
-  ]
- 
+  ];
+
+  if (notifierRequest.error)
+  {
+    return <AwxError error={notifierRequest.error} />;
+  }
+
+  if (!notifierRequest.data && mode === 'edit')
+  {
+    return <LoadingPage />
+  }
+
   return (
   <PageLayout>
       <PageHeader breadcrumbs={breadcrumbs} title={ mode === 'edit' ? t('Edit notifier') : t('Add notifier')} />

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -23,6 +23,7 @@ import { awxAPI } from '../../common/api/awx-utils';
 import { useGet } from '../../../common/crud/useGet';
 import { AwxError } from '../../common/AwxError';
 import { PageFormSelectOrganization } from '../../access/organizations/components/PageFormOrganizationSelect';
+import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -82,6 +83,24 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
             placeholder={t('Enter a description')}
           />
           <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
+          <PageFormSingleSelect
+            name="type"
+            id="type"
+            label={t(`Type`)}
+            placeholder={t('Choose a Notification Type')}
+            options={[
+              { value: 'email', label: t('Email') },
+              { value: 'grafana', label: t('Grafana') },
+              { value: 'irc', label: t('IRC') },
+              { value: 'mattermost', label: t('Mattermost') },
+              { value: 'pagerduty', label: t('Pagerduty') },
+              { value: 'rocketchat', label: t('Rocket.Chat') },
+              { value: 'slack', label: t('Slack') },
+              { value: 'twilio', label: t('Twilio') },
+              { value: 'webhook', label: t('Webhook') },
+            ]}
+          />
+
       </AwxPageForm>
     </PageLayout>
   );

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -438,15 +438,40 @@ function GrafanaForm() {
     <>
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.grafana_url'}
+        name={'notification_configuration.grafana_url'}
         label={t('Grafana URL')}
-        placeholder={''}
+        labelHelp={t('The base URL of the Grafana server - the /api/annotations endpoint will be added automatically to the base Grafana URL.')}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
-        name={'type_data.grafana_key'}
+        type={'password'}
+        name={'notification_configuration.grafana_key'}
         label={t('Grafana API Key')}
-        placeholder={''}
+        isRequired
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'notification_configuration.dashboardId'}
+        label={t('ID of the dashboard (optional)')}
+      />
+     
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'notification_configuration.panelId'}
+        label={t('ID of the panel (optional)')}
+      />
+
+      <PageFormTextArea<NotificationTemplate>
+        name={'notification_configuration.annotation_tags'}
+        label={t('Tags for the annotation (optional)')}
+        labelHelp={t('Use one Annotation Tag per line, without commas.')}
+      />
+
+         
+      <PageFormCheckbox<NotificationTemplate>
+        name={'notification_configuration.grafana_no_verify_ssl'}
+        label={t('Disable SSL verification')}
       />
     </>
   );
@@ -632,6 +657,11 @@ function isList(key: string, notification_type: string) {
   }
 
   if (key === 'to_numbers' && notification_type === 'twilio')
+  {
+    return true;
+  }
+
+  if (key === 'annotation_tags' && notification_type === 'grafana')
   {
     return true;
   }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -374,28 +374,39 @@ function TwilioForm() {
     <>
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.account_sid'}
+        name={'notification_configuration.account_sid'}
         label={t('Account SID')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
-        name={'type_data.account_token'}
+        type={'password'}
+        name={'notification_configuration.account_token'}
         label={t('Account Token')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.from_number'}
+        name={'notification_configuration.from_number'}
         label={t('Source Phone Number')}
-        placeholder={''}
+        validate={(value) => twilioPhoneNumber(value, t)}
+        isRequired
+        labelHelp={t('The number associated with the "Messaging Service" in Twilio with the format +18005550199.')}
       />
 
       <PageFormTextArea<NotificationTemplate>
-        name={'type_data.to_numbers'}
+        name={'notification_configuration.to_numbers'}
         label={t('Destination SMS Numbers')}
-        placeholder={''}
+        validate={(value) => twilioPhoneNumber(value, t)}
+        labelHelp={
+          <Trans>
+          Use one phone number per line to specify where to route SMS messages. 
+          Phone numbers should be formatted +11231231234. 
+          For more information see Twilio <a href=''>documentation</a>
+          
+          </Trans>}
+        isRequired
       />
     </>
   );
@@ -634,6 +645,11 @@ function isList(key: string, notification_type: string) {
     return true;
   }
 
+  if (key === 'to_numbers' && notification_type === 'twilio')
+  {
+    return true;
+  }
+
   return false;
 }
 
@@ -644,7 +660,11 @@ function validateEmail(value : string, t : TFunction<"translation", undefined>) 
 
     // This is ok, because the server will always do strict validation for us.
 
-    const splitVals = value.split('@');
+    if (value === '')
+    {
+      return undefined;
+    }
+    const splitVals = value?.split('@');
 
     if (splitVals.length >= 2) {
       if (splitVals[0] && splitVals[1]) {
@@ -666,4 +686,27 @@ function validateNumber(str : string, min : number, max : number, t : TFunction<
   }
 
   return t('This field must be a number and have a value between {{min}} and {{max}}', { min, max});
+}
+
+export function twilioPhoneNumber(value : string, t : TFunction<"translation", undefined>) {
+ 
+    if (value === '')
+    {
+      return undefined;
+    }
+
+    const phoneNumbers = value?.split('\n');
+    let error = undefined;
+
+    phoneNumbers?.forEach((v) => {
+      if (v === '')
+      {
+        return;
+      }
+
+      if (!/^\s*(?:\+?(\d{1,3}))?[. (]*(\d{7,12})$/.test(v)) {
+           error =  t('Please enter valid phone numbers.');
+      }
+    });
+    return error;
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -49,6 +49,8 @@ export type NotificationTemplateOptions = {
   };
 };
 
+type NotificationTemplatEdit = Omit<NotificationTemplate, "id">;
+
 function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -89,7 +91,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   }
 
   const onSubmit: PageFormSubmitHandler<NotificationTemplate> = async (formData) => {
-    const data: NotificationTemplate =
+    const data: NotificationTemplate | NotificationTemplatEdit =
       mode === 'add'
         ? formData
         : {
@@ -102,18 +104,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
           };
 
     stringToArrays(data);
-
-    // delete unused parameters
-    if (mode === 'edit') {
-      delete data.created;
-      delete data.id;
-      delete data.related;
-      delete data.summary_fields;
-      delete data.modified;
-      delete data.type;
-      delete data.url;
-    }
-
+ 
     let fieldValue;
     // fix notification data types
     const fields =
@@ -612,7 +603,7 @@ function arraysToString(data: NotificationTemplate) {
   }
 }
 
-function stringToArrays(data: NotificationTemplate) {
+function stringToArrays(data: NotificationTemplate | NotificationTemplatEdit) {
   if (!data.notification_configuration) {
     return;
   }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -122,7 +122,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         fieldValue = fields[field];
         if (fieldValue.type === 'int' && typeof notification_configuration[field] === 'string') {
           notification_configuration[field] = Number.parseInt(
-            notification_configuration[field] as string
+            notification_configuration[field] as string, 10
           );
         }
 
@@ -713,7 +713,7 @@ function validateNumber(
   max: number,
   t: TFunction<'translation', undefined>
 ) {
-  const val = Number.parseInt(str);
+  const val = Number.parseInt(str, 10);
   if (val >= min && val <= max) {
     return undefined;
   }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -7,8 +7,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   ICatalogBreadcrumb,
   LoadingPage,
+  PageFormCheckbox,
   PageFormDataEditor,
   PageFormSubmitHandler,
+  PageFormTextArea,
   PageFormTextInput,
   PageHeader,
   PageLayout,
@@ -130,7 +132,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         <PageFormWatch watch="notification_type">{(notification_type : string) => 
           <>
             {notification_type && optionsRequest.data && 
-              <PageFormSection singleColumn>
+              <PageFormSection>
                 <PageFormGroup
                   label={t('Type Details')}
                 >
@@ -159,7 +161,7 @@ function textType(type : string)
     return 'password';
   }
 
-  if (type === 'number')
+  if (type === 'int')
   {
     return 'number';
   }
@@ -182,33 +184,12 @@ function TypeForm(props: { mode: 'add' | 'edit', notification_type : string, opt
 
   return <>
     {Object.keys(options).map( (key) => {
-      const option = options[key];
-
-      if (!option?.label)
-      {
-        return <></>;
-      }
-
-      if (option.type === 'string' || option.type === 'number' || option.type === 'password')
-      {
-        return (
-          <>
-          <PageFormTextInput<NotificationTemplate>
-            type={textType(option.type)}
-            name={'type_data.' + key}
-            id={'type_data.' + key}
-            label={t(option.label)}
-            placeholder={''}
-            isRequired={isRequired(props.mode, props.notification_type, option.label)}
-            maxLength={150}
-          /> 
-          </>
-        );
-      }
-
-       
-
-      return <></>;
+      return <ComponentFromOptions
+        mode = {props.mode}
+        notification_type= {props.notification_type}
+        optionsData={props.optionsData}
+        field = {key}
+      ></ComponentFromOptions>;
     })}
   </>;
   }catch(error)
@@ -216,7 +197,83 @@ function TypeForm(props: { mode: 'add' | 'edit', notification_type : string, opt
     debugger;
     return <>{error}</>;
   }
-  return <></>;
+}
+
+function ComponentFromOptions(props: { mode: 'add' | 'edit', notification_type : string, field : string, optionsData :  NotificationTemplateOptions })
+{
+
+  const { t } = useTranslation();
+
+  try
+  {
+    const options = props.optionsData.actions.GET.notification_configuration[props.notification_type];
+    const field = props.field;
+    if (!options)
+    {
+      return <></>;
+    }
+
+    const option = options[field];
+
+    if (!option)
+    {
+      return <></>;
+    }
+
+    const name = 'type_data.' + field;
+        
+    const label = t(option.label);
+        
+        if (option.type === 'string' || option.type === 'number' || option.type === 'password')
+        {
+          return (
+            <>
+            <PageFormTextInput<NotificationTemplate>
+              type={textType(option.type)}
+              name={name}
+              label={label}
+              placeholder={''}
+              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+            /> 
+            </>
+          );
+        }
+
+        if (option.type === 'list')
+        {
+          return (
+            <>
+            <PageFormTextArea<NotificationTemplate>
+              type={textType(option.type)}
+              name={name}
+              label={label}
+              placeholder={''}
+              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+            /> 
+            </>
+          );
+        }
+
+        if (option.type === 'bool')
+        {
+          return (
+            <>
+            <PageFormCheckbox<NotificationTemplate>
+              type={textType(option.type)}
+              name={name}
+              label={label}
+              placeholder={''}
+              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+            /> 
+            </>
+          );
+        }
+        return <></>;
+    }catch(error)
+    {
+      debugger;
+      return <>{t('Error loading component')}</>;
+    }
 }
 
 

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -68,56 +68,51 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         submitText={t('Save host')}
         onSubmit={() => {}}
         cancelText={t('Cancel')}
-        onCancel={ () => navigate(-1)}
+        onCancel={() => navigate(-1)}
         defaultValue={defaultValue}
       >
-          <PageFormTextInput<NotificationTemplate>
-            name="name"
-            label={t('Name')}
-            placeholder={t('Enter a name')}
-            isRequired
-            maxLength={150}
-          />
-          <PageFormTextInput<NotificationTemplate>
-            name="description"
-            label={t('Description')}
-            placeholder={t('Enter a description')}
-          />
-          <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
-          <PageFormSingleSelect
-            name="notification_type"
-            id="notification_type"
-            label={t(`Type`)}
-            placeholder={t('Choose a Notification Type')}
-            isRequired={true}
-            options={[
-              { value: 'email', label: t('Email') },
-              { value: 'grafana', label: t('Grafana') },
-              { value: 'irc', label: t('IRC') },
-              { value: 'mattermost', label: t('Mattermost') },
-              { value: 'pagerduty', label: t('Pagerduty') },
-              { value: 'rocketchat', label: t('Rocket.Chat') },
-              { value: 'slack', label: t('Slack') },
-              { value: 'twilio', label: t('Twilio') },
-              { value: 'webhook', label: t('Webhook') },
-            ]}
-          />
-          <PageFormWatch watch="notification_type">
-          {() =>
-            <TypeForm mode={mode}/>
-          }
-          </PageFormWatch>
+        <PageFormTextInput<NotificationTemplate>
+          name="name"
+          label={t('Name')}
+          placeholder={t('Enter a name')}
+          isRequired
+          maxLength={150}
+        />
+        <PageFormTextInput<NotificationTemplate>
+          name="description"
+          label={t('Description')}
+          placeholder={t('Enter a description')}
+        />
+        <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
+        <PageFormSingleSelect
+          name="notification_type"
+          id="notification_type"
+          label={t(`Type`)}
+          placeholder={t('Choose a Notification Type')}
+          isRequired={true}
+          options={[
+            { value: 'email', label: t('Email') },
+            { value: 'grafana', label: t('Grafana') },
+            { value: 'irc', label: t('IRC') },
+            { value: 'mattermost', label: t('Mattermost') },
+            { value: 'pagerduty', label: t('Pagerduty') },
+            { value: 'rocketchat', label: t('Rocket.Chat') },
+            { value: 'slack', label: t('Slack') },
+            { value: 'twilio', label: t('Twilio') },
+            { value: 'webhook', label: t('Webhook') },
+          ]}
+        />
+        <PageFormWatch watch="notification_type">{() => <TypeForm mode={mode} />}</PageFormWatch>
       </AwxPageForm>
     </PageLayout>
   );
 }
 
-function TypeForm(props : {mode : 'add' | 'edit'})
-{
+function TypeForm(props: { mode: 'add' | 'edit' }) {
   const context = useFormContext<NotificationTemplate>();
   const notification_type = context.getValues().notification_type;
- 
-  const {mode} = props;
+
+  const { mode } = props;
   switch (notification_type) {
     case 'email':
       return <EmailForm mode={mode} />;
@@ -177,4 +172,3 @@ function TwilioForm(props: { mode: 'add' | 'edit' }) {
 function WebhookForm(props: { mode: 'add' | 'edit' }) {
   return <></>;
 }
-

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -53,6 +53,8 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
     return <LoadingPage />;
   }
 
+  const defaultValue = mode === 'add' ? {} : notifierRequest.data;
+
   return (
     <PageLayout>
       <PageHeader
@@ -64,8 +66,21 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         onSubmit={() => {}}
         cancelText={t('Cancel')}
         onCancel={ () => navigate(-1)}
-        defaultValue={{}}
-      ></AwxPageForm>
+        defaultValue={defaultValue}
+      >
+          <PageFormTextInput<NotificationTemplate>
+            name="name"
+            label={t('Name')}
+            placeholder={t('Enter a name')}
+            isRequired
+            maxLength={150}
+          />
+          <PageFormTextInput<NotificationTemplate>
+            name="description"
+            label={t('Description')}
+            placeholder={t('Enter a description')}
+          />
+      </AwxPageForm>
     </PageLayout>
   );
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -60,7 +60,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
   const navigate = useNavigate();
 
-  const optionsRequest = useOptions<NotificationTemplateOptions>(awxAPI`/notification_templates/`);
+  //const optionsRequest = useOptions<NotificationTemplateOptions>(awxAPI`/notification_templates/`);
 
   const breadcrumbs: ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
@@ -71,19 +71,29 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
     return <AwxError error={notifierRequest.error} />;
   }
 
-  if (optionsRequest.error) {
+  /*if (optionsRequest.error) {
     return <AwxError error={optionsRequest.error} />;
-  }
+  }*/
 
   if (!notifierRequest.data && mode === 'edit') {
     return <LoadingPage />;
   }
 
-  if (!optionsRequest.data) {
+  /*if (!optionsRequest.data) {
     return <LoadingPage />;
-  }
+  }*/
 
   const defaultValue = mode === 'add' ? {} : notifierRequest.data;
+
+  if (defaultValue && mode === 'edit') {
+    arraysToString(defaultValue as NotificationTemplate);
+  }
+
+  const onSubmit: PageFormSubmitHandler<NotificationTemplate> = async (data) => {
+    stringToArrays(data);
+
+    console.log(data);
+  };
 
   return (
     <PageLayout>
@@ -93,65 +103,61 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
       />
       <AwxPageForm<NotificationTemplate>
         submitText={t('Save host')}
-        onSubmit={() => {}}
+        onSubmit={onSubmit}
         cancelText={t('Cancel')}
         onCancel={() => navigate(-1)}
         defaultValue={defaultValue}
       >
-        <PageFormTextInput<NotificationTemplate>
-          name="name"
-          label={t('Name')}
-          placeholder={t('Enter a name')}
-          isRequired
-          maxLength={150}
-        />
-        <PageFormTextInput<NotificationTemplate>
-          name="description"
-          label={t('Description')}
-          placeholder={t('Enter a description')}
-        />
-        <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
-        <PageFormSingleSelect
-          name="notification_type"
-          id="notification_type"
-          label={t(`Type`)}
-          placeholder={t('Choose a Notification Type')}
-          isRequired={true}
-          options={[
-            { value: 'email', label: t('Email') },
-            { value: 'grafana', label: t('Grafana') },
-            { value: 'irc', label: t('IRC') },
-            { value: 'mattermost', label: t('Mattermost') },
-            { value: 'pagerduty', label: t('Pagerduty') },
-            { value: 'rocketchat', label: t('Rocket.Chat') },
-            { value: 'slack', label: t('Slack') },
-            { value: 'twilio', label: t('Twilio') },
-            { value: 'webhook', label: t('Webhook') },
-          ]}
-        />
-        <PageFormWatch watch="notification_type">
-          {(notification_type: string) => (
-            <>
-              {optionsRequest.data && (
-                <PageFormSection singleColumn={true}>
-                  <PageFormGroup label={t('Type Details')}>
-                    <InnerForm
-                      notification_type={notification_type}
-                    />
-
-                    {genericForm(optionsRequest.data)}
-                  </PageFormGroup>
-                </PageFormSection>
-              )}
-            </>
-          )}
-        </PageFormWatch>
+        <PageFormSection>
+          <PageFormTextInput<NotificationTemplate>
+            name="name"
+            label={t('Name')}
+            placeholder={t('Enter a name')}
+            isRequired
+            maxLength={150}
+          />
+          <PageFormTextInput<NotificationTemplate>
+            name="description"
+            label={t('Description')}
+            placeholder={t('Enter a description')}
+          />
+          <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
+          <PageFormSingleSelect
+            name="notification_type"
+            id="notification_type"
+            label={t(`Type`)}
+            placeholder={t('Choose a Notification Type')}
+            isRequired={true}
+            options={[
+              { value: 'email', label: t('Email') },
+              { value: 'grafana', label: t('Grafana') },
+              { value: 'irc', label: t('IRC') },
+              { value: 'mattermost', label: t('Mattermost') },
+              { value: 'pagerduty', label: t('Pagerduty') },
+              { value: 'rocketchat', label: t('Rocket.Chat') },
+              { value: 'slack', label: t('Slack') },
+              { value: 'twilio', label: t('Twilio') },
+              { value: 'webhook', label: t('Webhook') },
+            ]}
+          />
+        </PageFormSection>
+        <PageFormSection>
+          <PageFormWatch watch="notification_type">
+            {(notification_type: string) => (
+              <>
+                <PageFormGroup label={t('Type Details')}>
+                  <InnerForm notification_type={notification_type} />
+                </PageFormGroup>
+              </>
+            )}
+          </PageFormWatch>
+        </PageFormSection>
       </AwxPageForm>
     </PageLayout>
   );
 }
 
-function InnerForm(props : {notification_type: string}) {
+function InnerForm(props: { notification_type: string }) {
   const notification_type = props.notification_type;
   if (notification_type === 'email') {
     return <EmailForm />;
@@ -193,74 +199,72 @@ function InnerForm(props : {notification_type: string}) {
 }
 
 function EmailForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.host'}
-        label={t('Host')}
-        placeholder={''}
-      />
-
-      <PageFormTextInput<NotificationTemplate>
-        type={'number'}
-        name={'type_data.port'}
-        label={t('Port')}
-        placeholder={''}
-      />
-
-      <PageFormTextInput<NotificationTemplate>
-        type={'text'}
-        name={'type_data.username'}
+        name={'notification_configuration.username'}
         label={t('Username')}
-        placeholder={''}
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'password'}
-        name={'type_data.password'}
+        name={'notification_configuration.password'}
         label={t('Password')}
-        placeholder={''}
-      />
-
-      <PageFormCheckbox<NotificationTemplate>
-        name={'type_data.use_tls'}
-        label={t('Use TLS')}
-        placeholder={''}
-      />
-
-      <PageFormCheckbox<NotificationTemplate>
-        name={'type_data.use_ssl'}
-        label={t('Use SSL')}
-        placeholder={''}
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.sender'}
-        label={t('Sender Email')}
-        placeholder={''}
+        name={'notification_configuration.host'}
+        label={t('Host')}
+        isRequired
       />
 
       <PageFormTextArea<NotificationTemplate>
-        name={'type_data.recipients'}
+        name={'notification_configuration.recipients'}
         label={t('Recipient List')}
-        placeholder={''}
+        isRequired
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'notification_configuration.sender'}
+        label={t('Sender Email')}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'number'}
-        name={'type_data.timeout'}
-        label={t('Timeout')}
-        placeholder={''}
+        name={'notification_configuration.port'}
+        label={t('Port')}
+        isRequired
       />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'number'}
+        name={'notification_configuration.timeout'}
+        label={t('Timeout')}
+        isRequired
+      />
+
+      <PageFormGroup label={t('Email Options ')}>
+        <PageFormCheckbox<NotificationTemplate>
+          name={'notification_configuration.use_tls'}
+          label={t('Use TLS')}
+        />
+
+        <PageFormCheckbox<NotificationTemplate>
+          name={'notification_configuration.use_ssl'}
+          label={t('Use SSL')}
+        />
+      </PageFormGroup>
     </>
   );
 }
 
 function SlackForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -279,7 +283,7 @@ function SlackForm() {
 }
 
 function TwilioForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -312,7 +316,7 @@ function TwilioForm() {
 }
 
 function PagerdutyForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -346,7 +350,7 @@ function PagerdutyForm() {
 }
 
 function GrafanaForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -366,7 +370,7 @@ function GrafanaForm() {
 }
 
 function WebhookForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -413,7 +417,7 @@ function WebhookForm() {
 }
 
 function MattermostForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -433,7 +437,7 @@ function MattermostForm() {
 }
 
 function RocketchatForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -453,7 +457,7 @@ function RocketchatForm() {
 }
 
 function IrcForm() {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
@@ -496,4 +500,48 @@ function IrcForm() {
       />
     </>
   );
+}
+
+function arraysToString(data: NotificationTemplate) {
+  if (!data.notification_configuration) {
+    return;
+  }
+
+  for (const key in data.notification_configuration) {
+    if (!isList(key, data.notification_type || '')) {
+      continue;
+    }
+
+    // transform array of strings into string
+    const arr = data?.notification_configuration[key] as string[];
+    if (arr && arr.join) {
+      data.notification_configuration[key] = arr.join('\n');
+    }
+  }
+}
+
+function stringToArrays(data: NotificationTemplate) {
+  if (!data.notification_configuration) {
+    return;
+  }
+
+  for (const key in data.notification_configuration) {
+    if (!isList(key, data.notification_type || '')) {
+      continue;
+    }
+
+    // transform array of strings into string
+    const str = data?.notification_configuration[key] as string;
+    if (str && str.split) {
+      data.notification_configuration[key] = str.split('\n');
+    }
+  }
+}
+
+function isList(key: string, notification_type: string) {
+  if (key === 'recipients' && notification_type === 'email') {
+    return true;
+  }
+
+  return false;
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -25,6 +25,8 @@ import { AwxError } from '../../common/AwxError';
 import { PageFormSelectOrganization } from '../../access/organizations/components/PageFormOrganizationSelect';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
 import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatch';
+import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGroup';
+import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -102,17 +104,27 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
             { value: 'webhook', label: t('Webhook') },
           ]}
         />
-        <PageFormWatch watch="notification_type">{() => <TypeForm mode={mode} />}</PageFormWatch>
+        <PageFormWatch watch="notification_type">{(notification_type : string) => 
+          <>
+            {notification_type && 
+              <PageFormSection singleColumn>
+                <PageFormGroup
+                  label={t('Type Details')}
+                >
+                  <TypeForm mode={mode} notification_type={notification_type} />
+                </PageFormGroup>
+              </PageFormSection>
+            }
+          </>
+        }</PageFormWatch>
       </AwxPageForm>
     </PageLayout>
   );
 }
 
-function TypeForm(props: { mode: 'add' | 'edit' }) {
+function TypeForm(props: { mode: 'add' | 'edit', notification_type : string }) {
   const context = useFormContext<NotificationTemplate>();
-  const notification_type = context.getValues().notification_type;
-
-  const { mode } = props;
+  const { mode, notification_type } = props;
   switch (notification_type) {
     case 'email':
       return <EmailForm mode={mode} />;

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -30,7 +30,7 @@ import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatc
 import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGroup';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 import { useOptions } from '../../../common/crud/useOptions';
-import { text } from 'd3';
+import { TFunction } from 'i18next';
 
 
 export function EditNotifier() {
@@ -132,11 +132,11 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         <PageFormWatch watch="notification_type">{(notification_type : string) => 
           <>
             {notification_type && optionsRequest.data && 
-              <PageFormSection>
+              <PageFormSection singleColumn={true}>
                 <PageFormGroup
                   label={t('Type Details')}
                 >
-                  <TypeForm mode={mode} notification_type={notification_type} optionsData={optionsRequest.data} />
+                  {genericForm(t, mode, notification_type, optionsRequest.data)}
                 </PageFormGroup>
               </PageFormSection>
             }
@@ -170,13 +170,11 @@ function textType(type : string)
 }
 
 
-function TypeForm(props: { mode: 'add' | 'edit', notification_type : string, optionsData :  NotificationTemplateOptions })
+function genericForm(t : TFunction<"translation", undefined>, mode: 'add' | 'edit', notification_type : string, optionsData :  NotificationTemplateOptions)
 {
-  const {t} = useTranslation();
-
   try
   {
-  const options = props.optionsData.actions.GET.notification_configuration[props.notification_type];
+  const options = optionsData.actions.GET.notification_configuration[notification_type];
   if (!options)
   {
     return <></>;
@@ -184,12 +182,7 @@ function TypeForm(props: { mode: 'add' | 'edit', notification_type : string, opt
 
   return <>
     {Object.keys(options).map( (key) => {
-      return <ComponentFromOptions
-        mode = {props.mode}
-        notification_type= {props.notification_type}
-        optionsData={props.optionsData}
-        field = {key}
-      ></ComponentFromOptions>;
+      return componentFromOptions(t, mode, notification_type, key, optionsData);
     })}
   </>;
   }catch(error)
@@ -199,15 +192,11 @@ function TypeForm(props: { mode: 'add' | 'edit', notification_type : string, opt
   }
 }
 
-function ComponentFromOptions(props: { mode: 'add' | 'edit', notification_type : string, field : string, optionsData :  NotificationTemplateOptions })
+function componentFromOptions(t : TFunction<"translation", undefined>, mode: 'add' | 'edit', notification_type : string, field : string, optionsData :  NotificationTemplateOptions)
 {
-
-  const { t } = useTranslation();
-
   try
   {
-    const options = props.optionsData.actions.GET.notification_configuration[props.notification_type];
-    const field = props.field;
+    const options = optionsData.actions.GET.notification_configuration[notification_type];
     if (!options)
     {
       return <></>;
@@ -233,7 +222,7 @@ function ComponentFromOptions(props: { mode: 'add' | 'edit', notification_type :
               name={name}
               label={label}
               placeholder={''}
-              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+              isRequired={isRequired(mode, notification_type, option.label)}
             /> 
             </>
           );
@@ -248,7 +237,7 @@ function ComponentFromOptions(props: { mode: 'add' | 'edit', notification_type :
               name={name}
               label={label}
               placeholder={''}
-              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+              isRequired={isRequired(mode, notification_type, option.label)}
             /> 
             </>
           );
@@ -263,7 +252,7 @@ function ComponentFromOptions(props: { mode: 'add' | 'edit', notification_type :
               name={name}
               label={label}
               placeholder={''}
-              isRequired={isRequired(props.mode, props.notification_type, option.label)}
+              isRequired={isRequired(mode, notification_type, option.label)}
             /> 
             </>
           );

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -399,13 +399,7 @@ function TwilioForm() {
         name={'notification_configuration.to_numbers'}
         label={t('Destination SMS Numbers')}
         validate={(value) => twilioPhoneNumber(value, t)}
-        labelHelp={
-          <Trans>
-          Use one phone number per line to specify where to route SMS messages. 
-          Phone numbers should be formatted +11231231234. 
-          For more information see Twilio <a href=''>documentation</a>
-          
-          </Trans>}
+        labelHelp={t('Use one phone number per line to specify where to route SMS messages. Phone numbers should be formatted +11231231234. For more information see Twilio documentation')}
         isRequired
       />
     </>

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Button } from '@patternfly/react-core';
 import { useCallback, useEffect, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useForm, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -24,6 +24,7 @@ import { useGet } from '../../../common/crud/useGet';
 import { AwxError } from '../../common/AwxError';
 import { PageFormSelectOrganization } from '../../access/organizations/components/PageFormOrganizationSelect';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
+import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatch';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -84,10 +85,11 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
           />
           <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
           <PageFormSingleSelect
-            name="type"
-            id="type"
+            name="notification_type"
+            id="notification_type"
             label={t(`Type`)}
             placeholder={t('Choose a Notification Type')}
+            isRequired={true}
             options={[
               { value: 'email', label: t('Email') },
               { value: 'grafana', label: t('Grafana') },
@@ -100,8 +102,79 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
               { value: 'webhook', label: t('Webhook') },
             ]}
           />
-
+          <PageFormWatch watch="notification_type">
+          {() =>
+            <TypeForm mode={mode}/>
+          }
+          </PageFormWatch>
       </AwxPageForm>
     </PageLayout>
   );
 }
+
+function TypeForm(props : {mode : 'add' | 'edit'})
+{
+  const context = useFormContext<NotificationTemplate>();
+  const notification_type = context.getValues().notification_type;
+ 
+  const {mode} = props;
+  switch (notification_type) {
+    case 'email':
+      return <EmailForm mode={mode} />;
+    case 'grafana':
+      return <GrafanaForm mode={mode} />;
+    case 'irc':
+      return <IRCForm mode={mode} />;
+    case 'mattermost':
+      return <MattermostForm mode={mode} />;
+    case 'pagerduty':
+      return <PagerdutyForm mode={mode} />;
+    case 'rocketchat':
+      return <RocketChatForm mode={mode} />;
+    case 'slack':
+      return <SlackForm mode={mode} />;
+    case 'twilio':
+      return <TwilioForm mode={mode} />;
+    case 'webhook':
+      return <WebhookForm mode={mode} />;
+    default:
+      return <></>;
+  }
+}
+
+function EmailForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function GrafanaForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function IRCForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function MattermostForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function PagerdutyForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function RocketChatForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function SlackForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function TwilioForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+
+function WebhookForm(props: { mode: 'add' | 'edit' }) {
+  return <></>;
+}
+

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -28,6 +28,7 @@ import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSe
 import { useOptions } from '../../../common/crud/useOptions';
 import { requestCommon } from '../../../common/crud/requestCommon';
 import { usePageNavigate } from '../../../../framework';
+import { TFunction, t } from 'i18next';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -288,6 +289,7 @@ function EmailForm() {
         name={'notification_configuration.sender'}
         label={t('Sender Email')}
         isRequired
+        validate={(value) => validateEmail(value, t)}
       />
 
       <PageFormTextInput<NotificationTemplate>
@@ -295,6 +297,7 @@ function EmailForm() {
         name={'notification_configuration.port'}
         label={t('Port')}
         isRequired
+        validate={(value) => validateNumber(value, 1, 65535, t)}
       />
 
       <PageFormTextInput<NotificationTemplate>
@@ -302,6 +305,7 @@ function EmailForm() {
         name={'notification_configuration.timeout'}
         label={t('Timeout')}
         isRequired
+        validate={(value) => validateNumber(value, 1, 120, t)}
       />
 
       <PageFormGroup label={t('Email Options ')}>
@@ -600,4 +604,35 @@ function isList(key: string, notification_type: string) {
   }
 
   return false;
+}
+
+function validateEmail(value : string, t : TFunction<"translation", undefined>) {
+    // copied from old app to keep app consistent
+    // This isn't a perfect validator. It's likely to let a few
+    // invalid (though unlikely) email addresses through.
+
+    // This is ok, because the server will always do strict validation for us.
+
+    const splitVals = value.split('@');
+
+    if (splitVals.length >= 2) {
+      if (splitVals[0] && splitVals[1]) {
+        // We get here if the string has an '@' that is enclosed by
+        // non-empty substrings
+        return undefined;
+      }
+    }
+
+    return t('Invalid email address');
+}
+
+function validateNumber(str : string, min : number, max : number, t : TFunction<"translation", undefined>)
+{
+  const val = Number.parseInt(str);
+  if (val >= min && val <= max)
+  {
+    return undefined;
+  }
+
+  return t('This field must be a number and have a value between {{min}} and {{max}}', { min, max});
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -23,50 +23,48 @@ import { awxAPI } from '../../common/api/awx-utils';
 import { useGet } from '../../../common/crud/useGet';
 import { AwxError } from '../../common/AwxError';
 
-export function EditNotifier()
-{
+export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
 }
 
-export function AddNotifier()
-{
+export function AddNotifier() {
   return <NotifierForm mode={'add'} />;
 }
 
-function NotifierForm(props : {mode : 'add' | 'edit'})
-{
-  const {t} = useTranslation();
+function NotifierForm(props: { mode: 'add' | 'edit' }) {
+  const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
-  const {mode } = props;
-  const params = useParams<{ id : string }>();
+  const { mode } = props;
+  const params = useParams<{ id: string }>();
   let getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
 
-  const breadcrumbs : ICatalogBreadcrumb[] = [
+  const breadcrumbs: ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
-    { label: mode === 'add' ? t('Add') : t('Edit') }
+    { label: mode === 'add' ? t('Add') : t('Edit') },
   ];
 
-  if (notifierRequest.error)
-  {
+  if (notifierRequest.error) {
     return <AwxError error={notifierRequest.error} />;
   }
 
-  if (!notifierRequest.data && mode === 'edit')
-  {
-    return <LoadingPage />
+  if (!notifierRequest.data && mode === 'edit') {
+    return <LoadingPage />;
   }
 
   return (
-  <PageLayout>
-      <PageHeader breadcrumbs={breadcrumbs} title={ mode === 'edit' ? t('Edit notifier') : t('Add notifier')} />
+    <PageLayout>
+      <PageHeader
+        breadcrumbs={breadcrumbs}
+        title={mode === 'edit' ? t('Edit notifier') : t('Add notifier')}
+      />
       <AwxPageForm<NotificationTemplate>
         submitText={t('Save host')}
-        onSubmit={ () => {}}
+        onSubmit={() => {}}
         cancelText={t('Cancel')}
-        onCancel={ () => {}}
-        defaultValue={ {} }
-      >
-      </AwxPageForm>
-    </PageLayout>);
+        onCancel={() => {}}
+        defaultValue={{}}
+      ></AwxPageForm>
+    </PageLayout>
+  );
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   ICatalogBreadcrumb,
@@ -282,6 +282,7 @@ function EmailForm() {
         name={'notification_configuration.recipients'}
         label={t('Recipient List')}
         isRequired
+        labelHelp={t('Use one email address per line to create a recipient list for this type of notification.')}
       />
 
       <PageFormTextInput<NotificationTemplate>
@@ -306,9 +307,16 @@ function EmailForm() {
         label={t('Timeout')}
         isRequired
         validate={(value) => validateNumber(value, 1, 120, t)}
+        labelHelp={t('The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds.')}
       />
 
-      <PageFormGroup label={t('Email Options ')}>
+      <PageFormGroup label={t('Email Options ')}
+        labelHelp={
+          <Trans>
+            See Django <a href='https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-EMAIL_USE_TLS'>documentation</a> for more information.
+          </Trans>
+        }
+      >
         <PageFormCheckbox<NotificationTemplate>
           name={'notification_configuration.use_tls'}
           label={t('Use TLS')}

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -28,7 +28,7 @@ import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSe
 import { useOptions } from '../../../common/crud/useOptions';
 import { requestCommon } from '../../../common/crud/requestCommon';
 import { usePageNavigate } from '../../../../framework';
-import { TFunction, t } from 'i18next';
+import { TFunction } from 'i18next';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -49,14 +49,15 @@ export type NotificationTemplateOptions = {
   };
 };
 
-type NotificationTemplatEdit = Omit<NotificationTemplate, "id">;
+type NotificationTemplatEdit = Omit<NotificationTemplate, 'id'>;
 
+// TODO - finish rest of the form in the next PR
 function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const { mode } = props;
   const params = useParams<{ id: string }>();
-  let getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
+  const getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
@@ -94,17 +95,17 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
     const data: NotificationTemplate | NotificationTemplatEdit =
       mode === 'add'
         ? formData
-        : {
+        : ({
             description: formData.description,
             messages: formData.messages,
             name: formData.name,
             notification_configuration: formData.notification_configuration,
             notification_type: formData.notification_type,
             organization: formData.organization,
-          };
+          } as NotificationTemplatEdit);
 
     stringToArrays(data);
- 
+
     let fieldValue;
     // fix notification data types
     const fields =
@@ -228,19 +229,19 @@ function InnerForm(props: { notification_type: string }) {
   }
 
   if (notification_type === 'webhook') {
-    return <WebhookForm />;
+    //return <WebhookForm />;
   }
 
   if (notification_type === 'mattermost') {
-    return <MattermostForm />;
+    //return <MattermostForm />;
   }
 
   if (notification_type === 'rocketchat') {
-    return <RocketchatForm />;
+    //return <RocketchatForm />;
   }
 
   if (notification_type === 'irc') {
-    return <IrcForm />;
+    //return <IrcForm />;
   }
 
   return <></>;
@@ -273,7 +274,9 @@ function EmailForm() {
         name={'notification_configuration.recipients'}
         label={t('Recipient List')}
         isRequired
-        labelHelp={t('Use one email address per line to create a recipient list for this type of notification.')}
+        labelHelp={t(
+          'Use one email address per line to create a recipient list for this type of notification.'
+        )}
       />
 
       <PageFormTextInput<NotificationTemplate>
@@ -298,13 +301,20 @@ function EmailForm() {
         label={t('Timeout')}
         isRequired
         validate={(value) => validateNumber(value, 1, 120, t)}
-        labelHelp={t('The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds.')}
+        labelHelp={t(
+          'The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds.'
+        )}
       />
 
-      <PageFormGroup label={t('Email Options ')}
+      <PageFormGroup
+        label={t('Email Options ')}
         labelHelp={
           <Trans>
-            See Django <a href='https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-EMAIL_USE_TLS'>documentation</a> for more information.
+            See Django{' '}
+            <a href="https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-EMAIL_USE_TLS">
+              documentation
+            </a>{' '}
+            for more information.
           </Trans>
         }
       >
@@ -339,11 +349,14 @@ function SlackForm() {
         isRequired
         labelHelp={
           <Trans>
-            One Slack channel per line. The pound symbol (#) is required for channels. 
-            To respond to or start a thread to a specific message add the parent message Id 
-            to the channel where the parent message Id is 16 digits. A dot (.) 
-            must be manually inserted after the 10th digit. ie:#destination-channel, 1231257890.006423. 
-            See Slack <a href='https://api.slack.com/messaging/retrieving#individual_messages'>documentation</a> for more information.
+            One Slack channel per line. The pound symbol (#) is required for channels. To respond to
+            or start a thread to a specific message add the parent message Id to the channel where
+            the parent message Id is 16 digits. A dot (.) must be manually inserted after the 10th
+            digit. ie:#destination-channel, 1231257890.006423. See Slack{' '}
+            <a href="https://api.slack.com/messaging/retrieving#individual_messages">
+              documentation
+            </a>{' '}
+            for more information.
           </Trans>
         }
       />
@@ -351,9 +364,9 @@ function SlackForm() {
       <PageFormTextInput<NotificationTemplate>
         name={'notification_configuration.hex_color'}
         label={t('Notification color')}
-        labelHelp={
-          t('Specify a notification color. Acceptable colors are hex color code (example: #3af or #789abc).')
-        }
+        labelHelp={t(
+          'Specify a notification color. Acceptable colors are hex color code (example: #3af or #789abc).'
+        )}
       />
     </>
   );
@@ -383,14 +396,18 @@ function TwilioForm() {
         label={t('Source Phone Number')}
         validate={(value) => twilioPhoneNumber(value, t)}
         isRequired
-        labelHelp={t('The number associated with the "Messaging Service" in Twilio with the format +18005550199.')}
+        labelHelp={t(
+          'The number associated with the "Messaging Service" in Twilio with the format +18005550199.'
+        )}
       />
 
       <PageFormTextArea<NotificationTemplate>
         name={'notification_configuration.to_numbers'}
         label={t('Destination SMS Numbers')}
         validate={(value) => twilioPhoneNumber(value, t)}
-        labelHelp={t('Use one phone number per line to specify where to route SMS messages. Phone numbers should be formatted +11231231234. For more information see Twilio documentation')}
+        labelHelp={t(
+          'Use one phone number per line to specify where to route SMS messages. Phone numbers should be formatted +11231231234. For more information see Twilio documentation'
+        )}
         isRequired
       />
     </>
@@ -440,7 +457,9 @@ function GrafanaForm() {
         type={'text'}
         name={'notification_configuration.grafana_url'}
         label={t('Grafana URL')}
-        labelHelp={t('The base URL of the Grafana server - the /api/annotations endpoint will be added automatically to the base Grafana URL.')}
+        labelHelp={t(
+          'The base URL of the Grafana server - the /api/annotations endpoint will be added automatically to the base Grafana URL.'
+        )}
         isRequired
       />
 
@@ -455,7 +474,6 @@ function GrafanaForm() {
         name={'notification_configuration.dashboardId'}
         label={t('ID of the dashboard (optional)')}
       />
-     
 
       <PageFormTextInput<NotificationTemplate>
         name={'notification_configuration.panelId'}
@@ -468,7 +486,6 @@ function GrafanaForm() {
         labelHelp={t('Use one Annotation Tag per line, without commas.')}
       />
 
-         
       <PageFormCheckbox<NotificationTemplate>
         name={'notification_configuration.grafana_no_verify_ssl'}
         label={t('Disable SSL verification')}
@@ -477,11 +494,12 @@ function GrafanaForm() {
   );
 }
 
+/*
 function WebhookForm() {
   const { t } = useTranslation();
   return (
     <>
-     <PageFormTextInput<NotificationTemplate>
+      <PageFormTextInput<NotificationTemplate>
         type={'text'}
         name={'notification_configuration.username'}
         label={t('Username')}
@@ -510,19 +528,19 @@ function WebhookForm() {
         label={t('HTTP Headers')}
       />
 
-
       <PageFormSingleSelect<NotificationTemplate>
         name={'notification_configuration.http_method'}
         label={t('HTTP Method')}
         placeholder={t('Choose an HTTP method')}
         options={[
-          { label: 'POST', value : 'POST'},
-          { label: 'PUT', value : 'PUT'},
+          { label: 'POST', value: 'POST' },
+          { label: 'PUT', value: 'PUT' },
         ]}
       />
     </>
   );
 }
+
 
 function MattermostForm() {
   const { t } = useTranslation();
@@ -608,7 +626,7 @@ function IrcForm() {
       />
     </>
   );
-}
+}*/
 
 function arraysToString(data: NotificationTemplate) {
   if (!data.notification_configuration) {
@@ -651,78 +669,77 @@ function isList(key: string, notification_type: string) {
     return true;
   }
 
-  if (key === 'channels' && notification_type === 'slack')
-  {
+  if (key === 'channels' && notification_type === 'slack') {
     return true;
   }
 
-  if (key === 'to_numbers' && notification_type === 'twilio')
-  {
+  if (key === 'to_numbers' && notification_type === 'twilio') {
     return true;
   }
 
-  if (key === 'annotation_tags' && notification_type === 'grafana')
-  {
+  if (key === 'annotation_tags' && notification_type === 'grafana') {
     return true;
   }
 
   return false;
 }
 
-function validateEmail(value : string, t : TFunction<"translation", undefined>) {
-    // copied from old app to keep app consistent
-    // This isn't a perfect validator. It's likely to let a few
-    // invalid (though unlikely) email addresses through.
+function validateEmail(value: string, t: TFunction<'translation', undefined>) {
+  // copied from old app to keep app consistent
+  // This isn't a perfect validator. It's likely to let a few
+  // invalid (though unlikely) email addresses through.
 
-    // This is ok, because the server will always do strict validation for us.
+  // This is ok, because the server will always do strict validation for us.
 
-    if (value === '')
-    {
+  if (value === '') {
+    return undefined;
+  }
+  const splitVals = value?.split('@');
+
+  if (splitVals.length >= 2) {
+    if (splitVals[0] && splitVals[1]) {
+      // We get here if the string has an '@' that is enclosed by
+      // non-empty substrings
       return undefined;
     }
-    const splitVals = value?.split('@');
+  }
 
-    if (splitVals.length >= 2) {
-      if (splitVals[0] && splitVals[1]) {
-        // We get here if the string has an '@' that is enclosed by
-        // non-empty substrings
-        return undefined;
-      }
-    }
-
-    return t('Invalid email address');
+  return t('Invalid email address');
 }
 
-function validateNumber(str : string, min : number, max : number, t : TFunction<"translation", undefined>)
-{
+function validateNumber(
+  str: string,
+  min: number,
+  max: number,
+  t: TFunction<'translation', undefined>
+) {
   const val = Number.parseInt(str);
-  if (val >= min && val <= max)
-  {
+  if (val >= min && val <= max) {
     return undefined;
   }
 
-  return t('This field must be a number and have a value between {{min}} and {{max}}', { min, max});
+  return t('This field must be a number and have a value between {{min}} and {{max}}', {
+    min,
+    max,
+  });
 }
 
-export function twilioPhoneNumber(value : string, t : TFunction<"translation", undefined>) {
- 
-    if (value === '')
-    {
-      return undefined;
+export function twilioPhoneNumber(value: string, t: TFunction<'translation', undefined>) {
+  if (value === '') {
+    return undefined;
+  }
+
+  const phoneNumbers = value?.split('\n');
+  let error = undefined;
+
+  phoneNumbers?.forEach((v) => {
+    if (v === '') {
+      return;
     }
 
-    const phoneNumbers = value?.split('\n');
-    let error = undefined;
-
-    phoneNumbers?.forEach((v) => {
-      if (v === '')
-      {
-        return;
-      }
-
-      if (!/^\s*(?:\+?(\d{1,3}))?[. (]*(\d{7,12})$/.test(v)) {
-           error =  t('Please enter valid phone numbers.');
-      }
-    });
-    return error;
+    if (!/^\s*(?:\+?(\d{1,3}))?[. (]*(\d{7,12})$/.test(v)) {
+      error = t('Please enter valid phone numbers.');
+    }
+  });
+  return error;
 }

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -412,29 +412,30 @@ function PagerdutyForm() {
     <>
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.subdomain'}
+        name={'notification_configuration.subdomain'}
         label={t('Pagerduty subdomain')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
-        name={'type_data.token'}
+        type={'password'}
+        name={'notification_configuration.token'}
         label={t('API Token')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.service_key'}
+        name={'notification_configuration.service_key'}
         label={t('API Service/Integration Key')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.client_name'}
+        name={'notification_configuration.client_name'}
         label={t('Client Identifier')}
-        placeholder={''}
+        isRequired
       />
     </>
   );

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -122,7 +122,8 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         fieldValue = fields[field];
         if (fieldValue.type === 'int' && typeof notification_configuration[field] === 'string') {
           notification_configuration[field] = Number.parseInt(
-            notification_configuration[field] as string, 10
+            notification_configuration[field] as string,
+            10
           );
         }
 

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -27,6 +27,7 @@ import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/Page
 import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatch';
 import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGroup';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
+import { requestCommon } from '../../../common/crud/requestCommon';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -36,6 +37,8 @@ export function AddNotifier() {
   return <NotifierForm mode={'add'} />;
 }
 
+type NotificationTemplateOptions = {};
+
 function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -44,6 +47,8 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   let getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
   const navigate = useNavigate();
+
+  const optionsRequest = useGet<NotificationTemplateOptions>(awxAPI`/notification_templates/`, undefined, { });
 
   const breadcrumbs: ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
@@ -122,6 +127,11 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   );
 }
 
+function TypeForm(props: { mode: 'add' | 'edit', notification_type : string })
+{
+  return <></>;
+}
+/*
 function TypeForm(props: { mode: 'add' | 'edit', notification_type : string }) {
   const context = useFormContext<NotificationTemplate>();
   const { mode, notification_type } = props;
@@ -183,4 +193,4 @@ function TwilioForm(props: { mode: 'add' | 'edit' }) {
 
 function WebhookForm(props: { mode: 'add' | 'edit' }) {
   return <></>;
-}
+}*/

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -336,15 +336,33 @@ function SlackForm() {
   return (
     <>
       <PageFormTextInput<NotificationTemplate>
-        name={'type_data.token'}
+        type={'password'}
+        name={'notification_configuration.token'}
         label={t('Token')}
-        placeholder={''}
+        isRequired
       />
 
       <PageFormTextArea<NotificationTemplate>
-        name={'type_data.channels'}
+        name={'notification_configuration.channels'}
         label={t('Destination Channels')}
-        placeholder={''}
+        isRequired
+        labelHelp={
+          <Trans>
+            One Slack channel per line. The pound symbol (#) is required for channels. 
+            To respond to or start a thread to a specific message add the parent message Id 
+            to the channel where the parent message Id is 16 digits. A dot (.) 
+            must be manually inserted after the 10th digit. ie:#destination-channel, 1231257890.006423. 
+            See Slack <a href='https://api.slack.com/messaging/retrieving#individual_messages'>documentation</a> for more information.
+          </Trans>
+        }
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'notification_configuration.hex_color'}
+        label={t('Notification color')}
+        labelHelp={
+          t('Specify a notification color. Acceptable colors are hex color code (example: #3af or #789abc).')
+        }
       />
     </>
   );
@@ -608,6 +626,11 @@ function stringToArrays(data: NotificationTemplate) {
 
 function isList(key: string, notification_type: string) {
   if (key === 'recipients' && notification_type === 'email') {
+    return true;
+  }
+
+  if (key === 'channels' && notification_type === 'slack')
+  {
     return true;
   }
 

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Button } from '@patternfly/react-core';
+import { useCallback, useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ICatalogBreadcrumb,
+  PageFormDataEditor,
+  PageFormSubmitHandler,
+  PageFormTextInput,
+  PageHeader,
+  PageLayout,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../framework';
+import { AwxPageForm } from '../../common/AwxPageForm';
+import { NotificationTemplate } from '../../interfaces/NotificationTemplate';
+import { AwxRoute } from '../../main/AwxRoutes';
+
+export function EditNotifier()
+{
+  return <NotifierForm mode={'edit'} />;
+}
+
+export function AddNotifier()
+{
+  return <NotifierForm mode={'add'} />;
+}
+
+function NotifierForm(props : {mode : 'add' | 'edit'})
+{
+  const {t} = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const {mode } = props;
+
+  const breadcrumbs : ICatalogBreadcrumb[] = [
+    { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
+    { label: mode === 'add' ? t('Add') : t('Edit') }
+  ]
+ 
+  return (
+  <PageLayout>
+      <PageHeader breadcrumbs={breadcrumbs} title={ mode === 'edit' ? t('Edit notifier') : t('Add notifier')} />
+      <AwxPageForm<NotificationTemplate>
+        submitText={t('Save host')}
+        onSubmit={ () => {}}
+        cancelText={t('Cancel')}
+        onCancel={ () => {}}
+        defaultValue={ {} }
+      >
+      </AwxPageForm>
+    </PageLayout>);
+}

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -481,44 +481,44 @@ function WebhookForm() {
   const { t } = useTranslation();
   return (
     <>
-      <PageFormTextInput<NotificationTemplate>
+     <PageFormTextInput<NotificationTemplate>
         type={'text'}
-        name={'type_data.url'}
-        label={t('Target URL')}
-        placeholder={''}
-      />
-
-      <PageFormTextInput<NotificationTemplate>
-        type={'text'}
-        name={'type_data.http_method'}
-        label={t('HTTP Method')}
-        placeholder={''}
-      />
-
-      <PageFormCheckbox<NotificationTemplate>
-        name={'type_data.disable_ssl_verification'}
-        label={t('Verify SSL')}
-        placeholder={''}
-      />
-
-      <PageFormTextInput<NotificationTemplate>
-        type={'text'}
-        name={'type_data.username'}
+        name={'notification_configuration.username'}
         label={t('Username')}
-        placeholder={''}
       />
 
       <PageFormTextInput<NotificationTemplate>
         type={'password'}
-        name={'type_data.password'}
+        name={'notification_configuration.password'}
         label={t('Password')}
-        placeholder={''}
       />
 
       <PageFormTextInput<NotificationTemplate>
-        name={'type_data.headers'}
+        type={'text'}
+        name={'notification_configuration.url'}
+        label={t('Target URL')}
+        isRequired
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'notification_configuration.disable_ssl_verification'}
+        label={t('Disable SSL verification ')}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'notification_configuration.headers'}
         label={t('HTTP Headers')}
-        placeholder={''}
+      />
+
+
+      <PageFormSingleSelect<NotificationTemplate>
+        name={'notification_configuration.http_method'}
+        label={t('HTTP Method')}
+        placeholder={t('Choose an HTTP method')}
+        options={[
+          { label: 'POST', value : 'POST'},
+          { label: 'PUT', value : 'PUT'},
+        ]}
       />
     </>
   );

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -30,8 +30,7 @@ import { PageFormWatch } from '../../../../framework/PageForm/Utils/PageFormWatc
 import { PageFormGroup } from '../../../../framework/PageForm/Inputs/PageFormGroup';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 import { useOptions } from '../../../common/crud/useOptions';
-import { TFunction } from 'i18next';
-
+import { genericForm } from './NotifierFormGenerator';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -41,13 +40,15 @@ export function AddNotifier() {
   return <NotifierForm mode={'add'} />;
 }
 
-type NotificationTemplateOptions = {
-  actions : {
-    GET : {
-      notification_configuration: 
-        Record<string, Record<string, { label : string, type : string, default : unknown }>>
-    }
-  }
+export type NotificationTemplateOptions = {
+  actions: {
+    GET: {
+      notification_configuration: Record<
+        string,
+        Record<string, { label: string; type: string; default: unknown }>
+      >;
+    };
+  };
 };
 
 function NotifierForm(props: { mode: 'add' | 'edit' }) {
@@ -78,8 +79,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
     return <LoadingPage />;
   }
 
-  if (!optionsRequest.data)
-  {
+  if (!optionsRequest.data) {
     return <LoadingPage />;
   }
 
@@ -129,183 +129,371 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
             { value: 'webhook', label: t('Webhook') },
           ]}
         />
-        <PageFormWatch watch="notification_type">{(notification_type : string) => 
-          <>
-            {notification_type && optionsRequest.data && 
-              <PageFormSection singleColumn={true}>
-                <PageFormGroup
-                  label={t('Type Details')}
-                >
-                  {genericForm(t, mode, notification_type, optionsRequest.data)}
-                </PageFormGroup>
-              </PageFormSection>
-            }
-          </>
-        }</PageFormWatch>
+        <PageFormWatch watch="notification_type">
+          {(notification_type: string) => (
+            <>
+              {optionsRequest.data && (
+                <PageFormSection singleColumn={true}>
+                  <PageFormGroup label={t('Type Details')}>
+                    <InnerForm
+                      notification_type={notification_type}
+                    />
+
+                    {genericForm(optionsRequest.data)}
+                  </PageFormGroup>
+                </PageFormSection>
+              )}
+            </>
+          )}
+        </PageFormWatch>
       </AwxPageForm>
     </PageLayout>
   );
 }
 
-
-function isRequired(mode : 'add' | 'edit', notification_type : string, label : string) : boolean
-{
-
-  return false;
-}
-
-function textType(type : string)
-{
-  if (type === 'password')
-  {
-    return 'password';
+function InnerForm(props : {notification_type: string}) {
+  const notification_type = props.notification_type;
+  if (notification_type === 'email') {
+    return <EmailForm />;
   }
 
-  if (type === 'int')
-  {
-    return 'number';
+  if (notification_type === 'slack') {
+    return <SlackForm />;
   }
 
-  return 'text';
-}
-
-
-function genericForm(t : TFunction<"translation", undefined>, mode: 'add' | 'edit', notification_type : string, optionsData :  NotificationTemplateOptions)
-{
-  try
-  {
-  const options = optionsData.actions.GET.notification_configuration[notification_type];
-  if (!options)
-  {
-    return <></>;
+  if (notification_type === 'twilio') {
+    return <TwilioForm />;
   }
 
-  return <>
-    {Object.keys(options).map( (key) => {
-      return componentFromOptions(t, mode, notification_type, key, optionsData);
-    })}
-  </>;
-  }catch(error)
-  {
-    debugger;
-    return <>{error}</>;
+  if (notification_type === 'pagerduty') {
+    return <PagerdutyForm />;
   }
+
+  if (notification_type === 'grafana') {
+    return <GrafanaForm />;
+  }
+
+  if (notification_type === 'webhook') {
+    return <WebhookForm />;
+  }
+
+  if (notification_type === 'mattermost') {
+    return <MattermostForm />;
+  }
+
+  if (notification_type === 'rocketchat') {
+    return <RocketchatForm />;
+  }
+
+  if (notification_type === 'irc') {
+    return <IrcForm />;
+  }
+
+  return <></>;
 }
 
-function componentFromOptions(t : TFunction<"translation", undefined>, mode: 'add' | 'edit', notification_type : string, field : string, optionsData :  NotificationTemplateOptions)
-{
-  try
-  {
-    const options = optionsData.actions.GET.notification_configuration[notification_type];
-    if (!options)
-    {
-      return <></>;
-    }
-
-    const option = options[field];
-
-    if (!option)
-    {
-      return <></>;
-    }
-
-    const name = 'type_data.' + field;
-        
-    const label = t(option.label);
-        
-        if (option.type === 'string' || option.type === 'number' || option.type === 'password')
-        {
-          return (
-            <>
-            <PageFormTextInput<NotificationTemplate>
-              type={textType(option.type)}
-              name={name}
-              label={label}
-              placeholder={''}
-              isRequired={isRequired(mode, notification_type, option.label)}
-            /> 
-            </>
-          );
-        }
-
-        if (option.type === 'list')
-        {
-          return (
-            <>
-            <PageFormTextArea<NotificationTemplate>
-              type={textType(option.type)}
-              name={name}
-              label={label}
-              placeholder={''}
-              isRequired={isRequired(mode, notification_type, option.label)}
-            /> 
-            </>
-          );
-        }
-
-        if (option.type === 'bool')
-        {
-          return (
-            <>
-            <PageFormCheckbox<NotificationTemplate>
-              type={textType(option.type)}
-              name={name}
-              label={label}
-              placeholder={''}
-              isRequired={isRequired(mode, notification_type, option.label)}
-            /> 
-            </>
-          );
-        }
-        return <></>;
-    }catch(error)
-    {
-      debugger;
-      return <>{t('Error loading component')}</>;
-    }
-}
-
-
-// list of form elements names for translations:
-// this hook is here only for translator static string crawler, so he can find those
-function useStaticTranslations()
-{
+function EmailForm() {
   const {t} = useTranslation();
-t('Notification configuration');
-t('Host');
-t('Port');
-t('Username');
-t('Password');
-t('Use TLS');
-t('Use SSL');
-t('Sender Email');
-t('Recipient List');
-t('Timeout');
-t('Token');
-t('Destination Channels');
-t('Account SID');
-t('Account Token');
-t('Source Phone Number');
-t('Destination SMS Numbers');
-t('Pagerduty subdomain');
-t('API Token');
-t('API Service/Integration Key');
-t('Client Identifier');
-t('Grafana URL');
-t('Grafana API Key');
-t('Target URL');
-t('HTTP Method');
-t('Verify SSL');
-t('Username', {'context': 'within webhook and mattermost'});
-t('Password', {'context': 'within webhook'});
-t('HTTP Headers');
-t('Target URL', {'context': 'within mattermost and rocketchat'});
-t('Verify SSL', {'context': 'within mattermost and rocketchat'});
-t('IRC Server Address');
-t('IRC Server Port');
-t('IRC Nick');
-t('IRC Server Password');
-t('SSL Connection');
-t('Destination Channels or Users');
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.host'}
+        label={t('Host')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'number'}
+        name={'type_data.port'}
+        label={t('Port')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.username'}
+        label={t('Username')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'password'}
+        name={'type_data.password'}
+        label={t('Password')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.use_tls'}
+        label={t('Use TLS')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.use_ssl'}
+        label={t('Use SSL')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.sender'}
+        label={t('Sender Email')}
+        placeholder={''}
+      />
+
+      <PageFormTextArea<NotificationTemplate>
+        name={'type_data.recipients'}
+        label={t('Recipient List')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'number'}
+        name={'type_data.timeout'}
+        label={t('Timeout')}
+        placeholder={''}
+      />
+    </>
+  );
 }
 
+function SlackForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.token'}
+        label={t('Token')}
+        placeholder={''}
+      />
+
+      <PageFormTextArea<NotificationTemplate>
+        name={'type_data.channels'}
+        label={t('Destination Channels')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function TwilioForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.account_sid'}
+        label={t('Account SID')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.account_token'}
+        label={t('Account Token')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.from_number'}
+        label={t('Source Phone Number')}
+        placeholder={''}
+      />
+
+      <PageFormTextArea<NotificationTemplate>
+        name={'type_data.to_numbers'}
+        label={t('Destination SMS Numbers')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function PagerdutyForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.subdomain'}
+        label={t('Pagerduty subdomain')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.token'}
+        label={t('API Token')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.service_key'}
+        label={t('API Service/Integration Key')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.client_name'}
+        label={t('Client Identifier')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function GrafanaForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.grafana_url'}
+        label={t('Grafana URL')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.grafana_key'}
+        label={t('Grafana API Key')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function WebhookForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.url'}
+        label={t('Target URL')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.http_method'}
+        label={t('HTTP Method')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.disable_ssl_verification'}
+        label={t('Verify SSL')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.username'}
+        label={t('Username')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'password'}
+        name={'type_data.password'}
+        label={t('Password')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.headers'}
+        label={t('HTTP Headers')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function MattermostForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.mattermost_url'}
+        label={t('Target URL')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.mattermost_no_verify_ssl'}
+        label={t('Verify SSL')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function RocketchatForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.rocketchat_url'}
+        label={t('Target URL')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.rocketchat_no_verify_ssl'}
+        label={t('Verify SSL')}
+        placeholder={''}
+      />
+    </>
+  );
+}
+
+function IrcForm() {
+  const {t} = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.server'}
+        label={t('IRC Server Address')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        name={'type_data.port'}
+        label={t('IRC Server Port')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'text'}
+        name={'type_data.nickname'}
+        label={t('IRC Nick')}
+        placeholder={''}
+      />
+
+      <PageFormTextInput<NotificationTemplate>
+        type={'password'}
+        name={'type_data.password'}
+        label={t('IRC Server Password')}
+        placeholder={''}
+      />
+
+      <PageFormCheckbox<NotificationTemplate>
+        name={'type_data.use_ssl'}
+        label={t('SSL Connection')}
+        placeholder={''}
+      />
+
+      <PageFormTextArea<NotificationTemplate>
+        name={'type_data.targets'}
+        label={t('Destination Channels or Users')}
+        placeholder={''}
+      />
+    </>
+  );
+}

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -38,6 +38,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
   const params = useParams<{ id: string }>();
   let getUrl = mode === 'add' ? '' : awxAPI`/notification_templates/${params.id || ''}/`;
   const notifierRequest = useGet<NotificationTemplate>(getUrl);
+  const navigate = useNavigate();
 
   const breadcrumbs: ICatalogBreadcrumb[] = [
     { label: t('Notifications'), to: getPageUrl(AwxRoute.NotificationTemplates) },
@@ -62,7 +63,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
         submitText={t('Save host')}
         onSubmit={() => {}}
         cancelText={t('Cancel')}
-        onCancel={() => {}}
+        onCancel={ () => navigate(-1)}
         defaultValue={{}}
       ></AwxPageForm>
     </PageLayout>

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -22,6 +22,7 @@ import { AwxRoute } from '../../main/AwxRoutes';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useGet } from '../../../common/crud/useGet';
 import { AwxError } from '../../common/AwxError';
+import { PageFormSelectOrganization } from '../../access/organizations/components/PageFormOrganizationSelect';
 
 export function EditNotifier() {
   return <NotifierForm mode={'edit'} />;
@@ -80,6 +81,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
             label={t('Description')}
             placeholder={t('Enter a description')}
           />
+          <PageFormSelectOrganization<NotificationTemplate> name="organization" isRequired />
       </AwxPageForm>
     </PageLayout>
   );

--- a/frontend/awx/administration/notifiers/NotifierForm.tsx
+++ b/frontend/awx/administration/notifiers/NotifierForm.tsx
@@ -139,7 +139,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
       }
     }
 
-    const result = await requestCommon({
+    await requestCommon({
       url:
         mode === 'add'
           ? awxAPI`/notification_templates/`
@@ -147,8 +147,7 @@ function NotifierForm(props: { mode: 'add' | 'edit' }) {
       method: mode === 'edit' ? 'PATCH' : 'POST',
       body: data,
     });
-    debugger;
-    console.log(result);
+
     pageNavigate(AwxRoute.NotificationTemplates);
   };
 

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
@@ -27,7 +27,8 @@ export function useNotifiersColumns() {
         cell: (template: NotificationTemplate) => (
           <StatusCell
             status={
-              template.summary_fields?.recent_notifications && template.summary_fields.recent_notifications.length > 0
+              template.summary_fields?.recent_notifications &&
+              template.summary_fields.recent_notifications.length > 0
                 ? template.summary_fields?.recent_notifications[0].status
                 : undefined
             }

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
@@ -27,8 +27,8 @@ export function useNotifiersColumns() {
         cell: (template: NotificationTemplate) => (
           <StatusCell
             status={
-              template.summary_fields.recent_notifications.length > 0
-                ? template.summary_fields.recent_notifications[0].status
+              template.summary_fields?.recent_notifications && template.summary_fields.recent_notifications.length > 0
+                ? template.summary_fields?.recent_notifications[0].status
                 : undefined
             }
           />

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -25,7 +25,7 @@ export interface NotificationTemplate
       description: string;
     };
   };
-  notification_configuration: { [key: string]: unknown };
+  notification_configuration: { [key: string]: number | string | boolean | string[] };
   notification_type:
     | 'email'
     | 'grafana'

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -5,7 +5,7 @@ export interface NotificationTemplate
     SwaggerNotificationTemplate,
     'id' | 'name' | 'organization' | 'summary_fields' | 'notification_type'
   > {
-  id?: number;
+  id: number;
   name: string;
   organization: number;
   summary_fields?: {

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -25,7 +25,7 @@ export interface NotificationTemplate
       description: string;
     };
   };
-  type_data : [string, unknown];
+  type_data: [string, unknown];
   notification_type:
     | 'email'
     | 'grafana'

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -25,6 +25,7 @@ export interface NotificationTemplate
       description: string;
     };
   };
+  type_data : [string, unknown];
   notification_type:
     | 'email'
     | 'grafana'

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -8,7 +8,7 @@ export interface NotificationTemplate
   id: number;
   name: string;
   organization: number;
-  summary_fields?: {
+  summary_fields: {
     recent_notifications: [
       {
         status: string;

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -5,10 +5,10 @@ export interface NotificationTemplate
     SwaggerNotificationTemplate,
     'id' | 'name' | 'organization' | 'summary_fields' | 'notification_type'
   > {
-  id: number;
+  id?: number;
   name: string;
   organization: number;
-  summary_fields: {
+  summary_fields?: {
     recent_notifications: [
       {
         status: string;
@@ -25,7 +25,7 @@ export interface NotificationTemplate
       description: string;
     };
   };
-  notification_configuration: [string, unknown];
+  notification_configuration: { [key: string]: unknown };
   notification_type:
     | 'email'
     | 'grafana'

--- a/frontend/awx/interfaces/NotificationTemplate.ts
+++ b/frontend/awx/interfaces/NotificationTemplate.ts
@@ -25,7 +25,7 @@ export interface NotificationTemplate
       description: string;
     };
   };
-  type_data: [string, unknown];
+  notification_configuration: [string, unknown];
   notification_type:
     | 'email'
     | 'grafana'

--- a/frontend/awx/main/routes/useAwxNotificationsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxNotificationsRoutes.tsx
@@ -5,6 +5,7 @@ import { PageNavigationItem } from '../../../../framework';
 import { PageNotImplemented } from '../../../../framework/PageEmptyStates/PageNotImplemented';
 import { Notifiers } from '../../administration/notifiers/Notifiers';
 import { AwxRoute } from '../AwxRoutes';
+import { AddNotifier, EditNotifier } from '../../administration/notifiers/NotifierForm';
 
 export function useAwxNotificationsRoutes() {
   const { t } = useTranslation();
@@ -29,6 +30,16 @@ export function useAwxNotificationsRoutes() {
               element: <Navigate to="details" />,
             },
           ],
+        },
+        {
+          id: AwxRoute.EditNotificationTemplate,
+          path: ':id/edit',
+          element: <EditNotifier />,
+        },
+        {
+          id: AwxRoute.AddNotificationTemplate,
+          path: 'create',
+          element: <AddNotifier />,
         },
         {
           path: '',


### PR DESCRIPTION
Notifiers- add/edit form.

It is big form, so this PR deals only with subset of it.

There is dropdown named Type, which changes the subform below.

What is implemented:
Email, Slack, Twillio, Pagerduty, Grafana

What is not implemented and will be covered in future PR:
rest of the dropdown items
Form Layout - items in subform will be fixed to be from left to right and not single column from top to bottom
Customize messages option is not implemented yet


Note: OPTIONS request gets the form metadata, which is then used in some type conversions. For example framework component uses strings when the API wants numbers, so those types are automaticaly converted using metadata - if field from OPTIONS has type int, it is converted from string automaticaly.