### PR TITLE
[UXD][AAP-10266]Hub added icon to empty state buttons

### DIFF
--- a/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
+++ b/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
@@ -34,7 +34,7 @@ export function PageFormExecutionEnvironmentSelect<
       label={props.label ?? t('Execution environment')}
       name={name}
       id="execution-environment-select"
-      placeholder={t('Add execution environment')}
+      placeholder={t('Create execution environment')}
       labelHelpTitle={t('Execution environment')}
       labelHelp={t('The container image to be used for execution.')}
       selectTitle={t('Select an execution environment')}

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryCollectionVersion.tsx
@@ -17,6 +17,7 @@ import { useHubBulkConfirmation } from '../../../common/useHubBulkConfirmation';
 import { useCallback } from 'react';
 import { ITableColumn } from '../../../../../framework';
 import { useAddCollections } from '../hooks/useAddCollections';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function RepositoryCollectionVersion() {
   const { t } = useTranslation();
@@ -76,6 +77,7 @@ export function RepositoryCollectionVersion() {
       rowActions={rowActions}
       errorStateTitle={t('Error loading collection versions')}
       emptyStateTitle={t('No collection versions yet')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Add collections')}
       emptyStateButtonClick={() => runAddModal()}
       emptyStateDescription={t('Collection versions will appear once the repository is modified.')}

--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryVersions.tsx
@@ -15,6 +15,7 @@ import { IPageAction } from '../../../../../framework';
 import { waitForTask } from '../../../common/api/hub-api-utils';
 import { postRequest } from '../../../../common/crud/Data';
 import { Repository } from '../Repository';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function RepositoryVersions() {
   const { t } = useTranslation();
@@ -41,6 +42,7 @@ export function RepositoryVersions() {
       errorStateTitle={t('Error loading collection versions')}
       emptyStateTitle={t('No collection versions yet')}
       emptyStateDescription={t('Collection versions will appear once the collection is modified.')}
+      emptyStateButtonIcon={<PlusCircleIcon />}
       emptyStateButtonText={t('Add collection')}
       emptyStateButtonClick={() => {}}
       {...view}

--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -165,7 +165,9 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
     <PageLayout>
       <PageHeader
         title={
-          props.mode === 'edit' ? t('Edit Execution Environment') : t('Add Execution Environment')
+          props.mode === 'edit'
+            ? t('Edit Execution Environment')
+            : t('Create Execution Environment')
         }
         breadcrumbs={[
           { label: t('Execution Environments'), to: getPageUrl(HubRoute.ExecutionEnvironments) },
@@ -176,7 +178,9 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
       {!isLoading && (
         <HubPageForm<ExecutionEnvironmentFormProps>
           submitText={
-            props.mode === 'edit' ? t('Edit Execution Environment') : t('Add Execution Environment')
+            props.mode === 'edit'
+              ? t('Edit Execution Environment')
+              : t('Create execution environment')
           }
           onCancel={() => navigate(HubRoute.ExecutionEnvironments)}
           onSubmit={onSubmit}

--- a/frontend/hub/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironments.tsx
@@ -42,7 +42,7 @@ export function ExecutionEnvironments() {
         rowActions={rowActions}
         errorStateTitle={t('Error loading execution environments')}
         emptyStateTitle={t('No execution environments yet')}
-        emptyStateButtonText={t('Add Execution Environment')}
+        emptyStateButtonText={t('Create execution environment')}
         emptyStateButtonIcon={
           <Icon>
             <PlusCircleIcon />

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCollections.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCollections.tsx
@@ -10,6 +10,7 @@ import { hubAPI } from '../../common/api/formatPath';
 import { collectionKeyFn } from '../../common/api/hub-api-utils';
 import { useHubView } from '../../common/useHubView';
 import { HubRoute } from '../../main/HubRoutes';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export function HubNamespaceCollections() {
   const { t } = useTranslation();
@@ -43,6 +44,7 @@ export function HubNamespaceCollections() {
         errorStateTitle={t('Error loading collections')}
         emptyStateTitle={t('No collections yet')}
         emptyStateDescription={t('To get started, upload a collection.')}
+        emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Upload collection')}
         emptyStateButtonClick={() => pageNavigate(HubRoute.UploadCollection)}
         {...view}


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-10266
Added icon to the empty state buttons in Hub areas. Some examples:
<img width="912" alt="Screenshot 2024-04-22 at 5 20 40 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/133efaa7-7d00-4a23-afe9-33bede7a82b3">
<img width="912" alt="Screenshot 2024-04-22 at 5 21 47 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/f0fde8cf-b0a4-470f-ab25-ebf1445c811b">

https://issues.redhat.com/browse/AAP-9132
Updated the empty state and form to say "Create execution environment" vs "Add Execution Environment"
<img width="1821" alt="Screenshot 2024-04-22 at 5 19 34 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/68f4e2cb-5048-4f44-a529-e147de9638f2">
<img width="910" alt="Screenshot 2024-04-22 at 5 19 40 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/d863f17e-6b3f-454f-89dc-d2c4f141b27c">
