### PR TITLE
Create secret management input component

### DIFF
--- a/framework/PageForm/Inputs/PageFormFileUpload.tsx
+++ b/framework/PageForm/Inputs/PageFormFileUpload.tsx
@@ -13,6 +13,7 @@ export type PageFormFileUploadProps<
   name: TFieldName;
   placeholder?: string;
   validate?: (value: File) => string | undefined;
+  isDisabled?: boolean;
 } & PageFormGroupProps &
   Omit<FileUploadProps, 'id'>;
 
@@ -30,7 +31,6 @@ export function PageFormFileUpload<
   } = useFormContext<TFieldValues>();
   const [filename, setFilename] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-
   const handleFileInputChange = useCallback((_: unknown, file: File) => setFilename(file.name), []);
   const handleFileReadStarted = (_fileHandle: File) => {
     setIsLoading(true);
@@ -96,6 +96,7 @@ export function PageFormFileUpload<
                   // browseButtonText={t('Upload')}
                   isReadOnly={props.isReadOnly || isSubmitting}
                   validated={error ? 'error' : undefined}
+                  isDisabled={props.isDisabled}
                 />
                 {props.icon}
               </div>

--- a/framework/PageForm/Inputs/PageFormSecret.tsx
+++ b/framework/PageForm/Inputs/PageFormSecret.tsx
@@ -33,6 +33,11 @@ interface IProps {
   children: ReactElement<ChildProps>;
 
   /**
+   * Optional text displayed in input field when the field value is hidden
+   */
+  placeholder?: string;
+
+  /**
    * Optional text that provides additional information or instructions
    * for the field, displayed alongside the label.
    */
@@ -45,7 +50,14 @@ interface IProps {
   label?: string;
 }
 
-export function PageFormSecret({ onClear, shouldHideField, label, labelHelp, children }: IProps) {
+export function PageFormSecret({
+  onClear,
+  shouldHideField,
+  label,
+  labelHelp,
+  children,
+  placeholder,
+}: IProps) {
   const { t } = useTranslation();
   const fieldLabel = label || children.props.label || '';
   const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
@@ -55,7 +67,7 @@ export function PageFormSecret({ onClear, shouldHideField, label, labelHelp, chi
         <InputGroup>
           <TextInput
             aria-label={t('hidden value')}
-            placeholder="••••••••••••••••••••••"
+            placeholder={placeholder ? placeholder : '••••••••••••••••••••••'}
             type="password"
             autoComplete="off"
             isDisabled={true}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -381,7 +381,7 @@ function PageFormSecretInput({
           onClear={handleHideField}
           shouldHideField={shouldHideField}
           label={field.label}
-          placeholder={t('$ENCRYPTED')}
+          placeholder={t('ENCRYPTED')}
         >
           <InputGroup>
             <Tooltip content={t(`Reset`)}>
@@ -427,7 +427,7 @@ function PageFormSecretInput({
           }}
           shouldHideField={shouldHideField}
           label={field.label}
-          placeholder={t('$ENCRYPTED')}
+          placeholder={t('ENCRYPTED')}
         >
           <InputGroup>
             <InputGroupItem>

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -368,11 +368,10 @@ function PageFormSecretInput({
   const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
   const { resetField } = useForm();
   const [clear, setClear] = useState(false);
-  const { setValue, clearErrors } = useFormContext();
+  const { setValue } = useFormContext();
 
   const handleHideField = () => {
     setShouldHideField(!shouldHideField);
-    console.log(field.id);
     resetField(field.id);
     setClear(!clear);
     //hide field
@@ -400,7 +399,7 @@ function PageFormSecretInput({
       <PageFormSecret
         //key={field.id}
         onClear={() => {
-          console.log(field.id);
+          //console.log(field.id);
           setValue(field.id, '');
           //resetField('security-token');
           setShouldHideField(!shouldHideField);

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -40,6 +40,7 @@ import {
 } from './CredentialPlugins/hooks/useCredentialPluginsDialog';
 import { CredentialInputSource } from '../../interfaces/CredentialInputSource';
 import { SecretManagementInputField } from './components/SecretManagementInputField';
+import { BecomeMethodField } from './components/BecomeMethodField';
 
 interface CredentialForm extends Credential {
   user?: number;
@@ -365,13 +366,11 @@ function PageFormSecretInput({
 }) {
   const [t] = useTranslation();
   const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
-  const { resetField } = useForm();
   const [clear, setClear] = useState(false);
   const { setValue } = useFormContext();
 
   const handleHideField = () => {
     setShouldHideField(!shouldHideField);
-    resetField(field.id);
     setClear(!clear);
   };
 
@@ -382,7 +381,7 @@ function PageFormSecretInput({
           onClear={handleHideField}
           shouldHideField={shouldHideField}
           label={field.label}
-          placeholder={t('ENCRYPTED')}
+          placeholder={t('$ENCRYPTED')}
         >
           <InputGroup>
             <Tooltip content={t(`Reset`)}>
@@ -400,6 +399,14 @@ function PageFormSecretInput({
             />
           </InputGroup>
         </SecretManagementInputField>
+      );
+    } else if (credentialType.kind === 'ssh' && field.id === 'become_method') {
+      return (
+        <BecomeMethodField
+          key={field.id}
+          fieldOptions={field}
+          isRequired={requiredFields.includes(field.id)}
+        />
       );
     } else {
       return (
@@ -420,7 +427,7 @@ function PageFormSecretInput({
           }}
           shouldHideField={shouldHideField}
           label={field.label}
-          placeholder={t('ENCRYPTED')}
+          placeholder={t('$ENCRYPTED')}
         >
           <InputGroup>
             <InputGroupItem>

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -370,7 +370,7 @@ function HiddenInputField({
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
 }) {
   const [t] = useTranslation();
-  const { getValues } = useFormContext();
+  const { getValues } = useFormContext<{ [key: string]: string }>();
   const openCredentialPluginsModal = useCredentialPluginsModal();
   const fieldValue = getValues(field.id);
   const isFieldValueEmpty = fieldValue === undefined || fieldValue === '';

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -34,7 +34,7 @@ import { PageFormSelectCredentialType } from './components/PageFormSelectCredent
 
 interface SecretInput {
   onClear?: (name: string) => void;
-  shouldHideField?: (name: string) => boolean;
+  //shouldHideField?: (name: string) => boolean;
 }
 import {
   CredentialPluginsInputSource,
@@ -367,7 +367,7 @@ function CredentialSubForm(
     accumulatedPluginValues: CredentialPluginsInputSource[];
     setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
   },
-  { onClear, shouldHideField }: SecretInput
+  { onClear /*shouldHideField*/ }: SecretInput
 ) {
   const { t } = useTranslation();
   if (!credentialType || !credentialType?.inputs?.fields) {

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -352,15 +352,22 @@ function CredentialInputs({
 function HiddenInputField({
   field,
   isEditMode,
+  setCredentialPluginValues,
   credentialType,
   requiredFields,
+  accumulatedPluginValues,
+  setAccumulatedPluginValues,
 }: {
   field: CredentialInputField;
   isEditMode: boolean;
+  setCredentialPluginValues: (values: CredentialPluginsInputSource[]) => void;
   credentialType: CredentialType;
   requiredFields: string[];
+  accumulatedPluginValues: CredentialPluginsInputSource[];
+  setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
 }) {
   const [t] = useTranslation();
+  const openCredentialPluginsModal = useCredentialPluginsModal();
   const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
   const [clear, setClear] = useState(false);
   const { setValue } = useFormContext();
@@ -379,7 +386,7 @@ function HiddenInputField({
         placeholder={t('ENCRYPTED')}
       >
         <InputGroup>
-          <Tooltip content={t(`Reset`)}>
+          <Tooltip content={t(`Revert`)}>
             <Button
               size="sm"
               variant="control"
@@ -388,13 +395,18 @@ function HiddenInputField({
             ></Button>
           </Tooltip>
           <CredentialMultilineInput
+            accumulatedPluginValues={accumulatedPluginValues}
             kind={credentialType.kind}
+            key={field.id}
             field={field}
             requiredFields={requiredFields}
-            handleModalToggle={function (): void {
-              throw new Error('Function not implemented.');
+            handleModalToggle={() => {
+              openCredentialPluginsModal({
+                field,
+                setCredentialPluginValues,
+                accumulatedPluginValues,
+              });
             }}
-            accumulatedPluginValues={[]}
           />
         </InputGroup>
       </SecretManagementInputField>
@@ -411,22 +423,20 @@ function HiddenInputField({
         placeholder={t('ENCRYPTED')}
       >
         <InputGroup>
-          <Tooltip content={t(`Reset`)}>
-            <Button
-              size="sm"
-              variant="control"
-              onClick={handleHideField}
-              icon={<RedoIcon />}
-            ></Button>
-          </Tooltip>
           <CredentialTextInput
+            accumulatedPluginValues={accumulatedPluginValues}
+            setAccumulatedPluginValues={setAccumulatedPluginValues}
+            key={field.id}
             field={field}
+            isDisabled={field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode}
             isRequired={requiredFields.includes(field.id)}
-            credentialType={credentialType}
-            handleModalToggle={function (): void {
-              throw new Error('Function not implemented.');
-            }}
-            accumulatedPluginValues={[]}
+            handleModalToggle={() =>
+              openCredentialPluginsModal({
+                field,
+                setCredentialPluginValues,
+                accumulatedPluginValues,
+              })
+            }
           />
         </InputGroup>
       </SecretManagementInputField>
@@ -448,6 +458,7 @@ function CredentialSubForm({
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
 }) {
   const { t } = useTranslation();
+  const openCredentialPluginsModal = useCredentialPluginsModal();
   if (!credentialType || !credentialType?.inputs?.fields) {
     return null;
   }
@@ -483,37 +494,50 @@ function CredentialSubForm({
             return (
               <HiddenInputField
                 key={field.id}
+                accumulatedPluginValues={accumulatedPluginValues}
                 field={field}
                 isEditMode={isEditMode}
                 credentialType={credentialType}
                 requiredFields={requiredFields}
+                setCredentialPluginValues={setCredentialPluginValues}
               ></HiddenInputField>
             );
           } else {
             if (field.multiline) {
               return (
                 <CredentialMultilineInput
-                  key={field.id}
+                  accumulatedPluginValues={accumulatedPluginValues}
                   kind={credentialType.kind}
+                  key={field.id}
                   field={field}
                   requiredFields={requiredFields}
-                  handleModalToggle={function (): void {
-                    throw new Error('Function not implemented.');
+                  handleModalToggle={() => {
+                    openCredentialPluginsModal({
+                      field,
+                      setCredentialPluginValues,
+                      accumulatedPluginValues,
+                    });
                   }}
-                  accumulatedPluginValues={[]}
                 />
               );
             } else {
               return (
                 <CredentialTextInput
+                  accumulatedPluginValues={accumulatedPluginValues}
+                  setAccumulatedPluginValues={setAccumulatedPluginValues}
                   key={field.id}
                   field={field}
+                  isDisabled={
+                    field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode
+                  }
                   isRequired={requiredFields.includes(field.id)}
-                  credentialType={credentialType}
-                  handleModalToggle={function (): void {
-                    throw new Error('Function not implemented.');
-                  }}
-                  accumulatedPluginValues={[]}
+                  handleModalToggle={() =>
+                    openCredentialPluginsModal({
+                      field,
+                      setCredentialPluginValues,
+                      accumulatedPluginValues,
+                    })
+                  }
                 />
               );
             }

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -423,6 +423,8 @@ function HiddenInputField({
         shouldHideField={shouldHideField}
         label={field.label}
         placeholder={t('ENCRYPTED')}
+        requiredFields={requiredFields}
+        field={field}
       >
         <InputGroup>
           <CredentialTextInput
@@ -578,7 +580,7 @@ function CredentialSubForm({
   ) : null;
 }
 
-function CredentialTextInput({
+export function CredentialTextInput({
   credentialType,
   field,
   handleModalToggle,
@@ -587,6 +589,7 @@ function CredentialTextInput({
   accumulatedPluginValues,
   setAccumulatedPluginValues,
   buttons,
+  placeholder,
 }: {
   credentialType?: CredentialType | undefined;
   field: CredentialInputField;
@@ -596,6 +599,7 @@ function CredentialTextInput({
   accumulatedPluginValues: CredentialPluginsInputSource[];
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
   buttons?: ReactNode;
+  placeholder?: string;
 }) {
   const { t } = useTranslation();
   const { setValue, clearErrors } = useFormContext();
@@ -690,7 +694,7 @@ function CredentialTextInput({
         key={field.id}
         name={field.id}
         label={field.label}
-        placeholder={(field?.default || t('Enter value')).toString()}
+        placeholder={(placeholder ? placeholder : t('Enter value')).toString()}
         type={field.secret ? 'password' : 'text'}
         isRequired={handleIsRequired()}
         isDisabled={!!isPromptOnLaunchChecked || isDisabled}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -387,6 +387,8 @@ function HiddenInputField({
         shouldHideField={shouldHideField}
         label={field.label}
         placeholder={t('ENCRYPTED')}
+        field={field}
+        requiredFields={[]}
       >
         <CredentialMultilineInput
           accumulatedPluginValues={accumulatedPluginValues}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -25,11 +25,9 @@ import { Credential } from '../../interfaces/Credential';
 import { CredentialInputField, CredentialType } from '../../interfaces/CredentialType';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
-import { BecomeMethodField } from './components/BecomeMethodField';
 import { CredentialMultilineInput } from './components/CredentialMultilineInput';
-import { PageFormSecret } from '../../../../framework/PageForm/Inputs/PageFormSecret';
-import { Button, Icon } from '@patternfly/react-core';
-import { KeyIcon } from '@patternfly/react-icons';
+import { Button, Icon, InputGroup, InputGroupItem, Tooltip } from '@patternfly/react-core';
+import { KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormSelectCredentialType } from './components/PageFormSelectCredentialType';
 
 interface SecretInput {
@@ -41,6 +39,7 @@ import {
   useCredentialPluginsModal,
 } from './CredentialPlugins/hooks/useCredentialPluginsDialog';
 import { CredentialInputSource } from '../../interfaces/CredentialInputSource';
+import { SecretManagementInputField } from './components/SecretManagementInputField';
 
 interface CredentialForm extends Credential {
   user?: number;
@@ -374,50 +373,83 @@ function PageFormSecretInput({
     setShouldHideField(!shouldHideField);
     resetField(field.id);
     setClear(!clear);
-    //hide field
   };
 
   if (field.multiline) {
-    return (
-      <PageFormSecret
-        //key={field.id}
-        onClear={handleHideField}
-        shouldHideField={shouldHideField}
-        label={field.label}
-        placeholder={t('ENCRYPTED')}
-      >
+    if (field.secret && isEditMode) {
+      return (
+        <SecretManagementInputField
+          onClear={handleHideField}
+          shouldHideField={shouldHideField}
+          label={field.label}
+          placeholder={t('ENCRYPTED')}
+        >
+          <InputGroup>
+            <Tooltip content={t(`Reset`)}>
+              <Button
+                size="sm"
+                variant="control"
+                onClick={handleHideField}
+                icon={<RedoIcon />}
+              ></Button>
+            </Tooltip>
+            <CredentialMultilineInput
+              kind={credentialType.kind}
+              field={field}
+              requiredFields={requiredFields}
+            />
+          </InputGroup>
+        </SecretManagementInputField>
+      );
+    } else {
+      return (
         <CredentialMultilineInput
           kind={credentialType.kind}
-          //key={field.id}
           field={field}
           requiredFields={requiredFields}
         />
-      </PageFormSecret>
-    );
+      );
+    }
   } else {
-    return (
-      <PageFormSecret
-        //key={field.id}
-        onClear={() => {
-          //console.log(field.id);
-          setValue(field.id, '');
-          //resetField('security-token');
-          setShouldHideField(!shouldHideField);
-        }}
-        shouldHideField={shouldHideField}
-        label={field.label}
-        placeholder={t('ENCRYPTED')}
-      >
+    if (field.secret && isEditMode) {
+      return (
+        <SecretManagementInputField
+          onClear={() => {
+            setValue(field.id, '');
+            setShouldHideField(!shouldHideField);
+          }}
+          shouldHideField={shouldHideField}
+          label={field.label}
+          placeholder={t('ENCRYPTED')}
+        >
+          <InputGroup>
+            <InputGroupItem>
+              <Button
+                size="sm"
+                variant="control"
+                onClick={handleHideField}
+                icon={<RedoIcon />}
+              ></Button>
+            </InputGroupItem>
+            <InputGroupItem>
+              <CredentialTextInput
+                field={field}
+                isRequired={requiredFields.includes(field.id)}
+                credentialType={credentialType}
+              />
+            </InputGroupItem>
+          </InputGroup>
+        </SecretManagementInputField>
+      );
+    } else {
+      return (
         <CredentialTextInput
-          //key={field.id}
-          //placeholder={t('ENCRYPTED')}
-          //name={field.id}
           field={field}
           isRequired={requiredFields.includes(field.id)}
           credentialType={credentialType}
         />
-      </PageFormSecret>
-    );
+      );
+    }
   }
 }
 

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -361,7 +361,6 @@ function CredentialSubForm({
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
 }) {
   const { t } = useTranslation();
-  const openCredentialPluginsModal = useCredentialPluginsModal();
   if (!credentialType || !credentialType?.inputs?.fields) {
     return null;
   }
@@ -428,6 +427,7 @@ function CredentialSubForm({
                     accumulatedPluginValues,
                   })
                 }
+                credentialType={credentialType}
               />
             );
           }
@@ -599,7 +599,7 @@ function CredentialTextInput({
                 </Button>
               ) : null}
             </>
-          ) : undefined
+          ) : null
         }
         additionalControls={
           field?.ask_at_runtime && (

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -35,7 +35,10 @@ import {
   useCredentialPluginsModal,
 } from './CredentialPlugins/hooks/useCredentialPluginsDialog';
 import { CredentialInputSource } from '../../interfaces/CredentialInputSource';
-import { SecretManagementInputField } from './components/SecretManagementInputField';
+import {
+  MultiLineEncryptedInput,
+  SingleLineEncryptedInput,
+} from './components/SecretManagementInputField';
 import { BecomeMethodField } from './components/BecomeMethodField';
 
 interface CredentialForm extends Credential {
@@ -379,41 +382,40 @@ function HiddenInputField({
 
   if (field.multiline) {
     return (
-      <SecretManagementInputField
+      <MultiLineEncryptedInput
         onClear={handleHideField}
         shouldHideField={shouldHideField}
         label={field.label}
         placeholder={t('ENCRYPTED')}
       >
-        <InputGroup>
-          <Tooltip content={t(`Revert`)}>
-            <Button
-              size="sm"
-              variant="control"
-              onClick={handleHideField}
-              icon={<RedoIcon />}
-            ></Button>
-          </Tooltip>
-          <CredentialMultilineInput
-            accumulatedPluginValues={accumulatedPluginValues}
-            kind={credentialType.kind}
-            key={field.id}
-            field={field}
-            requiredFields={requiredFields}
-            handleModalToggle={() => {
-              openCredentialPluginsModal({
-                field,
-                setCredentialPluginValues,
-                accumulatedPluginValues,
-              });
-            }}
-          />
-        </InputGroup>
-      </SecretManagementInputField>
+        <CredentialMultilineInput
+          accumulatedPluginValues={accumulatedPluginValues}
+          kind={credentialType.kind}
+          key={field.id}
+          field={field}
+          requiredFields={requiredFields}
+          handleModalToggle={() => {
+            openCredentialPluginsModal({
+              field,
+              setCredentialPluginValues,
+              accumulatedPluginValues,
+            });
+          }}
+          buttons={
+            <Tooltip content={t(`Revert`)}>
+              <Button variant="control" onClick={handleHideField}>
+                <Icon>
+                  <RedoIcon />
+                </Icon>
+              </Button>
+            </Tooltip>
+          }
+        />
+      </MultiLineEncryptedInput>
     );
   } else {
     return (
-      <SecretManagementInputField
+      <SingleLineEncryptedInput
         onClear={() => {
           setValue(field.id, '');
           setShouldHideField(!shouldHideField);
@@ -437,9 +439,16 @@ function HiddenInputField({
                 accumulatedPluginValues,
               })
             }
+            buttons={
+              <Button variant="control" onClick={handleHideField}>
+                <Icon>
+                  <RedoIcon />
+                </Icon>
+              </Button>
+            }
           />
         </InputGroup>
-      </SecretManagementInputField>
+      </SingleLineEncryptedInput>
     );
   }
 }
@@ -577,6 +586,7 @@ function CredentialTextInput({
   isRequired = false,
   accumulatedPluginValues,
   setAccumulatedPluginValues,
+  buttons,
 }: {
   credentialType?: CredentialType | undefined;
   field: CredentialInputField;
@@ -585,6 +595,7 @@ function CredentialTextInput({
   isRequired?: boolean;
   accumulatedPluginValues: CredentialPluginsInputSource[];
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
+  buttons?: ReactNode;
 }) {
   const { t } = useTranslation();
   const { setValue, clearErrors } = useFormContext();
@@ -687,30 +698,33 @@ function CredentialTextInput({
         labelHelp={field.help_text}
         helperText={handleHelperText(field)}
         button={
-          credentialType?.kind !== 'external' ? (
-            <>
-              <Button
-                isDisabled={isDisabled}
-                data-cy={'secret-management-input'}
-                variant="control"
-                icon={
-                  <Icon>
-                    <KeyIcon />
-                  </Icon>
-                }
-                onClick={handleModalToggle}
-              ></Button>
-              {accumulatedPluginValues.some((cp) => cp.input_field_name === field.id) ? (
+          <>
+            {credentialType?.kind !== 'external' ? (
+              <>
                 <Button
-                  data-cy={'clear-secret-management-input'}
+                  isDisabled={isDisabled}
+                  data-cy={'secret-management-input'}
                   variant="control"
-                  onClick={onClear}
-                >
-                  {t(`Clear`)}
-                </Button>
-              ) : null}
-            </>
-          ) : null
+                  icon={
+                    <Icon>
+                      <KeyIcon />
+                    </Icon>
+                  }
+                  onClick={handleModalToggle}
+                ></Button>
+                {accumulatedPluginValues.some((cp) => cp.input_field_name === field.id) ? (
+                  <Button
+                    data-cy={'clear-secret-management-input'}
+                    variant="control"
+                    onClick={onClear}
+                  >
+                    {t(`Clear`)}
+                  </Button>
+                ) : null}
+              </>
+            ) : null}
+            {buttons}
+          </>
         }
         additionalControls={
           field?.ask_at_runtime && (

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -366,15 +366,22 @@ function PageFormSecretInput({
 }) {
   const [t] = useTranslation();
   const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
+  const { resetField } = useForm();
+  const [clear, setClear] = useState(false);
+  const { setValue, clearErrors } = useFormContext();
 
   const handleHideField = () => {
     setShouldHideField(!shouldHideField);
+    console.log(field.id);
+    resetField(field.id);
+    setClear(!clear);
+    //hide field
   };
 
   if (field.multiline) {
     return (
       <PageFormSecret
-        key={field.id}
+        //key={field.id}
         onClear={handleHideField}
         shouldHideField={shouldHideField}
         label={field.label}
@@ -382,7 +389,7 @@ function PageFormSecretInput({
       >
         <CredentialMultilineInput
           kind={credentialType.kind}
-          key={field.id}
+          //key={field.id}
           field={field}
           requiredFields={requiredFields}
         />
@@ -391,14 +398,21 @@ function PageFormSecretInput({
   } else {
     return (
       <PageFormSecret
-        key={field.id}
-        onClear={handleHideField}
+        //key={field.id}
+        onClear={() => {
+          console.log(field.id);
+          setValue(field.id, '');
+          //resetField('security-token');
+          setShouldHideField(!shouldHideField);
+        }}
         shouldHideField={shouldHideField}
         label={field.label}
         placeholder={t('ENCRYPTED')}
       >
         <CredentialTextInput
-          key={field.id}
+          //key={field.id}
+          //placeholder={t('ENCRYPTED')}
+          //name={field.id}
           field={field}
           isRequired={requiredFields.includes(field.id)}
           credentialType={credentialType}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -312,7 +312,6 @@ function CredentialInputs({
 
   const isGalaxyCredential =
     !!credentialTypes && credentialTypes?.[credentialTypeID]?.kind === 'galaxy';
-  console.log('edit mode in credentialinputs: ', isEditMode);
   return (
     <>
       <PageFormTextInput<Credential>
@@ -373,8 +372,6 @@ function CredentialSubForm(
   if (!credentialType || !credentialType?.inputs?.fields) {
     return null;
   }
-
-  console.log(isEditMode);
 
   const stringFields =
     credentialType?.inputs?.fields?.filter(

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -277,7 +277,7 @@ export function EditCredential() {
         defaultValue={initialValues}
       >
         <CredentialInputs
-          isEditMode
+          isEditMode={true}
           credentialTypes={parsedCredentialTypes || {}}
           selectedCredentialTypeId={credential?.credential_type}
           setCredentialPluginValues={setCredentialPluginValues}
@@ -312,7 +312,7 @@ function CredentialInputs({
 
   const isGalaxyCredential =
     !!credentialTypes && credentialTypes?.[credentialTypeID]?.kind === 'galaxy';
-
+  console.log('edit mode in credentialinputs: ', isEditMode);
   return (
     <>
       <PageFormTextInput<Credential>
@@ -374,14 +374,11 @@ function CredentialSubForm(
     return null;
   }
 
-  const encryptedFields =
-    credentialType?.inputs?.fields?.filter(
-      (field) => field.secret === true && !field?.choices?.length
-    ) || [];
+  console.log(isEditMode);
 
   const stringFields =
     credentialType?.inputs?.fields?.filter(
-      (field) => field.type === 'string' && field.secret !== true && !field?.choices?.length
+      (field) => field.type === 'string' && !field?.choices?.length
     ) || [];
 
   const choiceFields =
@@ -399,20 +396,27 @@ function CredentialSubForm(
         stringFields.map((field) => {
           if (field?.multiline) {
             return (
-              <CredentialMultilineInput
-                accumulatedPluginValues={accumulatedPluginValues}
-                kind={credentialType.kind}
+              <PageFormSecret
                 key={field.id}
-                field={field}
-                requiredFields={requiredFields}
-                handleModalToggle={() => {
-                  openCredentialPluginsModal({
-                    field,
-                    setCredentialPluginValues,
-                    accumulatedPluginValues,
-                  });
-                }}
-              />
+                onClear={() => {}}
+                shouldHideField={field.secret && isEditMode}
+                label={field.label}
+              >
+                <CredentialMultilineInput
+                  accumulatedPluginValues={accumulatedPluginValues}
+                  kind={credentialType.kind}
+                  key={field.id}
+                  field={field}
+                  requiredFields={requiredFields}
+                  handleModalToggle={() => {
+                    openCredentialPluginsModal({
+                      field,
+                      setCredentialPluginValues,
+                      accumulatedPluginValues,
+                    });
+                  }}
+                />
+              </PageFormSecret>
             );
           } else if (credentialType.kind === 'ssh' && field.id === 'become_method') {
             return (
@@ -424,24 +428,31 @@ function CredentialSubForm(
             );
           } else {
             return (
-              <CredentialTextInput
-                accumulatedPluginValues={accumulatedPluginValues}
-                setAccumulatedPluginValues={setAccumulatedPluginValues}
+              <PageFormSecret
                 key={field.id}
-                field={field}
-                isDisabled={
-                  field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode
-                }
-                isRequired={requiredFields.includes(field.id)}
-                handleModalToggle={() =>
-                  openCredentialPluginsModal({
-                    field,
-                    setCredentialPluginValues,
-                    accumulatedPluginValues,
-                  })
-                }
-                credentialType={credentialType}
-              />
+                onClear={() => {}}
+                shouldHideField={field.secret && isEditMode}
+                label={field.label}
+              >
+                <CredentialTextInput
+                  accumulatedPluginValues={accumulatedPluginValues}
+                  setAccumulatedPluginValues={setAccumulatedPluginValues}
+                  key={field.id}
+                  field={field}
+                  isDisabled={
+                    field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode
+                  }
+                  isRequired={requiredFields.includes(field.id)}
+                  handleModalToggle={() =>
+                    openCredentialPluginsModal({
+                      field,
+                      setCredentialPluginValues,
+                      accumulatedPluginValues,
+                    })
+                  }
+                  credentialType={credentialType}
+                />
+              </PageFormSecret>
             );
           }
         })}
@@ -466,23 +477,6 @@ function CredentialSubForm(
             isRequired={requiredFields.includes(field.id)}
             labelHelp={field.help_text}
           />
-        ))}
-      {encryptedFields.length > 0 &&
-        encryptedFields.map((field) => (
-          <PageFormSecret
-            key={field.id}
-            onClear={() => {
-              onClear && onClear(field.id);
-            }}
-            shouldHideField={field.secret}
-            label={field.label}
-          >
-            <CredentialTextInput
-              key={field.id}
-              field={field}
-              isRequired={requiredFields.includes(field.id)}
-            />
-          </PageFormSecret>
         ))}
     </PageFormSection>
   ) : null;

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -26,7 +26,7 @@ import { CredentialInputField, CredentialType } from '../../interfaces/Credentia
 import { AwxRoute } from '../../main/AwxRoutes';
 import { PageFormSelectOrganization } from '../organizations/components/PageFormOrganizationSelect';
 import { CredentialMultilineInput } from './components/CredentialMultilineInput';
-import { Button, Icon, InputGroup, InputGroupItem, Tooltip } from '@patternfly/react-core';
+import { Button, Icon, InputGroup, Tooltip } from '@patternfly/react-core';
 import { KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormSelectCredentialType } from './components/PageFormSelectCredentialType';
 

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useForm, useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -30,10 +30,6 @@ import { Button, Icon, InputGroup, Tooltip } from '@patternfly/react-core';
 import { KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormSelectCredentialType } from './components/PageFormSelectCredentialType';
 
-interface SecretInput {
-  onClear?: (name: string) => void;
-  //shouldHideField?: (name: string) => boolean;
-}
 import {
   CredentialPluginsInputSource,
   useCredentialPluginsModal,
@@ -395,6 +391,10 @@ function HiddenInputField({
             kind={credentialType.kind}
             field={field}
             requiredFields={requiredFields}
+            handleModalToggle={function (): void {
+              throw new Error('Function not implemented.');
+            }}
+            accumulatedPluginValues={[]}
           />
         </InputGroup>
       </SecretManagementInputField>
@@ -423,6 +423,10 @@ function HiddenInputField({
             field={field}
             isRequired={requiredFields.includes(field.id)}
             credentialType={credentialType}
+            handleModalToggle={function (): void {
+              throw new Error('Function not implemented.');
+            }}
+            accumulatedPluginValues={[]}
           />
         </InputGroup>
       </SecretManagementInputField>
@@ -430,22 +434,19 @@ function HiddenInputField({
   }
 }
 
-function CredentialSubForm(
-  {
-    credentialType,
-    setCredentialPluginValues,
-    isEditMode = false,
-    accumulatedPluginValues,
-    setAccumulatedPluginValues,
-  }: {
-    credentialType: CredentialType | undefined;
-    setCredentialPluginValues: (values: CredentialPluginsInputSource[]) => void;
-    isEditMode?: boolean;
-    accumulatedPluginValues: CredentialPluginsInputSource[];
-    setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
-  },
-  { onClear /*shouldHideField*/ }: SecretInput
-) {
+function CredentialSubForm({
+  credentialType,
+  setCredentialPluginValues,
+  isEditMode = false,
+  accumulatedPluginValues,
+  setAccumulatedPluginValues,
+}: {
+  credentialType: CredentialType | undefined;
+  setCredentialPluginValues: (values: CredentialPluginsInputSource[]) => void;
+  isEditMode?: boolean;
+  accumulatedPluginValues: CredentialPluginsInputSource[];
+  setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
+}) {
   const { t } = useTranslation();
   if (!credentialType || !credentialType?.inputs?.fields) {
     return null;
@@ -496,6 +497,10 @@ function CredentialSubForm(
                   kind={credentialType.kind}
                   field={field}
                   requiredFields={requiredFields}
+                  handleModalToggle={function (): void {
+                    throw new Error('Function not implemented.');
+                  }}
+                  accumulatedPluginValues={[]}
                 />
               );
             } else {
@@ -505,6 +510,10 @@ function CredentialSubForm(
                   field={field}
                   isRequired={requiredFields.includes(field.id)}
                   credentialType={credentialType}
+                  handleModalToggle={function (): void {
+                    throw new Error('Function not implemented.');
+                  }}
+                  accumulatedPluginValues={[]}
                 />
               );
             }

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -370,8 +370,13 @@ function HiddenInputField({
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
 }) {
   const [t] = useTranslation();
+  const { getValues } = useFormContext();
   const openCredentialPluginsModal = useCredentialPluginsModal();
-  const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
+  const fieldValue = getValues(field.id);
+  const isFieldValueEmpty = fieldValue === undefined || fieldValue === '';
+  const [shouldHideField, setShouldHideField] = useState(
+    field.secret && isEditMode && !isFieldValueEmpty
+  );
   const [clear, setClear] = useState(false);
   const { setValue } = useFormContext();
 
@@ -475,7 +480,6 @@ function CredentialSubForm({
   if (!credentialType || !credentialType?.inputs?.fields) {
     return null;
   }
-
   const stringFields =
     credentialType?.inputs?.fields?.filter(
       (field) => field.type === 'string' && !field?.choices?.length
@@ -488,7 +492,6 @@ function CredentialSubForm({
     credentialType?.inputs?.fields?.filter((field) => field.type === 'boolean') || [];
 
   const requiredFields = credentialType?.inputs?.required || [];
-
   const hasFields = stringFields.length > 0 || choiceFields.length > 0 || booleanFields.length > 0;
   return hasFields ? (
     <PageFormSection title={t('Type Details')}>

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -352,6 +352,62 @@ function CredentialInputs({
     </>
   );
 }
+
+function PageFormSecretInput({
+  field,
+  isEditMode,
+  credentialType,
+  requiredFields,
+}: {
+  field: CredentialInputField;
+  isEditMode: boolean;
+  credentialType: CredentialType;
+  requiredFields: string[];
+}) {
+  const [t] = useTranslation();
+  const [shouldHideField, setShouldHideField] = useState(field.secret && isEditMode);
+
+  const handleHideField = () => {
+    setShouldHideField(!shouldHideField);
+  };
+
+  if (field.multiline) {
+    return (
+      <PageFormSecret
+        key={field.id}
+        onClear={handleHideField}
+        shouldHideField={shouldHideField}
+        label={field.label}
+        placeholder={t('ENCRYPTED')}
+      >
+        <CredentialMultilineInput
+          kind={credentialType.kind}
+          key={field.id}
+          field={field}
+          requiredFields={requiredFields}
+        />
+      </PageFormSecret>
+    );
+  } else {
+    return (
+      <PageFormSecret
+        key={field.id}
+        onClear={handleHideField}
+        shouldHideField={shouldHideField}
+        label={field.label}
+        placeholder={t('ENCRYPTED')}
+      >
+        <CredentialTextInput
+          key={field.id}
+          field={field}
+          isRequired={requiredFields.includes(field.id)}
+          credentialType={credentialType}
+        />
+      </PageFormSecret>
+    );
+  }
+}
+
 function CredentialSubForm(
   {
     credentialType,

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -398,6 +398,7 @@ function CredentialSubForm(
                 onClear={() => {}}
                 shouldHideField={field.secret && isEditMode}
                 label={field.label}
+                placeholder={'ENCRYPTED'}
               >
                 <CredentialMultilineInput
                   accumulatedPluginValues={accumulatedPluginValues}
@@ -430,6 +431,7 @@ function CredentialSubForm(
                 onClear={() => {}}
                 shouldHideField={field.secret && isEditMode}
                 label={field.label}
+                placeholder={'ENCRYPTED'}
               >
                 <CredentialTextInput
                   accumulatedPluginValues={accumulatedPluginValues}

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -353,7 +353,7 @@ function CredentialInputs({
   );
 }
 
-function PageFormSecretInput({
+function HiddenInputField({
   field,
   isEditMode,
   credentialType,
@@ -375,88 +375,58 @@ function PageFormSecretInput({
   };
 
   if (field.multiline) {
-    if (field.secret && isEditMode) {
-      return (
-        <SecretManagementInputField
-          onClear={handleHideField}
-          shouldHideField={shouldHideField}
-          label={field.label}
-          placeholder={t('ENCRYPTED')}
-        >
-          <InputGroup>
-            <Tooltip content={t(`Reset`)}>
-              <Button
-                size="sm"
-                variant="control"
-                onClick={handleHideField}
-                icon={<RedoIcon />}
-              ></Button>
-            </Tooltip>
-            <CredentialMultilineInput
-              kind={credentialType.kind}
-              field={field}
-              requiredFields={requiredFields}
-            />
-          </InputGroup>
-        </SecretManagementInputField>
-      );
-    } else if (credentialType.kind === 'ssh' && field.id === 'become_method') {
-      return (
-        <BecomeMethodField
-          key={field.id}
-          fieldOptions={field}
-          isRequired={requiredFields.includes(field.id)}
-        />
-      );
-    } else {
-      return (
-        <CredentialMultilineInput
-          kind={credentialType.kind}
-          field={field}
-          requiredFields={requiredFields}
-        />
-      );
-    }
+    return (
+      <SecretManagementInputField
+        onClear={handleHideField}
+        shouldHideField={shouldHideField}
+        label={field.label}
+        placeholder={t('ENCRYPTED')}
+      >
+        <InputGroup>
+          <Tooltip content={t(`Reset`)}>
+            <Button
+              size="sm"
+              variant="control"
+              onClick={handleHideField}
+              icon={<RedoIcon />}
+            ></Button>
+          </Tooltip>
+          <CredentialMultilineInput
+            kind={credentialType.kind}
+            field={field}
+            requiredFields={requiredFields}
+          />
+        </InputGroup>
+      </SecretManagementInputField>
+    );
   } else {
-    if (field.secret && isEditMode) {
-      return (
-        <SecretManagementInputField
-          onClear={() => {
-            setValue(field.id, '');
-            setShouldHideField(!shouldHideField);
-          }}
-          shouldHideField={shouldHideField}
-          label={field.label}
-          placeholder={t('ENCRYPTED')}
-        >
-          <InputGroup>
-            <InputGroupItem>
-              <Button
-                size="sm"
-                variant="control"
-                onClick={handleHideField}
-                icon={<RedoIcon />}
-              ></Button>
-            </InputGroupItem>
-            <InputGroupItem>
-              <CredentialTextInput
-                field={field}
-                isRequired={requiredFields.includes(field.id)}
-                credentialType={credentialType}
-              />
-            </InputGroupItem>
-          </InputGroup>
-        </SecretManagementInputField>
-      );
-    } else {
-      return (
-        <CredentialTextInput
-          field={field}
-          isRequired={requiredFields.includes(field.id)}
-          credentialType={credentialType}
-        />
-      );
-    }
+    return (
+      <SecretManagementInputField
+        onClear={() => {
+          setValue(field.id, '');
+          setShouldHideField(!shouldHideField);
+        }}
+        shouldHideField={shouldHideField}
+        label={field.label}
+        placeholder={t('ENCRYPTED')}
+      >
+        <InputGroup>
+          <Tooltip content={t(`Reset`)}>
+            <Button
+              size="sm"
+              variant="control"
+              onClick={handleHideField}
+              icon={<RedoIcon />}
+            ></Button>
+          </Tooltip>
+          <CredentialTextInput
+            field={field}
+            isRequired={requiredFields.includes(field.id)}
+            credentialType={credentialType}
+          />
+        </InputGroup>
+      </SecretManagementInputField>
+    );
   }
 }
 
@@ -499,32 +469,7 @@ function CredentialSubForm(
     <PageFormSection title={t('Type Details')}>
       {stringFields.length > 0 &&
         stringFields.map((field) => {
-          if (field?.multiline) {
-            return (
-              <PageFormSecret
-                key={field.id}
-                onClear={() => {}}
-                shouldHideField={field.secret && isEditMode}
-                label={field.label}
-                placeholder={'ENCRYPTED'}
-              >
-                <CredentialMultilineInput
-                  accumulatedPluginValues={accumulatedPluginValues}
-                  kind={credentialType.kind}
-                  key={field.id}
-                  field={field}
-                  requiredFields={requiredFields}
-                  handleModalToggle={() => {
-                    openCredentialPluginsModal({
-                      field,
-                      setCredentialPluginValues,
-                      accumulatedPluginValues,
-                    });
-                  }}
-                />
-              </PageFormSecret>
-            );
-          } else if (credentialType.kind === 'ssh' && field.id === 'become_method') {
+          if (credentialType.kind === 'ssh' && field.id === 'become_method') {
             return (
               <BecomeMethodField
                 key={field.id}
@@ -532,35 +477,37 @@ function CredentialSubForm(
                 isRequired={requiredFields.includes(field.id)}
               />
             );
-          } else {
+          }
+          if (field.secret && isEditMode) {
             return (
-              <PageFormSecret
+              <HiddenInputField
                 key={field.id}
-                onClear={() => {}}
-                shouldHideField={field.secret && isEditMode}
-                label={field.label}
-                placeholder={'ENCRYPTED'}
-              >
+                field={field}
+                isEditMode={isEditMode}
+                credentialType={credentialType}
+                requiredFields={requiredFields}
+              ></HiddenInputField>
+            );
+          } else {
+            if (field.multiline) {
+              return (
+                <CredentialMultilineInput
+                  key={field.id}
+                  kind={credentialType.kind}
+                  field={field}
+                  requiredFields={requiredFields}
+                />
+              );
+            } else {
+              return (
                 <CredentialTextInput
-                  accumulatedPluginValues={accumulatedPluginValues}
-                  setAccumulatedPluginValues={setAccumulatedPluginValues}
                   key={field.id}
                   field={field}
-                  isDisabled={
-                    field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode
-                  }
                   isRequired={requiredFields.includes(field.id)}
-                  handleModalToggle={() =>
-                    openCredentialPluginsModal({
-                      field,
-                      setCredentialPluginValues,
-                      accumulatedPluginValues,
-                    })
-                  }
                   credentialType={credentialType}
                 />
-              </PageFormSecret>
-            );
+              );
+            }
           }
         })}
       {choiceFields.length > 0 &&

--- a/frontend/awx/access/credentials/components/CredentialMultilineInput.tsx
+++ b/frontend/awx/access/credentials/components/CredentialMultilineInput.tsx
@@ -7,7 +7,7 @@ import { Credential } from '../../../interfaces/Credential';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { CredentialPluginsInputSource } from '../CredentialPlugins/hooks/useCredentialPluginsDialog';
-import { useCallback, useEffect } from 'react';
+import { ReactNode, useCallback, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 export function CredentialMultilineInput({
@@ -16,12 +16,14 @@ export function CredentialMultilineInput({
   kind,
   handleModalToggle,
   accumulatedPluginValues,
+  buttons,
 }: {
   field: CredentialInputField;
   requiredFields: CredentialType['inputs']['required'];
   kind: CredentialType['kind'];
   handleModalToggle: () => void;
   accumulatedPluginValues: CredentialPluginsInputSource[];
+  buttons?: ReactNode;
 }) {
   const { t } = useTranslation();
   const { setValue } = useFormContext();
@@ -89,9 +91,12 @@ export function CredentialMultilineInput({
         isReadOnly={handleIsDisabled(field)}
         allowEditingUploadedText={true}
         icon={
-          kind !== 'external' ? (
-            <Button icon={<KeyIcon />} variant="control" onClick={handleModalToggle} />
-          ) : undefined
+          <>
+            {kind !== 'external' ? (
+              <Button icon={<KeyIcon />} variant="control" onClick={handleModalToggle} />
+            ) : undefined}
+            {buttons}
+          </>
         }
       />
     </>

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -1,9 +1,7 @@
-import { Button, Icon, InputGroup, TextInput, Tooltip } from '@patternfly/react-core';
+import { Button, Icon, InputGroup } from '@patternfly/react-core';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
-import { EyeSlashIcon, KeyIcon, RedoIcon } from '@patternfly/react-icons';
-import { PageFormCheckbox, PageFormTextInput } from '../../../../../framework';
+import { KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
 import { CredentialInputField } from '../../../interfaces/CredentialType';
 import { CredentialTextInput } from '../CredentialForm';
@@ -67,6 +65,8 @@ export function SingleLineEncryptedInput({
   requiredFields,
   placeholder,
 }: IProps) {
+  const { t } = useTranslation();
+
   if (shouldHideField) {
     return (
       <InputGroup>
@@ -98,7 +98,6 @@ export function MultiLineEncryptedInput({
   onClear,
   shouldHideField,
   label,
-  labelHelp,
   children,
   placeholder,
 }: IProps) {

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -1,0 +1,89 @@
+import { Button, Icon, InputGroup, TextInput, Tooltip } from '@patternfly/react-core';
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
+import { EyeSlashIcon, RedoIcon } from '@patternfly/react-icons';
+
+interface ChildProps {
+  labelHelp?: string;
+  label?: string;
+}
+
+/**
+ * Props for the SecretManagementInputField component.
+ * @interface IProps
+ */
+interface IProps {
+  /**
+   * Indicates if the value of the field should be hidden.
+   * When true, the field value is masked.
+   * When false, children components are displayed for user interaction.
+   */
+  shouldHideField: boolean | undefined;
+
+  /**
+   * Callback function triggered when the replace button is clicked.
+   * It is used to reset the field value to null or empty.
+   */
+  onClear: () => void;
+
+  /**
+   * The components to be displayed when the field value is not hidden,
+   * typically used for user interaction to input or edit the value.
+   */
+  children: ReactElement<ChildProps>;
+
+  /**
+   * Optional text displayed in input field when the field value is hidden
+   */
+  placeholder?: string;
+
+  /**
+   * Optional text that provides additional information or instructions
+   * for the field, displayed alongside the label.
+   */
+  labelHelp?: string;
+
+  /**
+   * The text label displayed above the field to indicate what
+   * information the field contains or expects.
+   */
+  label?: string;
+}
+
+export function SecretManagementInputField({
+  onClear,
+  shouldHideField,
+  label,
+  labelHelp,
+  children,
+  placeholder,
+}: IProps) {
+  const { t } = useTranslation();
+  const fieldLabel = label || children.props.label || '';
+  const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
+  if (shouldHideField) {
+    return (
+      <PageFormGroup label={fieldLabel} labelHelp={fieldLabelHelp}>
+        <InputGroup>
+          <Tooltip content={t(`Replace`)}>
+            <Button variant="control" onClick={() => onClear()}>
+              <Icon>
+                <RedoIcon />
+              </Icon>
+            </Button>
+          </Tooltip>
+          <TextInput
+            aria-label={t('hidden value')}
+            placeholder={placeholder ? placeholder : 'ENCRYPTED'}
+            type="password"
+            autoComplete="off"
+            isDisabled={true}
+          />
+          <Button variant="control" isDisabled={true} icon={<EyeSlashIcon />}></Button>
+        </InputGroup>
+      </PageFormGroup>
+    );
+  }
+  return <>{children}</>;
+}

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -3,8 +3,9 @@ import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
 import { EyeSlashIcon, KeyIcon, RedoIcon } from '@patternfly/react-icons';
-import { PageFormTextInput } from '../../../../../framework';
+import { PageFormCheckbox, PageFormTextInput } from '../../../../../framework';
 import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
+import { CredentialInputField } from '../../../interfaces/CredentialType';
 
 interface ChildProps {
   labelHelp?: string;
@@ -35,6 +36,8 @@ interface IProps {
    */
   children: ReactElement<ChildProps>;
 
+  field: CredentialInputField;
+
   /**
    * Optional text displayed in input field when the field value is hidden
    */
@@ -55,6 +58,7 @@ interface IProps {
 
 export function SingleLineEncryptedInput({
   onClear,
+  field,
   shouldHideField,
   label,
   labelHelp,
@@ -66,32 +70,30 @@ export function SingleLineEncryptedInput({
   const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
   if (shouldHideField) {
     return (
-      <PageFormGroup label={fieldLabel} labelHelp={fieldLabelHelp}>
-        <InputGroup>
-          <PageFormTextInput
-            aria-label={t('hidden value')}
-            placeholder={placeholder ? placeholder : t('ENCRYPTED')}
-            type="password"
-            autoComplete="off"
-            isDisabled={true}
-            name={''}
-            button={
-              <>
-                <Button isDisabled={true} variant="control" onClick={() => onClear()}>
-                  <Icon>
-                    <KeyIcon />
-                  </Icon>
-                </Button>
-                <Button variant="control" onClick={() => onClear()}>
-                  <Icon>
-                    <RedoIcon />
-                  </Icon>
-                </Button>
-              </>
-            }
-          />
-        </InputGroup>
-      </PageFormGroup>
+      <PageFormTextInput
+        aria-label={t('hidden value')}
+        label={fieldLabel}
+        labelHelp={fieldLabelHelp}
+        placeholder={placeholder ? placeholder : t('ENCRYPTED')}
+        type="password"
+        autoComplete="off"
+        isDisabled={true}
+        name={''}
+        button={
+          <>
+            <Button isDisabled={true} variant="control" onClick={() => onClear()}>
+              <Icon>
+                <KeyIcon />
+              </Icon>
+            </Button>
+            <Button variant="control" onClick={() => onClear()}>
+              <Icon>
+                <RedoIcon />
+              </Icon>
+            </Button>
+          </>
+        }
+      />
     );
   }
   return <>{children}</>;

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -6,6 +6,7 @@ import { EyeSlashIcon, KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormCheckbox, PageFormTextInput } from '../../../../../framework';
 import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
 import { CredentialInputField } from '../../../interfaces/CredentialType';
+import { CredentialTextInput } from '../CredentialForm';
 
 interface ChildProps {
   labelHelp?: string;
@@ -38,6 +39,8 @@ interface IProps {
 
   field: CredentialInputField;
 
+  requiredFields: string[];
+
   /**
    * Optional text displayed in input field when the field value is hidden
    */
@@ -60,40 +63,32 @@ export function SingleLineEncryptedInput({
   onClear,
   field,
   shouldHideField,
-  label,
-  labelHelp,
   children,
+  requiredFields,
   placeholder,
 }: IProps) {
-  const { t } = useTranslation();
-  const fieldLabel = label || children.props.label || '';
-  const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
   if (shouldHideField) {
     return (
-      <PageFormTextInput
-        aria-label={t('hidden value')}
-        label={fieldLabel}
-        labelHelp={fieldLabelHelp}
-        placeholder={placeholder ? placeholder : t('ENCRYPTED')}
-        type="password"
-        autoComplete="off"
-        isDisabled={true}
-        name={''}
-        button={
-          <>
-            <Button isDisabled={true} variant="control" onClick={() => onClear()}>
-              <Icon>
-                <KeyIcon />
-              </Icon>
-            </Button>
+      <InputGroup>
+        <CredentialTextInput
+          key={field.id}
+          field={field}
+          isDisabled={true}
+          isRequired={requiredFields.includes(field.id)}
+          placeholder={placeholder ? placeholder : t('ENCRYPTED')}
+          buttons={
             <Button variant="control" onClick={() => onClear()}>
               <Icon>
                 <RedoIcon />
               </Icon>
             </Button>
-          </>
-        }
-      />
+          }
+          handleModalToggle={function (): void {
+            throw new Error('Function not implemented.');
+          }}
+          accumulatedPluginValues={[]}
+        />
+      </InputGroup>
     );
   }
   return <>{children}</>;

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -103,8 +103,6 @@ export function MultiLineEncryptedInput({
   placeholder,
 }: IProps) {
   const { t } = useTranslation();
-  const fieldLabel = label || children.props.label || '';
-  const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
   if (shouldHideField) {
     return (
       <InputGroup>

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -11,6 +11,11 @@ interface ChildProps {
   label?: string;
 }
 
+interface EncryptedInputButtonsProps {
+  onClear: () => void;
+  isDisabled?: boolean;
+}
+
 /**
  * Props for the SecretManagementInputField component.
  * @interface IProps
@@ -57,6 +62,23 @@ interface IProps {
   label?: string;
 }
 
+export const EncryptedInputButtons = ({
+  onClear,
+  isDisabled = true,
+}: EncryptedInputButtonsProps) => (
+  <div style={{ display: 'flex', gap: '0.0rem' }}>
+    <Button isDisabled={isDisabled} variant={'control'} onClick={() => onClear()}>
+      <Icon>
+        <KeyIcon />
+      </Icon>
+    </Button>
+    <Button variant={'control'} onClick={() => onClear()}>
+      <Icon>
+        <RedoIcon />
+      </Icon>
+    </Button>
+  </div>
+);
 export function SingleLineEncryptedInput({
   onClear,
   field,
@@ -73,7 +95,7 @@ export function SingleLineEncryptedInput({
         <CredentialTextInput
           key={field.id}
           field={field}
-          isDisabled={true}
+          isDisabled={shouldHideField}
           isRequired={requiredFields.includes(field.id)}
           placeholder={placeholder ? placeholder : t('ENCRYPTED')}
           buttons={
@@ -108,24 +130,11 @@ export function MultiLineEncryptedInput({
         <PageFormFileUpload
           label={label}
           name={''}
-          isDisabled={true}
+          isDisabled={shouldHideField}
           textAreaPlaceholder={placeholder ? placeholder : t('ENCRYPTED')}
           type="text"
           autoComplete="off"
-          icon={
-            <>
-              <Button isDisabled={true} variant="control" onClick={() => onClear()}>
-                <Icon>
-                  <KeyIcon />
-                </Icon>
-              </Button>
-              <Button variant="control" onClick={() => onClear()}>
-                <Icon>
-                  <RedoIcon />
-                </Icon>
-              </Button>
-            </>
-          }
+          icon={<EncryptedInputButtons onClear={onClear} isDisabled={true} />}
         />
       </InputGroup>
     );

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -75,7 +75,7 @@ export function SecretManagementInputField({
           </Tooltip>
           <TextInput
             aria-label={t('hidden value')}
-            placeholder={placeholder ? placeholder : 'ENCRYPTED'}
+            placeholder={placeholder ? placeholder : t('$ENCRYPTED')}
             type="password"
             autoComplete="off"
             isDisabled={true}

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -75,7 +75,7 @@ export function SecretManagementInputField({
           </Tooltip>
           <TextInput
             aria-label={t('hidden value')}
-            placeholder={placeholder ? placeholder : t('$ENCRYPTED')}
+            placeholder={placeholder ? placeholder : t('ENCRYPTED')}
             type="password"
             autoComplete="off"
             isDisabled={true}

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -2,7 +2,8 @@ import { Button, Icon, InputGroup, TextInput, Tooltip } from '@patternfly/react-
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
-import { EyeSlashIcon, RedoIcon } from '@patternfly/react-icons';
+import { EyeSlashIcon, KeyIcon, RedoIcon } from '@patternfly/react-icons';
+import { PageFormTextInput } from '../../../../../framework';
 
 interface ChildProps {
   labelHelp?: string;
@@ -66,21 +67,28 @@ export function SecretManagementInputField({
     return (
       <PageFormGroup label={fieldLabel} labelHelp={fieldLabelHelp}>
         <InputGroup>
-          <Tooltip content={t(`Replace`)}>
-            <Button variant="control" onClick={() => onClear()}>
-              <Icon>
-                <RedoIcon />
-              </Icon>
-            </Button>
-          </Tooltip>
-          <TextInput
+          <PageFormTextInput
             aria-label={t('hidden value')}
             placeholder={placeholder ? placeholder : t('ENCRYPTED')}
             type="password"
             autoComplete="off"
             isDisabled={true}
+            name={''}
+            button={
+              <>
+                <Button isDisabled={true} variant="control" onClick={() => onClear()}>
+                  <Icon>
+                    <KeyIcon />
+                  </Icon>
+                </Button>
+                <Button variant="control" onClick={() => onClear()}>
+                  <Icon>
+                    <RedoIcon />
+                  </Icon>
+                </Button>
+              </>
+            }
           />
-          <Button variant="control" isDisabled={true} icon={<EyeSlashIcon />}></Button>
         </InputGroup>
       </PageFormGroup>
     );

--- a/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
+++ b/frontend/awx/access/credentials/components/SecretManagementInputField.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
 import { EyeSlashIcon, KeyIcon, RedoIcon } from '@patternfly/react-icons';
 import { PageFormTextInput } from '../../../../../framework';
+import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
 
 interface ChildProps {
   labelHelp?: string;
@@ -52,7 +53,7 @@ interface IProps {
   label?: string;
 }
 
-export function SecretManagementInputField({
+export function SingleLineEncryptedInput({
   onClear,
   shouldHideField,
   label,
@@ -91,6 +92,48 @@ export function SecretManagementInputField({
           />
         </InputGroup>
       </PageFormGroup>
+    );
+  }
+  return <>{children}</>;
+}
+
+export function MultiLineEncryptedInput({
+  onClear,
+  shouldHideField,
+  label,
+  labelHelp,
+  children,
+  placeholder,
+}: IProps) {
+  const { t } = useTranslation();
+  const fieldLabel = label || children.props.label || '';
+  const fieldLabelHelp = labelHelp || children.props.labelHelp || '';
+  if (shouldHideField) {
+    return (
+      <InputGroup>
+        <PageFormFileUpload
+          label={label}
+          name={''}
+          isDisabled={true}
+          textAreaPlaceholder={placeholder ? placeholder : t('ENCRYPTED')}
+          type="text"
+          autoComplete="off"
+          icon={
+            <>
+              <Button isDisabled={true} variant="control" onClick={() => onClear()}>
+                <Icon>
+                  <KeyIcon />
+                </Icon>
+              </Button>
+              <Button variant="control" onClick={() => onClear()}>
+                <Icon>
+                  <RedoIcon />
+                </Icon>
+              </Button>
+            </>
+          }
+        />
+      </InputGroup>
     );
   }
   return <>{children}</>;


### PR DESCRIPTION
Adds button to open secret management wizard for credential types without kind of 'external'. 

Before:
![Screenshot 2024-04-26 at 11 56 50 AM](https://github.com/ansible/ansible-ui/assets/14355897/1054462f-22ff-4308-9365-970376905f19)

After:
![Screenshot 2024-04-26 at 11 56 28 AM](https://github.com/ansible/ansible-ui/assets/14355897/6e8dca46-d7ad-4c0c-9aa6-8dab3d57f28a)
