### PR TITLE
Convert tabbed Groups list to use advanced search.

### DIFF
--- a/cypress/e2e/awx/resources/hosts.cy.ts
+++ b/cypress/e2e/awx/resources/hosts.cy.ts
@@ -81,7 +81,7 @@ describe('host and inventory host', () => {
         /// single disassociate
         // TODO: need to change this when
         // https://issues.redhat.com/browse/AAP-22914 change will applyed
-        cy.searchAndDisplayResource(group.name);
+        cy.filterTableByMultiSelect('name', [group.name]);
         cy.get(`[data-cy="row-id-${group.id}"] [data-cy="checkbox-column-cell"]`).click();
         disassociate();
         navigateToHost(url, host.name, '[data-cy="name-column-cell"] a');

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -76,7 +76,8 @@ describe('Inventory Groups', () => {
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
         cy.clickLink(/^Groups$/);
-        cy.clickTableRowKebabAction(group.name, 'edit-group', true);
+        cy.filterTableByMultiSelect('name', [group.name]);
+        cy.clickTableRowKebabAction(group.name, 'edit-group', false);
         cy.verifyPageTitle('Edit group');
         cy.get('[data-cy="name-form-group"]').type('-changed');
         cy.get('[data-cy="Submit"]').click();
@@ -148,7 +149,8 @@ describe('Inventory Groups', () => {
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
         cy.clickLink(/^Groups$/);
-        cy.clickTableRow(group.name); //Refactor this line to use the updated custom command
+        cy.filterTableByMultiSelect('name', [group.name]);
+        cy.clickTableRowLink('name', group.name, { disableFilter: true });
         cy.verifyPageTitle(group.name);
         cy.get('[data-cy="edit-group"]').click();
         cy.verifyPageTitle('Edit group');
@@ -201,7 +203,8 @@ describe('Inventory Groups', () => {
         cy.get(`[href*="/infrastructure/inventories/inventory/${inventory.id}/hosts?"]`).click();
         cy.getByDataCy('name-column-cell').should('contain', host.name);
         cy.clickLink(/^Groups$/);
-        cy.clickTableRow(group.name); //Refactor this line to use the updated custom command
+        cy.filterTableByMultiSelect('name', [group.name]);
+        cy.clickTableRowLink('name', group.name, { disableFilter: true });
         cy.verifyPageTitle(group.name);
         cy.clickLink(/^Related Groups/);
         cy.clickButton(/^New group/);
@@ -209,7 +212,8 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="name-form-group"]').type(newRelatedGroup);
         cy.get('[data-cy="Submit"]').click();
         cy.contains(newRelatedGroup);
-        cy.selectTableRow(newRelatedGroup, true);
+        cy.filterTableByMultiSelect('name', [newRelatedGroup]);
+        cy.selectTableRow(newRelatedGroup, false);
         cy.clickToolbarKebabAction('disassociate-selected-groups');
         cy.get('#confirm').click();
         cy.clickButton(/^Disassociate groups/);
@@ -236,14 +240,17 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="name-form-group"]').type(newGroup);
         cy.get('[data-cy="Submit"]').click();
         cy.clickLink(/^Back to Groups/);
-        cy.clickTableRow(group.name); //Refactor this line to use the updated custom command
+        cy.filterTableByMultiSelect('name', [group.name]);
+        cy.clickTableRowLink('name', group.name, { disableFilter: true });
         cy.verifyPageTitle(group.name);
         cy.clickLink(/^Related Groups/);
         cy.clickButton(/^Existing group/);
-        cy.selectTableRow(newGroup);
+        cy.filterTableByMultiSelect('name', [newGroup]);
+        cy.selectTableRow(newGroup, false);
         cy.clickButton(/^Add groups/);
         cy.contains(newGroup);
-        cy.selectTableRow(newGroup, true);
+        cy.filterTableByMultiSelect('name', [newGroup]);
+        cy.selectTableRow(newGroup, false);
         cy.clickToolbarKebabAction('disassociate-selected-groups');
         cy.get('#confirm').click();
         cy.clickButton(/^Disassociate groups/);

--- a/frontend/awx/common/useDynamicFilters.tsx
+++ b/frontend/awx/common/useDynamicFilters.tsx
@@ -86,7 +86,8 @@ function craftRequestUrl(
       url += `&${key}=${value}`;
     });
   }
-  return url;
+  const decodedUrl = url.split('%2F').join('/');
+  return decodedUrl;
 }
 
 export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
@@ -96,7 +97,9 @@ export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
   const { optionsPath, preSortedKeys, preFilledValueKeys, additionalFilters, removeFilters } =
     useRef(props).current;
   const { t } = useTranslation();
-  const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/${optionsPath}/`);
+  const url = awxAPI`/${optionsPath}/`;
+  const decodedUrl = url.split('%2F').join('/');
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(decodedUrl);
   const filterableFields = useFilters(data?.actions?.GET);
   const queryResource = useCallback<
     (

--- a/frontend/awx/common/useDynamicFilters.tsx
+++ b/frontend/awx/common/useDynamicFilters.tsx
@@ -86,7 +86,8 @@ function craftRequestUrl(
       url += `&${key}=${value}`;
     });
   }
-  const decodedUrl = url.split('%2F').join('/');
+  // decode the returned url
+  const decodedUrl = decodeURIComponent(url);
   return decodedUrl;
 }
 
@@ -98,7 +99,8 @@ export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
     useRef(props).current;
   const { t } = useTranslation();
   const url = awxAPI`/${optionsPath}/`;
-  const decodedUrl = url.split('%2F').join('/');
+  // decode the returned url
+  const decodedUrl = decodeURIComponent(url);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(decodedUrl);
   const filterableFields = useFilters(data?.actions?.GET);
   const queryResource = useCallback<

--- a/frontend/awx/resources/groups/GroupRelatedGroups.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.tsx
@@ -17,7 +17,7 @@ export function GroupRelatedGroups() {
   const { t } = useTranslation();
   const tableColumns = useRelatedGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string; group_id: string }>();
-  const toolbarFilters = useGroupsFilters(`groups/${params.group_id ?? ''}/children`);
+  const toolbarFilters = useGroupsFilters({ url: `groups/${params.group_id ?? ''}/children` });
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/groups/${params.group_id ?? ''}/children/`,
     toolbarFilters,

--- a/frontend/awx/resources/groups/GroupRelatedGroups.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.tsx
@@ -15,9 +15,9 @@ import { useRelatedGroupsEmptyStateActions } from './hooks/useRelatedGroupsEmpty
 
 export function GroupRelatedGroups() {
   const { t } = useTranslation();
-  const toolbarFilters = useGroupsFilters();
   const tableColumns = useRelatedGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string; group_id: string }>();
+  const toolbarFilters = useGroupsFilters(`groups/${params.group_id ?? ''}/children/`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/groups/${params.group_id ?? ''}/children/`,
     toolbarFilters,

--- a/frontend/awx/resources/groups/GroupRelatedGroups.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.tsx
@@ -17,7 +17,7 @@ export function GroupRelatedGroups() {
   const { t } = useTranslation();
   const tableColumns = useRelatedGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string; group_id: string }>();
-  const toolbarFilters = useGroupsFilters(`groups/${params.group_id ?? ''}/children/`);
+  const toolbarFilters = useGroupsFilters(`groups/${params.group_id ?? ''}/children`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/groups/${params.group_id ?? ''}/children/`,
     toolbarFilters,

--- a/frontend/awx/resources/groups/hooks/useGroupSelectDialog.tsx
+++ b/frontend/awx/resources/groups/hooks/useGroupSelectDialog.tsx
@@ -14,9 +14,13 @@ export interface GroupSelectModalProps {
 
 export function GroupSelectDialog({ onSelectedGroups, groupId }: GroupSelectModalProps) {
   const { t } = useTranslation();
-  const toolbarFilters = useGroupsFilters(
-    `groups/${groupId}/potential_children/?not__id=${groupId}&not__parents=${groupId}`
-  );
+  const toolbarFilters = useGroupsFilters({
+    url: `groups/${groupId}/potential_children`,
+    queryParams: {
+      not__id: groupId,
+      not__parents: groupId,
+    },
+  });
   const nameColumn = useNameColumn();
   const createdColumn = useCreatedColumn();
   const modifiedColumn = useModifiedColumn();

--- a/frontend/awx/resources/groups/hooks/useGroupSelectDialog.tsx
+++ b/frontend/awx/resources/groups/hooks/useGroupSelectDialog.tsx
@@ -14,7 +14,9 @@ export interface GroupSelectModalProps {
 
 export function GroupSelectDialog({ onSelectedGroups, groupId }: GroupSelectModalProps) {
   const { t } = useTranslation();
-  const toolbarFilters = useGroupsFilters();
+  const toolbarFilters = useGroupsFilters(
+    `groups/${groupId}/potential_children/?not__id=${groupId}&not__parents=${groupId}`
+  );
   const nameColumn = useNameColumn();
   const createdColumn = useCreatedColumn();
   const modifiedColumn = useModifiedColumn();

--- a/frontend/awx/resources/groups/hooks/useGroupsFilters.tsx
+++ b/frontend/awx/resources/groups/hooks/useGroupsFilters.tsx
@@ -1,25 +1,27 @@
-import { useMemo } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
 import {
-  useNameToolbarFilter,
   useCreatedByToolbarFilter,
   useModifiedByToolbarFilter,
   useGroupTypeToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
+import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
-export function useGroupsFilters() {
-  const nameToolbarFilter = useNameToolbarFilter();
+export function useGroupsFilters(url?: string) {
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
   const groupTypeToolbarFilter = useGroupTypeToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [
-      nameToolbarFilter,
-      groupTypeToolbarFilter,
-      createdByToolbarFilter,
-      modifiedByToolbarFilter,
-    ],
-    [nameToolbarFilter, groupTypeToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
-  );
+  const toolbarFilters = useDynamicToolbarFilters({
+    optionsPath: url ? url : 'groups',
+    preFilledValueKeys: {
+      name: {
+        apiPath: url ? url : 'groups',
+      },
+      id: {
+        apiPath: url ? url : 'groups',
+      },
+    },
+    preSortedKeys: ['name', 'id', 'description', 'created-by', 'modified-by', 'group'],
+    additionalFilters: [modifiedByToolbarFilter, createdByToolbarFilter, groupTypeToolbarFilter],
+    removeFilters: ['inventory'],
+  });
   return toolbarFilters;
 }

--- a/frontend/awx/resources/groups/hooks/useGroupsFilters.tsx
+++ b/frontend/awx/resources/groups/hooks/useGroupsFilters.tsx
@@ -5,7 +5,13 @@ import {
 } from '../../../common/awx-toolbar-filters';
 import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
-export function useGroupsFilters(url?: string) {
+export function useGroupsFilters({
+  url,
+  queryParams,
+}: {
+  url?: string;
+  queryParams?: Record<string, string>;
+}) {
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
   const groupTypeToolbarFilter = useGroupTypeToolbarFilter();
@@ -14,9 +20,11 @@ export function useGroupsFilters(url?: string) {
     preFilledValueKeys: {
       name: {
         apiPath: url ? url : 'groups',
+        queryParams: queryParams ? queryParams : {},
       },
       id: {
         apiPath: url ? url : 'groups',
+        queryParams: queryParams ? queryParams : {},
       },
     },
     preSortedKeys: ['name', 'id', 'description', 'created-by', 'modified-by', 'group'],

--- a/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
@@ -22,9 +22,9 @@ export function HostSelectDialog({ onSelectedHosts, groupId, inventoryId }: Host
     () => [nameColumn, createdColumn, modifiedColumn],
     [nameColumn, createdColumn, modifiedColumn]
   );
-  const toolbarFilters = useGroupsFilters(
-    `inventories/${inventoryId}/hosts/?not__groups=${groupId}`
-  );
+  const toolbarFilters = useGroupsFilters({
+    url: `inventories/${inventoryId}/hosts/?not__groups=${groupId}`,
+  });
   const view = useAwxView<AwxHost>({
     url: awxAPI`/inventories/${inventoryId}/hosts/?not__groups=${groupId}&order_by=name&page=1&page_size=5`,
     toolbarFilters,

--- a/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
@@ -15,13 +15,15 @@ export interface HostSelectModalProps {
 
 export function HostSelectDialog({ onSelectedHosts, groupId, inventoryId }: HostSelectModalProps) {
   const { t } = useTranslation();
-  const toolbarFilters = useGroupsFilters();
   const nameColumn = useNameColumn();
   const createdColumn = useCreatedColumn();
   const modifiedColumn = useModifiedColumn();
   const tableColumns = useMemo<ITableColumn<AwxHost>[]>(
     () => [nameColumn, createdColumn, modifiedColumn],
     [nameColumn, createdColumn, modifiedColumn]
+  );
+  const toolbarFilters = useGroupsFilters(
+    `inventories/${inventoryId}/hosts/?not__groups=${groupId}&order_by=name&page=1&page_size=5`
   );
   const view = useAwxView<AwxHost>({
     url: awxAPI`/inventories/${inventoryId}/hosts/?not__groups=${groupId}&order_by=name&page=1&page_size=5`,

--- a/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostSelectDialog.tsx
@@ -23,7 +23,7 @@ export function HostSelectDialog({ onSelectedHosts, groupId, inventoryId }: Host
     [nameColumn, createdColumn, modifiedColumn]
   );
   const toolbarFilters = useGroupsFilters(
-    `inventories/${inventoryId}/hosts/?not__groups=${groupId}&order_by=name&page=1&page_size=5`
+    `inventories/${inventoryId}/hosts/?not__groups=${groupId}`
   );
   const view = useAwxView<AwxHost>({
     url: awxAPI`/inventories/${inventoryId}/hosts/?not__groups=${groupId}&order_by=name&page=1&page_size=5`,

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -18,7 +18,7 @@ export function InventoryGroups() {
   const pageNavigate = usePageNavigate();
   const tableColumns = useInventoriesGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string }>();
-  const toolbarFilters = useGroupsFilters(`inventories/${params.id ?? ''}/groups/`);
+  const toolbarFilters = useGroupsFilters(`inventories/${params.id ?? ''}/groups`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/inventories/${params.id ?? ''}/groups/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -16,9 +16,9 @@ import { AwxRoute } from '../../../main/AwxRoutes';
 export function InventoryGroups() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const toolbarFilters = useGroupsFilters();
   const tableColumns = useInventoriesGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string }>();
+  const toolbarFilters = useGroupsFilters(`inventories/${params.id ?? ''}/groups/`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/inventories/${params.id ?? ''}/groups/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -18,7 +18,7 @@ export function InventoryGroups() {
   const pageNavigate = usePageNavigate();
   const tableColumns = useInventoriesGroupsColumns();
   const params = useParams<{ id: string; inventory_type: string }>();
-  const toolbarFilters = useGroupsFilters(`inventories/${params.id ?? ''}/groups`);
+  const toolbarFilters = useGroupsFilters({ url: `inventories/${params.id ?? ''}/groups` });
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/inventories/${params.id ?? ''}/groups/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.cy.tsx
@@ -42,59 +42,79 @@ describe('Inventory Host Groups List', () => {
       });
 
       it(`Filter Host Groups by name (${type})`, () => {
+        cy.intercept(
+          {
+            method: 'OPTIONS',
+            url: '/api/v2/hosts/1/all_groups/',
+            hostname: 'localhost',
+          },
+          {
+            fixture: 'mock_options.json',
+          }
+        ).as('getFilterOptions');
+        cy.intercept(
+          {
+            method: 'GET',
+            url: '/api/v2/hosts/1/all_groups/*',
+            hostname: 'localhost',
+          },
+          {
+            fixture: 'groups.json',
+          }
+        ).as('getGroups');
+        cy.intercept('/api/v2/hosts/1/all_groups/?name=*').as('nameFilterRequest');
         cy.mount(<InventoryHostGroups page={type} />, {
           path: path,
           initialEntries: initialEntries,
         });
-        cy.intercept(
-          {
-            method: 'GET',
-            url: '/api/v2/hosts/*/all_groups/?name__icontains=Related%20to%20group%201*',
-          },
-          {
-            fixture: 'group.json',
-          }
-        ).as('nameFilter');
-        cy.filterTableByTypeAndText(/^Name$/, 'Related to group 1');
-        cy.get('@nameFilter.all').should('have.length.least', 1);
+        cy.filterTableByMultiSelect('name', ['Related to group 1']);
+        cy.wait('@nameFilterRequest');
         cy.clearAllFilters();
       });
 
       it(`Filter Host Groups by created by (${type})`, () => {
+        cy.intercept(
+          {
+            method: 'OPTIONS',
+            url: '/api/v2/hosts/1/all_groups/',
+            hostname: 'localhost',
+          },
+          {
+            fixture: 'mock_options.json',
+          }
+        ).as('getFilterOptions');
+        cy.intercept('/api/v2/hosts/1/all_groups/?created_by__username__icontains=*').as(
+          'createdByFilterRequest'
+        );
         cy.mount(<InventoryHostGroups page={type} />, {
           path: path,
           initialEntries: initialEntries,
         });
-        cy.intercept(
-          {
-            method: 'GET',
-            url: '/api/v2/hosts/*/all_groups/?created_by__username__icontains=test*',
-          },
-          {
-            fixture: 'group.json',
-          }
-        ).as('createdByFilter');
-        cy.filterTableByTypeAndText(/^Created by$/, 'test');
-        cy.get('@createdByFilter.all').should('have.length.least', 1);
+        cy.filterTableByTextFilter('created-by', 'test');
+        cy.wait('@createdByFilterRequest');
         cy.clearAllFilters();
       });
 
       it(`Filter Host Groups by modified by  (${type})`, () => {
+        cy.intercept(
+          {
+            method: 'OPTIONS',
+            url: '/api/v2/hosts/1/all_groups/',
+            hostname: 'localhost',
+          },
+          {
+            fixture: 'mock_options.json',
+          }
+        ).as('getFilterOptions');
+        cy.intercept('/api/v2/hosts/1/all_groups/?modified_by__username__icontains=*').as(
+          'modifiedByFilterRequest'
+        );
         cy.mount(<InventoryHostGroups page={type} />, {
           path: path,
           initialEntries: initialEntries,
         });
-        cy.intercept(
-          {
-            method: 'GET',
-            url: '/api/v2/hosts/*/all_groups/?modified_by__username__icontains=test*',
-          },
-          {
-            fixture: 'group.json',
-          }
-        ).as('modifiedByFilter');
-        cy.filterTableByTypeAndText(/^Modified by$/, 'test');
-        cy.get('@modifiedByFilter.all').should('have.length.least', 1);
+        cy.filterTableByTextFilter('modified-by', 'test');
+        cy.wait('@modifiedByFilterRequest');
         cy.clearAllFilters();
       });
 

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -26,7 +26,7 @@ export function InventoryHostGroups(props: { page: string }) {
   const inventoryId = String(host?.inventory) ?? '';
   const hostId = isHostPage ? params.id ?? '' : params.host_id ?? '';
 
-  const toolbarFilters = useHostsGroupsFilters(`hosts/${hostId ?? ''}/all_groups/`);
+  const toolbarFilters = useHostsGroupsFilters(`hosts/${hostId ?? ''}/all_groups`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/hosts/${hostId ?? ''}/all_groups/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -18,7 +18,6 @@ import { useGetHost } from '../../hosts/hooks/useGetHost';
 
 export function InventoryHostGroups(props: { page: string }) {
   const { t } = useTranslation();
-  const toolbarFilters = useHostsGroupsFilters();
   const tableColumns = useHostsGroupsColumns();
   const isHostPage: boolean = props.page === 'host';
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
@@ -27,6 +26,7 @@ export function InventoryHostGroups(props: { page: string }) {
   const inventoryId = String(host?.inventory) ?? '';
   const hostId = isHostPage ? params.id ?? '' : params.host_id ?? '';
 
+  const toolbarFilters = useHostsGroupsFilters(`hosts/${hostId ?? ''}/all_groups/`);
   const view = useAwxView<InventoryGroup>({
     url: awxAPI`/hosts/${hostId ?? ''}/all_groups/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
@@ -22,7 +22,7 @@ describe('Inventory Host Groups List', () => {
         {
           fixture: 'groups.json',
         }
-      );
+      ).as('getGroupResults');
       cy.intercept(
         { method: 'OPTIONS', url: '/api/v2/groups' },
         { fixture: 'groups_options.json' }
@@ -44,7 +44,12 @@ describe('Inventory Host Groups List', () => {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
-      cy.get('tbody').find('tr').should('have.length', 4);
+      cy.wait('@getGroupResults')
+        .its('response.body.results')
+        .then((groups: InventoryGroup[]) => {
+          const fixtureCount = groups.length;
+          cy.get('tbody').find('tr').should('have.length', fixtureCount);
+        });
     });
 
     it('Filter Host Groups by name', () => {

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.cy.tsx
@@ -30,67 +30,97 @@ describe('Inventory Host Groups List', () => {
     });
 
     it('Inventory Groups Add Modal Renders', () => {
+      cy.intercept(
+        {
+          method: 'OPTIONS',
+          url: '/api/v2/inventories/1/groups/',
+          hostname: 'localhost',
+        },
+        {
+          fixture: 'mock_options.json',
+        }
+      ).as('getFilterOptions');
       cy.mount(<InventoryHostGroupsAddModal {...props} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
-      cy.get('tbody').find('tr').should('have.length', 10);
+      cy.get('tbody').find('tr').should('have.length', 4);
     });
 
     it('Filter Host Groups by name', () => {
+      cy.intercept(
+        {
+          method: 'OPTIONS',
+          url: '/api/v2/inventories/1/groups/',
+          hostname: 'localhost',
+        },
+        {
+          fixture: 'mock_options.json',
+        }
+      ).as('getFilterOptions');
+      cy.intercept(
+        {
+          method: 'GET',
+          url: '/api/v2/inventories/1/groups/*',
+          hostname: 'localhost',
+        },
+        {
+          fixture: 'groups.json',
+        }
+      ).as('getGroups');
+      cy.intercept('/api/v2/inventories/1/groups/?not__hosts=1&name=*').as('nameFilterRequest');
       cy.mount(<InventoryHostGroupsAddModal {...props} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
-      cy.intercept(
-        {
-          method: 'GET',
-          url: '/api/v2/inventories/*/groups/?not__hosts=*&name__icontains=Related%20to%20group%201*',
-        },
-        {
-          fixture: 'group.json',
-        }
-      ).as('nameFilter');
-      cy.filterTableByTypeAndText(/^Name$/, 'Related to group 1');
-      cy.get('@nameFilter.all').should('have.length.least', 1);
+      cy.filterTableByMultiSelect('name', ['Related to group 1']);
+      cy.wait('@nameFilterRequest');
       cy.clearAllFilters();
     });
 
     it('Filter Host Groups by created by', () => {
+      cy.intercept(
+        {
+          method: 'OPTIONS',
+          url: '/api/v2/inventories/1/groups/',
+          hostname: 'localhost',
+        },
+        {
+          fixture: 'mock_options.json',
+        }
+      ).as('getFilterOptions');
+      cy.intercept(
+        '/api/v2/inventories/1/groups/?not__hosts=1&created_by__username__icontains=*'
+      ).as('createdByFilterRequest');
       cy.mount(<InventoryHostGroupsAddModal {...props} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
-      cy.intercept(
-        {
-          method: 'GET',
-          url: '/api/v2/inventories/*/groups/?not__hosts=*&created_by__username__icontains=test*',
-        },
-        {
-          fixture: 'group.json',
-        }
-      ).as('createdByFilter');
-      cy.filterTableByTypeAndText(/^Created by$/, 'test');
-      cy.get('@createdByFilter.all').should('have.length.least', 1);
+      cy.filterTableByTextFilter('created-by', 'test');
+      cy.wait('@createdByFilterRequest');
       cy.clearAllFilters();
     });
 
     it('Filter Host Groups by modified by', () => {
+      cy.intercept(
+        {
+          method: 'OPTIONS',
+          url: '/api/v2/inventories/1/groups/',
+          hostname: 'localhost',
+        },
+        {
+          fixture: 'mock_options.json',
+        }
+      ).as('getFilterOptions');
+      cy.intercept(
+        '/api/v2/inventories/1/groups/?not__hosts=1&modified_by__username__icontains=*'
+      ).as('modifiedByFilterRequest');
       cy.mount(<InventoryHostGroupsAddModal {...props} />, {
         path: '/inventories/:inventory_type/:id/hosts/:host_id/*',
         initialEntries: ['/inventories/inventory/1/hosts/1/groups'],
       });
-      cy.intercept(
-        {
-          method: 'GET',
-          url: '/api/v2/inventories/*/groups/?not__hosts=*&modified_by__username__icontains=test*',
-        },
-        {
-          fixture: 'group.json',
-        }
-      ).as('modifiedByFilter');
-      cy.filterTableByTypeAndText(/^Modified by$/, 'test');
-      cy.get('@modifiedByFilter.all').should('have.length.least', 1);
+      cy.filterTableByTextFilter('modified-by', 'test');
+      cy.wait('@modifiedByFilterRequest');
       cy.clearAllFilters();
     });
 

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
@@ -18,7 +18,7 @@ export function InventoryHostGroupsAddModal(props: {
   inventoryId: string;
   hostId: string;
 }) {
-  const toolbarFilters = useHostsGroupsFilters();
+  const toolbarFilters = useHostsGroupsFilters(`inventories/${props.inventoryId ?? ''}/groups/`);
   const tableColumns = useHostsGroupsColumns({ disableLinks: true });
 
   const view = useAwxView<InventoryGroup>({

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
@@ -18,7 +18,7 @@ export function InventoryHostGroupsAddModal(props: {
   inventoryId: string;
   hostId: string;
 }) {
-  const toolbarFilters = useHostsGroupsFilters(`inventories/${props.inventoryId ?? ''}/groups/`);
+  const toolbarFilters = useHostsGroupsFilters(`inventories/${props.inventoryId ?? ''}/groups`);
   const tableColumns = useHostsGroupsColumns({ disableLinks: true });
 
   const view = useAwxView<InventoryGroup>({

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsFilters.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsFilters.tsx
@@ -1,18 +1,24 @@
-import { useMemo } from 'react';
-import { IToolbarFilter } from '../../../../../../framework';
 import {
   useCreatedByToolbarFilter,
   useModifiedByToolbarFilter,
-  useNameToolbarFilter,
 } from '../../../../common/awx-toolbar-filters';
+import { useDynamicToolbarFilters } from '../../../../common/useDynamicFilters';
 
-export function useHostsGroupsFilters() {
+export function useHostsGroupsFilters(url?: string) {
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
-  const nameToolbarFilter = useNameToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [nameToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter],
-    [nameToolbarFilter, createdByToolbarFilter, modifiedByToolbarFilter]
-  );
+  const toolbarFilters = useDynamicToolbarFilters({
+    optionsPath: url ? url : 'groups',
+    preFilledValueKeys: {
+      name: {
+        apiPath: url ? url : 'groups',
+      },
+      id: {
+        apiPath: url ? url : 'groups',
+      },
+    },
+    preSortedKeys: ['name', 'id', 'description', 'created-by', 'modified-by'],
+    additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
+  });
   return toolbarFilters;
 }


### PR DESCRIPTION
The Groups tabbed view exists in several areas:

- Inventory -> Groups
- Inventory -> Groups -> Related Groups
- Inventory -> Hosts -> Groups

The various filter hooks for these lists have been refactored to use the `useDynamicFilters` hook and we pass a `url` prop to correctly filter down the results.