### PR TITLE
[AAP-23637] Hook up run command wizard to toolbar buttons

### DIFF
--- a/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
+++ b/frontend/awx/administration/execution-environments/components/PageFormExecutionEnvironmentSelect.tsx
@@ -19,11 +19,18 @@ export function PageFormExecutionEnvironmentSelect<
   additionalControls?: ReactElement;
   isRequired?: boolean;
   label?: string;
+  placeholder?: string;
   isDisabled?: boolean;
   // tooltip?: string;
 }) {
-  const { name, organizationId, executionEnvironmentIdPath, executionEnvironmentPath, ...rest } =
-    props;
+  const {
+    name,
+    organizationId,
+    executionEnvironmentIdPath,
+    executionEnvironmentPath,
+    placeholder,
+    ...rest
+  } = props;
   const { t } = useTranslation();
   const selectExecutionEnvironment = useSelectExecutionEnvironments(organizationId ?? undefined);
   const { setValue } = useFormContext();
@@ -34,7 +41,7 @@ export function PageFormExecutionEnvironmentSelect<
       label={props.label ?? t('Execution environment')}
       name={name}
       id="execution-environment-select"
-      placeholder={t('Create execution environment')}
+      placeholder={placeholder ?? t('Create execution environment')}
       labelHelpTitle={t('Execution environment')}
       labelHelp={t('The container image to be used for execution.')}
       selectTitle={t('Select an execution environment')}

--- a/frontend/awx/common/adapters/awxErrorAdapter.tsx
+++ b/frontend/awx/common/adapters/awxErrorAdapter.tsx
@@ -35,6 +35,8 @@ export const awxErrorAdapter = (error: unknown): ErrorOutput => {
           }
         });
       }
+    } else if ('module_args' in data) {
+      genericErrors.push({ message: data.module_args as string });
     }
 
     // handle API responses {error: 'Cannot assign a Credential of kind `galaxy`.'}

