### PR TITLE
Query Param Fix For Instances List

### DIFF
--- a/frontend/awx/administration/instances/components/InstancesList.tsx
+++ b/frontend/awx/administration/instances/components/InstancesList.tsx
@@ -36,7 +36,7 @@ export function InstancesList(props: {
       : awxAPI`/instances/`,
     toolbarFilters,
     tableColumns,
-    queryParams: defaultParams,
+    queryParams: instanceGroupId ? defaultParams : {},
   });
 
   const rowActions = useRowActions(view.unselectItemsAndRefresh);


### PR DESCRIPTION
Query params should only be applied to the list if the list is being rendered inside of the instances group section of the UI. Otherwise do not pass query params.