### PR TITLE
Fix inventory groups tests

### DIFF
--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -4,7 +4,7 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Credential } from '../../../../frontend/awx/interfaces/Credential';
 import { ExecutionEnvironment } from '../../../../frontend/awx/interfaces/ExecutionEnvironment';
 
-describe.skip('Inventory Groups', () => {
+describe('Inventory Groups', () => {
   let organization: Organization;
   let inventory: Inventory;
   let machineCredential: Credential;

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -93,6 +93,7 @@ describe('Inventory Groups', () => {
         //1) Use the inventory created in beforeEach block, access the groups tab of that inventory
         cy.navigateTo('awx', 'inventories');
         cy.filterTableBySingleSelect('name', inventory.name);
+        cy.wait(2000);
         cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.verifyPageTitle(inventory.name);
         cy.clickLink(/^Groups$/);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -136,11 +136,9 @@ describe('Inventory Groups', () => {
           }
         });
 
-        // those lines are for sync only, those modals are badly implemented and can occasionaly flick
-        // this is ugly fix, but since we dont want to use waits, until app is repaired, this is necessity
-        cy.contains('span', 'Select credential');
-        cy.get(`[aria-label="Simple table"]`);
-        cy.get(`[aria-label="Select credential"]`);
+        // this is for sync only, those modals are badly implemented and can occasionaly flick
+        // this is ugly fix, until app is repaired, this is necessity
+        cy.wait(2000);
 
         cy.selectTableRowByCheckbox('name', machineCredential.name);
         cy.clickButton(/^Confirm$/);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -140,7 +140,7 @@ describe('Inventory Groups', () => {
         // this is ugly fix, but since we dont want to use waits, until app is repaired, this is necessity
         cy.contains('span', 'Select credential');
         cy.get(`[aria-label="Simple table"]`);
-        cy.get(`[aria-label="Select credential]"`);
+        cy.get(`[aria-label="Select credential"]`);
 
         cy.selectTableRowByCheckbox('name', machineCredential.name);
         cy.clickButton(/^Confirm$/);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -3,6 +3,7 @@ import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Credential } from '../../../../frontend/awx/interfaces/Credential';
 import { ExecutionEnvironment } from '../../../../frontend/awx/interfaces/ExecutionEnvironment';
+import { awxAPI } from '../../../../frontend/awx/common/api/awx-utils';
 
 describe('Inventory Groups', () => {
   let organization: Organization;
@@ -92,8 +93,12 @@ describe('Inventory Groups', () => {
         const { inventory, group } = result;
         //1) Use the inventory created in beforeEach block, access the groups tab of that inventory
         cy.navigateTo('awx', 'inventories');
+
+        const intercept_url = awxAPI`/inventories/?page_size=20&order_by=name&name__icontains=${inventory.name}`;
+        cy.intercept('GET', intercept_url).as('filteredInventories');
         cy.filterTableBySingleSelect('name', inventory.name);
-        cy.wait(2000);
+        cy.wait('@filteredInventories');
+
         cy.clickTableRowLink('name', inventory.name, { disableFilter: true });
         cy.verifyPageTitle(inventory.name);
         cy.clickLink(/^Groups$/);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -135,6 +135,13 @@ describe('Inventory Groups', () => {
             });
           }
         });
+
+        // those lines are for sync only, those modals are badly implemented and can occasionaly flick
+        // this is ugly fix, but since we dont want to use waits, until app is repaired, this is necessity
+        cy.contains('span', 'Select credential');
+        cy.get(`[aria-label="Simple table"]`);
+        cy.get(`[aria-label="Select credential]"`);
+
         cy.selectTableRowByCheckbox('name', machineCredential.name);
         cy.clickButton(/^Confirm$/);
         cy.clickButton(/^Next$/);


### PR DESCRIPTION
Credentials selection in the run command modal can flick sometimes,

The flicking causes failures, because cypress tries to get element, which dissapeares and appear again, but the new element is not selected, the old one dissapeared is and it fails.

![image](https://github.com/ansible/ansible-ui/assets/23277791/e603776e-fbe5-4b24-8311-0c19d0e7d2e5)

Another problem was filter for inventory in run command test. Inventories were displayed slowly, so I added intercept and wait to wait for the filtered result.



