### PR TITLE
[UXD][AAP-10266] Added icon to empty state buttons on AWX & EDA

### DIFF
--- a/frontend/awx/access/common/ResourceAccessList.tsx
+++ b/frontend/awx/access/common/ResourceAccessList.tsx
@@ -165,6 +165,7 @@ export function ResourceAccessList(props: { url: string; resource: ResourceType 
       errorStateTitle={t('Error loading users')}
       emptyStateTitle={t('No users yet')}
       emptyStateDescription={t('To get started, create a user.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Create user')}
       emptyStateButtonClick={() => pageNavigate(AwxRoute.CreateUser)}
       {...view}

--- a/frontend/awx/access/credential-types/CredentialTypes.tsx
+++ b/frontend/awx/access/credential-types/CredentialTypes.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { PageHeader, PageLayout, PageTable, usePageNavigate } from '../../../../framework';
 import { useOptions } from '../../../common/crud/useOptions';
@@ -72,6 +72,7 @@ export function CredentialTypes() {
               )
         }
         emptyStateIcon={canCreateCredentialType ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateCredentialType ? t('Create credential type') : undefined}
         emptyStateButtonClick={
           canCreateCredentialType ? () => pageNavigate(AwxRoute.CreateCredentialType) : undefined

--- a/frontend/awx/access/credentials/CredentialsList.tsx
+++ b/frontend/awx/access/credentials/CredentialsList.tsx
@@ -8,6 +8,7 @@ import { useCredentialToolbarActions } from './hooks/useCredentialToolbarActions
 import { useCredentialsColumns } from './hooks/useCredentialsColumns';
 import { useCredentialsFilters } from './hooks/useCredentialsFilters';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function CredentialsList(props: { url: string }) {
   const { t } = useTranslation();
@@ -35,6 +36,7 @@ export function CredentialsList(props: { url: string }) {
       errorStateTitle={t('Error loading credentials')}
       emptyStateTitle={t('No credentials yet')}
       emptyStateDescription={t('To get started, create an credential.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Create credential')}
       emptyStateButtonClick={() => pageNavigate(AwxRoute.CreateCredential)}
       {...view}

--- a/frontend/awx/access/organizations/OrganizationPage/OrganizationTeams.tsx
+++ b/frontend/awx/access/organizations/OrganizationPage/OrganizationTeams.tsx
@@ -8,6 +8,7 @@ import { Team } from '../../../interfaces/Team';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useTeamsColumns } from '../../teams/hooks/useTeamsColumns';
 import { useTeamsFilters } from '../../teams/hooks/useTeamsFilters';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function OrganizationTeams() {
   const params = useParams<{ id: string }>();
@@ -29,6 +30,7 @@ export function OrganizationTeams() {
       errorStateTitle={t('Error loading teams')}
       emptyStateTitle={t('No teams yet')}
       emptyStateDescription={t('To get started, create a team.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Create team')}
       emptyStateButtonClick={() => pageHistory(AwxRoute.CreateTeam)}
       {...view}

--- a/frontend/awx/access/organizations/Organizations.tsx
+++ b/frontend/awx/access/organizations/Organizations.tsx
@@ -177,6 +177,7 @@ export function Organizations() {
         errorStateTitle={t('Error loading organizations')}
         emptyStateTitle={t('No organizations yet')}
         emptyStateDescription={t('To get started, create an organization.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create organization')}
         emptyStateButtonClick={() => pageNavigate(AwxRoute.CreateOrganization)}
         {...view}

--- a/frontend/awx/access/teams/TeamPage/TeamRoles.tsx
+++ b/frontend/awx/access/teams/TeamPage/TeamRoles.tsx
@@ -88,6 +88,7 @@ export function TeamRolesInner(props: { team: Team }) {
       errorStateTitle={t('Error loading roles')}
       emptyStateTitle={t('Team does not have any roles.')}
       emptyStateDescription={t('To get started, add roles to the team.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Add role to team')}
       emptyStateButtonClick={() =>
         pageNavigate(AwxRoute.AddRolesToTeam, { params: { id: team.id } })

--- a/frontend/awx/access/teams/Teams.tsx
+++ b/frontend/awx/access/teams/Teams.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { PageHeader, PageLayout, PageTable, usePageNavigate } from '../../../../framework';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
@@ -71,6 +71,7 @@ export function Teams() {
               )
         }
         emptyStateIcon={canCreateTeam ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateTeam ? t('Create team') : undefined}
         emptyStateButtonClick={canCreateTeam ? () => pageNavigate(AwxRoute.CreateTeam) : undefined}
         {...view}

--- a/frontend/awx/access/users/UserPage/UserOrganizations.tsx
+++ b/frontend/awx/access/users/UserPage/UserOrganizations.tsx
@@ -108,6 +108,7 @@ function UserOrganizationsInternal(props: { user: AwxUser }) {
         errorStateTitle={t('Error loading organizations')}
         emptyStateTitle={t('User is not a member of any organizations.')}
         emptyStateDescription={t('To get started, add the user to an organization.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Add user to organization')}
         emptyStateButtonClick={() => selectOrganizationsAddUsers([user])}
         {...view}

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -117,6 +117,7 @@ function UserRolesInternal(props: { user: AwxUser }) {
         errorStateTitle={t('Error loading roles')}
         emptyStateTitle={t('User does not have any roles.')}
         emptyStateDescription={t('To get started, add roles to the user.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Add role to user')}
         // emptyStateButtonClick={() => history(RouteObj.CreateUser)}
         {...view}

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -237,6 +237,7 @@ export function Users() {
               )
         }
         emptyStateIcon={canCreateUser ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateUser ? t('Create user') : undefined}
         emptyStateButtonClick={canCreateUser ? () => pageNavigate(AwxRoute.CreateUser) : undefined}
         {...view}
@@ -310,6 +311,7 @@ export function AccessTable(props: { url: string }) {
       errorStateTitle={t('Error loading users')}
       emptyStateTitle={t('No users yet')}
       emptyStateDescription={t('To get started, create a user.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Create user')}
       emptyStateButtonClick={() => pageNavigate(AwxRoute.CreateUser)}
       {...view}

--- a/frontend/awx/administration/applications/Applications.tsx
+++ b/frontend/awx/administration/applications/Applications.tsx
@@ -132,6 +132,7 @@ export function Applications() {
                 'Please contact your organization administrator if there is an issue with your access.'
               )
         }
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateApplication ? t('Create application') : undefined}
         emptyStateButtonClick={
           canCreateApplication ? () => pageNavigate(AwxRoute.CreateApplication) : undefined

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -14,6 +14,7 @@ import { useExecutionEnvironmentsFilters } from './hooks/useExecutionEnvironment
 import { useOptions } from '../../../common/crud/useOptions';
 import { OptionsResponse, ActionsResponse } from '../../interfaces/OptionsResponse';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function ExecutionEnvironments() {
   const { t } = useTranslation();
@@ -66,6 +67,7 @@ export function ExecutionEnvironments() {
                 'Please contact your organization administrator if there is an issue with your access.'
               )
         }
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={
           canCreateExecutionEnvironment ? t('Create execution environment') : undefined
         }

--- a/frontend/awx/administration/instances/InstancePeers.tsx
+++ b/frontend/awx/administration/instances/InstancePeers.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PlusCircleIcon, PlusIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { IPageAction, PageActionSelection, PageActionType, PageTable } from '../../../../framework';
@@ -80,6 +80,7 @@ export function ResourcePeersList(props: { url: string }) {
       errorStateTitle={t('Error loading peers')}
       emptyStateTitle={t('No peers found')}
       emptyStateDescription={t('Please add Peers to populate this list.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Associate peer')}
       emptyStateButtonClick={multiSelectelectPeer}
       {...view}

--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.tsx
@@ -8,6 +8,7 @@ import { AwxRoute } from '../../../main/AwxRoutes';
 import { useManagementJobFilters } from '../hooks/useManagementJobFilters';
 import { useManagementJobColumns } from '../hooks/useManagementJobColumns';
 import { SystemJobTemplate } from '../../../interfaces/SystemJobTemplate';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function ManagementJobSchedules() {
   const params = useParams<{ id: string }>();
@@ -28,7 +29,8 @@ export function ManagementJobSchedules() {
       tableColumns={tableColumns}
       errorStateTitle={t('Error loading schedules')}
       emptyStateTitle={t('No schedules yet')}
-      emptyStateDescription={t('To get started, create a schedules.')}
+      emptyStateDescription={t('To get started, create a schedule.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Create schedule')}
       emptyStateButtonClick={() => pageHistory(AwxRoute.CreateSchedule)}
       {...view}

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -13,6 +13,7 @@ import { useNotifiersRowActions } from './hooks/useNotifiersRowActions';
 import { useOptions } from '../../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
 import { AwxRoute } from '../../main/AwxRoutes';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Notifiers() {
   const { t } = useTranslation();
@@ -65,6 +66,7 @@ export function Notifiers() {
                 'Please contact your organization administrator if there is an issue with your access.'
               )
         }
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canAddNotificationTemplate ? t('Add notifier') : undefined}
         emptyStateButtonClick={
           canAddNotificationTemplate

--- a/frontend/awx/resources/groups/GroupHosts.tsx
+++ b/frontend/awx/resources/groups/GroupHosts.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PageTable } from '../../../../framework';
@@ -54,6 +54,7 @@ export function GroupHosts() {
             )
       }
       emptyStateIcon={canCreateHost ? undefined : CubesIcon}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={canCreateHost ? t('Create host') : undefined}
       emptyStateActions={emptyStateActions}
       {...view}

--- a/frontend/awx/resources/groups/GroupRelatedGroups.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { InventoryGroup } from '../../interfaces/InventoryGroup';
 import { PageTable } from '../../../../framework';
-import { CubeIcon } from '@patternfly/react-icons';
+import { CubeIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useGroupsFilters } from './hooks/useGroupsFilters';
 import { useParams } from 'react-router-dom';
 import { useRelatedGroupsToolbarActions } from './hooks/useRelatedGroupsToolbarActions';
@@ -59,6 +59,7 @@ export function GroupRelatedGroups() {
             )
       }
       emptyStateIcon={canCreateGroup ? undefined : CubeIcon}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={canCreateGroup && !isConstructed ? t('Add related groups') : undefined}
       emptyStateActions={emptyStateActions}
       {...view}

--- a/frontend/awx/resources/hosts/Hosts.tsx
+++ b/frontend/awx/resources/hosts/Hosts.tsx
@@ -13,6 +13,7 @@ import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 import { useHostsActions } from './hooks/useHostsActions';
 import { useOptions } from '../../../common/crud/useOptions';
 import { OptionsResponse, ActionsResponse } from '../../interfaces/OptionsResponse';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Hosts() {
   const { t } = useTranslation();
@@ -70,6 +71,7 @@ export function Hosts() {
                 'Please contact your organization administrator if there is an issue with your access.'
               )
         }
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateHost ? t('Create host') : undefined}
         emptyStateButtonClick={canCreateHost ? () => pageNavigate(AwxRoute.CreateHost) : undefined}
         {...view}

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -10,7 +10,7 @@ import { useInventoriesGroupsToolbarActions } from '../hooks/useInventoriesGroup
 import { useInventoriesGroupsActions } from '../hooks/useInventoriesGroupsActions';
 import { useOptions } from '../../../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
-import { CubeIcon } from '@patternfly/react-icons';
+import { CubeIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
 export function InventoryGroups() {
@@ -58,6 +58,7 @@ export function InventoryGroups() {
               )
       }
       emptyStateIcon={canCreateGroup ? undefined : CubeIcon}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={canCreateGroup ? t('Create group') : undefined}
       emptyStateButtonClick={
         canCreateGroup

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PageLayout, PageTable, usePageNavigate } from '../../../../../framework';
@@ -65,6 +65,7 @@ export function InventoryHosts() {
         emptyStateTitle={emptyStateTitle}
         emptyStateDescription={emptyStateDescription}
         emptyStateIcon={canCreateHost ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateHost ? t('Create host') : undefined}
         emptyStateButtonClick={
           canCreateHost

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PageLayout, PageTable, usePageNavigate } from '../../../../../framework';
@@ -62,6 +62,7 @@ export function InventorySources() {
               )
         }
         emptyStateIcon={canCreateSource ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateSource ? t('Add source') : undefined}
         emptyStateButtonClick={
           canCreateSource

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PageLayout, PageTable } from '../../../../../framework';
@@ -68,6 +68,7 @@ export function InventoryHostGroups(props: { page: string }) {
               )
         }
         emptyStateIcon={canCreateGroup ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateGroup ? t('Associate groups') : undefined}
         emptyStateButtonClick={
           canCreateGroup

--- a/frontend/awx/resources/projects/Projects.tsx
+++ b/frontend/awx/resources/projects/Projects.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageHeader, PageLayout, PageTable, usePageNavigate } from '../../../../framework';
@@ -99,6 +99,7 @@ export function Projects() {
               )
         }
         emptyStateIcon={canCreateProject ? undefined : CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={canCreateProject ? t('Create project') : undefined}
         emptyStateButtonClick={
           canCreateProject ? () => pageNavigate(AwxRoute.CreateProject) : undefined

--- a/frontend/awx/resources/templates/TemplatesList.tsx
+++ b/frontend/awx/resources/templates/TemplatesList.tsx
@@ -169,6 +169,7 @@ export function TemplatesList(props: {
               'Please contact your organization administrator if there is an issue with your access.'
             )
       }
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={
         canCreateJobTemplate || canCreateWFJobTemplate ? t('Create template') : undefined
       }

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleRules.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleRules.tsx
@@ -96,6 +96,7 @@ export function ScheduleRules() {
         errorStateTitle={t('Error loading rule')}
         emptyStateTitle={t('No rules yet')}
         emptyStateDescription={t('To get started, create a rule.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create Rule')}
         emptyStateButtonClick={() => navigate(createUrl)}
         defaultSubtitle={t('Rules')}

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { PageTable } from '../../../../framework';
@@ -66,6 +66,7 @@ export function SchedulesList(props: { sublistEndpoint?: string }) {
             )
       }
       emptyStateIcon={canCreateSchedule ? undefined : CubesIcon}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={canCreateSchedule ? t('Create schedule') : undefined}
       emptyStateButtonClick={canCreateSchedule ? () => navigate(createUrl) : undefined}
       {...view}

--- a/frontend/awx/views/schedules/components/RulesList.tsx
+++ b/frontend/awx/views/schedules/components/RulesList.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { RRule } from 'rrule';
 import { useRuleRowActions } from '../hooks/useRuleRowActions';
 import { RuleListItemType } from '../types';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function RulesList(props: {
   setIsOpen: (isOpen: boolean | number) => void;
@@ -76,6 +77,7 @@ export function RulesList(props: {
             ? t('To get started, create an exception.')
             : t('To get started, create an rule.')
         }
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={isExceptions ? t('Create exception') : t('Create Rule')}
         emptyStateButtonClick={() => props.setIsOpen(true)}
         defaultSubtitle={isExceptions ? t('Exceptions') : t('Rules')}

--- a/frontend/eda/access/common/Access.tsx
+++ b/frontend/eda/access/common/Access.tsx
@@ -171,6 +171,7 @@ export function Access<T extends Assignment>(props: {
           ? t('Please add a team by using the button below.')
           : t('Please add an user by using the button below.')
       }
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={props.type === 'team' ? t('Add team') : t('Add user')}
       emptyStateActions={toolbarActions.slice(0, 1)}
       {...view}

--- a/frontend/eda/access/credential-types/CredentialTypes.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypes.tsx
@@ -1,4 +1,4 @@
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { PageHeader, PageLayout, PageTable, usePageNavigate } from '../../../../framework';
 import { EdaCredentialType } from '../../interfaces/EdaCredentialType';
@@ -44,6 +44,7 @@ export function CredentialTypes() {
         emptyStateTitle={t('There are currently no credential types added.')}
         emptyStateDescription={t('Please create a credential type by using the button below.')}
         emptyStateIcon={CubesIcon}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create credential type')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateCredentialType)}
         {...view}

--- a/frontend/eda/access/credentials/Credentials.tsx
+++ b/frontend/eda/access/credentials/Credentials.tsx
@@ -8,6 +8,7 @@ import { useCredentialActions } from './hooks/useCredentialActions';
 import { useCredentialColumns } from './hooks/useCredentialColumns';
 import { useCredentialFilters } from './hooks/useCredentialFilters';
 import { useCredentialsActions } from './hooks/useCredentialsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Credentials() {
   const { t } = useTranslation();
@@ -38,6 +39,7 @@ export function Credentials() {
         errorStateTitle={t('Error loading credentials')}
         emptyStateTitle={t('There are currently no credentials created for your organization.')}
         emptyStateDescription={t('Please create a credential by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create credential')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateCredential)}
         {...view}

--- a/frontend/eda/access/organizations/Organizations.tsx
+++ b/frontend/eda/access/organizations/Organizations.tsx
@@ -112,6 +112,7 @@ export function Organizations() {
         errorStateTitle={t('Error loading organizations')}
         emptyStateTitle={t('There are currently no organizations created.')}
         emptyStateDescription={t('Please create an organization by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create organization')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateOrganization)}
         {...view}

--- a/frontend/eda/access/users/UserPage/ControllerTokens.tsx
+++ b/frontend/eda/access/users/UserPage/ControllerTokens.tsx
@@ -7,6 +7,7 @@ import { EdaRoute } from '../../../main/EdaRoutes';
 import { useControllerTokenActions } from '../hooks/useControllerTokenActions';
 import { useControllerTokensActions } from '../hooks/useControllerTokensActions';
 import { useControllerTokensColumns } from '../hooks/useControllerTokensColumns';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function ControllerTokens() {
   const { t } = useTranslation();
@@ -31,6 +32,7 @@ export function ControllerTokens() {
         emptyStateDescription={t(
           'Please create a token from Automation Controller by using the button below.'
         )}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create controller token')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateControllerToken)}
         {...view}

--- a/frontend/eda/access/users/Users.tsx
+++ b/frontend/eda/access/users/Users.tsx
@@ -7,6 +7,7 @@ import { EdaRoute } from '../../main/EdaRoutes';
 import { useUserActions } from './hooks/useUserActions';
 import { useUserColumns } from './hooks/useUserColumns';
 import { useUsersActions } from './hooks/useUsersActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Users() {
   const { t } = useTranslation();
@@ -34,6 +35,7 @@ export function Users() {
         errorStateTitle={t('Error loading users')}
         emptyStateTitle={t('There are currently no users created for your organization.')}
         emptyStateDescription={t('Please create a user by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create user')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateUser)}
         {...view}

--- a/frontend/eda/decision-environments/DecisionEnvironments.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironments.tsx
@@ -9,6 +9,7 @@ import { useDecisionEnvironmentActions } from './hooks/useDecisionEnvironmentAct
 import { useDecisionEnvironmentsColumns } from './hooks/useDecisionEnvironmentColumns';
 import { useDecisionEnvironmentFilters } from './hooks/useDecisionEnvironmentFilters';
 import { useDecisionEnvironmentsActions } from './hooks/useDecisionEnvironmentsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function DecisionEnvironments() {
   const { t } = useTranslation();
@@ -40,6 +41,7 @@ export function DecisionEnvironments() {
           'There are currently no decision environments created for your organization.'
         )}
         emptyStateDescription={t('Please create a decision environment by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create decision environment')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateDecisionEnvironment)}
         {...view}

--- a/frontend/eda/event-streams/EventStreams.tsx
+++ b/frontend/eda/event-streams/EventStreams.tsx
@@ -8,6 +8,7 @@ import { useEventStreamActions } from './hooks/useEventStreamActions';
 import { useEventStreamColumns } from './hooks/useEventStreamColumns';
 import { useEventStreamFilters } from './hooks/useEventStreamFilters';
 import { useEventStreamsActions } from './hooks/useEventStreamsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function EventStreams() {
   const { t } = useTranslation();
@@ -33,6 +34,7 @@ export function EventStreams() {
         errorStateTitle={t('Error loading event streams')}
         emptyStateTitle={t('There are currently no event streams created for your organization.')}
         emptyStateDescription={t('Please create a event stream by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create event stream')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateEventStream)}
         {...view}

--- a/frontend/eda/projects/Projects.tsx
+++ b/frontend/eda/projects/Projects.tsx
@@ -8,6 +8,7 @@ import { useProjectActions } from './hooks/useProjectActions';
 import { useProjectColumns } from './hooks/useProjectColumns';
 import { useProjectFilters } from './hooks/useProjectFilters';
 import { useProjectsActions } from './hooks/useProjectsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Projects() {
   const { t } = useTranslation();
@@ -36,6 +37,7 @@ export function Projects() {
         errorStateTitle={t('Error loading projects')}
         emptyStateTitle={t('There are currently no projects created for your organization.')}
         emptyStateDescription={t('Please create a project by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create project')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateProject)}
         {...view}

--- a/frontend/eda/rulebook-activations/RulebookActivations.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivations.tsx
@@ -8,6 +8,7 @@ import { useRulebookActivationActions } from './hooks/useRulebookActivationActio
 import { useRulebookActivationColumns } from './hooks/useRulebookActivationColumns';
 import { useRulebookActivationFilters } from './hooks/useRulebookActivationFilters';
 import { useRulebookActivationsActions } from './hooks/useRulebookActivationsActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function RulebookActivations() {
   const { t } = useTranslation();
@@ -38,6 +39,7 @@ export function RulebookActivations() {
           'There are currently no rulebook activations created for your organization.'
         )}
         emptyStateDescription={t('Please create a rulebook activation by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create rulebook activation')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateRulebookActivation)}
         {...view}

--- a/frontend/eda/webhooks/Webhooks.tsx
+++ b/frontend/eda/webhooks/Webhooks.tsx
@@ -8,6 +8,7 @@ import { useWebhookActions } from './hooks/useWebhookActions';
 import { useWebhookColumns } from './hooks/useWebhookColumns';
 import { useWebhookFilters } from './hooks/useWebhookFilters';
 import { useWebhooksActions } from './hooks/useWebhooksActions';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function Webhooks() {
   const { t } = useTranslation();
@@ -33,6 +34,7 @@ export function Webhooks() {
         errorStateTitle={t('Error loading webhooks')}
         emptyStateTitle={t('There are currently no webhooks created for your organization.')}
         emptyStateDescription={t('Please create a webhook by using the button below.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create webhook')}
         emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateWebhook)}
         {...view}


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-10266
Added the PlusCircleIcon to the empty state button areas within AWX and EDA that had the emptyStateButtonText string
Some examples:
<img width="1380" alt="Screenshot 2024-04-15 at 5 19 52 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/a11beed7-0fc3-4205-a481-75dcc9d83bbb">
<img width="1382" alt="Screenshot 2024-04-15 at 5 23 51 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/3dbb0e97-a8a1-4b44-be8b-aa42d77004e3">
<img width="1385" alt="Screenshot 2024-04-15 at 5 23 24 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/3c4ac7f2-b293-4002-96a6-2b0b550c72c4">

