### PR TITLE
Controller -> Credentials: refactor tests

### DIFF
--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -70,7 +70,7 @@ describe('Credentials', () => {
           cy.wait('@deleted')
             .its('response')
             .then((deleted) => {
-              expect(deleted.statusCode).to.eql(204);
+              expect(deleted?.statusCode).to.eql(204);
               cy.verifyPageTitle('Credentials');
             });
         });
@@ -112,7 +112,7 @@ describe('Credentials', () => {
       cy.wait('@deleted')
         .its('response')
         .then((deleted) => {
-          expect(deleted.statusCode).to.eql(204);
+          expect(deleted?.statusCode).to.eql(204);
           cy.contains(/^Success$/);
           cy.clickButton(/^Close$/);
           cy.clickButton(/^Clear all filters$/);
@@ -131,7 +131,7 @@ describe('Credentials', () => {
       cy.wait('@deleted')
         .its('response')
         .then((deleted) => {
-          expect(deleted.statusCode).to.eql(204);
+          expect(deleted?.statusCode).to.eql(204);
           cy.contains(/^Success$/);
           cy.clickButton(/^Close$/);
           cy.clickButton(/^Clear all filters$/);
@@ -177,7 +177,7 @@ describe('Credentials', () => {
       cy.wait('@deleted')
         .its('response')
         .then((deleted) => {
-          expect(deleted.statusCode).to.eql(204);
+          expect(deleted?.statusCode).to.eql(204);
           cy.verifyPageTitle('Credentials');
         });
     });

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { randomString } from '../../../../framework/utils/random-string';
 import { Credential } from '../../../../frontend/awx/interfaces/Credential';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
-describe('credentials', () => {
+describe('Credentials', () => {
   let organization: Organization;
   let credential: Credential;
   let user: AwxUser;
@@ -14,10 +12,8 @@ describe('credentials', () => {
   before(() => {
     cy.awxLogin();
 
-    cy.requestPost<Organization>(awxAPI`/organizations/`, {
-      name: 'E2E Credentials ' + randomString(4),
-    }).then((testOrg) => {
-      organization = testOrg;
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
       cy.createAwxUser(organization).then((testUser) => {
         user = testUser;
       });
@@ -25,131 +21,174 @@ describe('credentials', () => {
   });
 
   beforeEach(() => {
-    cy.requestPost<Credential>(awxAPI`/credentials/`, {
-      name: 'E2E Credential ' + randomString(4),
-      credential_type: 1,
+    cy.createAWXCredential({
+      kind: 'machine',
       organization: organization.id,
-    }).then((testCredential) => {
-      credential = testCredential;
-      //Assign normal user the 'Use' role of the newly created credential
+      credential_type: 1,
+    }).then((cred) => {
+      credential = cred;
       cy.giveUserCredentialsAccess(credential.name, user.id, 'Use');
-    });
-    cy.navigateTo('awx', 'credentials');
-  });
-
-  afterEach(() => {
-    cy.requestDelete(awxAPI`/credentials/${credential.id.toString()}/`, {
-      failOnStatusCode: false,
     });
   });
 
   after(() => {
     cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.requestDelete(awxAPI`/organizations/${organization.id.toString()}/`, {
-      failOnStatusCode: false,
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  });
+
+  afterEach(() => {
+    cy.deleteAwxCredential(credential, { failOnStatusCode: false });
+  });
+
+  describe('Credentials: List View', () => {
+    it('can create and delete a machine credential', () => {
+      const credentialName = 'E2E Credential ' + randomString(4);
+      cy.navigateTo('awx', 'credentials');
+      cy.clickButton(/^Create credential$/);
+      cy.get('[data-cy="name"]').type(credentialName);
+      cy.selectDropdownOptionByResourceName('credential-type', 'Amazon Web Services');
+      cy.get('[data-cy="username"]').type('username');
+      cy.get('[data-cy="password"]').type('password');
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.intercept('POST', awxAPI`/credentials/`).as('newCred');
+      cy.clickButton(/^Create credential$/);
+      cy.wait('@newCred')
+        .its('response.body')
+        .then((newCred: Credential) => {
+          expect(newCred.name).to.eql(credentialName);
+          cy.verifyPageTitle(newCred.name);
+          cy.contains('Access Key').should('be.visible');
+          cy.get('[data-cy="access-key"]').contains('username');
+          cy.contains('Secret Key').should('be.visible');
+          cy.get('[data-cy="secret-key"]').contains('Encrypted');
+          cy.contains('Organization').should('be.visible');
+          cy.contains(organization.name);
+          cy.clickPageAction('delete-credential');
+          cy.get('#confirm').click();
+          cy.intercept('DELETE', awxAPI`/credentials/${newCred.id.toString()}/`).as('deleted');
+          cy.clickButton(/^Delete credential/);
+          cy.wait('@deleted')
+            .its('response')
+            .then((deleted) => {
+              expect(deleted.statusCode).to.eql(204);
+              cy.verifyPageTitle('Credentials');
+            });
+        });
+    });
+
+    it.skip('can create and delete one of each kind of credential', () => {
+      //Write this test in a loop to test the creation of each kind of credential
+      //Assert the different required and non-required form fields that each cred has
+      //Assert info on the details page following the POST request
+      //Assert the deletion of the credential at the end of the test
+    });
+
+    it('can edit machine credential from the list row action', () => {
+      cy.navigateTo('awx', 'credentials');
+      cy.filterTableByMultiSelect('name', [credential.name]);
+      cy.get(`[data-cy="row-id-${credential.id}"]`).within(() => {
+        cy.get('[data-cy="edit-credential"]').click();
+      });
+      cy.verifyPageTitle('Edit Credential');
+      cy.get('[data-cy="name"]').clear().type(`${credential.name} - edited`);
+      cy.clickButton(/^Save credential$/);
+      cy.clearAllFilters();
+      cy.filterTableByMultiSelect('name', [`${credential.name} - edited`]);
+      cy.clickTableRowLink('name', `${credential.name} - edited`, { disableFilter: true });
+      cy.verifyPageTitle(`${credential.name} - edited`);
+      cy.clickButton(/^Edit credential$/);
+      cy.get('[data-cy="name"]').clear().type(`${credential.name}`);
+      cy.clickButton(/^Save credential$/);
+      cy.verifyPageTitle(credential.name);
+    });
+
+    it('can delete machine credential from the list row action', () => {
+      cy.navigateTo('awx', 'credentials');
+      cy.filterTableByMultiSelect('name', [credential.name]);
+      cy.clickTableRowKebabAction(credential.name, 'delete-credential', false);
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
+      cy.clickButton(/^Delete credential/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((deleted) => {
+          expect(deleted.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+          cy.clickButton(/^Clear all filters$/);
+          cy.verifyPageTitle('Credentials');
+        });
+    });
+
+    it('can delete machine credential from the list toolbar', () => {
+      cy.navigateTo('awx', 'credentials');
+      cy.filterTableByMultiSelect('name', [credential.name]);
+      cy.selectTableRowByCheckbox('name', credential.name, { disableFilter: true });
+      cy.clickToolbarKebabAction('delete-selected-credentials');
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
+      cy.clickButton(/^Delete credential/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((deleted) => {
+          expect(deleted.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+          cy.clickButton(/^Clear all filters$/);
+          cy.verifyPageTitle('Credentials');
+        });
     });
   });
 
-  it('create and delete credential', () => {
-    const credentialName = 'E2E Credential ' + randomString(4);
-    cy.navigateTo('awx', 'credentials');
-    cy.clickButton(/^Create credential$/);
-    cy.get('[data-cy="name"]').type(credentialName);
-    cy.selectDropdownOptionByResourceName('credential-type', 'Amazon Web Services');
-    cy.get('[data-cy="username"]').type('username');
-    cy.get('[data-cy="password"]').type('password');
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.clickButton(/^Create credential$/);
-    cy.verifyPageTitle(credentialName);
-    cy.contains('Access Key').should('be.visible');
-    cy.get('[data-cy="access-key"]').contains('username');
-    cy.contains('Secret Key').should('be.visible');
-    cy.get('[data-cy="secret-key"]').contains('Encrypted');
-    cy.contains('Organization').should('be.visible');
-    cy.contains(organization.name);
-    // //delete created credential
-    cy.clickPageAction('delete-credential');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.verifyPageTitle('Credentials');
-  });
-
-  it('credential details', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.clickTableRowLink('name', credential.name, {
-      disableFilter: true,
+  describe('Credentials: Details View', () => {
+    it('can edit machine credential from the details page', () => {
+      cy.navigateTo('awx', 'credentials');
+      cy.filterTableByMultiSelect('name', [credential.name]);
+      cy.clickTableRowLink('name', credential.name, {
+        disableFilter: true,
+      });
+      cy.clickButton(/^Edit credential$/);
+      cy.verifyPageTitle('Edit Credential');
+      cy.get('[data-cy="name"]')
+        .clear()
+        .type(credential.name + '-edited');
+      cy.intercept('PATCH', awxAPI`/credentials/${credential.id.toString()}/`).as('edited');
+      cy.clickButton(/^Save credential$/);
+      cy.wait('@edited')
+        .its('response.body')
+        .then((edited: Credential) => {
+          expect(edited.name).to.eql(credential.name + '-edited');
+          cy.getByDataCy('name').should('contain', edited.name);
+          cy.verifyPageTitle(edited.name);
+        });
     });
-    cy.verifyPageTitle(credential.name);
-    cy.clickLink(/^Details$/);
-    cy.contains('#name', credential.name);
-  });
 
-  it('edit credential from row action', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.get(`[data-cy="row-id-${credential.id}"]`).within(() => {
-      cy.get('[data-cy="edit-credential"]').click();
+    it('can delete a machine credential from the details page', () => {
+      cy.navigateTo('awx', 'credentials');
+      cy.filterTableByMultiSelect('name', [credential.name]);
+      cy.clickTableRowLink('name', credential.name, {
+        disableFilter: true,
+      });
+      cy.verifyPageTitle(credential.name);
+      cy.clickPageAction('delete-credential');
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
+      cy.clickButton(/^Delete credential/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((deleted) => {
+          expect(deleted.statusCode).to.eql(204);
+          cy.verifyPageTitle('Credentials');
+        });
     });
-    cy.verifyPageTitle('Edit Credential');
-    cy.get('[data-cy="name"]').clear().type(`${credential.name} - edited`);
-    cy.clickButton(/^Save credential$/);
-    cy.clearAllFilters();
-    cy.filterTableByMultiSelect('name', [`${credential.name} - edited`]);
-    cy.clickTableRowLink('name', `${credential.name} - edited`, { disableFilter: true });
-    cy.verifyPageTitle(`${credential.name} - edited`);
-    cy.clickButton(/^Edit credential$/);
-    cy.get('[data-cy="name"]').clear().type(`${credential.name}`);
-    cy.clickButton(/^Save credential$/);
-    cy.verifyPageTitle(credential.name);
   });
 
-  it('credential details edit credential', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.clickTableRowLink('name', credential.name, {
-      disableFilter: true,
+  describe('Credentials: Templates View', () => {
+    it.skip('can associate a cred with a newly created job template and view that JT on the templates tab of the cred', () => {
+      //use the credential created in the beforeEach block
+      //create a JT in this test and specifically associate the cred to it
+      //visit the templates tab of the credential and assert the JT showing there
+      //delete the JT at the end of this test
     });
-    cy.clickButton(/^Edit credential$/);
-    cy.verifyPageTitle('Edit Credential');
-    cy.get('[data-cy="name"]').type(credential.name + 'a');
-    cy.clickButton(/^Save credential$/);
-    cy.verifyPageTitle(`${credential.name}`);
-  });
-
-  it('credential details delete credential', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.clickTableRowLink('name', credential.name, {
-      disableFilter: true,
-    });
-    cy.verifyPageTitle(credential.name);
-    cy.clickPageAction('delete-credential');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.verifyPageTitle('Credentials');
-  });
-
-  it('credentials table row delete credential', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.clickTableRowKebabAction(credential.name, 'delete-credential', false);
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
-  });
-
-  it('credentials toolbar delete credentials', () => {
-    cy.navigateTo('awx', 'credentials');
-    cy.filterTableByMultiSelect('name', [credential.name]);
-    cy.selectTableRowByCheckbox('name', credential.name, { disableFilter: true });
-    cy.clickToolbarKebabAction('delete-selected-credentials');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.clickButton(/^Clear all filters$/);
   });
 });


### PR DESCRIPTION
This PR does the following:

- stubs out some missing tests that need to be written, including necessary assertions
- replaces API requests with corresponding custom commands
- adds more robust assertions to several tests
- updates test cases to be more explicit
- removes a cy.navigateTo that was in the beforeEach block which could potentially cause test flakiness