### PR TITLE
[UXD][AAP-20682] Updates to DE Image field tooltip

### DIFF
--- a/frontend/eda/decision-environments/DecisionEnvironmentForm.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentForm.tsx
@@ -40,7 +40,7 @@ function DecisionEnvironmentInputs() {
         )}
       </p>
       <br />
-      <p>{t('Examples:')}</p>
+      <p>{t('Examples: ')}</p>
       <Trans>
         <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
       </Trans>

--- a/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentDetails.tsx
+++ b/frontend/eda/decision-environments/DecisionEnvironmentPage/DecisionEnvironmentDetails.tsx
@@ -20,7 +20,7 @@ export function DecisionEnvironmentDetails() {
         )}
       </p>
       <br />
-      <p>{t('Examples:')}</p>
+      <p>{t('Examples: ')}</p>
       <Trans>
         <code>quay.io/ansible/awx-latest repo/project/image-name:tag</code>
       </Trans>


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-20682

Update the "Image" field tooltips on Create/Details pages to include the heading "Example" as in the mocks and to match on Controller.
<img width="824" alt="Screenshot 2024-04-22 at 2 50 14 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/557a0f8a-0c2d-4a91-bcc5-756e4be9d9e1">
