### PR TITLE
Notifications actions

### DIFF
--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -20,8 +20,7 @@ export function NotificationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
-  const { runningNotifications, onNotifierStartTest, checkNotifiers } =
-    useNotificationsWatch('detail');
+  const { runningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch();
 
   // set refresh interval to be faster when test is running
   const {
@@ -44,11 +43,11 @@ export function NotificationPage() {
     runningNotifications,
   });
 
-  useEffect( () => {
-    if (notificationTemplate)
-    {
-      checkNotifiers(notificationTemplate);
+  useEffect(() => {
+    if (notificationTemplate) {
+      checkNotifiers([notificationTemplate]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notificationTemplate]);
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -16,13 +16,14 @@ import { usePageNavigate } from '../../../../../framework';
 import { useState } from 'react';
 import { usePageAlertToaster } from '../../../../../framework';
 import { StatusLabel } from '../../../../common/Status';
-import { RunningNotificationsType } from '../hooks/useNotifiersRowActions';
+import { useNotificationsWatch } from '../hooks/useNotificationsWatch';
+
 
 export function NotificationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
-  // key:value = notification_template_id:notification_id
-  const [runningNotifications, setRunningNotifications] = useState<RunningNotificationsType>({});
+
+  const {runningNotifications, setRunningNotifications } = useNotificationsWatch();
 
   // set refresh interval to be faster when test is running
   const {

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -23,7 +23,7 @@ export function NotificationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
-  const {runningNotifications, setRunningNotifications } = useNotificationsWatch();
+  const {runningNotifications, setRunningNotifications, onNotifierStartTest } = useNotificationsWatch();
 
   // set refresh interval to be faster when test is running
   const {
@@ -44,11 +44,7 @@ export function NotificationPage() {
       pageNavigate(AwxRoute.NotificationTemplates);
     },
     undefined,
-    (template_id: string, notificationId: string) => {
-      const obj = { ...runningNotifications };
-      obj[template_id] = notificationId;
-      setRunningNotifications(obj);
-    },
+    onNotifierStartTest,
     'detail',
     runningNotifications,
   );
@@ -77,7 +73,6 @@ export function NotificationPage() {
 
   return (
     <PageLayout>
-      {JSON.stringify(runningNotifications, null, 4)}
       <PageHeader
         title={notificationTemplate?.name}
         breadcrumbs={[

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -49,7 +49,8 @@ export function NotificationPage() {
       obj[template_id] = notificationId;
       setRunningNotifications(obj);
     },
-    'detail'
+    'detail',
+    runningNotifications,
   );
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
@@ -76,6 +77,7 @@ export function NotificationPage() {
 
   return (
     <PageLayout>
+      {JSON.stringify(runningNotifications, null, 4)}
       <PageHeader
         title={notificationTemplate?.name}
         breadcrumbs={[

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -13,17 +13,14 @@ import { useNotifiersRowActions } from '../hooks/useNotifiersRowActions';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { PageActions } from '../../../../../framework';
 import { usePageNavigate } from '../../../../../framework';
-import { useState } from 'react';
-import { usePageAlertToaster } from '../../../../../framework';
-import { StatusLabel } from '../../../../common/Status';
 import { useNotificationsWatch } from '../hooks/useNotificationsWatch';
-
 
 export function NotificationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
-  const {runningNotifications, setRunningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('detail');
+  const { runningNotifications, onNotifierStartTest, checkNotifiers } =
+    useNotificationsWatch('detail');
 
   // set refresh interval to be faster when test is running
   const {
@@ -36,8 +33,6 @@ export function NotificationPage() {
 
   const pageNavigate = usePageNavigate();
 
-  const alertToaster = usePageAlertToaster();
-
   const getPageUrl = useGetPageUrl();
   const pageActions = useNotifiersRowActions(
     () => {
@@ -46,7 +41,7 @@ export function NotificationPage() {
     undefined,
     onNotifierStartTest,
     'detail',
-    runningNotifications,
+    runningNotifications
   );
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
@@ -56,7 +51,7 @@ export function NotificationPage() {
   const notificationId = runningNotifications[notificationTemplate.id.toString()];
 
   checkNotifiers(notificationTemplate);
-  
+
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -61,7 +61,8 @@ export function NotificationPage() {
   const notification = notifications.find(
     (notification) => notification.id.toString() === notificationId
   );
-  if (notification) {
+ 
+  if (notification && notification.status !== 'pending') {
     alertToaster.addAlert({
       variant: 'info',
       title: t('Notifier (id {{id}}) test result', { id: notificationId }),

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -34,16 +34,14 @@ export function NotificationPage() {
   const pageNavigate = usePageNavigate();
 
   const getPageUrl = useGetPageUrl();
-  const pageActions = useNotifiersRowActions(
-  {
-    onComplete : () => {
+  const pageActions = useNotifiersRowActions({
+    onComplete: () => {
       pageNavigate(AwxRoute.NotificationTemplates);
     },
     onNotifierStartTest,
-    type : 'detail',
+    type: 'detail',
     runningNotifications,
-  }
-  );
+  });
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!notificationTemplate) return <LoadingPage breadcrumbs tabs />;

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -23,7 +23,7 @@ export function NotificationPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
 
-  const {runningNotifications, setRunningNotifications, onNotifierStartTest } = useNotificationsWatch();
+  const {runningNotifications, setRunningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('detail');
 
   // set refresh interval to be faster when test is running
   const {
@@ -55,22 +55,8 @@ export function NotificationPage() {
   // search for notification id
   const notificationId = runningNotifications[notificationTemplate.id.toString()];
 
-  const notifications = notificationTemplate.summary_fields?.recent_notifications;
-  const notification = notifications.find(
-    (notification) => notification.id.toString() === notificationId
-  );
- 
-  if (notification && notification.status !== 'pending') {
-    alertToaster.addAlert({
-      variant: 'info',
-      title: t('Notifier (id {{id}}) test result', { id: notificationId }),
-      children: <StatusLabel status={notification.status} />,
-    });
-    const obj = { ...runningNotifications };
-    delete obj[notificationTemplate.id];
-    setRunningNotifications(obj);
-  }
-
+  checkNotifiers(notificationTemplate);
+  
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -35,13 +35,14 @@ export function NotificationPage() {
 
   const getPageUrl = useGetPageUrl();
   const pageActions = useNotifiersRowActions(
-    () => {
+  {
+    onComplete : () => {
       pageNavigate(AwxRoute.NotificationTemplates);
     },
-    undefined,
     onNotifierStartTest,
-    'detail',
-    runningNotifications
+    type : 'detail',
+    runningNotifications,
+  }
   );
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationPage.tsx
@@ -14,6 +14,7 @@ import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { PageActions } from '../../../../../framework';
 import { usePageNavigate } from '../../../../../framework';
 import { useNotificationsWatch } from '../hooks/useNotificationsWatch';
+import { useEffect } from 'react';
 
 export function NotificationPage() {
   const { t } = useTranslation();
@@ -43,13 +44,18 @@ export function NotificationPage() {
     runningNotifications,
   });
 
+  useEffect( () => {
+    if (notificationTemplate)
+    {
+      checkNotifiers(notificationTemplate);
+    }
+  }, [notificationTemplate]);
+
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!notificationTemplate) return <LoadingPage breadcrumbs tabs />;
 
   // search for notification id
   const notificationId = runningNotifications[notificationTemplate.id.toString()];
-
-  checkNotifiers(notificationTemplate);
 
   return (
     <PageLayout>

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -15,6 +15,7 @@ import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsRespon
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useNotificationsWatch } from './hooks/useNotificationsWatch';
+import { useEffect } from 'react';
 
 export function Notifiers() {
   const { t } = useTranslation();
@@ -49,11 +50,16 @@ export function Notifiers() {
     notificationsOptions && notificationsOptions.actions && notificationsOptions.actions['POST']
   );
 
-  if (view.pageItems) {
-    view.pageItems.forEach((item) => {
-      checkNotifiers(item);
-    });
-  }
+
+  useEffect( () => {
+    if (view.pageItems) {
+      view.pageItems.forEach((item) => {
+        checkNotifiers(item);
+      });
+    }
+  }, [view.pageItems]);
+
+  
 
   return (
     <PageLayout>

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -14,6 +14,7 @@ import { useOptions } from '../../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useNotificationsWatch } from './hooks/useNotificationsWatch';
 
 export function Notifiers() {
   const { t } = useTranslation();
@@ -26,9 +27,10 @@ export function Notifiers() {
   });
   const config = useAwxConfig();
   const pageNavigate = usePageNavigate();
+  const {runningNotifications, setRunningNotifications, onNotifierStartTest } = useNotificationsWatch('list');
 
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
-  const rowActions = useNotifiersRowActions(view.unselectItemsAndRefresh);
+  const rowActions = useNotifiersRowActions(view.unselectItemsAndRefresh, undefined, onNotifierStartTest, 'list', runningNotifications );
 
   const notificationsOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/notification_templates/`
@@ -47,6 +49,7 @@ export function Notifiers() {
         titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/notifications.html`}
         headerActions={<ActivityStreamIcon type={'notification_template'} />}
       />
+      {JSON.stringify(runningNotifications, null, 4)}
       <PageTable
         id="awx-host-metrics-table"
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -18,8 +18,9 @@ import { useNotificationsWatch } from './hooks/useNotificationsWatch';
 
 export function Notifiers() {
   const { t } = useTranslation();
+  const {runningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('list');
   const toolbarFilters = useNotifiersFilters();
-  const tableColumns = useNotifiersColumns();
+  const tableColumns = useNotifiersColumns({runningNotifications});
   const view = useAwxView<NotificationTemplate>({
     url: awxAPI`/notification_templates/`,
     toolbarFilters,
@@ -27,8 +28,7 @@ export function Notifiers() {
   });
   const config = useAwxConfig();
   const pageNavigate = usePageNavigate();
-  const {runningNotifications, setRunningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('list');
-
+ 
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
   const rowActions = useNotifiersRowActions(view.unselectItemsAndRefresh, undefined, onNotifierStartTest, 'list', runningNotifications );
 

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -31,14 +31,16 @@ export function Notifiers() {
   const pageNavigate = usePageNavigate();
 
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
+  
   const rowActions = useNotifiersRowActions(
-    view.unselectItemsAndRefresh,
-    undefined,
-    onNotifierStartTest,
-    'list',
-    runningNotifications
-  );
-
+    {
+      onComplete: view.unselectItemsAndRefresh,
+      onNotifierCopied: () => view.refresh(),
+      onNotifierStartTest,
+      type : 'list',
+      runningNotifications
+    });
+  
   const notificationsOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/notification_templates/`
   ).data;

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -18,9 +18,10 @@ import { useNotificationsWatch } from './hooks/useNotificationsWatch';
 
 export function Notifiers() {
   const { t } = useTranslation();
-  const {runningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('list');
+  const { runningNotifications, onNotifierStartTest, checkNotifiers } =
+    useNotificationsWatch('list');
   const toolbarFilters = useNotifiersFilters();
-  const tableColumns = useNotifiersColumns({runningNotifications});
+  const tableColumns = useNotifiersColumns({ runningNotifications });
   const view = useAwxView<NotificationTemplate>({
     url: awxAPI`/notification_templates/`,
     toolbarFilters,
@@ -28,9 +29,15 @@ export function Notifiers() {
   });
   const config = useAwxConfig();
   const pageNavigate = usePageNavigate();
- 
+
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
-  const rowActions = useNotifiersRowActions(view.unselectItemsAndRefresh, undefined, onNotifierStartTest, 'list', runningNotifications );
+  const rowActions = useNotifiersRowActions(
+    view.unselectItemsAndRefresh,
+    undefined,
+    onNotifierStartTest,
+    'list',
+    runningNotifications
+  );
 
   const notificationsOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/notification_templates/`
@@ -39,11 +46,10 @@ export function Notifiers() {
     notificationsOptions && notificationsOptions.actions && notificationsOptions.actions['POST']
   );
 
-  if (view.pageItems)
-  {
-    view.pageItems.forEach( (item) => {
+  if (view.pageItems) {
+    view.pageItems.forEach((item) => {
       checkNotifiers(item);
-    })
+    });
   }
 
   return (
@@ -56,7 +62,6 @@ export function Notifiers() {
         titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/notifications.html`}
         headerActions={<ActivityStreamIcon type={'notification_template'} />}
       />
-      {JSON.stringify(runningNotifications, null, 4)}
       <PageTable
         id="awx-host-metrics-table"
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -31,16 +31,17 @@ export function Notifiers() {
   const pageNavigate = usePageNavigate();
 
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
-  
-  const rowActions = useNotifiersRowActions(
-    {
-      onComplete: view.unselectItemsAndRefresh,
-      onNotifierCopied: () => view.refresh(),
-      onNotifierStartTest,
-      type : 'list',
-      runningNotifications
-    });
-  
+
+  const rowActions = useNotifiersRowActions({
+    onComplete: view.unselectItemsAndRefresh,
+    onNotifierCopied: () => {
+      void view.refresh();
+    },
+    onNotifierStartTest,
+    type: 'list',
+    runningNotifications,
+  });
+
   const notificationsOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/notification_templates/`
   ).data;

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -19,8 +19,7 @@ import { useEffect } from 'react';
 
 export function Notifiers() {
   const { t } = useTranslation();
-  const { runningNotifications, onNotifierStartTest, checkNotifiers } =
-    useNotificationsWatch('list');
+  const { runningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch();
   const toolbarFilters = useNotifiersFilters();
   const tableColumns = useNotifiersColumns({ runningNotifications });
   const view = useAwxView<NotificationTemplate>({
@@ -50,16 +49,12 @@ export function Notifiers() {
     notificationsOptions && notificationsOptions.actions && notificationsOptions.actions['POST']
   );
 
-
-  useEffect( () => {
+  useEffect(() => {
     if (view.pageItems) {
-      view.pageItems.forEach((item) => {
-        checkNotifiers(item);
-      });
+      checkNotifiers(view.pageItems);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view.pageItems]);
-
-  
 
   return (
     <PageLayout>

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -27,7 +27,7 @@ export function Notifiers() {
   });
   const config = useAwxConfig();
   const pageNavigate = usePageNavigate();
-  const {runningNotifications, setRunningNotifications, onNotifierStartTest } = useNotificationsWatch('list');
+  const {runningNotifications, setRunningNotifications, onNotifierStartTest, checkNotifiers } = useNotificationsWatch('list');
 
   const toolbarActions = useNotifiersToolbarActions(view.unselectItemsAndRefresh);
   const rowActions = useNotifiersRowActions(view.unselectItemsAndRefresh, undefined, onNotifierStartTest, 'list', runningNotifications );
@@ -38,6 +38,13 @@ export function Notifiers() {
   const canAddNotificationTemplate = Boolean(
     notificationsOptions && notificationsOptions.actions && notificationsOptions.actions['POST']
   );
+
+  if (view.pageItems)
+  {
+    view.pageItems.forEach( (item) => {
+      checkNotifiers(item);
+    })
+  }
 
   return (
     <PageLayout>

--- a/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
@@ -1,0 +1,15 @@
+import { useState } from "react";
+import { RunningNotificationsType } from './useNotifiersRowActions';
+
+export function useNotificationsWatch()
+{
+      // key:value = notification_template_id:notification_id
+  const [runningNotifications, setRunningNotifications] = useState<RunningNotificationsType>({});
+
+
+  return {
+    runningNotifications,
+    setRunningNotifications,
+
+  }
+}

--- a/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
@@ -1,13 +1,12 @@
-import { useState } from "react";
+import { useState } from 'react';
 import { RunningNotificationsType } from './useNotifiersRowActions';
-import { NotificationTemplate } from "../../../interfaces/NotificationTemplate";
-import { usePageAlertToaster } from "../../../../../framework";
-import { StatusLabel } from "../../../../common/Status";
-import { useTranslation } from "react-i18next";
+import { NotificationTemplate } from '../../../interfaces/NotificationTemplate';
+import { usePageAlertToaster } from '../../../../../framework';
+import { StatusLabel } from '../../../../common/Status';
+import { useTranslation } from 'react-i18next';
 
-export function useNotificationsWatch(type : 'detail' | 'list')
-{
-      // key:value = notification_template_id:notification_id
+export function useNotificationsWatch(type: 'detail' | 'list') {
+  // key:value = notification_template_id:notification_id
   const [runningNotifications, setRunningNotifications] = useState<RunningNotificationsType>({});
   const alertToaster = usePageAlertToaster();
   const { t } = useTranslation();
@@ -15,33 +14,31 @@ export function useNotificationsWatch(type : 'detail' | 'list')
   return {
     runningNotifications,
     setRunningNotifications,
-    onNotifierStartTest : (template_id: string, notificationId: string) => {
-        const obj = { ...runningNotifications };
-        obj[template_id] = notificationId;
-        setRunningNotifications(obj);
-      },
-    checkNotifiers : (notificationTemplate : NotificationTemplate) => 
-    {
-        // search for notification id
-        const notificationId = runningNotifications[notificationTemplate.id.toString()];
-        const notifications = notificationTemplate.summary_fields?.recent_notifications;
-        const notification = notifications.find(
-          (notification) => notification.id.toString() === notificationId
-        );
-       
-        if (notification && notification.status !== 'pending') {
-        if (type === 'detail')
-        {
+    onNotifierStartTest: (template_id: string, notificationId: string) => {
+      const obj = { ...runningNotifications };
+      obj[template_id] = notificationId;
+      setRunningNotifications(obj);
+    },
+    checkNotifiers: (notificationTemplate: NotificationTemplate) => {
+      // search for notification id
+      const notificationId = runningNotifications[notificationTemplate.id.toString()];
+      const notifications = notificationTemplate.summary_fields?.recent_notifications;
+      const notification = notifications.find(
+        (notification) => notification.id.toString() === notificationId
+      );
+
+      if (notification && notification.status !== 'pending') {
+        if (type === 'detail') {
           alertToaster.addAlert({
             variant: 'info',
             title: t('Notifier (id {{id}}) test result', { id: notificationId }),
             children: <StatusLabel status={notification.status} />,
           });
         }
-          const obj = { ...runningNotifications };
-          delete obj[notificationTemplate.id];
-          setRunningNotifications(obj);
-        }
-    }
-  }
+        const obj = { ...runningNotifications };
+        delete obj[notificationTemplate.id];
+        setRunningNotifications(obj);
+      }
+    },
+  };
 }

--- a/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
@@ -1,11 +1,16 @@
 import { useState } from "react";
 import { RunningNotificationsType } from './useNotifiersRowActions';
+import { NotificationTemplate } from "../../../interfaces/NotificationTemplate";
+import { usePageAlertToaster } from "../../../../../framework";
+import { StatusLabel } from "../../../../common/Status";
+import { useTranslation } from "react-i18next";
 
-export function useNotificationsWatch()
+export function useNotificationsWatch(type : 'detail' | 'list')
 {
       // key:value = notification_template_id:notification_id
   const [runningNotifications, setRunningNotifications] = useState<RunningNotificationsType>({});
-
+  const alertToaster = usePageAlertToaster();
+  const { t } = useTranslation();
 
   return {
     runningNotifications,
@@ -15,5 +20,28 @@ export function useNotificationsWatch()
         obj[template_id] = notificationId;
         setRunningNotifications(obj);
       },
+    checkNotifiers : (notificationTemplate : NotificationTemplate) => 
+    {
+        // search for notification id
+        const notificationId = runningNotifications[notificationTemplate.id.toString()];
+        const notifications = notificationTemplate.summary_fields?.recent_notifications;
+        const notification = notifications.find(
+          (notification) => notification.id.toString() === notificationId
+        );
+       
+        if (notification && notification.status !== 'pending') {
+        if (type === 'detail')
+        {
+          alertToaster.addAlert({
+            variant: 'info',
+            title: t('Notifier (id {{id}}) test result', { id: notificationId }),
+            children: <StatusLabel status={notification.status} />,
+          });
+        }
+          const obj = { ...runningNotifications };
+          delete obj[notificationTemplate.id];
+          setRunningNotifications(obj);
+        }
+    }
   }
 }

--- a/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotificationsWatch.tsx
@@ -10,6 +10,10 @@ export function useNotificationsWatch()
   return {
     runningNotifications,
     setRunningNotifications,
-
+    onNotifierStartTest : (template_id: string, notificationId: string) => {
+        const obj = { ...runningNotifications };
+        obj[template_id] = notificationId;
+        setRunningNotifications(obj);
+      },
   }
 }

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
@@ -8,7 +8,7 @@ import { AwxRoute } from '../../../main/AwxRoutes';
 import { useGetPageUrl } from '../../../../../framework';
 import { RunningNotificationsType } from './useNotifiersRowActions';
 
-export function useNotifiersColumns(params?: {runningNotifications? : RunningNotificationsType}) {
+export function useNotifiersColumns(params?: { runningNotifications?: RunningNotificationsType }) {
   const { t } = useTranslation();
 
   const organizationColumn = useOrganizationNameColumn(AwxRoute.OrganizationDetails);
@@ -37,20 +37,20 @@ export function useNotifiersColumns(params?: {runningNotifications? : RunningNot
       {
         header: t('Status'),
         cell: (template: NotificationTemplate) => {
-          if (runningNotifications && runningNotifications[template.id])
-          {
-            return <StatusCell status={'running'}></StatusCell>
+          if (runningNotifications && runningNotifications[template.id]) {
+            return <StatusCell status={'running'}></StatusCell>;
           }
           return (
-          <StatusCell
-            status={
-              template.summary_fields?.recent_notifications &&
-              template.summary_fields.recent_notifications.length > 0
-                ? template.summary_fields?.recent_notifications[0].status
-                : undefined
-            }
-          />
-        )},
+            <StatusCell
+              status={
+                template.summary_fields?.recent_notifications &&
+                template.summary_fields.recent_notifications.length > 0
+                  ? template.summary_fields?.recent_notifications[0].status
+                  : undefined
+              }
+            />
+          );
+        },
       },
       {
         header: t('Type'),

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
@@ -6,12 +6,14 @@ import { StatusCell } from '../../../../common/Status';
 import { useOrganizationNameColumn } from '../../../../common/columns';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useGetPageUrl } from '../../../../../framework';
+import { RunningNotificationsType } from './useNotifiersRowActions';
 
-export function useNotifiersColumns() {
+export function useNotifiersColumns(params?: {runningNotifications? : RunningNotificationsType}) {
   const { t } = useTranslation();
 
   const organizationColumn = useOrganizationNameColumn(AwxRoute.OrganizationDetails);
   const getPageUrl = useGetPageUrl();
+  const runningNotifications = params?.runningNotifications;
 
   const tableColumns = useMemo<ITableColumn<NotificationTemplate>[]>(
     () => [
@@ -34,7 +36,12 @@ export function useNotifiersColumns() {
       },
       {
         header: t('Status'),
-        cell: (template: NotificationTemplate) => (
+        cell: (template: NotificationTemplate) => {
+          if (runningNotifications && runningNotifications[template.id])
+          {
+            return <StatusCell status={'running'}></StatusCell>
+          }
+          return (
           <StatusCell
             status={
               template.summary_fields?.recent_notifications &&
@@ -43,7 +50,7 @@ export function useNotifiersColumns() {
                 : undefined
             }
           />
-        ),
+        )},
       },
       {
         header: t('Type'),
@@ -52,7 +59,7 @@ export function useNotifiersColumns() {
       },
       organizationColumn,
     ],
-    [t, organizationColumn, getPageUrl]
+    [t, organizationColumn, getPageUrl, runningNotifications]
   );
   return tableColumns;
 }

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../../common/utils/RBAChelpers';
 import { postRequest } from '../../../../common/crud/Data';
 import { awxAPI } from '../../../common/api/awx-utils';
-usePageAlertToaster;
 
 export function useNotifiersRowActions(
   onComplete: (notification: NotificationTemplate[]) => void,
@@ -43,7 +42,7 @@ export function useNotifiersRowActions(
         selection: PageActionSelection.Single,
         icon: BellIcon,
         label: t(`Test notifier`),
-        onClick: () => {},
+        onClick: (notification) => { postRequest(awxAPI`/notification_templates/${notification.id.toString()}/test/`, {})},
         isDisabled: (notification) => isNotificationRunning(notification) ? t('Notification is running') : '' ,
         isDanger: false,
         isPinned: true,

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
@@ -22,20 +22,18 @@ import { awxAPI } from '../../../common/api/awx-utils';
 
 export type RunningNotificationsType = { [key: string]: string };
 
-export function useNotifiersRowActions(params:
-  {
-    onComplete?: (notification: NotificationTemplate[]) => void,
-    onNotifierCopied?: () => void,
-    onNotifierStartTest?: (template_id: string, notificationId: string) => void,
-    type?: 'detail' | 'list',
-    runningNotifications?: RunningNotificationsType
-  }
-) {
-  const {onComplete, onNotifierCopied, onNotifierStartTest, type, runningNotifications} = params;
+export function useNotifiersRowActions(params: {
+  onComplete?: (notification: NotificationTemplate[]) => void;
+  onNotifierCopied?: () => void;
+  onNotifierStartTest?: (template_id: string, notificationId: string) => void;
+  type?: 'detail' | 'list';
+  runningNotifications?: RunningNotificationsType;
+}) {
+  const { onComplete, onNotifierCopied, onNotifierStartTest, type, runningNotifications } = params;
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const deleteNotifiers = useDeleteNotifiers(onComplete || (() => {}));
-  const copyNotifier = useCopyNotifier(onNotifierCopied  || (() => {}));
+  const copyNotifier = useCopyNotifier(onNotifierCopied || (() => {}));
   const alertToaster = usePageAlertToaster();
 
   return useMemo<IPageAction<NotificationTemplate>[]>(() => {

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon, PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
+import { CopyIcon, PencilAltIcon, BellIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -55,7 +55,7 @@ export function useNotifiersRowActions(params: {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: RocketIcon,
+        icon: BellIcon,
         label: t(`Test notifier`),
         isDisabled: (notification) => {
           const found = runningNotifications?.[notification.id];

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
@@ -1,4 +1,5 @@
-import { CopyIcon, PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
+
+import { BellIcon, CopyIcon, PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -37,6 +38,17 @@ export function useNotifiersRowActions(
 
   return useMemo<IPageAction<NotificationTemplate>[]>(() => {
     return [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: BellIcon,
+        label: t(`Test notifier`),
+        onClick: () => {},
+        isDisabled: (notification) => isNotificationRunning(notification) ? t('Notification is running') : '' ,
+        isDanger: false,
+        isPinned: true,
+      },
+      // Edit form not yet implemented
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -111,4 +123,18 @@ export function useNotifiersRowActions(
     alertToaster,
     testDisabled,
   ]);
+}
+
+function isNotificationRunning(notification : NotificationTemplate)
+{
+  const status = notification.summary_fields.recent_notifications.length > 0
+                ? notification.summary_fields.recent_notifications[0].status
+                : undefined;
+
+  if (status === 'running')
+  {
+    return true;
+  }
+
+  return false;
 }

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersRowActions.tsx
@@ -22,17 +22,20 @@ import { awxAPI } from '../../../common/api/awx-utils';
 
 export type RunningNotificationsType = { [key: string]: string };
 
-export function useNotifiersRowActions(
-  onComplete: (notification: NotificationTemplate[]) => void,
-  onNotifierCopied = () => null,
-  onNotifierStartTest?: (template_id: string, notificationId: string) => void,
-  type?: 'detail' | 'list',
-  runningNotifications?: RunningNotificationsType
+export function useNotifiersRowActions(params:
+  {
+    onComplete?: (notification: NotificationTemplate[]) => void,
+    onNotifierCopied?: () => void,
+    onNotifierStartTest?: (template_id: string, notificationId: string) => void,
+    type?: 'detail' | 'list',
+    runningNotifications?: RunningNotificationsType
+  }
 ) {
+  const {onComplete, onNotifierCopied, onNotifierStartTest, type, runningNotifications} = params;
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const deleteNotifiers = useDeleteNotifiers(onComplete);
-  const copyNotifier = useCopyNotifier(onNotifierCopied);
+  const deleteNotifiers = useDeleteNotifiers(onComplete || (() => {}));
+  const copyNotifier = useCopyNotifier(onNotifierCopied  || (() => {}));
   const alertToaster = usePageAlertToaster();
 
   return useMemo<IPageAction<NotificationTemplate>[]>(() => {


### PR DESCRIPTION
Adds test action for list and detail.

Test  action calls API, that starts notification test and returns notification id (one notification template can have multiple notifications). The page then watches the running particular notification id and then it alerts the result (for detail), for list, the alert is not shown since there can be multiple notifications templates running.