### PR TITLE
Fix failing HUB remote registry cleanup code

### DIFF
--- a/cypress/e2e/hub/remote-registries.cy.ts
+++ b/cypress/e2e/hub/remote-registries.cy.ts
@@ -25,7 +25,7 @@ describe('Remote Registry', () => {
         for (const remoteRegistry of response.data) {
           if (remoteRegistry.name.includes(testSignature)) {
             cy.log(`Deleting remote registry ${remoteRegistry.name}`);
-            cy.deleteRemoteRegistry(remoteRegistry.id);
+            cy.deleteHubRemoteRegistry({ id: remoteRegistry.id, failOnStatusCode: false });
           }
         }
       }


### PR DESCRIPTION
Sometimes this returns a 404... maybe because of the async delete nature of hub.
Fix is to ignore failures on cleanup.