### PR TITLE
Associate/Disassociate Instances from Instance Group

### DIFF
--- a/framework/useView.tsx
+++ b/framework/useView.tsx
@@ -84,7 +84,7 @@ export interface ViewOptions {
 }
 
 export type QueryParams = {
-  [key: string]: string;
+  [key: string]: string | string[];
 };
 
 export interface ViewExtendedOptions<T extends object> extends ViewOptions {

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupPage.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupPage.tsx
@@ -59,11 +59,18 @@ export function InstanceGroupPage() {
           page: AwxRoute.InstanceGroups,
           persistentFilterKey: 'instance_groups',
         }}
-        tabs={[
-          { label: t('Details'), page: AwxRoute.InstanceGroupDetails },
-          { label: t('Instances'), page: AwxRoute.InstanceGroupInstances },
-          { label: t('Jobs'), page: AwxRoute.InstanceGroupJobs },
-        ]}
+        tabs={
+          instanceGroup?.is_container_group
+            ? [
+                { label: t('Details'), page: AwxRoute.InstanceGroupDetails },
+                { label: t('Jobs'), page: AwxRoute.InstanceGroupJobs },
+              ]
+            : [
+                { label: t('Details'), page: AwxRoute.InstanceGroupDetails },
+                { label: t('Instances'), page: AwxRoute.InstanceGroupInstances },
+                { label: t('Jobs'), page: AwxRoute.InstanceGroupJobs },
+              ]
+        }
         params={{ id: instanceGroup.id }}
       />
     </PageLayout>

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceModal.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceModal.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { MultiSelectDialog, usePageDialogs } from '../../../../../../framework';
+import { useAwxView } from '../../../../common/useAwxView';
+import { Instance } from '../../../../interfaces/Instance';
+import { useInstancesColumns } from '../../../instances/hooks/useInstancesColumns';
+import { useInstancesFilters } from '../../../instances/hooks/useInstancesFilter';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { useTranslation } from 'react-i18next';
+
+export interface AssociateInstanceModalProps {
+  instanceGroupId: string;
+  onAssociate: (items: Instance[]) => void;
+}
+
+function AssociateInstanceModal(props: AssociateInstanceModalProps) {
+  const { t } = useTranslation();
+  const tableColumns = useInstancesColumns();
+  const toolbarFilters = useInstancesFilters();
+  const { instanceGroupId, onAssociate } = props;
+
+  const view = useAwxView<Instance>({
+    url: awxAPI`/instances/`,
+    queryParams: { not__node_type: 'control', not__rampart_groups__id: instanceGroupId },
+    toolbarFilters,
+    tableColumns,
+  });
+
+  return (
+    <MultiSelectDialog
+      title={t('Select instances')}
+      view={view}
+      tableColumns={tableColumns}
+      toolbarFilters={toolbarFilters}
+      onSelect={onAssociate}
+    />
+  );
+}
+
+export function useAssociateInstanceModal() {
+  const { pushDialog, popDialog } = usePageDialogs();
+  const [props, setProps] = useState<AssociateInstanceModalProps>();
+
+  useEffect(() => {
+    if (props) {
+      pushDialog(<AssociateInstanceModal {...props} />);
+    } else {
+      popDialog();
+    }
+  }, [props, pushDialog, popDialog]);
+
+  return setProps;
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceModal.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceModal.tsx
@@ -20,7 +20,7 @@ function AssociateInstanceModal(props: AssociateInstanceModalProps) {
 
   const view = useAwxView<Instance>({
     url: awxAPI`/instances/`,
-    queryParams: { not__node_type: 'control', not__rampart_groups__id: instanceGroupId },
+    queryParams: { not__node_type: ['control', 'hop'], not__rampart_groups__id: instanceGroupId },
     toolbarFilters,
     tableColumns,
   });

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceToIG.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceToIG.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings } from '../../../../../../framework';
+import { useNameColumn } from '../../../../../common/columns';
+import { getItemKey, postRequest } from '../../../../../common/crud/Data';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { useAwxBulkActionDialog } from '../../../../common/useAwxBulkActionDialog';
+import { Instance } from '../../../../interfaces/Instance';
+
+export function useAssociateInstanceToIG(
+  onComplete: (instances: Instance[]) => void,
+  instanceGroupId: string
+) {
+  const { t } = useTranslation();
+  const addActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [addActionNameColumn], [addActionNameColumn]);
+  const bulkAction = useAwxBulkActionDialog<Instance>();
+  const associateInstanceToIG = (instances: Instance[]) => {
+    bulkAction({
+      title: t('Associate instance to instance groups', { count: instances.length }),
+      items: instances.sort((l, r) => compareStrings(l.name, r.name)),
+      keyFn: getItemKey,
+      actionColumns,
+      onComplete,
+      actionFn: async (instance: Instance, signal: AbortSignal) => {
+        await postRequest(
+          awxAPI`/instance_groups/${instanceGroupId}/instances/`,
+          {
+            id: instance.id,
+          },
+          signal
+        );
+      },
+      processingText: t('Adding host to group...', { count: instances.length }),
+    });
+  };
+  return associateInstanceToIG;
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceToIG.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useAssociateInstanceToIG.tsx
@@ -31,7 +31,7 @@ export function useAssociateInstanceToIG(
           signal
         );
       },
