### PR TITLE
[AAP-7480] Instance Group Details

### DIFF
--- a/cypress/e2e/awx/administration/topology-view.cy.ts
+++ b/cypress/e2e/awx/administration/topology-view.cy.ts
@@ -66,7 +66,7 @@ describe('Topology view', () => {
           .then((instanceGroups: InstanceGroup[]) => {
             cy.clickLink(`${instanceGroups[0].name}`);
             // TODO Instance groups detail page not yet implemented; check URL for now
-            cy.url().should('contain', `/instance-groups/${instanceGroups[0].id}`);
+            cy.url().should('contain', `/instance_groups/${instanceGroups[0].id}`);
           });
       });
   });

--- a/cypress/fixtures/container_group.json
+++ b/cypress/fixtures/container_group.json
@@ -1,0 +1,32 @@
+{
+  "id": 1,
+  "type": "instance_group",
+  "url": "/api/v2/instance_groups/1/",
+  "related": {
+    "jobs": "/api/v2/instance_groups/1/jobs/",
+    "instances": "/api/v2/instance_groups/1/instances/"
+  },
+  "name": "Test Container Group",
+  "created": "2022-12-09T15:26:58.492885Z",
+  "modified": "2022-12-09T15:26:58.503037Z",
+  "capacity": 611,
+  "consumed_capacity": 0,
+  "percent_capacity_remaining": 100.0,
+  "jobs_running": 0,
+  "max_concurrent_jobs": 23,
+  "max_forks": 12,
+  "jobs_total": 48,
+  "instances": 1,
+  "is_container_group": true,
+  "credential": null,
+  "policy_instance_percentage": 100,
+  "policy_instance_minimum": 0,
+  "policy_instance_list": [],
+  "pod_spec_override": "",
+  "summary_fields": {
+    "user_capabilities": {
+      "edit": true,
+      "delete": false
+    }
+  }
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.cy.tsx
@@ -1,0 +1,66 @@
+import { InstanceGroup } from '../../../interfaces/InstanceGroup';
+import { InstanceGroupDetails } from './InstanceGroupDetails';
+import { formatDateString } from '../../../../../framework/utils/formatDateString';
+
+describe('Instance Group Details', () => {
+  it('Render instance group details', () => {
+    cy.intercept(
+      { method: 'GET', url: '/api/v2/instance_groups/*' },
+      { fixture: 'instance_group.json' }
+    );
+    cy.mount(<InstanceGroupDetails />, {
+      path: 'instance_groups/:id/details',
+      initialEntries: ['/instance_groups/1/details'],
+    });
+    cy.fixture('instance_group').then((instance_group: InstanceGroup) => {
+      cy.get('[data-cy="name"]').should('have.text', instance_group.name);
+      cy.get('[data-cy="type"]').should('have.text', 'Instance Group');
+      cy.get('[data-cy="policy-instance-minimum"]').should(
+        'have.text',
+        instance_group.policy_instance_minimum
+      );
+      cy.get('[data-cy="policy-instance-percentage"]').should(
+        'have.text',
+        `${instance_group.policy_instance_percentage}%`
+      );
+      cy.get('[data-cy="max-concurrent-jobs"]').should(
+        'have.text',
+        instance_group.max_concurrent_jobs
+      );
+      cy.get('[data-cy="max-forks"]').should('have.text', instance_group.max_forks);
+      cy.get('[data-cy="used-capacity"]').should('have.text', instance_group.consumed_capacity);
+      cy.get('[data-cy="created"]').should('have.text', formatDateString(instance_group.created));
+      cy.get('[data-cy="last-modified"]').should(
+        'have.text',
+        formatDateString(instance_group.modified)
+      );
+    });
+  });
+  it('Render container group details', () => {
+    cy.intercept(
+      { method: 'GET', url: '/api/v2/instance_groups/*' },
+      { fixture: 'container_group.json' }
+    );
+    cy.mount(<InstanceGroupDetails />, {
+      path: 'instance_groups/:id/details',
+      initialEntries: ['/instance_groups/2/details'],
+    });
+    cy.fixture('container_group').then((container_group: InstanceGroup) => {
+      cy.get('[data-cy="name"]').should('have.text', container_group.name);
+      cy.get('[data-cy="type"]').should('have.text', 'Container Group');
+      cy.get('[data-cy="policy-instance-minimum"]').should('not.exist');
+      cy.get('[data-cy="policy-instance-percentage"]').should('not.exist');
+      cy.get('[data-cy="max-concurrent-jobs"]').should(
+        'have.text',
+        container_group.max_concurrent_jobs
+      );
+      cy.get('[data-cy="max-forks"]').should('have.text', container_group.max_forks);
+      cy.get('[data-cy="used-capacity"]').should('not.exist');
+      cy.get('[data-cy="created"]').should('have.text', formatDateString(container_group.created));
+      cy.get('[data-cy="last-modified"]').should(
+        'have.text',
+        formatDateString(container_group.modified)
+      );
+    });
+  });
+});

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.tsx
@@ -1,0 +1,69 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { PageDetails, PageDetail, DateTimeCell } from '../../../../../framework';
+import { useGetItem } from '../../../../common/crud/useGet';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { InstanceGroup } from '../../../interfaces/InstanceGroup';
+
+export function InstanceGroupDetails() {
+  const params = useParams<{ id: string }>();
+  const { data: instanceGroup } = useGetItem<InstanceGroup>(awxAPI`/instance_groups/`, params.id);
+  return instanceGroup ? <InstanceGroupDetailInner instanceGroup={instanceGroup} /> : null;
+}
+
+export function InstanceGroupDetailInner(props: { instanceGroup: InstanceGroup }) {
+  const { t } = useTranslation();
+  const { instanceGroup } = props;
+
+  return (
+    <PageDetails>
+      <PageDetail label={t('Name')}>{instanceGroup.name}</PageDetail>
+      <PageDetail label={t('Type')}>
+        {instanceGroup.is_container_group ? t('Container Group') : t('Instance Group')}
+      </PageDetail>
+      <PageDetail
+        label={t('Policy Instance Minimum')}
+        helpText={t(
+          'Minimum number of instances that will be automatically assigned to this group when new instances come online.'
+        )}
+        isEmpty={instanceGroup.is_container_group}
+      >
+        {instanceGroup.policy_instance_minimum}
+      </PageDetail>
+      <PageDetail
+        label={t('Policy instance percentage')}
+        helpText={t(
+          'Minimum percentage of all instances that will be automatically assigned to this group when new instances come online.'
+        )}
+        isEmpty={instanceGroup.is_container_group}
+      >
+        {instanceGroup.policy_instance_percentage}%
+      </PageDetail>
+      <PageDetail
+        label={t('Max concurrent jobs')}
+        helpText={t(
+          'Maximum number of jobs to run concurrently on this group. Zero means no limit will be enforced.'
+        )}
+      >
+        {instanceGroup.max_concurrent_jobs}
+      </PageDetail>
+      <PageDetail
+        label={t('Max forks')}
+        helpText={t(
+          'Maximum number of forks to allow across all jobs running concurrently on this group. Zero means no limit will be enforced.'
+        )}
+      >
+        {instanceGroup.max_forks}
+      </PageDetail>
+      <PageDetail label={t('Used Capacity')} isEmpty={instanceGroup.is_container_group}>
+        {instanceGroup.consumed_capacity}
+      </PageDetail>
+      <PageDetail label={t('Created')}>
+        <DateTimeCell value={instanceGroup.created} />
+      </PageDetail>
+      <PageDetail label={t('Last modified')}>
+        <DateTimeCell value={instanceGroup.modified} />
+      </PageDetail>
+    </PageDetails>
+  );
+}

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.tsx
@@ -1,13 +1,23 @@
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { PageDetails, PageDetail, DateTimeCell } from '../../../../../framework';
+import { PageDetails, PageDetail, DateTimeCell, LoadingPage } from '../../../../../framework';
 import { useGetItem } from '../../../../common/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { InstanceGroup } from '../../../interfaces/InstanceGroup';
+import { AwxError } from '../../../common/AwxError';
 
 export function InstanceGroupDetails() {
   const params = useParams<{ id: string }>();
-  const { data: instanceGroup } = useGetItem<InstanceGroup>(awxAPI`/instance_groups/`, params.id);
+  const {
+    data: instanceGroup,
+    isLoading,
+    error,
+    refresh,
+  } = useGetItem<InstanceGroup>(awxAPI`/instance_groups/`, params.id);
+
+  if (error) return <AwxError error={error} handleRefresh={refresh} />;
+  if (isLoading && !instanceGroup) return <LoadingPage />;
+
   return instanceGroup ? <InstanceGroupDetailInner instanceGroup={instanceGroup} /> : null;
 }
 

--- a/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
@@ -12,6 +12,7 @@ import {
   CreateInstanceGroup,
   EditInstanceGroup,
 } from '../../administration/instance-groups/InstanceGroupForm';
+import { InstanceGroupDetails } from '../../administration/instance-groups/InstanceGroupPage/InstanceGroupDetails';
 
 export function useAwxInstanceGroupsRoutes() {
   const { t } = useTranslation();
@@ -19,7 +20,7 @@ export function useAwxInstanceGroupsRoutes() {
     () => ({
       id: AwxRoute.InstanceGroups,
       label: t('Instance Groups'),
-      path: 'instance-groups',
+      path: 'instance_groups',
       children: [
         {
           id: AwxRoute.CreateInstanceGroup,
@@ -39,7 +40,7 @@ export function useAwxInstanceGroupsRoutes() {
             {
               id: AwxRoute.InstanceGroupDetails,
               path: 'details',
-              element: <PageNotImplemented />,
+              element: <InstanceGroupDetails />,
             },
             {
               id: AwxRoute.InstanceGroupInstances,


### PR DESCRIPTION
This PR is for AAP-7480 which adds the details page tab for instance group and container groups. A set of component tests have also been written to ensure the correct fields show up for the two respective instance types.