### PR TITLE
Convert Inventory Sources tab to advanced search.

### DIFF
--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -17,9 +17,11 @@ import { useInventorySourceColumns } from '../hooks/useInventorySourceColumns';
 export function InventorySources() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const toolbarFilters = useInventorySourceFilters();
   const tableColumns = useInventorySourceColumns();
   const params = useParams<{ id: string; inventory_type: string }>();
+  const toolbarFilters = useInventorySourceFilters(
+    `inventories/${params.id ?? ''}/inventory_sources/`
+  );
   const view = useAwxView<InventorySource>({
     url: awxAPI`/inventories/${params.id ?? ''}/inventory_sources/`,
     toolbarFilters,

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceFilters.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceFilters.tsx
@@ -1,9 +1,17 @@
-import { useMemo } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
-import { useNameToolbarFilter } from '../../../common/awx-toolbar-filters';
+import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
-export function useInventorySourceFilters() {
-  const nameToolbarFilter = useNameToolbarFilter();
-  const toolbarFilters = useMemo<IToolbarFilter[]>(() => [nameToolbarFilter], [nameToolbarFilter]);
+export function useInventorySourceFilters(url?: string) {
+  const toolbarFilters = useDynamicToolbarFilters({
+    optionsPath: url ? url : 'inventory_sources',
+    preFilledValueKeys: {
+      name: {
+        apiPath: url ? url : 'inventory_sources',
+      },
+      id: {
+        apiPath: url ? url : 'inventory_sources',
+      },
+    },
+    preSortedKeys: ['name', 'id', 'description'],
+  });
   return toolbarFilters;
 }

--- a/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
+++ b/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
@@ -14,11 +14,11 @@ function SelectInventorySource(props: {
   inventoryId?: number;
 }) {
   const { title, inventoryId, onSelect } = props;
-  const toolbarFilters = useInventorySourceFilters();
   const tableColumns = useInventorySourceColumns({ disableLinks: true });
   const url = inventoryId
     ? awxAPI`/inventories/${inventoryId.toString()}/inventory_sources/`
     : awxAPI`/inventory_sources/`;
+  const toolbarFilters = useInventorySourceFilters(url);
   const view = useAwxView<InventorySource>({
     url,
     toolbarFilters,


### PR DESCRIPTION
This PR converts the Inventory -> Sources tab to use the `useDynamicFilters` hook and refactors the useInventorySourcesFilter hook to accept a `url` prop to correctly filter down the results.