### PR TITLE
[UXD][AAP-22773] Hub Add icons to Repositories kebab menu

### DIFF
--- a/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositoryActions.tsx
@@ -1,5 +1,5 @@
 import { AlertProps, ButtonVariant } from '@patternfly/react-core';
-import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { CopyIcon, PencilAltIcon, SyncAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -46,6 +46,7 @@ export function useRepositoryActions(options: {
         type: PageActionType.Seperator,
       },
       {
+        icon: SyncAltIcon,
         label: t('Sync repository'),
         onClick: (repo) => {
           syncRepositories(repo);
@@ -59,6 +60,7 @@ export function useRepositoryActions(options: {
         },
       },
       {
+        icon: CopyIcon,
         label: t('Copy CLI configuration'),
         onClick: (repo) => {
           const alertNoDistro: AlertProps = {


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-22773
Added the Sync and Copy icon to the Repositories page kebab menu items
<img width="1820" alt="Screenshot 2024-04-24 at 9 50 25 AM" src="https://github.com/ansible/ansible-ui/assets/98424339/a151b157-608c-4029-8257-49b0afd278b7">