--- a/frontend/awx/interfaces/Inventory.ts
+++ b/frontend/awx/interfaces/Inventory.ts
@@ -65,7 +65,7 @@ export interface SmartInventory extends CommonInventory {
 export type Inventory = RegularInventory | ConstructedInventory | SmartInventory;
 
 export interface RunCommandWizard {
-  module: string;
+  module_name: string;
   module_args: string;
   verbosity: number;
   limit: string;

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -135,7 +135,7 @@ export function useAwxInventoryRoutes() {
         },
         {
           id: AwxRoute.InventoryRunCommand,
-          path: ':inventory_type/:id/groups/:group_id/run_command',
+          path: ':inventory_type/:id/run_command',
           element: <InventoryRunCommand />,
         },
         {

--- a/frontend/awx/resources/inventories/InventoryRunCommand.cy.tsx
+++ b/frontend/awx/resources/inventories/InventoryRunCommand.cy.tsx
@@ -34,7 +34,7 @@ describe('Run command wizard', () => {
   });
   it('reveiw step has correct values', () => {
     cy.mount(<InventoryRunCommand />);
-    cy.selectDropdownOptionByResourceName('module', 'shell');
+    cy.selectDropdownOptionByResourceName('module-name', 'shell');
     cy.getByDataCy('module-args-form-group').type('argument');
     cy.selectDropdownOptionByResourceName('verbosity', '1 (Verbose)');
     cy.getByDataCy('limit-form-group').within(() => {

--- a/frontend/awx/resources/inventories/InventoryRunCommand.tsx
+++ b/frontend/awx/resources/inventories/InventoryRunCommand.tsx
@@ -76,7 +76,7 @@ export function InventoryRunCommand() {
 
   const initialValues = {
     details: {
-      module: '',
+      module_name: '',
       module_args: '',
       verbosity: 0,
       limit: 'all',

--- a/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
+++ b/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
@@ -24,7 +24,7 @@ import { useWatch } from 'react-hook-form';
 export function RunCommandDetailStep() {
   const { t } = useTranslation();
   const module = useWatch<RunCommandWizard>({
-    name: 'module',
+    name: 'module_name',
   });
   const moduleOptions = [
     { label: t('command'), value: 'command' },
@@ -60,7 +60,7 @@ export function RunCommandDetailStep() {
   return (
     <PageFormSection singleColumn>
       <PageFormSelect
-        name="module"
+        name="module_name"
         placeholderText={t('Select a module')}
         isRequired
         label={t('Module')}
@@ -202,7 +202,7 @@ export function RunCommandReviewStep() {
   };
   const getPageUrl = useGetPageUrl();
   const {
-    module,
+    module_name,
     module_args,
     verbosity,
     limit,
@@ -219,7 +219,7 @@ export function RunCommandReviewStep() {
     <>
       <PageFormSection title={t('Review')} singleColumn>
         <PageDetails disablePadding>
-          <PageDetail label={t('Module')}>{module}</PageDetail>
+          <PageDetail label={t('Module')}>{module_name}</PageDetail>
           <PageDetail label={t('Arguments')}>{module_args}</PageDetail>
           <PageDetail label={t('Verbosity')}>{verbosity}</PageDetail>
           <PageDetail label={t('Limit')}>{limit}</PageDetail>

--- a/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
+++ b/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
@@ -168,6 +168,7 @@ export function RunCommandExecutionEnvionment(props: { orgId: string }) {
         name="execution_environment.name"
         executionEnvironmentIdPath="execution_environment.id"
         label={t('Execution Environment')}
+        placeholder={t('Select execution environment')}
         organizationId={props.orgId ?? ''}
       />
     </PageFormSection>

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupActions.tsx
@@ -6,27 +6,17 @@ import {
   usePageNavigate,
 } from '../../../../../framework';
 import { InventoryGroup } from '../../../interfaces/InventoryGroup';
-import { CodeIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { cannotDeleteResource, cannotEditResource } from '../../../../common/utils/RBAChelpers';
 import { useParams } from 'react-router-dom';
-import { useOptions } from '../../../../common/crud/useOptions';
-import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
-import { awxAPI } from '../../../common/api/awx-utils';
 import { useDeleteGroups } from '../../groups/hooks/useDeleteGroups';
 
 export function useInventoriesGroupActions() {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string }>();
-
-  const adHocOptions = useOptions<OptionsResponse<ActionsResponse>>(
-    awxAPI`/inventories/${params.id ?? ''}/ad_hoc_commands/`
-  ).data;
-  const canRunAdHocCommand = Boolean(
-    adHocOptions && adHocOptions.actions && adHocOptions.actions['POST']
-  );
 
   const onDelete = () => {
     pageNavigate(AwxRoute.InventoryGroups, {
@@ -58,33 +48,14 @@ export function useInventoriesGroupActions() {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: CodeIcon,
-        label: t('Run command'),
-        onClick: (group) =>
-          pageNavigate(AwxRoute.InventoryRunCommand, {
-            params: {
-              inventory_type: params.inventory_type,
-              id: group.inventory,
-              group_id: group.id,
-            },
-          }),
-        isDisabled: () =>
-          canRunAdHocCommand
-            ? undefined
-            : t(
-                'You do not have permission to run an ad hoc command. Please contact your organization administrator if there is an issue with your access.'
-              ),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
         icon: TrashIcon,
         label: t('Delete group'),
         isHidden: () => params.inventory_type === 'constructed_inventory',
         onClick: (group) => deleteGroups([group]),
         isDisabled: (group) => cannotDeleteResource(group, t),
+        isDanger: true,
       },
     ],
-    [t, pageNavigate, params.inventory_type, canRunAdHocCommand, deleteGroups]
+    [t, pageNavigate, params.inventory_type, deleteGroups]
   );
 }

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsToolbarActions.tsx
@@ -72,15 +72,16 @@ export function useInventoriesGroupsToolbarActions(view: IAwxView<InventoryGroup
       variant: ButtonVariant.secondary,
       isPinned: true,
       label: t('Run Command'),
-      onClick: () => pageNavigate(AwxRoute.Inventories),
+      onClick: () =>
+        pageNavigate(AwxRoute.InventoryRunCommand, {
+          params: { inventory_type: params.inventory_type, id: params.id },
+        }),
       isDisabled: () =>
-        view.selectedItems.length === 0
-          ? t('Select at least one item from the list')
-          : canRunAdHocCommand
-            ? undefined
-            : t(
-                'You do not have permission to run an ad hoc command. Please contact your organization administrator if there is an issue with your access.'
-              ),
+        canRunAdHocCommand
+          ? undefined
+          : t(
+              'You do not have permission to run an ad hoc command. Please contact your organization administrator if there is an issue with your access.'
+            ),
     });
 
     if (params.inventory_type === 'inventory') {

--- a/frontend/awx/resources/inventories/hooks/useInventoriesHostsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesHostsToolbarActions.tsx
@@ -65,7 +65,10 @@ export function useInventoriesHostsToolbarActions(view: IAwxView<AwxHost>) {
       variant: ButtonVariant.secondary,
       isPinned: true,
       label: t('Run Command'),
-      onClick: () => pageNavigate(AwxRoute.Inventories),
+      onClick: () =>
+        pageNavigate(AwxRoute.InventoryRunCommand, {
+          params: { inventory_type: params.inventory_type, id: params.id },
+        }),
       isDisabled: () =>
         canRunAdHocCommand
           ? undefined


### PR DESCRIPTION
This PR is for hooking up the run command buttons on the inventory host and groups toolbars to the run command wizard.
It also removes the inventory group page action to run a command because the run command wizard only runs commands against entire inventories. So having a run command page action on a group is not necessary in my opinion. The ability to run a command from the inventory groups page is also not there in the old UI