-      processingText: t('Adding host to group...', { count: instances.length }),
+      processingText: t('Adding host to group', { count: instances.length }),
     });
   };
   return associateInstanceToIG;

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useDisassociateInstanceFromIG.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useDisassociateInstanceFromIG.tsx
@@ -1,0 +1,43 @@
+import { useAwxBulkConfirmation } from '../../../../common/useAwxBulkConfirmation';
+import { useTranslation } from 'react-i18next';
+import { Instance } from '../../../../interfaces/Instance';
+import { useNameColumn } from '../../../../../common/columns';
+import { getItemKey, postRequest } from '../../../../../common/crud/Data';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { compareStrings } from '../../../../../../framework';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useInstancesColumns } from '../../../instances/hooks/useInstancesColumns';
+
+export function useDisassociateInstanceFromIG(onComplete: (instances: Instance[]) => void) {
+  const { t } = useTranslation();
+  const bulkConfirmation = useAwxBulkConfirmation<Instance>();
+  const confirmationColumns = useInstancesColumns({ disableLinks: true, disableSort: true });
+  const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
+  const params = useParams<{ id: string }>();
+
+  const disassociateInstance = (instances: Instance[]) => {
+    bulkConfirmation({
+      title: t('Disassociate instance from instance group'),
+      confirmText: t('Yes, I confirm that I want to disassociate these {{count}} instances.', {
+        count: instances.length,
+      }),
+      actionButtonText: t('Disassociate instances', { count: instances.length }),
+      items: instances.sort((l, r) => compareStrings(l.name, r.name)),
+      keyFn: getItemKey,
+      isDanger: true,
+      confirmationColumns,
+      actionColumns,
+      onComplete,
+      actionFn: (instance: Instance, signal) =>
+        postRequest(
+          awxAPI`/instance_groups/${String(params.id)}/instances/`,
+          { id: instance.id, disassociate: true },
+          signal
+        ),
+    });
+  };
+
+  return disassociateInstance;
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -8,14 +8,19 @@ import { t } from 'i18next';
 import { useAssociateInstanceToIG } from './useAssociateInstanceToIG';
 import { useParams } from 'react-router-dom';
 import { useAssociateInstanceModal } from './useAssociateInstanceModal';
+import { useDisassociateInstanceFromIG } from './useDisassociateInstanceFromIG';
+import { useGetItem } from '../../../../../common/crud/useGet';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
 
 export function useIGInstanceToolbarActions(view: IAwxView<Instance>) {
   const healthCheckAction = useRunHealthCheckToolbarAction(view, true);
   const associateAction = useIGInstanceAssociateToolbarAction(view);
+  const disassociateAction = useIGInstanceDisassociateToolbarAction(view);
 
   return useMemo<IPageAction<Instance>[]>(() => {
-    return [associateAction, healthCheckAction];
-  }, [associateAction, healthCheckAction]);
+    return [associateAction, disassociateAction, healthCheckAction];
+  }, [associateAction, disassociateAction, healthCheckAction]);
 }
 
 function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
@@ -37,6 +42,52 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
           instanceGroupId: id ?? '',
         }),
     }),
-    []
+    [associateInstanceToIG, id, openAssociateInstanceModal]
   );
