### PR TITLE
fixing Enable/Disable a Schedule from Details Page

### DIFF
--- a/frontend/awx/views/schedules/SchedulePage/SchedulePage.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/SchedulePage.tsx
@@ -46,7 +46,8 @@ export function SchedulePage(props: {
     isInventorySource ? params.source_id : params.id
   );
   const itemActions = useSchedulesActions({
-    onScheduleToggleorDeleteCompleted: () => navigate(getPageUrl(AwxRoute.Schedules)),
+    onScheduleDeleteCompleted: () => navigate(getPageUrl(AwxRoute.Schedules)),
+    onScheduleToggleCompleted: () => refresh(),
   });
 
   useEffect(() => {

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -43,7 +43,8 @@ export function SchedulesList(props: { sublistEndpoint?: string }) {
   const createUrl = useGetSchedulCreateUrl(apiEndPoint);
   const toolbarActions = useScheduleToolbarActions(view.unselectItemsAndRefresh, apiEndPoint);
   const rowActions = useSchedulesActions({
-    onScheduleToggleorDeleteCompleted: () => void view.refresh(),
+    onScheduleDeleteCompleted: () => void view.refresh(),
+    onScheduleToggleCompleted: () => void view.refresh(),
     sublistEndpoint: apiEndPoint,
   });
   return (

--- a/frontend/awx/views/schedules/hooks/useSchedulesActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useSchedulesActions.tsx
@@ -18,17 +18,18 @@ import { useDeleteSchedules } from './useDeleteSchedules';
 import { schedulePageUrl } from '../types';
 
 export function useSchedulesActions(options: {
-  onScheduleToggleorDeleteCompleted: () => void;
+  onScheduleDeleteCompleted: () => void;
+  onScheduleToggleCompleted: () => void;
   sublistEndpoint?: string;
 }) {
   const { t } = useTranslation();
-  const deleteSchedule = useDeleteSchedules(options?.onScheduleToggleorDeleteCompleted);
+  const deleteSchedule = useDeleteSchedules(options?.onScheduleDeleteCompleted);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/schedules/`);
   const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
   const handleToggleSchedule: (schedule: Schedule, enabled: boolean) => Promise<void> = useCallback(
     async (schedule, enabled) => {
       await requestPatch<Schedule>(awxAPI`/schedules/${schedule.id.toString()}/`, { enabled });
-      options?.onScheduleToggleorDeleteCompleted();
+      options.onScheduleToggleCompleted();
     },
     [options]
   );


### PR DESCRIPTION
This PR is fixing [AAP-23389](https://issues.redhat.com/browse/AAP-23389)


When a user clicks the enable/disable toggle button of a schedule shown on the details page of that schedule, there is an immediate redirect to the Schedules list page.
