### PR TITLE
Wizard step flow refactor

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -65,6 +65,9 @@ describe('Schedules', () => {
       cy.getBy('[data-cy="create-schedule"]').click();
       cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
       cy.selectDropdownOptionByResourceName('job-template-select', jobTemplate.name);
+      cy.get('[data-cy="name"]').type('Test Schedule');
+      cy.clickButton(/^Next$/);
+
       cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Prompts');
     });
   });
@@ -78,33 +81,45 @@ describe('Schedules', () => {
       cy.getBy('[data-cy="create-schedule"]').click();
       cy.selectDropdownOptionByResourceName('schedule_type', 'Workflow job template');
       cy.selectDropdownOptionByResourceName('job-template-select', workflowJobTemplate.name);
+      cy.get('[data-cy="name"]').type('Test Schedule');
+      cy.clickButton(/^Next$/);
+
       cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Prompts');
     });
   });
 
-  it('project does not renders prompt step', () => {
+  it('project does not render prompt step', () => {
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.getBy('[data-cy="schedule_type-form-group"]').click();
     cy.getBy('[data-cy="project-sync"]').click();
     cy.selectDropdownOptionByResourceName('project', project.name);
+    cy.get('[data-cy="name"]').type('Test Schedule');
+    cy.clickButton(/^Next$/);
+
     cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Rules');
   });
 
-  it('management jobs does not renders prompt step', () => {
+  it('management jobs does not render prompt step', () => {
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.selectDropdownOptionByResourceName('schedule_type', 'Management job template');
     cy.selectDropdownOptionByResourceName(
       'management-job-template-select',
       'Cleanup Activity Stream'
     );
+    cy.get('[data-cy="name"]').type('Test Schedule');
+    cy.clickButton(/^Next$/);
+
     cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Rules');
   });
 
-  it('inventory source does not renders prompt step', () => {
+  it('inventory source does not render prompt step', () => {
     cy.getBy('[data-cy="create-schedule"]').click();
     cy.selectDropdownOptionByResourceName('schedule_type', 'Inventory source');
     cy.selectDropdownOptionByResourceName('inventory', inventory.name);
     cy.selectDropdownOptionByResourceName('inventory-source-select', inventorySource.name);
+    cy.get('[data-cy="name"]').type('Test Schedule');
+    cy.clickButton(/^Next$/);
+
     cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Rules');
   });
 });

--- a/framework/PageWizard/PageWizard.tsx
+++ b/framework/PageWizard/PageWizard.tsx
@@ -47,7 +47,7 @@ export function PageWizard<T extends object>(props: {
           }}
         >
           <PageWizardNavigation />
-          <PageWizardBody<T>
+          <PageWizardBody
             errorAdapter={props.errorAdapter}
             onCancel={props.onCancel}
             disableGrid={props.disableGrid}

--- a/framework/PageWizard/PageWizard.tsx
+++ b/framework/PageWizard/PageWizard.tsx
@@ -19,7 +19,11 @@ export function PageWizard<T extends object>(props: {
   singleColumn?: boolean;
 }) {
   return (
-    <PageWizardProvider<T> steps={props.steps} defaultValue={props.defaultValue}>
+    <PageWizardProvider<T>
+      steps={props.steps}
+      defaultValue={props.defaultValue}
+      onSubmit={props.onSubmit}
+    >
       <div
         className="pf-v5-c-wizard"
         data-cy="wizard"
@@ -46,7 +50,6 @@ export function PageWizard<T extends object>(props: {
           <PageWizardBody<T>
             errorAdapter={props.errorAdapter}
             onCancel={props.onCancel}
-            onSubmit={props.onSubmit}
             disableGrid={props.disableGrid}
             isVertical={props.isVertical}
             singleColumn={props.singleColumn}

--- a/framework/PageWizard/PageWizardBody.cy.tsx
+++ b/framework/PageWizard/PageWizardBody.cy.tsx
@@ -5,8 +5,11 @@ import { PageWizardProvider } from './PageWizardProvider';
 describe('PageWizardBody', () => {
   it('should render the provided element within a page section', () => {
     cy.mount(
-      <PageWizardProvider steps={[{ id: 'step1', label: 'Step 1', element: <p>Step 1</p> }]}>
-        <PageWizardBody onCancel={() => {}} onSubmit={() => Promise.resolve()} />
+      <PageWizardProvider
+        steps={[{ id: 'step1', label: 'Step 1', element: <p>Step 1</p> }]}
+        onSubmit={() => Promise.resolve()}
+      >
+        <PageWizardBody onCancel={() => {}} />
       </PageWizardProvider>
     );
     cy.get('[data-cy="wizard-section-step1"]').should('exist');
@@ -18,8 +21,9 @@ describe('PageWizardBody', () => {
     cy.mount(
       <PageWizardProvider
         steps={[{ id: 'step1', label: 'Step 1', inputs: <input data-cy="mocked-input" /> }]}
+        onSubmit={() => Promise.resolve()}
       >
-        <PageWizardBody onCancel={() => {}} onSubmit={() => Promise.resolve()} />
+        <PageWizardBody onCancel={() => {}} />
       </PageWizardProvider>
     );
     cy.get('form').should('exist');

--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -7,37 +7,19 @@ import { useNavigate } from 'react-router-dom';
 import { RequestError } from '../../frontend/common/crud/RequestError';
 import { PageForm } from '../PageForm/PageForm';
 import { PageLayout } from '../PageLayout';
-import { useURLSearchParams } from '../components/useURLSearchParams';
 import { PageWizardFooter } from './PageWizardFooter';
-import { usePageWizard, isPageWizardParentStep, isStepVisible } from './PageWizardProvider';
+import { usePageWizard } from './PageWizardProvider';
 import type { PageWizardBody } from './types';
 
-export function PageWizardBody<T>({
+export function PageWizardBody({
   onCancel,
-  // onSubmit,
   disableGrid,
   errorAdapter,
   isVertical,
   singleColumn,
-}: PageWizardBody<T>) {
+}: PageWizardBody) {
   const navigate = useNavigate();
-  const {
-    activeStep,
-    steps,
-    setActiveStep,
-    setStepData,
-    setVisibleSteps,
-    setWizardData,
-    stepData,
-    // visibleSteps,
-    // visibleStepsFlattened,
-    wizardData,
-    onNext,
-    onBack,
-    submitError,
-    setSubmitError,
-  } = usePageWizard();
-  const [_, setSearchParams] = useURLSearchParams();
+  const { activeStep, stepData, onNext, onBack, submitError } = usePageWizard();
 
   const onClose = useCallback((): void => {
     if (onCancel) {

--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -9,12 +9,12 @@ import { PageForm } from '../PageForm/PageForm';
 import { PageLayout } from '../PageLayout';
 import { useURLSearchParams } from '../components/useURLSearchParams';
 import { PageWizardFooter } from './PageWizardFooter';
-import { isPageWizardParentStep, usePageWizard } from './PageWizardProvider';
+import { usePageWizard, isPageWizardParentStep, isStepVisible } from './PageWizardProvider';
 import type { PageWizardBody } from './types';
 
 export function PageWizardBody<T>({
   onCancel,
-  onSubmit,
+  // onSubmit,
   disableGrid,
   errorAdapter,
   isVertical,
@@ -23,12 +23,17 @@ export function PageWizardBody<T>({
   const navigate = useNavigate();
   const {
     activeStep,
+    steps,
     setActiveStep,
     setStepData,
+    setVisibleSteps,
     setWizardData,
     stepData,
-    visibleStepsFlattened,
+    // visibleSteps,
+    // visibleStepsFlattened,
     wizardData,
+    onNext,
+    onBack,
     submitError,
     setSubmitError,
   } = usePageWizard();
@@ -41,64 +46,6 @@ export function PageWizardBody<T>({
       navigate(-1);
     }
   }, [navigate, onCancel]);
-
-  const onNext = useCallback(
-    async (formData: object) => {
-      if (activeStep === null) {
-        return Promise.resolve();
-      }
-
-      if (!isPageWizardParentStep(activeStep) && activeStep.validate) {
-        await activeStep.validate(formData, wizardData);
-      }
-
-      const isLastStep =
-        activeStep?.id === visibleStepsFlattened[visibleStepsFlattened.length - 1]?.id;
-      if (isLastStep) {
-        try {
-          await onSubmit(wizardData as T);
-        } catch (e) {
-          setSubmitError(e instanceof Error ? e : new Error(t('An error occurred.')));
-        }
-        return;
-      }
-
-      const activeStepIndex = visibleStepsFlattened.findIndex((step) => step.id === activeStep?.id);
-      // If the next step is a parent step, mark its first substep as the next active step
-      const nextStep = isPageWizardParentStep(visibleStepsFlattened[activeStepIndex + 1])
-        ? visibleStepsFlattened[activeStepIndex + 2]
-        : visibleStepsFlattened[activeStepIndex + 1];
-
-      // Clear search params
-      setSearchParams(new URLSearchParams(''));
-      setWizardData((prev: object) => ({ ...prev, ...formData }));
-      setStepData((prev) => ({ ...prev, [activeStep?.id]: formData }));
-      setActiveStep(nextStep);
-      return Promise.resolve();
-    },
-    [
-      activeStep,
-      onSubmit,
-      setActiveStep,
-      setSearchParams,
-      setStepData,
-      setSubmitError,
-      setWizardData,
-      visibleStepsFlattened,
-      wizardData,
-    ]
-  );
-
-  const onBack = useCallback(() => {
-    const activeStepIndex = visibleStepsFlattened.findIndex((step) => step.id === activeStep?.id);
-    // If the previous step is a parent step, mark its first substep as the next active step
-    const previousStep = isPageWizardParentStep(visibleStepsFlattened[activeStepIndex - 1])
-      ? visibleStepsFlattened[activeStepIndex - 2]
-      : visibleStepsFlattened[activeStepIndex - 1];
-    // Clear search params
-    setSearchParams(new URLSearchParams(''));
-    setActiveStep(previousStep);
-  }, [visibleStepsFlattened, setSearchParams, setActiveStep, activeStep?.id]);
 
   return (
     <PageLayout>

--- a/framework/PageWizard/PageWizardFooter.cy.tsx
+++ b/framework/PageWizard/PageWizardFooter.cy.tsx
@@ -9,7 +9,7 @@ describe('PageWizardFooter', () => {
 
   const wizardContext = {
     activeStep: step1,
-    allSteps: [step1, step2, step3],
+    steps: [step1, step2, step3],
     visibleSteps: [step1, step2, step3],
     visibleStepsFlattened: [step1, step2, step3],
     isToggleExpanded: false,
@@ -18,11 +18,11 @@ describe('PageWizardFooter', () => {
     setStepError: () => {},
     setToggleExpanded: () => {},
     setWizardData: () => {},
-    setVisibleSteps: () => {},
-    setVisibleStepsFlattened: () => {},
     stepData: {},
     stepError: {},
     wizardData: {},
+    onNext: () => Promise.resolve(),
+    onBack: () => {},
     setSubmitError: () => {},
   };
 

--- a/framework/PageWizard/PageWizardProvider.tsx
+++ b/framework/PageWizard/PageWizardProvider.tsx
@@ -1,6 +1,14 @@
-import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
-
-import type { PageWizardParentStep, PageWizardState, PageWizardStep } from './types';
+import { useSearchParams } from 'react-router-dom';
+import {
+  createContext,
+  ReactNode,
+  useState,
+  useEffect,
+  useContext,
+  useMemo,
+  useCallback,
+} from 'react';
+import type { PageWizardStep, PageWizardState, PageWizardParentStep } from './types';
 
 export const PageWizardContext = createContext<PageWizardState>({} as PageWizardState);
 export function usePageWizard() {
@@ -19,53 +27,80 @@ export function PageWizardProvider<T extends object>(props: {
   children: ReactNode;
   steps: PageWizardStep[];
   defaultValue?: Record<string, object>;
+  onSubmit: (wizardData: T) => Promise<void>;
 }) {
+  const { steps, onSubmit } = props;
   const [isToggleExpanded, setToggleExpanded] = useState(false);
   const [activeStep, setActiveStep] = useState<PageWizardStep | null>(null);
   const [wizardData, setWizardData] = useState<Partial<T>>({});
   const [stepData, setStepData] = useState<Record<string, object>>(props.defaultValue ?? {});
   const [stepError, setStepError] = useState<Record<string, object>>({});
   const [submitError, setSubmitError] = useState<Error>();
-  const [visibleSteps, setVisibleSteps] = useState<PageWizardStep[]>(() => {
-    return props.steps.filter((step) => isStepVisible(step, wizardData));
-  });
-  /** allSteps is a flattened list of all the steps (this includes parent and substeps) */
-  const allSteps = useMemo(() => {
-    return props.steps.reduce((acc: PageWizardStep[], step) => {
-      acc.push(step);
-      if (isPageWizardParentStep(step)) {
-        acc.push(...step.substeps);
-      }
-      return acc;
-    }, []);
-  }, [props.steps]);
-  /** visibleStepsFlattened is a flattened list of all the steps filtered by visibility (this includes parent and substeps) */
-  const [visibleStepsFlattened, setVisibleStepsFlattened] = useState<PageWizardStep[]>(() => {
-    return allSteps.filter((step) => isStepVisible(step, wizardData));
-  });
 
-  useEffect(() => {
-    if (!activeStep && visibleSteps.length > 0) {
-      if ((visibleSteps[0] as PageWizardParentStep).substeps) {
-        setActiveStep((visibleSteps[0] as PageWizardParentStep).substeps[0]);
-      } else {
-        setActiveStep(visibleSteps[0]);
-      }
-    }
-  }, [activeStep, visibleSteps]);
+  const [_, setSearchParams] = useSearchParams();
+  const flattenedSteps = useMemo(() => getFlattenedSteps(steps), [steps]);
 
+  // set initial activeStep
   useEffect(() => {
-    if (visibleSteps.length) {
-      const flattened = visibleSteps.reduce((acc: PageWizardStep[], step) => {
-        acc.push(step);
-        if (isPageWizardParentStep(step)) {
-          acc.push(...step.substeps);
-        }
-        return acc;
-      }, []);
-      setVisibleStepsFlattened(flattened);
+    const visibleSteps = getVisibleSteps(steps, wizardData);
+    if (activeStep || !visibleSteps.length) {
+      return;
     }
-  }, [visibleSteps]);
+    if ((visibleSteps[0] as PageWizardParentStep).substeps) {
+      setActiveStep((visibleSteps[0] as PageWizardParentStep).substeps[0]);
+    } else {
+      setActiveStep(visibleSteps[0]);
+    }
+  }, [activeStep, steps, wizardData]);
+
+  const onNext = useCallback(
+    async (formData: object = {}) => {
+      const visibleStepsFlattened = getVisibleStepsFlattened(steps, {
+        ...wizardData,
+        ...formData,
+      });
+
+      if (activeStep === null) {
+        return Promise.resolve();
+      }
+
+      if (!isPageWizardParentStep(activeStep) && activeStep.validate) {
+        await activeStep.validate(formData, wizardData);
+      }
+
+      const isLastStep =
+        activeStep?.id === visibleStepsFlattened[visibleStepsFlattened.length - 1]?.id;
+      if (isLastStep) {
+        return onSubmit(wizardData as T);
+      }
+
+      const activeStepIndex = visibleStepsFlattened.findIndex((step) => step.id === activeStep?.id);
+      // If the next step is a parent step, mark its first substep as the next active step
+      const nextStep = isPageWizardParentStep(visibleStepsFlattened[activeStepIndex + 1])
+        ? visibleStepsFlattened[activeStepIndex + 2]
+        : visibleStepsFlattened[activeStepIndex + 1];
+
+      // Clear search params
+      setSearchParams(new URLSearchParams(''));
+      setWizardData((prev: object) => ({ ...prev, ...formData }));
+      setStepData((prev) => ({ ...prev, [activeStep?.id]: formData }));
+      setActiveStep(nextStep);
+      return Promise.resolve();
+    },
+    [activeStep, steps, onSubmit, setSearchParams, wizardData]
+  );
+
+  const onBack = useCallback(() => {
+    const visibleStepsFlattened = getVisibleSteps(flattenedSteps, wizardData);
+
+    const activeStepIndex = visibleStepsFlattened.findIndex((step) => step.id === activeStep?.id);
+    const previousStep = isPageWizardParentStep(visibleStepsFlattened[activeStepIndex - 1])
+      ? visibleStepsFlattened[activeStepIndex - 2]
+      : visibleStepsFlattened[activeStepIndex - 1];
+    // Clear search params
+    setSearchParams(new URLSearchParams(''));
+    setActiveStep(previousStep);
+  }, [activeStep?.id, flattenedSteps, setSearchParams, wizardData]);
 
   return (
     <PageWizardContext.Provider
@@ -74,11 +109,11 @@ export function PageWizardProvider<T extends object>(props: {
         setWizardData: setWizardData,
         stepData,
         setStepData: setStepData,
-        allSteps: allSteps,
-        visibleSteps,
-        setVisibleSteps: setVisibleSteps,
-        visibleStepsFlattened: visibleStepsFlattened,
-        setVisibleStepsFlattened: setVisibleStepsFlattened,
+        steps: props.steps,
+        visibleSteps: getVisibleSteps(steps, wizardData),
+        // setVisibleSteps: setVisibleSteps,
+        visibleStepsFlattened: getVisibleStepsFlattened(steps, wizardData),
+        // setVisibleStepsFlattened: setVisibleStepsFlattened,
         activeStep,
         setActiveStep: setActiveStep,
         stepError,
@@ -87,9 +122,37 @@ export function PageWizardProvider<T extends object>(props: {
         setSubmitError: setSubmitError,
         isToggleExpanded: isToggleExpanded,
         setToggleExpanded: setToggleExpanded,
+        onNext,
+        onBack,
       }}
     >
       {props.children}
     </PageWizardContext.Provider>
   );
+}
+
+function getFlattenedSteps(steps: PageWizardStep[]) {
+  return steps.reduce((acc: PageWizardStep[], step) => {
+    acc.push(step);
+    if (isPageWizardParentStep(step)) {
+      acc.push(...step.substeps);
+    }
+    return acc;
+  }, []);
+}
+
+function getVisibleSteps(steps: PageWizardStep[], wizardData: object) {
+  return steps.filter((step) => isStepVisible(step, wizardData));
+}
+
+function getVisibleStepsFlattened(steps: PageWizardStep[], wizardData: object) {
+  const visibleSteps = getVisibleSteps(steps, wizardData);
+
+  return visibleSteps.reduce((acc: PageWizardStep[], step) => {
+    acc.push(step);
+    if (isPageWizardParentStep(step)) {
+      acc.push(...step.substeps);
+    }
+    return acc;
+  }, []);
 }

--- a/framework/PageWizard/PageWizardProvider.tsx
+++ b/framework/PageWizard/PageWizardProvider.tsx
@@ -1,4 +1,3 @@
-import { useSearchParams } from 'react-router-dom';
 import {
   createContext,
   ReactNode,
@@ -8,6 +7,7 @@ import {
   useMemo,
   useCallback,
 } from 'react';
+import { useURLSearchParams } from '../components/useURLSearchParams';
 import type { PageWizardStep, PageWizardState, PageWizardParentStep } from './types';
 
 export const PageWizardContext = createContext<PageWizardState>({} as PageWizardState);
@@ -37,7 +37,7 @@ export function PageWizardProvider<T extends object>(props: {
   const [stepError, setStepError] = useState<Record<string, object>>({});
   const [submitError, setSubmitError] = useState<Error>();
 
-  const [_, setSearchParams] = useSearchParams();
+  const [_, setSearchParams] = useURLSearchParams();
   const flattenedSteps = useMemo(() => getFlattenedSteps(steps), [steps]);
 
   // set initial activeStep
@@ -111,9 +111,7 @@ export function PageWizardProvider<T extends object>(props: {
         setStepData: setStepData,
         steps: props.steps,
         visibleSteps: getVisibleSteps(steps, wizardData),
-        // setVisibleSteps: setVisibleSteps,
         visibleStepsFlattened: getVisibleStepsFlattened(steps, wizardData),
-        // setVisibleStepsFlattened: setVisibleStepsFlattened,
         activeStep,
         setActiveStep: setActiveStep,
         stepError,

--- a/framework/PageWizard/types.ts
+++ b/framework/PageWizard/types.ts
@@ -35,10 +35,8 @@ export interface PageWizardState {
   steps: PageWizardStep[];
   // Top-level visible steps (including parent steps of substeps)
   visibleSteps: PageWizardStep[];
-  // setVisibleSteps: (steps: PageWizardStep[]) => void;
   // Flattened list containing all visible steps including substeps
   visibleStepsFlattened: PageWizardStep[];
-  // setVisibleStepsFlattened: (steps: PageWizardStep[]) => void;
   wizardData: object;
   onNext: (formState: object) => Promise<void>;
   onBack: () => void;

--- a/framework/PageWizard/types.ts
+++ b/framework/PageWizard/types.ts
@@ -40,15 +40,14 @@ export interface PageWizardState {
   visibleStepsFlattened: PageWizardStep[];
   // setVisibleStepsFlattened: (steps: PageWizardStep[]) => void;
   wizardData: object;
-  onNext: () => Promise<void>;
+  onNext: (formState: object) => Promise<void>;
   onBack: () => void;
   submitError?: Error | undefined;
   setSubmitError: React.Dispatch<SetStateAction<Error | undefined>>;
 }
 
-export interface PageWizardBody<T> {
+export interface PageWizardBody {
   onCancel?: () => void;
-  onSubmit: (wizardData: T) => Promise<void>;
   errorAdapter?: ErrorAdapter;
   disableGrid?: boolean;
   isVertical?: boolean;

--- a/framework/PageWizard/types.ts
+++ b/framework/PageWizard/types.ts
@@ -32,14 +32,16 @@ export interface PageWizardState {
   setWizardData: (data: object) => void;
   stepData: Record<string, object>;
   stepError: Record<string, object>;
-  allSteps: PageWizardStep[];
+  steps: PageWizardStep[];
   // Top-level visible steps (including parent steps of substeps)
   visibleSteps: PageWizardStep[];
-  setVisibleSteps: (steps: PageWizardStep[]) => void;
+  // setVisibleSteps: (steps: PageWizardStep[]) => void;
   // Flattened list containing all visible steps including substeps
   visibleStepsFlattened: PageWizardStep[];
-  setVisibleStepsFlattened: (steps: PageWizardStep[]) => void;
+  // setVisibleStepsFlattened: (steps: PageWizardStep[]) => void;
   wizardData: object;
+  onNext: () => Promise<void>;
+  onBack: () => void;
   submitError?: Error | undefined;
   setSubmitError: React.Dispatch<SetStateAction<Error | undefined>>;
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
@@ -98,17 +98,18 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
       inputs: <NodePromptsStep />,
       hidden: (wizardData: Partial<WizardFormValues>) => {
         const { launch_config, resource, node_type } = wizardData;
-        const unmodifiedWizard = Object.keys(wizardData).length === 0;
-        if ('nodePromptsStep' in initialValues && unmodifiedWizard) {
-          return false;
+        if (!launch_config) {
+          return true;
         }
 
         if (
           (node_type === RESOURCE_TYPE.workflow_job || node_type === RESOURCE_TYPE.job) &&
-          resource &&
-          launch_config
+          resource
         ) {
           return shouldHideOtherStep(launch_config);
+        }
+        if ('nodePromptsStep' in initialValues) {
+          return false;
         }
         return true;
       },

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
@@ -36,7 +36,12 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
 
   const { defaultValues } = formState;
 
-  const { setWizardData, setStepData, stepData, setVisibleSteps, allSteps } = usePageWizard() as {
+  const {
+    setWizardData,
+    setStepData,
+    stepData,
+    steps: allSteps,
+  } = usePageWizard() as {
     setWizardData: Dispatch<SetStateAction<WizardFormValues>>;
     setStepData: (
       data:
@@ -49,8 +54,7 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
     };
     wizardData: Partial<WizardFormValues>;
     visibleSteps: PageWizardStep[];
-    setVisibleSteps: (steps: PageWizardStep[]) => void;
-    allSteps: PageWizardStep[];
+    steps: PageWizardStep[];
   };
 
   // Register form fields
@@ -77,34 +81,16 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
 
     if (isDirty) {
       setValue('resource', null);
-      const steps = allSteps.filter(
-        (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-      );
-      setVisibleSteps(steps);
     }
 
     if (isTouched && !isDirty && isApprovalType) {
       reset(undefined, {
         keepDefaultValues: true,
       });
-      const steps = allSteps.filter(
-        (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-      );
       setWizardData({ ...currentFormValues, launch_config: null });
       setStepData({ nodeTypeStep: currentFormValues });
-      setVisibleSteps(steps);
     }
-  }, [
-    nodeType,
-    getFieldState,
-    setValue,
-    reset,
-    allSteps,
-    setWizardData,
-    setStepData,
-    setVisibleSteps,
-    getValues,
-  ]);
+  }, [nodeType, getFieldState, setValue, reset, allSteps, setWizardData, setStepData, getValues]);
 
   useEffect(() => {
     const setLaunchToWizardData = async () => {
@@ -152,15 +138,6 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
           ...prev,
           launch_config: launchConfigResults,
         }));
-        if (shouldShowPromptStep && shouldShowSurveyStep) {
-          setVisibleSteps(allSteps);
-        } else if (shouldShowPromptStep) {
-          const filteredSteps = allSteps.filter((step) => step.id !== 'survey');
-          setVisibleSteps(filteredSteps);
-        } else {
-          const filteredSteps = allSteps.filter((step) => step.id !== 'nodePromptsStep');
-          setVisibleSteps(filteredSteps);
-        }
 
         if (stepData.nodePromptsStep && nodeResource) {
           const { isDirty: isNodeTypeDirty } = getFieldState('node_type');
@@ -177,10 +154,6 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
           }
         }
       } else {
-        const filteredSteps = allSteps.filter(
-          (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-        );
-        setVisibleSteps(filteredSteps);
         setWizardData((prev) => ({ ...prev, launch_config: null }));
       }
     };
@@ -196,7 +169,6 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
     nodeResource,
     nodeType,
     setValue,
-    setVisibleSteps,
     setWizardData,
     stepData,
   ]);

--- a/frontend/awx/views/schedules/wizard/ScheduleAddWizard.cy.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleAddWizard.cy.tsx
@@ -90,6 +90,8 @@ describe('ScheduleAddWizard', () => {
 
       cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
       cy.selectDropdownOptionByResourceName('job-template-select', 'Mock Job Template');
+      cy.get('[data-cy="name"]').type('Test Schedule');
+      cy.clickButton(/^Next$/);
 
       cy.get('[data-cy="wizard-nav"]').within(() => {
         ['Details', 'Prompts', 'Survey', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
@@ -113,8 +115,8 @@ describe('ScheduleAddWizard', () => {
           'Schedule name is required.'
         );
       });
-      cy.get('[data-cy="wizard-nav-item-nodePromptsStep"]').within(() => {
-        cy.get('button').should('be.disabled');
+      cy.get('[data-cy="wizard-nav-item-details"]').within(() => {
+        cy.get('button').should('have.attr', 'class').and('contain', 'pf-m-current');
       });
     });
   });

--- a/frontend/awx/views/schedules/wizard/ScheduleSelectStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleSelectStep.tsx
@@ -30,7 +30,12 @@ export function ScheduleSelectStep() {
     useFormContext<ScheduleFormWizard>();
   const { defaultValues } = formState;
   const resource = useWatch({ name: 'resource' }) as ScheduleResources;
-  const { setWizardData, setStepData, stepData, setVisibleSteps, allSteps } = usePageWizard() as {
+  const {
+    setWizardData,
+    setStepData,
+    stepData,
+    steps: allSteps,
+  } = usePageWizard() as {
     setWizardData: Dispatch<SetStateAction<ScheduleFormWizard>>;
     setStepData: (
       data:
@@ -43,8 +48,7 @@ export function ScheduleSelectStep() {
     };
     wizardData: Partial<ScheduleFormWizard>;
     visibleSteps: PageWizardStep[];
-    setVisibleSteps: (steps: PageWizardStep[]) => void;
-    allSteps: PageWizardStep[];
+    steps: PageWizardStep[];
   };
 
   // Register form fields
@@ -95,23 +99,12 @@ export function ScheduleSelectStep() {
 
     setValue('schedule_type', scheduleType, { shouldTouch: true });
 
-    if (isDirty) {
-      const steps = allSteps.filter(
-        (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-      );
-      setVisibleSteps(steps);
-    }
-
     if (isTouched && !isDirty) {
       reset(undefined, {
         keepDefaultValues: true,
       });
-      const steps = allSteps.filter(
-        (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-      );
       setWizardData({ ...currentFormValues, launch_config: null });
       setStepData({ details: currentFormValues });
-      setVisibleSteps(steps);
     }
   }, [
     scheduleType,
@@ -121,7 +114,6 @@ export function ScheduleSelectStep() {
     allSteps,
     setWizardData,
     setStepData,
-    setVisibleSteps,
     getValues,
   ]);
 
@@ -161,15 +153,6 @@ export function ScheduleSelectStep() {
           ...prev,
           launch_config: launchConfigResults,
         }));
-        if (shouldShowPromptStep && shouldShowSurveyStep) {
-          setVisibleSteps(allSteps);
-        } else if (shouldShowPromptStep) {
-          const filteredSteps = allSteps.filter((step) => step.id !== 'survey');
-          setVisibleSteps(filteredSteps);
-        } else {
-          const filteredSteps = allSteps.filter((step) => step.id !== 'nodePromptsStep');
-          setVisibleSteps(filteredSteps);
-        }
 
         if (stepData.nodePromptsStep && resource) {
           const { isDirty: isNodeTypeDirty } = getFieldState('schedule_type');
@@ -183,10 +166,6 @@ export function ScheduleSelectStep() {
           }
         }
       } else {
-        const filteredSteps = allSteps.filter(
-          (step) => step.id !== 'nodePromptsStep' && step.id !== 'survey'
-        );
-        setVisibleSteps(filteredSteps);
         setWizardData((prev) => ({ ...prev, launch_config: null }));
       }
     };
@@ -202,7 +181,6 @@ export function ScheduleSelectStep() {
     resource,
     scheduleType,
     setValue,
-    setVisibleSteps,
     setWizardData,
     stepData,
     isTopLevelScheduleForm,


### PR DESCRIPTION
Refactors wizard so that `flattenedSteps` and `visibleSteps` are derived directly from the `steps` array when needed rather than storing them to state variables. This resolves some navigation errors that prevented dynamic steps from being added back in as the form values changed.