### PR TITLE
fixing edit schedule test

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -424,7 +424,7 @@ describe('Schedules - Edit', () => {
           .should((el) => expect(el.text().trim()).to.equal(text));
       });
     });
-    cy.selectDropdownOptionByResourceName('timezone', 'Africa/Abidjan');
+    cy.selectSingleSelectOption('[data-cy="timezone"]', 'Africa/Abidjan');
     cy.getByDataCy('undefined-form-group').within(() => {
       cy.getBy('[aria-label="Time picker"]').click().type('{selectall} 5:00 AM');
     });

--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.cy.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.cy.tsx
@@ -170,7 +170,7 @@ describe('ScheduleAddWizard', () => {
       });
 
       cy.get('[data-cy="name"]').type('Test Schedule');
-      cy.selectDropdownOptionByResourceName('timezone', 'Zulu');
+      cy.selectSingleSelectOption('[data-cy="timezone"]', 'Zulu');
       cy.clickButton(/^Next$/);
     });
     it('Should update a basic rule.', () => {


### PR DESCRIPTION
- replacing last `selectDropdownOptionByResourceName` to `selectSingleSelectOption` that was introduced by [this PR](https://github.com/ansible/ansible-ui/pull/2034)
- update `ScheduleEditWizard.cy.tsx`