+}
+
+function useIGInstanceDisassociateToolbarAction(view: IAwxView<Instance>) {
+  const disassociateInstance = useDisassociateInstanceFromIG(view.unselectItemsAndRefresh);
+  const params = useParams<{ id: string }>();
+  const { id } = params;
+
+  const { data: instanceGroup } = useGetItem<InstanceGroup>(awxAPI`/instance_groups/`, id);
+
+  return useMemo<IPageAction<Instance>>(
+    () => ({
+      type: PageActionType.Button,
+      selection: PageActionSelection.Multiple,
+      variant: ButtonVariant.primary,
+      label: t('Disassociate'),
+      isPinned: true,
+      onClick: disassociateInstance,
+      isDisabled: (instances: Instance[]) =>
+        isDisassociateBtnDisabled(instances, instanceGroup?.name === 'controlplane'),
+    }),
+    [disassociateInstance, instanceGroup?.name]
+  );
+}
+
+function isDisassociateBtnDisabled(
+  itemsToDisassociate: Instance[],
+  verifyCannotDisassociate: boolean
+) {
+  if (verifyCannotDisassociate) {
+    const itemsUnableToDisassociate = itemsToDisassociate
+      .filter((item) =>
+        item.type === 'instance'
+          ? item.node_type === 'control' || item.node_type === 'hybrid'
+          : !item.summary_fields?.user_capabilities?.delete
+      )
+      .map((item) => item.name ?? item.hostname)
+      .join(', ');
+
+    if (itemsUnableToDisassociate) {
+      return t(
+        `You do not have permission to disassociate the following: ${itemsUnableToDisassociate}`
+      );
+    }
+  }
+
+  return '';
 }

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -1,13 +1,42 @@
 import { useMemo } from 'react';
-import { IPageAction } from '../../../../../../framework';
+import { IPageAction, PageActionSelection, PageActionType } from '../../../../../../framework';
 import { IAwxView } from '../../../../common/useAwxView';
 import { Instance } from '../../../../interfaces/Instance';
 import { useRunHealthCheckToolbarAction } from '../../../instances/hooks/useInstanceToolbarActions';
+import { ButtonVariant } from '@patternfly/react-core';
+import { t } from 'i18next';
+import { useAssociateInstanceToIG } from './useAssociateInstanceToIG';
+import { useParams } from 'react-router-dom';
+import { useAssociateInstanceModal } from './useAssociateInstanceModal';
 
 export function useIGInstanceToolbarActions(view: IAwxView<Instance>) {
   const healthCheckAction = useRunHealthCheckToolbarAction(view, true);
+  const associateAction = useIGInstanceAssociateToolbarAction(view);
 
   return useMemo<IPageAction<Instance>[]>(() => {
-    return [healthCheckAction];
-  }, [healthCheckAction]);
+    return [associateAction, healthCheckAction];
+  }, [associateAction, healthCheckAction]);
+}
+
+function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
+  const params = useParams<{ id: string }>();
+  const { id } = params;
+  const associateInstanceToIG = useAssociateInstanceToIG(view.unselectItemsAndRefresh, id ?? '');
+  const openAssociateInstanceModal = useAssociateInstanceModal();
+
+  return useMemo<IPageAction<Instance>>(
+    () => ({
+      type: PageActionType.Button,
+      selection: PageActionSelection.None,
+      variant: ButtonVariant.primary,
+      label: t('Associate'),
+      isPinned: true,
+      onClick: () =>
+        openAssociateInstanceModal({
+          onAssociate: associateInstanceToIG,
+          instanceGroupId: id ?? '',
+        }),
+    }),
+    []
+  );
 }

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -12,6 +12,8 @@ import { useDisassociateInstanceFromIG } from './useDisassociateInstanceFromIG';
 import { useGetItem } from '../../../../../common/crud/useGet';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
