### PR TITLE
Adds Instance Group Add and Edit Form along with InstanceGroupPage

### DIFF
--- a/cypress/e2e/awx/administration/instanceGroups.cy.ts
+++ b/cypress/e2e/awx/administration/instanceGroups.cy.ts
@@ -1,3 +1,4 @@
+import { randomString } from '../../../../framework/utils/random-string';
 import { InstanceGroup } from '../../../../frontend/awx/interfaces/InstanceGroup';
 
 describe('Instance Groups', () => {
@@ -18,18 +19,49 @@ describe('Instance Groups', () => {
   });
 
   describe('Instance Groups: List View', () => {
-    it.skip('can create new Instance Group, enable the instance, assert info on details page, then delete the instance group', () => {
-      //Assert navigation to Instance Group list
-      //Assert redirect to details page after creations
-      //Assert info displayed on details page
-      //Assert deletion of the Instance Group
-      //Delete the IG created in this test
+    it('can create new Instance Group, enable the instance, assert info on details page, then delete the instance group', () => {
+      const name = 'E2E Instance Group' + randomString(4);
+      cy.navigateTo('awx', 'instance-groups');
+      cy.clickButton(/^Create group$/);
+      cy.clickLink(/^Create instance group$/);
+      cy.get('[data-cy="name"]').type(name);
+
+      cy.get('[data-cy="policy-instance-minimum"]').clear();
+      cy.get('[data-cy="policy-instance-minimum"]').type('1');
+
+      cy.get('[data-cy="policy-instance-percentage"]').clear();
+      cy.get('[data-cy="policy-instance-percentage"]').type('2');
+
+      cy.get('[data-cy="max-concurrent-jobs"]').clear();
+      cy.get('[data-cy="max-concurrent-jobs"]').type('3');
+
+      cy.get('[data-cy="max-forks"]').clear();
+      cy.get('[data-cy="max-forks"]').type('4');
+      cy.clickButton(/^Create Instance Group$/);
+      cy.verifyPageTitle(name);
     });
 
-    it.skip('can edit Instance Group and assert the edited info', () => {
-      //Utilize the IG created in the beforeEach block
-      //Assert original info of the IG
-      //After edit, assert the edited info of the IG
+    it('can edit Instance Group and assert the edited info', () => {
+      cy.navigateTo('awx', 'instance-groups');
+      cy.filterTableBySingleSelect('name', instanceGroup.name);
+      cy.clickTableRowKebabAction(instanceGroup.name, 'edit-instance-group', false);
+      cy.get('[data-cy="name"]').clear();
+      cy.get('[data-cy="name"]').type(`${instanceGroup.name}- edited`);
+
+      cy.get('[data-cy="policy-instance-minimum"]').clear();
+      cy.get('[data-cy="policy-instance-minimum"]').type('1');
+
+      cy.get('[data-cy="policy-instance-percentage"]').clear();
+      cy.get('[data-cy="policy-instance-percentage"]').type('2');
+
+      cy.get('[data-cy="max-concurrent-jobs"]').clear();
+      cy.get('[data-cy="max-concurrent-jobs"]').type('3');
+
+      cy.get('[data-cy="max-forks"]').clear();
+      cy.get('[data-cy="max-forks"]').type('4');
+
+      cy.clickButton(/^Save Instance Group$/);
+      cy.verifyPageTitle(`${instanceGroup.name}- edited`);
     });
 
     it('can delete Instance Group and assert the deletion', () => {

--- a/cypress/fixtures/instance_group.json
+++ b/cypress/fixtures/instance_group.json
@@ -1,0 +1,32 @@
+{
+  "id": 1,
+  "type": "instance_group",
+  "url": "/api/v2/instance_groups/1/",
+  "related": {
+    "jobs": "/api/v2/instance_groups/1/jobs/",
+    "instances": "/api/v2/instance_groups/1/instances/"
+  },
+  "name": "controlplane",
+  "created": "2022-12-09T15:26:58.492885Z",
+  "modified": "2022-12-09T15:26:58.503037Z",
+  "capacity": 611,
+  "consumed_capacity": 0,
+  "percent_capacity_remaining": 100.0,
+  "jobs_running": 0,
+  "max_concurrent_jobs": 23,
+  "max_forks": 12,
+  "jobs_total": 48,
+  "instances": 1,
+  "is_container_group": false,
+  "credential": null,
+  "policy_instance_percentage": 100,
+  "policy_instance_minimum": 0,
+  "policy_instance_list": [],
+  "pod_spec_override": "",
+  "summary_fields": {
+    "user_capabilities": {
+      "edit": true,
+      "delete": false
+    }
+  }
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupForm.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupForm.cy.tsx
@@ -1,0 +1,112 @@
+import { InstanceGroup } from '../../interfaces/InstanceGroup';
+import { CreateInstanceGroup, EditInstanceGroup } from './InstanceGroupForm';
+
+describe('Create Edit Instance Group Form', () => {
+  describe('Create instance group', () => {
+    beforeEach(() => {
+      cy.intercept('POST', '/api/v2/instance_groups/', {
+        statusCode: 201,
+        fixture: 'execution_environment.json',
+      }).as('createIG');
+    });
+    it('should validate required fields on save', () => {
+      cy.mount(<CreateInstanceGroup />);
+      cy.clickButton(/^Create Instance Group$/);
+      cy.contains('Name is required.').should('be.visible');
+    });
+
+    it('should create instance group with only required values passed', () => {
+      cy.mount(<CreateInstanceGroup />);
+      cy.get('[data-cy="name"]').type('Test name');
+
+      cy.get('[data-cy="policy-instance-minimum"]').clear();
+      cy.get('[data-cy="policy-instance-minimum"]').type('1');
+
+      cy.get('[data-cy="policy-instance-percentage"]').clear();
+      cy.get('[data-cy="policy-instance-percentage"]').type('2');
+
+      cy.get('[data-cy="max-concurrent-jobs"]').clear();
+      cy.get('[data-cy="max-concurrent-jobs"]').type('3');
+
+      cy.get('[data-cy="max-forks"]').clear();
+      cy.get('[data-cy="max-forks"]').type('4');
+      cy.clickButton(/^Create Instance Group$/);
+      cy.wait('@createIG')
+        .its('request.body')
+        .then((createdIG) => {
+          expect(createdIG).to.deep.equal({
+            name: 'Test name',
+            policy_instance_minimum: 1,
+            policy_instance_percentage: 2,
+            max_concurrent_jobs: 3,
+            max_forks: 4,
+          });
+        });
+    });
+  });
+  describe('Edit Instance Group', () => {
+    beforeEach(() => {
+      cy.intercept('GET', `api/v2/instance_groups/*`, {
+        fixture: 'instance_group.json',
+      });
+      cy.intercept('PATCH', '/api/v2/instance_groups/*', {}).as('editIg');
+    });
+
+    it('should preload the form with current values', () => {
+      cy.mount(<EditInstanceGroup />, {
+        path: '/instance-groups/:id/edit',
+        initialEntries: [`/instance-groups/1/edit`],
+      });
+      cy.verifyPageTitle('Edit Instance Group');
+      cy.get('[data-cy="name"]').should('have.value', 'controlplane');
+      cy.get('[data-cy="policy-instance-minimum"]').should('have.value', '0');
+      cy.get('[data-cy="policy-instance-percentage"]').should('have.value', '100');
+      cy.get('[data-cy="max-concurrent-jobs"]').should('have.value', '23');
+      cy.get('[data-cy="max-forks"]').should('have.value', '12');
+    });
+
+    it('should pass correct request body after editing ee', () => {
+      cy.mount(<EditInstanceGroup />, {
+        path: '/instance_groups/:id/edit',
+        initialEntries: [`/instance_groups/1/edit`],
+      });
+      cy.get('[data-cy="name"]').clear();
+      cy.get('[data-cy="name"]').type('Test name- edited');
+
+      cy.get('[data-cy="policy-instance-minimum"]').clear();
+      cy.get('[data-cy="policy-instance-minimum"]').type('1');
+
+      cy.get('[data-cy="policy-instance-percentage"]').clear();
+      cy.get('[data-cy="policy-instance-percentage"]').type('2');
+
+      cy.get('[data-cy="max-concurrent-jobs"]').clear();
+      cy.get('[data-cy="max-concurrent-jobs"]').type('3');
+
+      cy.get('[data-cy="max-forks"]').clear();
+      cy.get('[data-cy="max-forks"]').type('4');
+
+      cy.clickButton(/^Save Instance Group$/);
+      cy.wait('@editIg')
+        .its('request.body')
+        .then((editedIG: InstanceGroup) => {
+          expect(editedIG.name).to.equal('Test name- edited');
+          expect(editedIG.policy_instance_minimum).to.equal(1);
+          expect(editedIG.policy_instance_percentage).to.equal(2);
+          expect(editedIG.max_concurrent_jobs).to.equal(3);
+          expect(editedIG.max_forks).to.equal(4);
+        });
+    });
+
+    it('should validate required fields on save', () => {
+      cy.mount(<EditInstanceGroup />, {
+        path: '/instance_groups/:id/edit',
+        initialEntries: [`/instance_groups/1/edit`],
+      });
+      cy.get('[data-cy="name"]').clear();
+      cy.clickButton(/^Save Instance Group$/);
+      cy.get(
+        '[data-cy="name-form-group"] > .pf-v5-c-form__group-control > .pf-v5-c-form__helper-text > .pf-v5-c-helper-text > .pf-v5-c-helper-text__item'
+      ).should('have.text', 'Name is required.');
+    });
+  });
+});

--- a/frontend/awx/administration/instance-groups/InstanceGroupForm.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupForm.tsx
@@ -1,0 +1,177 @@
+import { useTranslation } from 'react-i18next';
+import {
+  LoadingPage,
+  PageFormSubmitHandler,
+  PageFormTextInput,
+  PageHeader,
+  PageLayout,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../framework';
+import { AwxRoute } from '../../main/AwxRoutes';
+import { AwxPageForm } from '../../common/AwxPageForm';
+import { InstanceGroup } from '../../interfaces/InstanceGroup';
+import { awxAPI } from '../../common/api/awx-utils';
+import { usePostRequest } from '../../../common/crud/usePostRequest';
+import { useGetItem } from '../../../common/crud/useGet';
+import { useParams } from 'react-router-dom';
+import { AwxError } from '../../common/AwxError';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
+type InstanceGroupPayload = Partial<
+  Pick<
+    InstanceGroup,
+    | 'name'
+    | 'max_forks'
+    | 'max_concurrent_jobs'
+    | 'policy_instance_minimum'
+    | 'policy_instance_percentage'
+  >
+>;
+
+export function CreateInstanceGroup() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const pageNavigate = usePageNavigate();
+  const postRequest = usePostRequest<InstanceGroupPayload, InstanceGroup>();
+
+  const onSubmit: PageFormSubmitHandler<InstanceGroupPayload> = async (data) => {
+    const instanceGroup = await postRequest(awxAPI`/instance_groups/`, data);
+    pageNavigate(AwxRoute.InstanceGroupDetails, { params: { id: instanceGroup.id } });
+  };
+  const onCancel = () => {
+    pageNavigate(AwxRoute.InstanceGroups);
+  };
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Create Instance Group')}
+        breadcrumbs={[
+          { label: t('Instance Groups'), to: getPageUrl(AwxRoute.InstanceGroups) },
+          { label: t('Create Instance Group') },
+        ]}
+      />
+      <AwxPageForm
+        submitText={t('Create Instance Group')}
+        onSubmit={onSubmit}
+        cancelText={t('Cancel')}
+        onCancel={onCancel}
+        defaultValue={{
+          name: '',
+          policy_instance_minimum: 0,
+          policy_instance_percentage: 0,
+          max_concurrent_jobs: 0,
+          max_forks: 0,
+        }}
+      >
+        <InstanceGroupInputs />
+      </AwxPageForm>
+    </PageLayout>
+  );
+}
+
+export function EditInstanceGroup() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const pageNavigate = usePageNavigate();
+  const params = useParams<{ id: string }>();
+  const patchRequest = usePatchRequest<InstanceGroupPayload, InstanceGroup>();
+  const {
+    data: instanceGroup,
+    isLoading,
+    error,
+  } = useGetItem<InstanceGroup>(awxAPI`/instance_groups/`, params?.id?.toString());
+
+  const onCancel = () => {
+    pageNavigate(AwxRoute.InstanceGroups);
+  };
+  if (error) {
+    return <AwxError error={error} />;
+  }
+  if (isLoading || !instanceGroup) {
+    return <LoadingPage />;
+  }
+  const onSubmit: PageFormSubmitHandler<InstanceGroupPayload> = async (data) => {
+    const updateInstanceGroup = await patchRequest(
+      awxAPI`/instance_groups/${params?.id as string}/`,
+      data
+    );
+    pageNavigate(AwxRoute.InstanceGroupDetails, { params: { id: updateInstanceGroup.id } });
+  };
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Edit Instance Group')}
+        breadcrumbs={[
+          { label: t('Instance Groups'), to: getPageUrl(AwxRoute.InstanceGroups) },
+          { label: t('Edit Instance Group') },
+        ]}
+      />
+      <AwxPageForm
+        submitText={t('Save Instance Group')}
+        onSubmit={onSubmit}
+        cancelText={t('Cancel')}
+        onCancel={onCancel}
+        defaultValue={{
+          name: instanceGroup.name,
+          policy_instance_minimum: instanceGroup.policy_instance_minimum || 0,
+          policy_instance_percentage: instanceGroup.policy_instance_percentage || 0,
+          max_concurrent_jobs: instanceGroup.max_concurrent_jobs || 0,
+          max_forks: instanceGroup.max_forks || 0,
+        }}
+      >
+        <InstanceGroupInputs />
+      </AwxPageForm>
+    </PageLayout>
+  );
+}
+
+export function InstanceGroupInputs() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <PageFormTextInput<InstanceGroup>
+        name="name"
+        label={t('Name')}
+        placeholder={t('Enter a name')}
+        isRequired
+        maxLength={150}
+      />
+      <PageFormTextInput<InstanceGroup>
+        name="policy_instance_minimum"
+        type="number"
+        labelHelp={t(
+          'Minimum number of instances that will be automatically assigned to this group when new instances come online.'
+        )}
+        min={0}
+        label={t('Policy instance minimum')}
+      />
+      <PageFormTextInput<InstanceGroup>
+        name="policy_instance_percentage"
+        labelHelp={t(
+          'Minimum percentage of all instances that will be automatically assigned to this group when new instances come online.'
+        )}
+        type="number"
+        min={0}
+        label={t('Policy instance percentage')}
+      />
+      <PageFormTextInput<InstanceGroup>
+        name="max_concurrent_jobs"
+        labelHelp={t(
+          'Maximum number of jobs to run concurrently on this group. Zero means no limit will be enforced.'
+        )}
+        type="number"
+        min={0}
+        label={t('Max concurrent jobs')}
+      />
+      <PageFormTextInput<InstanceGroup>
+        labelHelp={t(
+          'Maximum number of forks to allow across all jobs running concurrently on this group. Zero means no limit will be enforced.'
+        )}
+        name="max_forks"
+        min={0}
+        type="number"
+        label={t('Max forks')}
+      />
+    </>
+  );
+}

--- a/frontend/awx/interfaces/InstanceGroup.ts
+++ b/frontend/awx/interfaces/InstanceGroup.ts
@@ -18,6 +18,8 @@ export interface InstanceGroup
   consumed_capacity: number;
   percent_capacity_remaining: number;
   is_container_group: boolean;
+  max_forks: number;
+  max_concurrent_jobs: number;
   capacity: number;
   results: InstanceGroup[];
   summary_fields: {

--- a/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
@@ -8,6 +8,10 @@ import { InstanceGroupPage } from '../../administration/instance-groups/Instance
 import { InstanceGroupInstances } from '../../administration/instance-groups/InstanceGroupPage/InstanceGroupInstances';
 import { InstanceDetails } from '../../administration/instances/InstanceDetails';
 import { InstanceGroupInstancesPage } from '../../administration/instance-groups/InstanceGroupPage/InstanceGroupInstancesPage/InstanceGroupInstancesPage';
+import {
+  CreateInstanceGroup,
+  EditInstanceGroup,
+} from '../../administration/instance-groups/InstanceGroupForm';
 
 export function useAwxInstanceGroupsRoutes() {
   const { t } = useTranslation();
@@ -20,12 +24,12 @@ export function useAwxInstanceGroupsRoutes() {
         {
           id: AwxRoute.CreateInstanceGroup,
           path: 'create',
-          element: <PageNotImplemented />,
+          element: <CreateInstanceGroup />,
         },
         {
           id: AwxRoute.EditInstanceGroup,
           path: ':id/edit',
-          element: <PageNotImplemented />,
+          element: <EditInstanceGroup />,
         },
         {
           id: AwxRoute.InstanceGroupPage,


### PR DESCRIPTION
This addresses AAP-8262, AAP-8303, and part of AAP-7840.  7840 is an issue for the instance group details view.  This pr brings in just the InstanceGroupPage.tsx.  Primarily I did this so that I could assert on the page title after editing or creating and IG in the e2e tests.