### PR TITLE
Add ids to credential columns

### DIFF
--- a/frontend/awx/access/credentials/hooks/useCredentialsColumns.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialsColumns.tsx
@@ -46,6 +46,7 @@ export function useCredentialsColumns(options?: { disableSort?: boolean; disable
       nameColumn,
       descriptionColumn,
       {
+        id: 'credential_type',
         header: t('Credential type'),
         cell: (credential) => {
           return credentialTypesMap && credentialTypesMap[credential.credential_type]

--- a/frontend/awx/access/credentials/hooks/useSelectCredential.tsx
+++ b/frontend/awx/access/credentials/hooks/useSelectCredential.tsx
@@ -37,7 +37,7 @@ export function useMultiSelectCredential(isLookup: boolean, credentialType?: num
   const columns = useMemo(
     () =>
       isLookup
-        ? tableColumns.filter((item) => ['Name', 'Credential type'].includes(item.header))
+        ? tableColumns.filter((item) => item?.id && ['name', 'credential_type'].includes(item?.id))
         : tableColumns,
     [isLookup, tableColumns]
   );

--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -59,6 +59,7 @@ export function useNameColumn<
   const { t } = useTranslation();
   const column = useMemo<ITableColumn<T>>(
     () => ({
+      id: 'name',
       header: options?.header ?? t('Name'),
       cell: (item: T) => (
         <TextCell
@@ -97,6 +98,7 @@ export function useDescriptionColumn<
   const { t } = useTranslation();
   const column = useMemo<ITableColumn<T>>(
     () => ({
+      id: 'description',
       header: t('Description'),
       type: 'description',
       value: (item) => item.description,
@@ -212,6 +214,7 @@ export function useCreatedColumn(options?: {
       }
   > = useMemo(
     () => ({
+      id: 'created',
       header: t('Created'),
       cell: (item) => {
         if (!item.created && !item.created_on && !item.date_joined && !item.pulp_created)
@@ -263,6 +266,7 @@ export function useModifiedColumn(options?: {
       }
   > = useMemo(
     () => ({
+      id: 'modified',
       header: t('Modified'),
       cell: (item) => {
         if (!item.modified && !item.modified_on) return <></>;


### PR DESCRIPTION
Add ids to credential columns to avoid use strings that would be selected to be translated as part of the logic.