+import { useOptions } from '../../../../../common/crud/useOptions';
+import { OptionsResponse, ActionsResponse } from '../../../../interfaces/OptionsResponse';
 
 export function useIGInstanceToolbarActions(view: IAwxView<Instance>) {
   const healthCheckAction = useRunHealthCheckToolbarAction(view, true);
@@ -29,6 +31,11 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
   const associateInstanceToIG = useAssociateInstanceToIG(view.unselectItemsAndRefresh, id ?? '');
   const openAssociateInstanceModal = useAssociateInstanceModal();
 
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(
+    awxAPI`/instance_groups/${id ?? ''}/instances/`
+  );
+  const canAssociateInstance = Boolean(data && data.actions && data.actions['POST']);
+
   return useMemo<IPageAction<Instance>>(
     () => ({
       type: PageActionType.Button,
@@ -36,6 +43,8 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
       variant: ButtonVariant.primary,
       label: t('Associate'),
       isPinned: true,
+      isDisabled: () =>
+        canAssociateInstance ? '' : t('You do not have permission to associate an instance.'),
       onClick: () =>
         openAssociateInstanceModal({
           onAssociate: associateInstanceToIG,

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -51,7 +51,7 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
           instanceGroupId: id ?? '',
         }),
     }),
-    [associateInstanceToIG, id, openAssociateInstanceModal]
+    [associateInstanceToIG, id, openAssociateInstanceModal, canAssociateInstance]
   );
 }
 

--- a/frontend/awx/administration/instances/Instances.cy.tsx
+++ b/frontend/awx/administration/instances/Instances.cy.tsx
@@ -1,4 +1,5 @@
 import { awxAPI } from '../../../../cypress/support/formatApiPathForAwx';
