### PR TITLE
Disable Page Action Button When `PageActionSelection` is `multiple` and No Items Selected

### DIFF
--- a/framework/PageActions/PageActionButton.tsx
+++ b/framework/PageActions/PageActionButton.tsx
@@ -12,6 +12,7 @@ import {
   PageActionType,
 } from './PageAction';
 import { usePageActionDisabled } from './PageActionUtils';
+import { useTranslation } from 'react-i18next';
 
 export function PageActionButton<T extends object>(props: {
   action:
@@ -42,6 +43,7 @@ export function PageActionButton<T extends object>(props: {
   const Icon = action.icon;
 
   let tooltip;
+  const { t } = useTranslation();
 
   if (isDisabled) {
     tooltip = isDisabled;
@@ -51,6 +53,15 @@ export function PageActionButton<T extends object>(props: {
     tooltip = action.label;
   } else {
     tooltip = undefined;
+  }
+
+  let isButtonDisabled = !!isDisabled;
+  if (
+    action.selection === PageActionSelection.Multiple &&
+    (!selectedItems || !selectedItems.length)
+  ) {
+    tooltip = t(`Select at least one item from the list`);
+    isButtonDisabled = true;
   }
 
   let variant = action.variant ?? ButtonVariant.secondary;
@@ -93,7 +104,7 @@ export function PageActionButton<T extends object>(props: {
           variant={variant}
           isDanger={action.isDanger}
           icon={Icon ? <Icon /> : undefined}
-          isAriaDisabled={!!isDisabled}
+          isAriaDisabled={isButtonDisabled}
           onClick={() => {
             if (action.type !== PageActionType.Link) {
               switch (action.selection) {


### PR DESCRIPTION
This PR fixes a bug I found where page action buttons that have their PageActionSelection as multiple were not disabled when no items were selected in the list. In the example below, the health check action should be disabled as it requires at least on instance to be selected to perform a health check on. In this case no instances were selected yet the page action was still not disabled allowing a user to attempt an action on no items.

<img width="1384" alt="Screenshot 2024-04-17 at 2 23 29 PM" src="https://github.com/ansible/ansible-ui/assets/112966709/c069968d-80f0-46ea-b497-b14efc0898ee">

