### PR TITLE
Add Credential File Upload component

### DIFF
--- a/framework/PageForm/Inputs/PageFormFileUpload.tsx
+++ b/framework/PageForm/Inputs/PageFormFileUpload.tsx
@@ -73,26 +73,54 @@ export function PageFormFileUpload<
             helperTextInvalid={helperTextInvalid}
             isRequired={isRequired}
           >
-            <FileUpload
-              id={id}
-              data-cy={id}
-              type={props.type || 'dataURL'}
-              value={value as string}
-              hideDefaultPreview={props.hideDefaultPreview}
-              filename={isLoading ? t('loading...') : filename}
-              filenamePlaceholder={props.placeholder}
-              onFileInputChange={handleFileInputChange}
-              onDataChange={(_event, value: string) => handleTextOrDataChange(value)}
-              onTextChange={(_event, value: string) => handleTextOrDataChange(value)}
-              onReadStarted={(_event, _fileHandle: File) => handleFileReadStarted(_fileHandle)}
-              onReadFinished={(_event, _fileHandle: File) => handleFileReadFinished(_fileHandle)}
-              onClearClick={handleClear}
-              // isLoading={isLoading}
-              allowEditingUploadedText={props.allowEditingUploadedText || false}
-              // browseButtonText={t('Upload')}
-              isReadOnly={props.isReadOnly || isSubmitting}
-              validated={error ? 'error' : undefined}
-            />
+            {props.icon && props.icon !== undefined ? (
+              <div style={{ display: 'grid', gridTemplateColumns: '10fr 1fr' }}>
+                <FileUpload
+                  id={id}
+                  data-cy={id}
+                  type={props.type || 'dataURL'}
+                  value={value as string}
+                  hideDefaultPreview={props.hideDefaultPreview}
+                  filename={isLoading ? t('loading...') : filename}
+                  filenamePlaceholder={props.placeholder}
+                  onFileInputChange={handleFileInputChange}
+                  onDataChange={(_event, value: string) => handleTextOrDataChange(value)}
+                  onTextChange={(_event, value: string) => handleTextOrDataChange(value)}
+                  onReadStarted={(_event, _fileHandle: File) => handleFileReadStarted(_fileHandle)}
+                  onReadFinished={(_event, _fileHandle: File) =>
+                    handleFileReadFinished(_fileHandle)
+                  }
+                  onClearClick={handleClear}
+                  // isLoading={isLoading}
+                  allowEditingUploadedText={props.allowEditingUploadedText || false}
+                  // browseButtonText={t('Upload')}
+                  isReadOnly={props.isReadOnly || isSubmitting}
+                  validated={error ? 'error' : undefined}
+                />
+                {props.icon}
+              </div>
+            ) : (
+              <FileUpload
+                id={id}
+                data-cy={id}
+                type={props.type || 'dataURL'}
+                value={value as string}
+                hideDefaultPreview={props.hideDefaultPreview}
+                filename={isLoading ? t('loading...') : filename}
+                filenamePlaceholder={props.placeholder}
+                onFileInputChange={handleFileInputChange}
+                onDataChange={(_event, value: string) => handleTextOrDataChange(value)}
+                onTextChange={(_event, value: string) => handleTextOrDataChange(value)}
+                onReadStarted={(_event, _fileHandle: File) => handleFileReadStarted(_fileHandle)}
+                onReadFinished={(_event, _fileHandle: File) => handleFileReadFinished(_fileHandle)}
+                onClearClick={handleClear}
+                // isLoading={isLoading}
+                allowEditingUploadedText={props.allowEditingUploadedText || false}
+                // browseButtonText={t('Upload')}
+                isReadOnly={props.isReadOnly || isSubmitting}
+                validated={error ? 'error' : undefined}
+              />
+            )}
           </PageFormGroup>
         );
       }}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -27,6 +27,7 @@ import { Credential } from '../../interfaces/Credential';
 import { CredentialInputField, CredentialType } from '../../interfaces/CredentialType';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
+import { CredentialMultilineInput } from './components/CredentialMultilineInput';
 
 interface CredentialForm extends Credential {
   user?: number;
@@ -308,13 +309,11 @@ function CredentialSubForm({ credentialType }: { credentialType: CredentialType 
         stringFields.map((field) => {
           if (field?.multiline) {
             return (
-              <PageFormTextArea<CredentialType>
+              <CredentialMultilineInput
+                kind={credentialType.kind}
                 key={field.id}
-                name={field.id as keyof CredentialType}
-                label={field.label}
-                placeholder={field?.default ? String(field?.default) : ''}
-                isRequired={requiredFields.includes(field.id)}
-                labelHelp={field.help_text}
+                field={field}
+                requiredFields={requiredFields}
               />
             );
           } else

--- a/frontend/awx/access/credentials/components/CredentialMultilineInput.tsx
+++ b/frontend/awx/access/credentials/components/CredentialMultilineInput.tsx
@@ -1,0 +1,42 @@
+import { KeyIcon } from '@patternfly/react-icons';
+import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
+import { CredentialInputField, CredentialType } from '../../../interfaces/CredentialType';
+import { Button } from '@patternfly/react-core';
+
+export function CredentialMultilineInput({
+  field,
+  requiredFields,
+  kind,
+}: {
+  field: CredentialInputField;
+  requiredFields: CredentialType['inputs']['required'];
+  kind: CredentialType['kind'];
+}) {
+  //TODO: Hook up Secret Management Wizard when user clicks the key icon
+  return (
+    <>
+      <PageFormFileUpload
+        key={field.id}
+        type="text"
+        label={field.label}
+        name={`inputs.${field.id}`}
+        labelHelpTitle={field.label}
+        labelHelp={field.help_text}
+        isRequired={requiredFields.includes(field.id)}
+        isReadOnly={false}
+        allowEditingUploadedText={true}
+        icon={
+          kind !== 'external' ? (
+            <Button
+              icon={<KeyIcon />}
+              variant="plain"
+              style={{
+                border: '1px solid var(--pf-v5-global--BorderColor--300)',
+              }}
+            />
+          ) : undefined
+        }
+      />
+    </>
+  );
+}


### PR DESCRIPTION
This PR adds a file upload component to the CredentialForms component. It modifies the existing `PageFormFileUpload` to display a key icon to hook up External Secret Management system later on.

Old UI:
![Screenshot 2024-04-24 at 2 38 53 PM](https://github.com/ansible/ansible-ui/assets/2293210/bc0f087c-b577-411a-8813-81b713fcc84c)

New UI:
<img width="1136" alt="Screenshot 2024-04-24 at 4 38 12 PM" src="https://github.com/ansible/ansible-ui/assets/2293210/d34a6d48-8593-42d9-b9b4-ea9753c5ae74">