+import * as useOptions from '../../../common/crud/useOptions';
 import { Instances } from './Instances';
 
 describe('Instances list', () => {
@@ -157,8 +158,40 @@ describe('Instance Empty list', () => {
     ).as('emptyList');
   });
 
-  it('Empty state is displayed correctly', () => {
+  it('Empty state is displayed correctly for instances with permission', () => {
+    cy.stub(useOptions, 'useOptions').callsFake(() => ({
+      data: {
+        actions: {
+          POST: {
+            name: {
+              type: 'string',
+              required: true,
+              label: 'Name',
+              max_length: 512,
+              help_text: 'Name of this instance.',
+              filterable: true,
+            },
+          },
+        },
+      },
+    }));
     cy.mount(<Instances />);
-    cy.get('[data-cy="empty-state-title"]').should('contain', 'No instances yet');
+    cy.contains(/^There are currently no instances added$/);
+    cy.contains(/^Please create an instance by using the button below.$/);
+    cy.contains('button', /^Create instance$/).should('be.visible');
+  });
+
+  it('Empty state is displayed correctly for user without permission to create instances', () => {
+    cy.stub(useOptions, 'useOptions').callsFake(() => ({
+      data: {
+        actions: {},
+      },
+    }));
+    cy.mount(<Instances />);
+    cy.contains(/^You do not have permission to create an instance.$/);
+    cy.contains(
+      /^Please contact your organization administrator if there is an issue with your access.$/
+    );
+    cy.contains('button', /^Create instance$/).should('not.exist');
   });
 });

--- a/frontend/awx/administration/instances/components/InstancesList.tsx
+++ b/frontend/awx/administration/instances/components/InstancesList.tsx
@@ -25,9 +25,9 @@ export function InstancesList(props: {
   const { useToolbarActions, useRowActions, tableColumns, instanceGroupId } = props;
 
   const defaultParams: {
-    not__node_type: string;
+    not__node_type: Array<string>;
   } = {
-    not__node_type: 'control,hybrid',
+    not__node_type: ['control', 'hybrid'],
   };
 
   const view = useAwxView<Instance>({

--- a/frontend/awx/administration/instances/components/InstancesList.tsx
+++ b/frontend/awx/administration/instances/components/InstancesList.tsx
@@ -1,10 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import { IPageAction, ITableColumn, PageTable } from '../../../../../framework';
+import { IPageAction, ITableColumn, PageTable, usePageNavigate } from '../../../../../framework';
 import { usePersistentFilters } from '../../../../common/PersistentFilters';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { IAwxView, useAwxView } from '../../../common/useAwxView';
 import { Instance } from '../../../interfaces/Instance';
 import { useInstancesFilters } from '../hooks/useInstancesFilter';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { OptionsResponse, ActionsResponse } from '../../../interfaces/OptionsResponse';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { AwxRoute } from '../../../main/AwxRoutes';
+import { useAssociateInstanceToIG } from '../../instance-groups/InstanceGroupPage/hooks/useAssociateInstanceToIG';
+import { useAssociateInstanceModal } from '../../instance-groups/InstanceGroupPage/hooks/useAssociateInstanceModal';
 
 export function InstancesList(props: {
   useToolbarActions: (view: IAwxView<Instance>) => IPageAction<Instance>[];
@@ -14,6 +20,7 @@ export function InstancesList(props: {
 }) {
   const toolbarFilters = useInstancesFilters();
   const { t } = useTranslation();
+  const pageNavigate = usePageNavigate();
 
   const { useToolbarActions, useRowActions, tableColumns, instanceGroupId } = props;
 
@@ -35,7 +42,18 @@ export function InstancesList(props: {
   const rowActions = useRowActions(view.unselectItemsAndRefresh);
   const toolbarActions = useToolbarActions(view);
 
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(
+    instanceGroupId ? awxAPI`/instance_groups/${instanceGroupId}/instances/` : awxAPI`/instances/`
+  );
+  const canCreateInstance = Boolean(data && data.actions && data.actions['POST']);
+
   usePersistentFilters('instances');
+
+  const associateInstance = useAssociateInstanceToIG(
+    view.unselectItemsAndRefresh,
+    instanceGroupId ?? ''
+  );
+  const openAssociateInstanceModal = useAssociateInstanceModal();
 
   return (
     <PageTable<Instance>
@@ -45,7 +63,39 @@ export function InstancesList(props: {
       tableColumns={tableColumns}
       rowActions={rowActions}
       errorStateTitle={t('Error loading instances')}
-      emptyStateTitle={t('No instances yet')}
+      emptyStateTitle={
+        canCreateInstance
+          ? t('There are currently no instances added')
+          : t('You do not have permission to create an instance.')
+      }
+      emptyStateDescription={
+        canCreateInstance
+          ? instanceGroupId
+            ? t('Please associate an instance by using the button below.')
+            : t('Please create an instance by using the button below.')
+          : t(
+              'Please contact your organization administrator if there is an issue with your access.'
+            )
+      }
+      emptyStateButtonIcon={<PlusCircleIcon />}
+      emptyStateButtonText={
+        canCreateInstance
+          ? instanceGroupId
+            ? t('Associate instance')
+            : t('Create instance')
+          : undefined
+      }
+      emptyStateButtonClick={
+        canCreateInstance
+          ? instanceGroupId
+            ? () =>
+                openAssociateInstanceModal({
+                  onAssociate: associateInstance,
+                  instanceGroupId: instanceGroupId,
+                })
+            : () => pageNavigate(AwxRoute.AddInstance)
+          : undefined
+      }
       {...view}
     />
   );

--- a/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstancesColumns.tsx
@@ -68,6 +68,7 @@ export function useInstancesColumns(
           <StatusCell status={instance.health_check_pending ? 'running' : instance.node_state} />
         ),
         sort: 'errors',
+        modal: 'hidden',
       },
       {
         cell: makeReadable,
@@ -112,6 +113,7 @@ export function useInstancesColumns(
             <Unavailable>{t(`Unavailable`)}</Unavailable>
           ),
         list: 'secondary',
+        modal: 'hidden',
       },
       {
         header: t('Running jobs'),

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -46,7 +46,13 @@ export function PageFormMultiSelectAwxResource<
         urlSearchParams.set('order_by', 'name');
         if (props.queryParams) {
           for (const [key, value] of Object.entries(props.queryParams)) {
-            urlSearchParams.set(key, value);
+            if (Array.isArray(value)) {
+              for (const subVal of value) {
+                urlSearchParams.set(key, subVal);
+              }
+            } else {
+              urlSearchParams.set(key, value);
+            }
           }
         }
         if (options.next) urlSearchParams.set('name__gt', options.next.toString());

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -47,7 +47,13 @@ export function PageFormSingleSelectAwxResource<
         urlSearchParams.set('order_by', 'name');
         if (props.queryParams) {
           for (const [key, value] of Object.entries(props.queryParams)) {
-            urlSearchParams.set(key, value);
+            if (Array.isArray(value)) {
+              for (const subVal of value) {
+                urlSearchParams.set(key, subVal);
+              }
+            } else {
+              urlSearchParams.set(key, value);
+            }
           }
         }
         if (options.next) urlSearchParams.set('name__gt', options.next.toString());

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -25,12 +25,22 @@ export type IAwxView<T extends { id: number }> = IView &
   };
 
 export type QueryParams = {
-  [key: string]: string;
+  [key: string]: string | Array<string>;
 };
 
 export function getQueryString(queryParams: QueryParams) {
   return Object.entries(queryParams)
-    .map(([key, value = '']) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .map(([key, value = '']) => {
+      if (Array.isArray(value)) {
+        const listKeyVals = value.map(
+          (subval) => `${encodeURIComponent(key)}=${encodeURIComponent(subval)}`
+        );
+        const queryString = listKeyVals.join('&');
+        return queryString;
+      } else {
+        return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+      }
+    })
     .join('&');
 }
 

--- a/frontend/awx/common/useDynamicFilters.tsx
+++ b/frontend/awx/common/useDynamicFilters.tsx
@@ -72,7 +72,7 @@ function craftRequestUrl(
   optionsPath: string,
   labelKey: string,
   queryKey: string,
-  queryParams?: Record<string, string>
+  queryParams?: Record<string, string | string[]>
 ) {
   let url = awxAPI`/${optionsPath}/?page_size=20&order_by=${queryKey}`;
   if (queryOptions.next) {
@@ -83,7 +83,13 @@ function craftRequestUrl(
   }
   if (queryParams) {
     Object.entries(queryParams).forEach(([key, value]) => {
-      url += `&${key}=${value}`;
+      if (Array.isArray(value)) {
+        for (const subVal of value) {
+          url += `&${key}=${subVal}`;
+        }
+      } else {
+        url += `&${key}=${value}`;
+      }
     });
   }
   // decode the returned url
@@ -308,7 +314,7 @@ interface AsyncKeyOptions {
   /**
    * Additional query parameters to be used when fetching the options
    */
-  queryParams?: Record<string, string>;
+  queryParams?: Record<string, string | string[]>;
 }
 
 /** A list of known keys that require querying specific endpoints. We pre-fetch these values if available */

--- a/frontend/awx/interfaces/Instance.ts
+++ b/frontend/awx/interfaces/Instance.ts
@@ -20,6 +20,7 @@ export interface Instance {
   summary_fields: {
     user_capabilities: {
       edit: boolean;
+      delete: boolean;
     };
   };
   uuid: string;

--- a/frontend/awx/interfaces/Instance.ts
+++ b/frontend/awx/interfaces/Instance.ts
@@ -44,7 +44,7 @@ export interface Instance {
   mem_capacity: number;
   enabled: boolean;
   managed_by_policy: boolean;
-  node_type: 'execution' | 'hop';
+  node_type: 'execution' | 'hop' | 'hybrid' | 'control';
   node_state: string;
   ip_address: null;
   listener_port: number;

--- a/frontend/hub/common/api/hub-api-utils.tsx
+++ b/frontend/hub/common/api/hub-api-utils.tsx
@@ -92,12 +92,22 @@ function firstResult(results: Results) {
 }
 
 export type QueryParams = {
-  [key: string]: string;
+  [key: string]: string | string[];
 };
 
 export function getQueryString(queryParams: QueryParams) {
   return Object.entries(queryParams)
-    .map(([key, value = '']) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .map(([key, value = '']) => {
+      if (Array.isArray(value)) {
+        const listKeyVals = value.map(
+          (subval) => `${encodeURIComponent(key)}=${encodeURIComponent(subval)}`
+        );
+        const queryString = listKeyVals.join('&');
+        return queryString;
+      } else {
+        return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+      }
+    })
     .join('&');
 }
 


### PR DESCRIPTION
This PR is for AAP-23129 which is about associating and disassociating an instance from an instance group. This PR adds... 

An associate button to the instance group instances list toolbar

- This button is enabled if the user has POST permissions to the instances endpoint.
- The associate button opens up a `MulitSelectDialog` that allows the user to select instances to associate.
- Upon selecting the instances to associate a `BulkActionDialog` is presented to confirm the users selection.

A disassociate button to instance group instances list toolbar

- This button is disabled based on the logic in a new function written [here](https://github.com/ansible/ansible-ui/pull/2183/files#diff-5980aa096a77feb4858d75eb1cd395ad2c6afec9f14cd2c380f60679c8443137R80)
- The disassociate button opens up a `BulkConfirmationDialog` here which allows to user to confirm their selection of instances to disassociate

List support for the useAwxView `queryParams` param

- This update allows passing a list of string values for multiple queries of the same key with a different value. Ex: 
- `const queryParam = {
    not__node_type: ['control', 'hybrid']
  }`