### PR TITLE
[AAP-23162] Add credentials test button

### DIFF
--- a/cypress/fixtures/credential_types.json
+++ b/cypress/fixtures/credential_types.json
@@ -1,8 +1,61 @@
 {
-  "count": 28,
-  "next": "/api/v2/credential_types/?page=2",
+  "count": 32,
+  "next": null,
   "previous": null,
   "results": [
+    {
+      "id": 32,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/32/",
+      "related": {
+        "created_by": "/api/v2/users/3/",
+        "modified_by": "/api/v2/users/3/",
+        "credentials": "/api/v2/credential_types/32/credentials/",
+        "activity_stream": "/api/v2/credential_types/32/activity_stream/"
+      },
+      "summary_fields": {
+        "created_by": {
+          "id": 3,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 3,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-13T17:40:18.292399Z",
+      "modified": "2024-05-13T17:40:18.292411Z",
+      "name": "00_Test_Details_Page",
+      "description": "",
+      "kind": "cloud",
+      "namespace": null,
+      "managed": false,
+      "inputs": {
+        "fields": [
+          {
+            "id": "username",
+            "type": "string",
+            "label": "Username"
+          },
+          {
+            "id": "password",
+            "type": "string",
+            "label": "Password",
+            "secret": true
+          }
+        ],
+        "required": ["username", "password"]
+      },
+      "injectors": {}
+    },
     {
       "id": 5,
       "type": "credential_type",
@@ -17,8 +70,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.576122Z",
-      "modified": "2022-12-09T15:25:33.576122Z",
+      "created": "2024-05-12T07:19:10.451304Z",
+      "modified": "2024-05-12T07:19:10.451304Z",
       "name": "Amazon Web Services",
       "description": "",
       "kind": "cloud",
@@ -50,6 +103,44 @@
       "injectors": {}
     },
     {
+      "id": 31,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/31/",
+      "related": {
+        "created_by": "/api/v2/users/3/",
+        "modified_by": "/api/v2/users/3/",
+        "credentials": "/api/v2/credential_types/31/credentials/",
+        "activity_stream": "/api/v2/credential_types/31/activity_stream/"
+      },
+      "summary_fields": {
+        "created_by": {
+          "id": 3,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 3,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-13T17:30:27.738542Z",
+      "modified": "2024-05-13T17:30:27.738555Z",
+      "name": "asdasasdas",
+      "description": "",
+      "kind": "cloud",
+      "namespace": null,
+      "managed": false,
+      "inputs": {},
+      "injectors": {}
+    },
+    {
       "id": 9,
       "type": "credential_type",
       "url": "/api/v2/credential_types/9/",
@@ -63,8 +154,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.583336Z",
-      "modified": "2022-12-09T15:25:33.583336Z",
+      "created": "2024-05-12T07:19:10.465492Z",
+      "modified": "2024-05-12T07:19:10.465492Z",
       "name": "Google Compute Engine",
       "description": "",
       "kind": "cloud",
@@ -112,8 +203,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.585085Z",
-      "modified": "2022-12-09T15:25:33.585085Z",
+      "created": "2024-05-12T07:19:10.467995Z",
+      "modified": "2024-05-12T07:19:10.467995Z",
       "name": "Microsoft Azure Resource Manager",
       "description": "",
       "kind": "cloud",
@@ -179,8 +270,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.577975Z",
-      "modified": "2022-12-09T15:25:33.577975Z",
+      "created": "2024-05-12T07:19:10.455548Z",
+      "modified": "2024-05-12T07:19:10.455548Z",
       "name": "OpenStack",
       "description": "",
       "kind": "cloud",
@@ -239,12 +330,12 @@
       "injectors": {}
     },
     {
-      "id": 15,
+      "id": 16,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/15/",
+      "url": "/api/v2/credential_types/16/",
       "related": {
-        "credentials": "/api/v2/credential_types/15/credentials/",
-        "activity_stream": "/api/v2/credential_types/15/activity_stream/"
+        "credentials": "/api/v2/credential_types/16/credentials/",
+        "activity_stream": "/api/v2/credential_types/16/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -252,8 +343,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.594251Z",
-      "modified": "2022-12-09T15:25:33.594251Z",
+      "created": "2024-05-12T07:19:10.483176Z",
+      "modified": "2024-05-12T07:19:10.483176Z",
       "name": "Red Hat Ansible Automation Platform",
       "description": "",
       "kind": "cloud",
@@ -324,8 +415,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.581527Z",
-      "modified": "2022-12-09T15:25:33.581527Z",
+      "created": "2024-05-12T07:19:10.462486Z",
+      "modified": "2024-05-12T07:19:10.462486Z",
       "name": "Red Hat Satellite 6",
       "description": "",
       "kind": "cloud",
@@ -356,12 +447,12 @@
       "injectors": {}
     },
     {
-      "id": 14,
+      "id": 15,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/14/",
+      "url": "/api/v2/credential_types/15/",
       "related": {
-        "credentials": "/api/v2/credential_types/14/credentials/",
-        "activity_stream": "/api/v2/credential_types/14/activity_stream/"
+        "credentials": "/api/v2/credential_types/15/credentials/",
+        "activity_stream": "/api/v2/credential_types/15/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -369,8 +460,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.592238Z",
-      "modified": "2022-12-09T15:25:33.592238Z",
+      "created": "2024-05-12T07:19:10.480551Z",
+      "modified": "2024-05-12T07:19:10.480551Z",
       "name": "Red Hat Virtualization",
       "description": "",
       "kind": "cloud",
@@ -417,41 +508,47 @@
       }
     },
     {
-      "id": 28,
+      "id": 21,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/28/",
+      "url": "/api/v2/credential_types/21/",
       "related": {
-        "created_by": "/api/v2/users/2/",
-        "modified_by": "/api/v2/users/2/",
-        "credentials": "/api/v2/credential_types/28/credentials/",
-        "activity_stream": "/api/v2/credential_types/28/activity_stream/"
+        "credentials": "/api/v2/credential_types/21/credentials/",
+        "activity_stream": "/api/v2/credential_types/21/activity_stream/"
       },
       "summary_fields": {
-        "created_by": {
-          "id": 2,
-          "username": "adminn",
-          "first_name": "",
-          "last_name": ""
-        },
-        "modified_by": {
-          "id": 2,
-          "username": "adminn",
-          "first_name": "",
-          "last_name": ""
-        },
         "user_capabilities": {
           "edit": true,
           "delete": true
         }
       },
-      "created": "2023-01-13T18:49:28.289451Z",
-      "modified": "2023-01-13T18:49:28.289465Z",
-      "name": "test",
+      "created": "2024-05-12T07:19:10.496069Z",
+      "modified": "2024-05-12T07:19:10.496069Z",
+      "name": "Terraform backend configuration",
       "description": "",
       "kind": "cloud",
-      "namespace": null,
-      "managed": false,
-      "inputs": {},
+      "namespace": "terraform",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "configuration",
+            "label": "Backend configuration",
+            "type": "string",
+            "secret": true,
+            "multiline": true,
+            "help_text": "Terraform backend config as Hashicorp configuration language."
+          },
+          {
+            "id": "gce_credentials",
+            "label": "Google Cloud Platform account credentials",
+            "type": "string",
+            "secret": true,
+            "multiline": true,
+            "help_text": "Google Cloud Platform account credentials in JSON format."
+          }
+        ],
+        "required": ["configuration"]
+      },
       "injectors": {}
     },
     {
@@ -468,8 +565,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.579757Z",
-      "modified": "2022-12-09T15:25:33.579757Z",
+      "created": "2024-05-12T07:19:10.459041Z",
+      "modified": "2024-05-12T07:19:10.459041Z",
       "name": "VMware vCenter",
       "description": "",
       "kind": "cloud",
@@ -500,12 +597,12 @@
       "injectors": {}
     },
     {
-      "id": 19,
+      "id": 20,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/19/",
+      "url": "/api/v2/credential_types/20/",
       "related": {
-        "credentials": "/api/v2/credential_types/19/credentials/",
-        "activity_stream": "/api/v2/credential_types/19/activity_stream/"
+        "credentials": "/api/v2/credential_types/20/credentials/",
+        "activity_stream": "/api/v2/credential_types/20/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -513,8 +610,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.601407Z",
-      "modified": "2022-12-09T15:25:33.601407Z",
+      "created": "2024-05-12T07:19:10.493899Z",
+      "modified": "2024-05-12T07:19:10.493899Z",
       "name": "GPG Public Key",
       "description": "",
       "kind": "cryptography",
@@ -536,12 +633,12 @@
       "injectors": {}
     },
     {
-      "id": 22,
+      "id": 23,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/22/",
+      "url": "/api/v2/credential_types/23/",
       "related": {
-        "credentials": "/api/v2/credential_types/22/credentials/",
-        "activity_stream": "/api/v2/credential_types/22/activity_stream/"
+        "credentials": "/api/v2/credential_types/23/credentials/",
+        "activity_stream": "/api/v2/credential_types/23/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -549,8 +646,60 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.607014Z",
-      "modified": "2022-12-09T15:25:33.607014Z",
+      "created": "2024-05-12T07:19:10.500434Z",
+      "modified": "2024-05-12T07:19:10.500434Z",
+      "name": "AWS Secrets Manager lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "aws_secretsmanager_credential",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "aws_access_key",
+            "label": "AWS Access Key",
+            "type": "string"
+          },
+          {
+            "id": "aws_secret_key",
+            "label": "AWS Secret Key",
+            "type": "string",
+            "secret": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "region_name",
+            "label": "AWS Secrets Manager Region",
+            "type": "string",
+            "help_text": "Region which the secrets manager is located"
+          },
+          {
+            "id": "secret_name",
+            "label": "AWS Secret Name",
+            "type": "string"
+          }
+        ],
+        "required": ["aws_access_key", "aws_secret_key", "region_name", "secret_name"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 25,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/25/",
+      "related": {
+        "credentials": "/api/v2/credential_types/25/credentials/",
+        "activity_stream": "/api/v2/credential_types/25/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.507889Z",
+      "modified": "2024-05-12T07:19:10.507889Z",
       "name": "Centrify Vault Credential Provider Lookup",
       "description": "",
       "kind": "external",
@@ -612,12 +761,12 @@
       "injectors": {}
     },
     {
-      "id": 20,
+      "id": 22,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/20/",
+      "url": "/api/v2/credential_types/22/",
       "related": {
-        "credentials": "/api/v2/credential_types/20/credentials/",
-        "activity_stream": "/api/v2/credential_types/20/activity_stream/"
+        "credentials": "/api/v2/credential_types/22/credentials/",
+        "activity_stream": "/api/v2/credential_types/22/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -625,9 +774,9 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.603404Z",
-      "modified": "2022-12-09T15:25:33.603404Z",
-      "name": "CyberArk AIM Central Credential Provider Lookup",
+      "created": "2024-05-12T07:19:10.498074Z",
+      "modified": "2024-05-12T07:19:10.498074Z",
+      "name": "CyberArk Central Credential Provider Lookup",
       "description": "",
       "kind": "external",
       "namespace": "aim",
@@ -636,9 +785,15 @@
         "fields": [
           {
             "id": "url",
-            "label": "CyberArk AIM URL",
+            "label": "CyberArk CCP URL",
             "type": "string",
             "format": "url"
+          },
+          {
+            "id": "webservice_id",
+            "label": "Web Service ID",
+            "type": "string",
+            "help_text": "The CCP Web Service ID. Leave blank to default to AIMWebService."
           },
           {
             "id": "app_id",
@@ -682,6 +837,12 @@
             "choices": ["Exact", "Regexp"]
           },
           {
+            "id": "object_property",
+            "label": "Object Property",
+            "type": "string",
+            "help_text": "The property of the object to return. Available properties: Username, Password and Address."
+          },
+          {
             "id": "reason",
             "label": "Reason",
             "type": "string",
@@ -693,12 +854,12 @@
       "injectors": {}
     },
     {
-      "id": 23,
+      "id": 26,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/23/",
+      "url": "/api/v2/credential_types/26/",
       "related": {
-        "credentials": "/api/v2/credential_types/23/credentials/",
-        "activity_stream": "/api/v2/credential_types/23/activity_stream/"
+        "credentials": "/api/v2/credential_types/26/credentials/",
+        "activity_stream": "/api/v2/credential_types/26/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -706,8 +867,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.608791Z",
-      "modified": "2022-12-09T15:25:33.608791Z",
+      "created": "2024-05-12T07:19:10.510795Z",
+      "modified": "2024-05-12T07:19:10.510795Z",
       "name": "CyberArk Conjur Secrets Manager Lookup",
       "description": "",
       "kind": "external",
@@ -763,12 +924,12 @@
       "injectors": {}
     },
     {
-      "id": 24,
+      "id": 27,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/24/",
+      "url": "/api/v2/credential_types/27/",
       "related": {
-        "credentials": "/api/v2/credential_types/24/credentials/",
-        "activity_stream": "/api/v2/credential_types/24/activity_stream/"
+        "credentials": "/api/v2/credential_types/27/credentials/",
+        "activity_stream": "/api/v2/credential_types/27/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -776,8 +937,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.610570Z",
-      "modified": "2022-12-09T15:25:33.610570Z",
+      "created": "2024-05-12T07:19:10.512914Z",
+      "modified": "2024-05-12T07:19:10.512914Z",
       "name": "HashiCorp Vault Secret Lookup",
       "description": "",
       "kind": "external",
@@ -822,6 +983,28 @@
             "help_text": "The Secret ID for AppRole Authentication"
           },
           {
+            "id": "client_cert_public",
+            "label": "Client Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The PEM-encoded client certificate used for TLS client authentication. This should include the certificate and any intermediate certififcates."
+          },
+          {
+            "id": "client_cert_private",
+            "label": "Client Certificate Key",
+            "type": "string",
+            "multiline": true,
+            "secret": true,
+            "help_text": "The certificate private key used for TLS client authentication."
+          },
+          {
+            "id": "client_cert_role",
+            "label": "TLS Authentication Role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The role configured in Hashicorp Vault for TLS client authentication. If not provided, Hashicorp Vault may assign roles based on the certificate used."
+          },
+          {
             "id": "namespace",
             "label": "Namespace name (Vault Enterprise only)",
             "type": "string",
@@ -834,6 +1017,20 @@
             "type": "string",
             "multiline": false,
             "help_text": "The Role for Kubernetes Authentication. This is the named role, configured in Vault server, for AWX pod auth policies. see https://www.vaultproject.io/docs/auth/kubernetes#configuration"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "type": "string",
+            "secret": false,
+            "help_text": "Username for user authentication."
+          },
+          {
+            "id": "password",
+            "label": "Password",
+            "type": "string",
+            "secret": true,
+            "help_text": "Password for user authentication."
           },
           {
             "id": "default_auth_path",
@@ -889,12 +1086,12 @@
       "injectors": {}
     },
     {
-      "id": 25,
+      "id": 28,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/25/",
+      "url": "/api/v2/credential_types/28/",
       "related": {
-        "credentials": "/api/v2/credential_types/25/credentials/",
-        "activity_stream": "/api/v2/credential_types/25/activity_stream/"
+        "credentials": "/api/v2/credential_types/28/credentials/",
+        "activity_stream": "/api/v2/credential_types/28/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -902,8 +1099,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.612341Z",
-      "modified": "2022-12-09T15:25:33.612341Z",
+      "created": "2024-05-12T07:19:10.514874Z",
+      "modified": "2024-05-12T07:19:10.514874Z",
       "name": "HashiCorp Vault Signed SSH",
       "description": "",
       "kind": "external",
@@ -948,6 +1145,28 @@
             "help_text": "The Secret ID for AppRole Authentication"
           },
           {
+            "id": "client_cert_public",
+            "label": "Client Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The PEM-encoded client certificate used for TLS client authentication. This should include the certificate and any intermediate certififcates."
+          },
+          {
+            "id": "client_cert_private",
+            "label": "Client Certificate Key",
+            "type": "string",
+            "multiline": true,
+            "secret": true,
+            "help_text": "The certificate private key used for TLS client authentication."
+          },
+          {
+            "id": "client_cert_role",
+            "label": "TLS Authentication Role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The role configured in Hashicorp Vault for TLS client authentication. If not provided, Hashicorp Vault may assign roles based on the certificate used."
+          },
+          {
             "id": "namespace",
             "label": "Namespace name (Vault Enterprise only)",
             "type": "string",
@@ -960,6 +1179,20 @@
             "type": "string",
             "multiline": false,
             "help_text": "The Role for Kubernetes Authentication. This is the named role, configured in Vault server, for AWX pod auth policies. see https://www.vaultproject.io/docs/auth/kubernetes#configuration"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "type": "string",
+            "secret": false,
+            "help_text": "Username for user authentication."
+          },
+          {
+            "id": "password",
+            "label": "Password",
+            "type": "string",
+            "secret": true,
+            "help_text": "Password for user authentication."
           },
           {
             "id": "default_auth_path",
@@ -1008,12 +1241,12 @@
       "injectors": {}
     },
     {
-      "id": 21,
+      "id": 24,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/21/",
+      "url": "/api/v2/credential_types/24/",
       "related": {
-        "credentials": "/api/v2/credential_types/21/credentials/",
-        "activity_stream": "/api/v2/credential_types/21/activity_stream/"
+        "credentials": "/api/v2/credential_types/24/credentials/",
+        "activity_stream": "/api/v2/credential_types/24/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1021,8 +1254,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.605177Z",
-      "modified": "2022-12-09T15:25:33.605177Z",
+      "created": "2024-05-12T07:19:10.504092Z",
+      "modified": "2024-05-12T07:19:10.504092Z",
       "name": "Microsoft Azure Key Vault",
       "description": "",
       "kind": "external",
@@ -1056,7 +1289,7 @@
             "id": "cloud_name",
             "label": "Cloud Environment",
             "help_text": "Specify which azure cloud environment to use.",
-            "choices": ["AzureCloud", "AzureUSGovernment", "AzureGermanCloud", "AzureChinaCloud"],
+            "choices": ["AzureGermanCloud", "AzureCloud", "AzureChinaCloud", "AzureUSGovernment"],
             "default": "AzureCloud"
           }
         ],
@@ -1079,12 +1312,12 @@
       "injectors": {}
     },
     {
-      "id": 26,
+      "id": 29,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/26/",
+      "url": "/api/v2/credential_types/29/",
       "related": {
-        "credentials": "/api/v2/credential_types/26/credentials/",
-        "activity_stream": "/api/v2/credential_types/26/activity_stream/"
+        "credentials": "/api/v2/credential_types/29/credentials/",
+        "activity_stream": "/api/v2/credential_types/29/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1092,8 +1325,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.614252Z",
-      "modified": "2022-12-09T15:25:33.614252Z",
+      "created": "2024-05-12T07:19:10.517178Z",
+      "modified": "2024-05-12T07:19:10.517178Z",
       "name": "Thycotic DevOps Secrets Vault",
       "description": "",
       "kind": "external",
@@ -1104,14 +1337,14 @@
           {
             "id": "tenant",
             "label": "Tenant",
-            "help_text": "The tenant e.g. \"ex\" when the URL is https://ex.secretservercloud.com",
+            "help_text": "The tenant e.g. \"ex\" when the URL is https://ex.secretsvaultcloud.com",
             "type": "string"
           },
           {
             "id": "tld",
             "label": "Top-level Domain (TLD)",
-            "help_text": "The TLD of the tenant e.g. \"com\" when the URL is https://ex.secretservercloud.com",
-            "choices": ["ca", "com", "com.au", "com.sg", "eu"],
+            "help_text": "The TLD of the tenant e.g. \"com\" when the URL is https://ex.secretsvaultcloud.com",
+            "choices": ["ca", "com", "com.au", "eu"],
             "default": "com"
           },
           {
@@ -1124,12 +1357,6 @@
             "label": "Client Secret",
             "type": "string",
             "secret": true
-          },
-          {
-            "id": "url_template",
-            "label": "URL template",
-            "type": "string",
-            "default": "https://{}.secretsvaultcloud.{}/v1"
           }
         ],
         "metadata": [
@@ -1138,19 +1365,40 @@
             "label": "Secret Path",
             "type": "string",
             "help_text": "The secret path e.g. /test/secret1"
+          },
+          {
+            "id": "secret_field",
+            "label": "Secret Field",
+            "help_text": "The field to extract from the secret",
+            "type": "string"
+          },
+          {
+            "id": "secret_decoding",
+            "label": "Should the secret be base64 decoded?",
+            "help_text": "Specify whether the secret should be base64 decoded, typically used for storing files, such as SSH keys",
+            "choices": ["No Decoding", "Decode Base64"],
+            "type": "string",
+            "default": "No Decoding"
           }
         ],
-        "required": ["tenant", "client_id", "client_secret", "path"]
+        "required": [
+          "tenant",
+          "client_id",
+          "client_secret",
+          "path",
+          "secret_field",
+          "secret_decoding"
+        ]
       },
       "injectors": {}
     },
     {
-      "id": 27,
+      "id": 30,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/27/",
+      "url": "/api/v2/credential_types/30/",
       "related": {
-        "credentials": "/api/v2/credential_types/27/credentials/",
-        "activity_stream": "/api/v2/credential_types/27/activity_stream/"
+        "credentials": "/api/v2/credential_types/30/credentials/",
+        "activity_stream": "/api/v2/credential_types/30/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1158,8 +1406,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.616015Z",
-      "modified": "2022-12-09T15:25:33.616015Z",
+      "created": "2024-05-12T07:19:10.519632Z",
+      "modified": "2024-05-12T07:19:10.519632Z",
       "name": "Thycotic Secret Server",
       "description": "",
       "kind": "external",
@@ -1177,6 +1425,12 @@
             "id": "username",
             "label": "Username",
             "help_text": "The (Application) user username",
+            "type": "string"
+          },
+          {
+            "id": "domain",
+            "label": "Domain",
+            "help_text": "The (Application) user domain",
             "type": "string"
           },
           {
@@ -1206,12 +1460,12 @@
       "injectors": {}
     },
     {
-      "id": 18,
+      "id": 19,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/18/",
+      "url": "/api/v2/credential_types/19/",
       "related": {
-        "credentials": "/api/v2/credential_types/18/credentials/",
-        "activity_stream": "/api/v2/credential_types/18/activity_stream/"
+        "credentials": "/api/v2/credential_types/19/credentials/",
+        "activity_stream": "/api/v2/credential_types/19/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1219,8 +1473,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.599656Z",
-      "modified": "2022-12-09T15:25:33.599656Z",
+      "created": "2024-05-12T07:19:10.491388Z",
+      "modified": "2024-05-12T07:19:10.491388Z",
       "name": "Ansible Galaxy/Automation Hub API Token",
       "description": "",
       "kind": "galaxy",
@@ -1253,12 +1507,12 @@
       "injectors": {}
     },
     {
-      "id": 13,
+      "id": 14,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/13/",
+      "url": "/api/v2/credential_types/14/",
       "related": {
-        "credentials": "/api/v2/credential_types/13/credentials/",
-        "activity_stream": "/api/v2/credential_types/13/activity_stream/"
+        "credentials": "/api/v2/credential_types/14/credentials/",
+        "activity_stream": "/api/v2/credential_types/14/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1266,8 +1520,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.590456Z",
-      "modified": "2022-12-09T15:25:33.590456Z",
+      "created": "2024-05-12T07:19:10.477875Z",
+      "modified": "2024-05-12T07:19:10.477875Z",
       "name": "Insights",
       "description": "",
       "kind": "insights",
@@ -1301,12 +1555,12 @@
       }
     },
     {
-      "id": 16,
+      "id": 17,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/16/",
+      "url": "/api/v2/credential_types/17/",
       "related": {
-        "credentials": "/api/v2/credential_types/16/credentials/",
-        "activity_stream": "/api/v2/credential_types/16/activity_stream/"
+        "credentials": "/api/v2/credential_types/17/credentials/",
+        "activity_stream": "/api/v2/credential_types/17/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1314,8 +1568,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.596034Z",
-      "modified": "2022-12-09T15:25:33.596034Z",
+      "created": "2024-05-12T07:19:10.485836Z",
+      "modified": "2024-05-12T07:19:10.485836Z",
       "name": "OpenShift or Kubernetes API Bearer Token",
       "description": "",
       "kind": "kubernetes",
@@ -1367,8 +1621,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.574339Z",
-      "modified": "2022-12-09T15:25:33.574339Z",
+      "created": "2024-05-12T07:19:10.446828Z",
+      "modified": "2024-05-12T07:19:10.446828Z",
       "name": "Network",
       "description": "",
       "kind": "net",
@@ -1421,12 +1675,12 @@
       "injectors": {}
     },
     {
-      "id": 17,
+      "id": 18,
       "type": "credential_type",
-      "url": "/api/v2/credential_types/17/",
+      "url": "/api/v2/credential_types/18/",
       "related": {
-        "credentials": "/api/v2/credential_types/17/credentials/",
-        "activity_stream": "/api/v2/credential_types/17/activity_stream/"
+        "credentials": "/api/v2/credential_types/18/credentials/",
+        "activity_stream": "/api/v2/credential_types/18/activity_stream/"
       },
       "summary_fields": {
         "user_capabilities": {
@@ -1434,8 +1688,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.597874Z",
-      "modified": "2022-12-09T15:25:33.597874Z",
+      "created": "2024-05-12T07:19:10.488679Z",
+      "modified": "2024-05-12T07:19:10.488679Z",
       "name": "Container Registry",
       "description": "",
       "kind": "registry",
@@ -1487,8 +1741,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.570660Z",
-      "modified": "2022-12-09T15:25:33.570660Z",
+      "created": "2024-05-12T07:19:10.440103Z",
+      "modified": "2024-05-12T07:19:10.440103Z",
       "name": "Source Control",
       "description": "",
       "kind": "scm",
@@ -1539,8 +1793,8 @@
           "delete": true
         }
       },
-      "created": "2022-12-09T15:25:33.568142Z",
-      "modified": "2022-12-09T15:25:33.568142Z",
+      "created": "2024-05-12T07:19:10.434499Z",
+      "modified": "2024-05-12T07:19:10.434499Z",
       "name": "Machine",
       "description": "",
       "kind": "ssh",
@@ -1601,6 +1855,153 @@
             "ask_at_runtime": true
           }
         ]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 13,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/13/",
+      "related": {
+        "credentials": "/api/v2/credential_types/13/credentials/",
+        "activity_stream": "/api/v2/credential_types/13/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.475312Z",
+      "modified": "2024-05-12T07:19:10.475312Z",
+      "name": "Bitbucket Data Center HTTP Access Token",
+      "description": "",
+      "kind": "token",
+      "namespace": "bitbucket_dc_token",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "This token needs to come from your user settings in Bitbucket"
+          }
+        ],
+        "required": ["token"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 11,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/11/",
+      "related": {
+        "credentials": "/api/v2/credential_types/11/credentials/",
+        "activity_stream": "/api/v2/credential_types/11/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.470223Z",
+      "modified": "2024-05-12T07:19:10.470223Z",
+      "name": "GitHub Personal Access Token",
+      "description": "",
+      "kind": "token",
+      "namespace": "github_token",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "This token needs to come from your profile settings in GitHub"
+          }
+        ],
+        "required": ["token"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 12,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/12/",
+      "related": {
+        "credentials": "/api/v2/credential_types/12/credentials/",
+        "activity_stream": "/api/v2/credential_types/12/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.472545Z",
+      "modified": "2024-05-12T07:19:10.472545Z",
+      "name": "GitLab Personal Access Token",
+      "description": "",
+      "kind": "token",
+      "namespace": "gitlab_token",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "This token needs to come from your profile settings in GitLab"
+          }
+        ],
+        "required": ["token"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 3,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/3/",
+      "related": {
+        "credentials": "/api/v2/credential_types/3/credentials/",
+        "activity_stream": "/api/v2/credential_types/3/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.444170Z",
+      "modified": "2024-05-12T07:19:10.444170Z",
+      "name": "Vault",
+      "description": "",
+      "kind": "vault",
+      "namespace": "vault",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "vault_password",
+            "label": "Vault Password",
+            "type": "string",
+            "secret": true,
+            "ask_at_runtime": true
+          },
+          {
+            "id": "vault_id",
+            "label": "Vault Identifier",
+            "type": "string",
+            "format": "vault_id",
+            "help_text": "Specify an (optional) Vault ID. This is equivalent to specifying the --vault-id Ansible parameter for providing multiple Vault passwords.  Note: this feature only works in Ansible 2.4+."
+          }
+        ],
+        "required": ["vault_password"]
       },
       "injectors": {}
     }

--- a/cypress/fixtures/externalCredential.json
+++ b/cypress/fixtures/externalCredential.json
@@ -1,0 +1,76 @@
+{
+  "id": 35,
+  "type": "credential",
+  "url": "/api/v2/credentials/35/",
+  "related": {
+    "named_url": "/api/v2/credentials/External credential++Centrify Vault Credential Provider Lookup+external++/",
+    "created_by": "/api/v2/users/3/",
+    "modified_by": "/api/v2/users/3/",
+    "activity_stream": "/api/v2/credentials/35/activity_stream/",
+    "access_list": "/api/v2/credentials/35/access_list/",
+    "object_roles": "/api/v2/credentials/35/object_roles/",
+    "owner_users": "/api/v2/credentials/35/owner_users/",
+    "owner_teams": "/api/v2/credentials/35/owner_teams/",
+    "copy": "/api/v2/credentials/35/copy/",
+    "input_sources": "/api/v2/credentials/35/input_sources/",
+    "credential_type": "/api/v2/credential_types/25/"
+  },
+  "summary_fields": {
+    "credential_type": {
+      "id": 25,
+      "name": "Centrify Vault Credential Provider Lookup",
+      "description": ""
+    },
+    "created_by": {
+      "id": 3,
+      "username": "dev",
+      "first_name": "",
+      "last_name": ""
+    },
+    "modified_by": {
+      "id": 3,
+      "username": "dev",
+      "first_name": "",
+      "last_name": ""
+    },
+    "object_roles": {
+      "admin_role": {
+        "description": "Can manage all aspects of the credential",
+        "name": "Admin",
+        "id": 3225
+      },
+      "use_role": {
+        "description": "Can use the credential in a job template",
+        "name": "Use",
+        "id": 3226
+      },
+      "read_role": {
+        "description": "May view settings for the credential",
+        "name": "Read",
+        "id": 3227
+      }
+    },
+    "user_capabilities": {
+      "edit": true,
+      "delete": true,
+      "copy": true,
+      "use": true
+    },
+    "owners": []
+  },
+  "created": "2024-05-14T01:48:51.895393Z",
+  "modified": "2024-05-14T01:48:51.895403Z",
+  "name": "External credential",
+  "description": "",
+  "organization": null,
+  "credential_type": 25,
+  "managed": false,
+  "inputs": {
+    "url": "http://foo.com",
+    "client_id": "foo",
+    "client_password": "$encrypted$"
+  },
+  "kind": "centrify_vault_kv",
+  "cloud": false,
+  "kubernetes": false
+}

--- a/cypress/fixtures/externalCredentialTypes.json
+++ b/cypress/fixtures/externalCredentialTypes.json
@@ -1,0 +1,834 @@
+{
+  "count": 8,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 23,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/23/",
+      "related": {
+        "credentials": "/api/v2/credential_types/23/credentials/",
+        "activity_stream": "/api/v2/credential_types/23/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.500434Z",
+      "modified": "2024-05-12T07:19:10.500434Z",
+      "name": "AWS Secrets Manager lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "aws_secretsmanager_credential",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "aws_access_key",
+            "label": "AWS Access Key",
+            "type": "string"
+          },
+          {
+            "id": "aws_secret_key",
+            "label": "AWS Secret Key",
+            "type": "string",
+            "secret": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "region_name",
+            "label": "AWS Secrets Manager Region",
+            "type": "string",
+            "help_text": "Region which the secrets manager is located"
+          },
+          {
+            "id": "secret_name",
+            "label": "AWS Secret Name",
+            "type": "string"
+          }
+        ],
+        "required": ["aws_access_key", "aws_secret_key", "region_name", "secret_name"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 25,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/25/",
+      "related": {
+        "credentials": "/api/v2/credential_types/25/credentials/",
+        "activity_stream": "/api/v2/credential_types/25/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.507889Z",
+      "modified": "2024-05-12T07:19:10.507889Z",
+      "name": "Centrify Vault Credential Provider Lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "centrify_vault_kv",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "Centrify Tenant URL",
+            "type": "string",
+            "help_text": "Centrify Tenant URL",
+            "format": "url"
+          },
+          {
+            "id": "client_id",
+            "label": "Centrify API User",
+            "type": "string",
+            "help_text": "Centrify API User, having necessary permissions as mentioned in support doc"
+          },
+          {
+            "id": "client_password",
+            "label": "Centrify API Password",
+            "type": "string",
+            "help_text": "Password of Centrify API User with necessary permissions",
+            "secret": true
+          },
+          {
+            "id": "oauth_application_id",
+            "label": "OAuth2 Application ID",
+            "type": "string",
+            "help_text": "Application ID of the configured OAuth2 Client (defaults to 'awx')",
+            "default": "awx"
+          },
+          {
+            "id": "oauth_scope",
+            "label": "OAuth2 Scope",
+            "type": "string",
+            "help_text": "Scope of the configured OAuth2 Client (defaults to 'awx')",
+            "default": "awx"
+          }
+        ],
+        "metadata": [
+          {
+            "id": "account-name",
+            "label": "Account Name",
+            "type": "string",
+            "help_text": "Local system account or Domain account name enrolled in Centrify Vault. eg. (root or DOMAIN/Administrator)"
+          },
+          {
+            "id": "system-name",
+            "label": "System Name",
+            "type": "string",
+            "help_text": "Machine Name enrolled with in Centrify Portal"
+          }
+        ],
+        "required": ["url", "account-name", "system-name", "client_id", "client_password"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 22,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/22/",
+      "related": {
+        "credentials": "/api/v2/credential_types/22/credentials/",
+        "activity_stream": "/api/v2/credential_types/22/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.498074Z",
+      "modified": "2024-05-12T07:19:10.498074Z",
+      "name": "CyberArk Central Credential Provider Lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "aim",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "CyberArk CCP URL",
+            "type": "string",
+            "format": "url"
+          },
+          {
+            "id": "webservice_id",
+            "label": "Web Service ID",
+            "type": "string",
+            "help_text": "The CCP Web Service ID. Leave blank to default to AIMWebService."
+          },
+          {
+            "id": "app_id",
+            "label": "Application ID",
+            "type": "string",
+            "secret": true
+          },
+          {
+            "id": "client_key",
+            "label": "Client Key",
+            "type": "string",
+            "secret": true,
+            "multiline": true
+          },
+          {
+            "id": "client_cert",
+            "label": "Client Certificate",
+            "type": "string",
+            "secret": true,
+            "multiline": true
+          },
+          {
+            "id": "verify",
+            "label": "Verify SSL Certificates",
+            "type": "boolean",
+            "default": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "object_query",
+            "label": "Object Query",
+            "type": "string",
+            "help_text": "Lookup query for the object. Ex: Safe=TestSafe;Object=testAccountName123"
+          },
+          {
+            "id": "object_query_format",
+            "label": "Object Query Format",
+            "type": "string",
+            "default": "Exact",
+            "choices": ["Exact", "Regexp"]
+          },
+          {
+            "id": "object_property",
+            "label": "Object Property",
+            "type": "string",
+            "help_text": "The property of the object to return. Available properties: Username, Password and Address."
+          },
+          {
+            "id": "reason",
+            "label": "Reason",
+            "type": "string",
+            "help_text": "Object request reason. This is only needed if it is required by the object's policy."
+          }
+        ],
+        "required": ["url", "app_id", "object_query"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 26,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/26/",
+      "related": {
+        "credentials": "/api/v2/credential_types/26/credentials/",
+        "activity_stream": "/api/v2/credential_types/26/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.510795Z",
+      "modified": "2024-05-12T07:19:10.510795Z",
+      "name": "CyberArk Conjur Secrets Manager Lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "conjur",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "Conjur URL",
+            "type": "string",
+            "format": "url"
+          },
+          {
+            "id": "api_key",
+            "label": "API Key",
+            "type": "string",
+            "secret": true
+          },
+          {
+            "id": "account",
+            "label": "Account",
+            "type": "string"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "type": "string"
+          },
+          {
+            "id": "cacert",
+            "label": "Public Key Certificate",
+            "type": "string",
+            "multiline": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "secret_path",
+            "label": "Secret Identifier",
+            "type": "string",
+            "help_text": "The identifier for the secret e.g., /some/identifier"
+          },
+          {
+            "id": "secret_version",
+            "label": "Secret Version",
+            "type": "string",
+            "help_text": "Used to specify a specific secret version (if left empty, the latest version will be used)."
+          }
+        ],
+        "required": ["url", "api_key", "account", "username"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 27,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/27/",
+      "related": {
+        "credentials": "/api/v2/credential_types/27/credentials/",
+        "activity_stream": "/api/v2/credential_types/27/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.512914Z",
+      "modified": "2024-05-12T07:19:10.512914Z",
+      "name": "HashiCorp Vault Secret Lookup",
+      "description": "",
+      "kind": "external",
+      "namespace": "hashivault_kv",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "Server URL",
+            "type": "string",
+            "format": "url",
+            "help_text": "The URL to the HashiCorp Vault"
+          },
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "The access token used to authenticate to the Vault server"
+          },
+          {
+            "id": "cacert",
+            "label": "CA Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The CA certificate used to verify the SSL certificate of the Vault server"
+          },
+          {
+            "id": "role_id",
+            "label": "AppRole role_id",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The Role ID for AppRole Authentication"
+          },
+          {
+            "id": "secret_id",
+            "label": "AppRole secret_id",
+            "type": "string",
+            "multiline": false,
+            "secret": true,
+            "help_text": "The Secret ID for AppRole Authentication"
+          },
+          {
+            "id": "client_cert_public",
+            "label": "Client Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The PEM-encoded client certificate used for TLS client authentication. This should include the certificate and any intermediate certififcates."
+          },
+          {
+            "id": "client_cert_private",
+            "label": "Client Certificate Key",
+            "type": "string",
+            "multiline": true,
+            "secret": true,
+            "help_text": "The certificate private key used for TLS client authentication."
+          },
+          {
+            "id": "client_cert_role",
+            "label": "TLS Authentication Role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The role configured in Hashicorp Vault for TLS client authentication. If not provided, Hashicorp Vault may assign roles based on the certificate used."
+          },
+          {
+            "id": "namespace",
+            "label": "Namespace name (Vault Enterprise only)",
+            "type": "string",
+            "multiline": false,
+            "help_text": "Name of the namespace to use when authenticate and retrieve secrets"
+          },
+          {
+            "id": "kubernetes_role",
+            "label": "Kubernetes role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The Role for Kubernetes Authentication. This is the named role, configured in Vault server, for AWX pod auth policies. see https://www.vaultproject.io/docs/auth/kubernetes#configuration"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "type": "string",
+            "secret": false,
+            "help_text": "Username for user authentication."
+          },
+          {
+            "id": "password",
+            "label": "Password",
+            "type": "string",
+            "secret": true,
+            "help_text": "Password for user authentication."
+          },
+          {
+            "id": "default_auth_path",
+            "label": "Path to Auth",
+            "type": "string",
+            "multiline": false,
+            "default": "approle",
+            "help_text": "The Authentication path to use if one isn't provided in the metadata when linking to an input field. Defaults to 'approle'"
+          },
+          {
+            "id": "api_version",
+            "label": "API Version",
+            "choices": ["v1", "v2"],
+            "help_text": "API v1 is for static key/value lookups.  API v2 is for versioned key/value lookups.",
+            "default": "v1"
+          }
+        ],
+        "metadata": [
+          {
+            "id": "secret_backend",
+            "label": "Name of Secret Backend",
+            "type": "string",
+            "help_text": "The name of the kv secret backend (if left empty, the first segment of the secret path will be used)."
+          },
+          {
+            "id": "secret_path",
+            "label": "Path to Secret",
+            "type": "string",
+            "help_text": "The path to the secret stored in the secret backend e.g, /some/secret/. It is recommended that you use the secret backend field to identify the storage backend and to use this field for locating a specific secret within that store. However, if you prefer to fully identify both the secret backend and one of its secrets using only this field, join their locations into a single path without any additional separators, e.g, /location/of/backend/some/secret."
+          },
+          {
+            "id": "auth_path",
+            "label": "Path to Auth",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The path where the Authentication method is mounted e.g, approle"
+          },
+          {
+            "id": "secret_key",
+            "label": "Key Name",
+            "type": "string",
+            "help_text": "The name of the key to look up in the secret."
+          },
+          {
+            "id": "secret_version",
+            "label": "Secret Version (v2 only)",
+            "type": "string",
+            "help_text": "Used to specify a specific secret version (if left empty, the latest version will be used)."
+          }
+        ],
+        "required": ["url", "secret_path", "api_version", "secret_key"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 28,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/28/",
+      "related": {
+        "credentials": "/api/v2/credential_types/28/credentials/",
+        "activity_stream": "/api/v2/credential_types/28/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.514874Z",
+      "modified": "2024-05-12T07:19:10.514874Z",
+      "name": "HashiCorp Vault Signed SSH",
+      "description": "",
+      "kind": "external",
+      "namespace": "hashivault_ssh",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "Server URL",
+            "type": "string",
+            "format": "url",
+            "help_text": "The URL to the HashiCorp Vault"
+          },
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "The access token used to authenticate to the Vault server"
+          },
+          {
+            "id": "cacert",
+            "label": "CA Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The CA certificate used to verify the SSL certificate of the Vault server"
+          },
+          {
+            "id": "role_id",
+            "label": "AppRole role_id",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The Role ID for AppRole Authentication"
+          },
+          {
+            "id": "secret_id",
+            "label": "AppRole secret_id",
+            "type": "string",
+            "multiline": false,
+            "secret": true,
+            "help_text": "The Secret ID for AppRole Authentication"
+          },
+          {
+            "id": "client_cert_public",
+            "label": "Client Certificate",
+            "type": "string",
+            "multiline": true,
+            "help_text": "The PEM-encoded client certificate used for TLS client authentication. This should include the certificate and any intermediate certififcates."
+          },
+          {
+            "id": "client_cert_private",
+            "label": "Client Certificate Key",
+            "type": "string",
+            "multiline": true,
+            "secret": true,
+            "help_text": "The certificate private key used for TLS client authentication."
+          },
+          {
+            "id": "client_cert_role",
+            "label": "TLS Authentication Role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The role configured in Hashicorp Vault for TLS client authentication. If not provided, Hashicorp Vault may assign roles based on the certificate used."
+          },
+          {
+            "id": "namespace",
+            "label": "Namespace name (Vault Enterprise only)",
+            "type": "string",
+            "multiline": false,
+            "help_text": "Name of the namespace to use when authenticate and retrieve secrets"
+          },
+          {
+            "id": "kubernetes_role",
+            "label": "Kubernetes role",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The Role for Kubernetes Authentication. This is the named role, configured in Vault server, for AWX pod auth policies. see https://www.vaultproject.io/docs/auth/kubernetes#configuration"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "type": "string",
+            "secret": false,
+            "help_text": "Username for user authentication."
+          },
+          {
+            "id": "password",
+            "label": "Password",
+            "type": "string",
+            "secret": true,
+            "help_text": "Password for user authentication."
+          },
+          {
+            "id": "default_auth_path",
+            "label": "Path to Auth",
+            "type": "string",
+            "multiline": false,
+            "default": "approle",
+            "help_text": "The Authentication path to use if one isn't provided in the metadata when linking to an input field. Defaults to 'approle'"
+          }
+        ],
+        "metadata": [
+          {
+            "id": "public_key",
+            "label": "Unsigned Public Key",
+            "type": "string",
+            "multiline": true
+          },
+          {
+            "id": "secret_path",
+            "label": "Path to Secret",
+            "type": "string",
+            "help_text": "The path to the secret stored in the secret backend e.g, /some/secret/. It is recommended that you use the secret backend field to identify the storage backend and to use this field for locating a specific secret within that store. However, if you prefer to fully identify both the secret backend and one of its secrets using only this field, join their locations into a single path without any additional separators, e.g, /location/of/backend/some/secret."
+          },
+          {
+            "id": "auth_path",
+            "label": "Path to Auth",
+            "type": "string",
+            "multiline": false,
+            "help_text": "The path where the Authentication method is mounted e.g, approle"
+          },
+          {
+            "id": "role",
+            "label": "Role Name",
+            "type": "string",
+            "help_text": "The name of the role used to sign."
+          },
+          {
+            "id": "valid_principals",
+            "label": "Valid Principals",
+            "type": "string",
+            "help_text": "Valid principals (either usernames or hostnames) that the certificate should be signed for."
+          }
+        ],
+        "required": ["url", "secret_path", "public_key", "role"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 24,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/24/",
+      "related": {
+        "credentials": "/api/v2/credential_types/24/credentials/",
+        "activity_stream": "/api/v2/credential_types/24/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.504092Z",
+      "modified": "2024-05-12T07:19:10.504092Z",
+      "name": "Microsoft Azure Key Vault",
+      "description": "",
+      "kind": "external",
+      "namespace": "azure_kv",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "url",
+            "label": "Vault URL (DNS Name)",
+            "type": "string",
+            "format": "url"
+          },
+          {
+            "id": "client",
+            "label": "Client ID",
+            "type": "string"
+          },
+          {
+            "id": "secret",
+            "label": "Client Secret",
+            "type": "string",
+            "secret": true
+          },
+          {
+            "id": "tenant",
+            "label": "Tenant ID",
+            "type": "string"
+          },
+          {
+            "id": "cloud_name",
+            "label": "Cloud Environment",
+            "help_text": "Specify which azure cloud environment to use.",
+            "choices": ["AzureGermanCloud", "AzureCloud", "AzureChinaCloud", "AzureUSGovernment"],
+            "default": "AzureCloud"
+          }
+        ],
+        "metadata": [
+          {
+            "id": "secret_field",
+            "label": "Secret Name",
+            "type": "string",
+            "help_text": "The name of the secret to look up."
+          },
+          {
+            "id": "secret_version",
+            "label": "Secret Version",
+            "type": "string",
+            "help_text": "Used to specify a specific secret version (if left empty, the latest version will be used)."
+          }
+        ],
+        "required": ["url", "client", "secret", "tenant", "secret_field"]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 29,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/29/",
+      "related": {
+        "credentials": "/api/v2/credential_types/29/credentials/",
+        "activity_stream": "/api/v2/credential_types/29/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.517178Z",
+      "modified": "2024-05-12T07:19:10.517178Z",
+      "name": "Thycotic DevOps Secrets Vault",
+      "description": "",
+      "kind": "external",
+      "namespace": "thycotic_dsv",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "tenant",
+            "label": "Tenant",
+            "help_text": "The tenant e.g. \"ex\" when the URL is https://ex.secretsvaultcloud.com",
+            "type": "string"
+          },
+          {
+            "id": "tld",
+            "label": "Top-level Domain (TLD)",
+            "help_text": "The TLD of the tenant e.g. \"com\" when the URL is https://ex.secretsvaultcloud.com",
+            "choices": ["ca", "com", "com.au", "eu"],
+            "default": "com"
+          },
+          {
+            "id": "client_id",
+            "label": "Client ID",
+            "type": "string"
+          },
+          {
+            "id": "client_secret",
+            "label": "Client Secret",
+            "type": "string",
+            "secret": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "path",
+            "label": "Secret Path",
+            "type": "string",
+            "help_text": "The secret path e.g. /test/secret1"
+          },
+          {
+            "id": "secret_field",
+            "label": "Secret Field",
+            "help_text": "The field to extract from the secret",
+            "type": "string"
+          },
+          {
+            "id": "secret_decoding",
+            "label": "Should the secret be base64 decoded?",
+            "help_text": "Specify whether the secret should be base64 decoded, typically used for storing files, such as SSH keys",
+            "choices": ["No Decoding", "Decode Base64"],
+            "type": "string",
+            "default": "No Decoding"
+          }
+        ],
+        "required": [
+          "tenant",
+          "client_id",
+          "client_secret",
+          "path",
+          "secret_field",
+          "secret_decoding"
+        ]
+      },
+      "injectors": {}
+    },
+    {
+      "id": 30,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/30/",
+      "related": {
+        "credentials": "/api/v2/credential_types/30/credentials/",
+        "activity_stream": "/api/v2/credential_types/30/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-05-12T07:19:10.519632Z",
+      "modified": "2024-05-12T07:19:10.519632Z",
+      "name": "Thycotic Secret Server",
+      "description": "",
+      "kind": "external",
+      "namespace": "thycotic_tss",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "server_url",
+            "label": "Secret Server URL",
+            "help_text": "The Base URL of Secret Server e.g. https://myserver/SecretServer or https://mytenant.secretservercloud.com",
+            "type": "string"
+          },
+          {
+            "id": "username",
+            "label": "Username",
+            "help_text": "The (Application) user username",
+            "type": "string"
+          },
+          {
+            "id": "domain",
+            "label": "Domain",
+            "help_text": "The (Application) user domain",
+            "type": "string"
+          },
+          {
+            "id": "password",
+            "label": "Password",
+            "help_text": "The corresponding password",
+            "type": "string",
+            "secret": true
+          }
+        ],
+        "metadata": [
+          {
+            "id": "secret_id",
+            "label": "Secret ID",
+            "help_text": "The integer ID of the secret",
+            "type": "string"
+          },
+          {
+            "id": "secret_field",
+            "label": "Secret Field",
+            "help_text": "The field to extract from the secret",
+            "type": "string"
+          }
+        ],
+        "required": ["server_url", "username", "password", "secret_id", "secret_field"]
+      },
+      "injectors": {}
+    }
+  ]
+}

--- a/framework/PageForm/GenericForm.tsx
+++ b/framework/PageForm/GenericForm.tsx
@@ -34,7 +34,7 @@ export function GenericForm<T extends object>(props: GenericFormProps<T>) {
         onSubmit={handleSubmit(async (data) => {
           setError(null);
           try {
-            await props.onSubmit(data, (error) => setError(error), setFieldError, undefined);
+            await props.onSubmit(data, (error) => setError(error), setFieldError);
           } catch (err) {
             handleSubmitError(err);
           }

--- a/framework/PageForm/GenericForm.tsx
+++ b/framework/PageForm/GenericForm.tsx
@@ -34,7 +34,7 @@ export function GenericForm<T extends object>(props: GenericFormProps<T>) {
         onSubmit={handleSubmit(async (data) => {
           setError(null);
           try {
-            await props.onSubmit(data, (error) => setError(error), setFieldError);
+            await props.onSubmit(data, (error) => setError(error), setFieldError, undefined);
           } catch (err) {
             handleSubmitError(err);
           }

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -172,7 +172,7 @@ export function CreateCredential() {
         submitText={t('Create credential')}
         onSubmit={onSubmit}
         onCancel={() => navigate(-1)}
-        additionalActionText={isExternalCredential ? 'Test' : undefined}
+        additionalActionText={isExternalCredential ? t('Test') : undefined}
         onClickAdditionalAction={(e) => {
           e.preventDefault();
           openCredentialsExternalTestModal({
@@ -394,7 +394,7 @@ export function EditCredential() {
         onSubmit={onSubmit}
         onCancel={() => navigate(-1)}
         defaultValue={initialValues}
-        additionalActionText={isExternalCredential ? 'Test' : undefined}
+        additionalActionText={isExternalCredential ? t('Test') : undefined}
         onClickAdditionalAction={(e) => {
           e.preventDefault();
           openCredentialsExternalTestModal({

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -73,6 +73,7 @@ export function CreateCredential() {
   const postRequest = usePostRequest<Credential | CredentialInputSource>();
   const getPageUrl = useGetPageUrl();
   const [selectedCredentialTypeId, setSelectedCredentialTypeId] = useState<number>(0);
+  const [watchedSubFormFields, setWatchedSubFormFields] = useState<unknown[]>([]);
   const alertToaster = usePageAlertToaster();
   const openCredentialsExternalTestModal = useCredentialsTestModal(alertToaster);
   const [credentialPluginValues, setCredentialPluginValues] = useState<
@@ -177,7 +178,7 @@ export function CreateCredential() {
         additionalActions={
           isExternalCredential ? (
             <Button
-              aria-label={'Test'}
+              aria-label={t('Test')}
               variant="secondary"
               onClick={(e) => {
                 e.preventDefault();
@@ -186,11 +187,12 @@ export function CreateCredential() {
                     parsedCredentialTypes !== undefined
                       ? parsedCredentialTypes?.[selectedCredentialTypeId]
                       : ({} as CredentialType),
+                  watchedSubFormFields: watchedSubFormFields,
                 });
               }}
               isDisabled={!isTestButtonEnabled || !isTestButtonEnabledSubForm}
             >
-              Test
+              {t('Test')}
             </Button>
           ) : undefined
         }
@@ -204,6 +206,7 @@ export function CreateCredential() {
           setSelectedCredentialTypeId={setSelectedCredentialTypeId}
           setIsTestButtonEnabled={setIsTestButtonEnabled}
           setIsTestButtonEnabledSubForm={setIsTestButtonEnabledSubForm}
+          setWatchedSubFormFields={setWatchedSubFormFields}
         />
       </AwxPageForm>
     </PageLayout>
@@ -253,6 +256,7 @@ export function EditCredential() {
   const openCredentialsExternalTestModal = useCredentialsTestModal(alertToaster);
   const [isTestButtonEnabled, setIsTestButtonEnabled] = useState(false);
   const [isTestButtonEnabledSubForm, setIsTestButtonEnabledSubForm] = useState(false);
+  const [watchedSubFormFields, setWatchedSubFormFields] = useState<unknown[]>([]);
 
   const { data: credential, isLoading: isLoadingCredential } = useGet<Credential>(
     awxAPI`/credentials/${id.toString()}/`
@@ -413,7 +417,7 @@ export function EditCredential() {
         additionalActions={
           isExternalCredential ? (
             <Button
-              aria-label={'Test'}
+              aria-label={t('Test')}
               variant="secondary"
               onClick={(e) => {
                 e.preventDefault();
@@ -423,11 +427,12 @@ export function EditCredential() {
                     parsedCredentialTypes !== undefined
                       ? parsedCredentialTypes?.[credential?.credential_type]
                       : ({} as CredentialType),
+                  watchedSubFormFields: watchedSubFormFields,
                 });
               }}
               isDisabled={!isTestButtonEnabled || !isTestButtonEnabledSubForm}
             >
-              Test
+              {t('Test')}
             </Button>
           ) : undefined
         }
@@ -442,6 +447,7 @@ export function EditCredential() {
           setPluginsToDelete={setPluginsToDelete}
           setIsTestButtonEnabled={setIsTestButtonEnabled}
           setIsTestButtonEnabledSubForm={setIsTestButtonEnabledSubForm}
+          setWatchedSubFormFields={setWatchedSubFormFields}
         />
       </AwxPageForm>
     </PageLayout>
@@ -459,6 +465,7 @@ function CredentialInputs({
   setSelectedCredentialTypeId,
   setIsTestButtonEnabled,
   setIsTestButtonEnabledSubForm,
+  setWatchedSubFormFields,
 }: {
   isEditMode?: boolean;
   selectedCredentialTypeId?: number;
@@ -470,6 +477,7 @@ function CredentialInputs({
   setSelectedCredentialTypeId?: (id: number) => void;
   setIsTestButtonEnabled: (enabled: boolean) => void;
   setIsTestButtonEnabledSubForm: (enabled: boolean) => void;
+  setWatchedSubFormFields: (fields: unknown[]) => void;
 }) {
   const { t } = useTranslation();
 
@@ -544,6 +552,7 @@ function CredentialInputs({
           setAccumulatedPluginValues={setAccumulatedPluginValues}
           setPluginsToDelete={setPluginsToDelete}
           setIsTestButtonEnabledSubForm={setIsTestButtonEnabledSubForm}
+          setWatchedSubFormFields={setWatchedSubFormFields}
         />
       ) : null}
     </>
@@ -557,14 +566,16 @@ function CredentialSubForm({
   setAccumulatedPluginValues,
   setPluginsToDelete,
   setIsTestButtonEnabledSubForm,
+  setWatchedSubFormFields,
 }: {
-  credentialType: CredentialType | undefined;
+  credentialType: CredentialType;
   setCredentialPluginValues: (values: CredentialPluginsInputSource[]) => void;
   isEditMode?: boolean;
   accumulatedPluginValues: CredentialPluginsInputSource[];
   setAccumulatedPluginValues?: (values: CredentialPluginsInputSource[]) => void;
   setPluginsToDelete?: React.Dispatch<React.SetStateAction<string[]>>;
   setIsTestButtonEnabledSubForm: (enabled: boolean) => void;
+  setWatchedSubFormFields: (fields: unknown[]) => void;
 }) {
   const { t } = useTranslation();
   const openCredentialPluginsModal = useCredentialPluginsModal();
@@ -572,10 +583,14 @@ function CredentialSubForm({
   const requiredFieldsInSubForm = credentialType.inputs.fields.filter((field) =>
     requiredFields.includes(field.id)
   );
+  const subFormFields = credentialType.inputs.fields.map((field) => field.id);
 
   const watchedRequiredFields = useWatch({
     name: requiredFields,
   });
+
+  const watchedAllFields = useWatch({ name: subFormFields });
+  setWatchedSubFormFields(watchedAllFields);
 
   useEffect(() => {
     const verify: string[] = [];

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -9,6 +9,7 @@ import {
   PageHeader,
   PageLayout,
   useGetPageUrl,
+  usePageAlertToaster,
   usePageNavigate,
 } from '../../../../framework';
 import { PageFormTextInput } from '../../../../framework/PageForm/Inputs/PageFormTextInput';
@@ -72,7 +73,8 @@ export function CreateCredential() {
   const postRequest = usePostRequest<Credential | CredentialInputSource>();
   const getPageUrl = useGetPageUrl();
   const [selectedCredentialTypeId, setSelectedCredentialTypeId] = useState<number>(0);
-  const openCredentialsExternalTestModal = useCredentialsTestModal();
+  const alertToaster = usePageAlertToaster();
+  const openCredentialsExternalTestModal = useCredentialsTestModal(alertToaster);
   const [credentialPluginValues, setCredentialPluginValues] = useState<
     CredentialPluginsInputSource[]
   >([]);
@@ -233,7 +235,8 @@ export function EditCredential() {
       return updatedValues;
     });
   }, [credentialPluginValues]);
-  const openCredentialsExternalTestModal = useCredentialsTestModal();
+  const alertToaster = usePageAlertToaster();
+  const openCredentialsExternalTestModal = useCredentialsTestModal(alertToaster);
 
   const { data: credential, isLoading: isLoadingCredential } = useGet<Credential>(
     awxAPI`/credentials/${id.toString()}/`

--- a/frontend/awx/access/credentials/hooks/useCredentialsTestModal.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialsTestModal.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+import { usePageDialogs } from '../../../../../framework';
+import {
+  CredentialsExternalTestModalProps,
+  CredentialsExternalTestModal,
+} from '../utils/CredentialsExternalTestModal';
+
+export function useCredentialsTestModal() {
+  const { pushDialog, popDialog } = usePageDialogs();
+  const [props, setProps] = useState<CredentialsExternalTestModalProps>();
+
+  useEffect(() => {
+    if (props) {
+      pushDialog(<CredentialsExternalTestModal {...{ ...props, popDialog: popDialog }} />);
+    } else {
+      popDialog();
+    }
+  }, [props, pushDialog, popDialog]);
+
+  return setProps;
+}

--- a/frontend/awx/access/credentials/hooks/useCredentialsTestModal.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialsTestModal.tsx
@@ -1,21 +1,23 @@
 import { useState, useEffect } from 'react';
-import { usePageDialogs } from '../../../../../framework';
+import { IPageAlertToaster, usePageDialogs } from '../../../../../framework';
 import {
   CredentialsExternalTestModalProps,
   CredentialsExternalTestModal,
 } from '../utils/CredentialsExternalTestModal';
 
-export function useCredentialsTestModal() {
+export function useCredentialsTestModal(alertToaster: IPageAlertToaster) {
   const { pushDialog, popDialog } = usePageDialogs();
   const [props, setProps] = useState<CredentialsExternalTestModalProps>();
 
   useEffect(() => {
     if (props) {
-      pushDialog(<CredentialsExternalTestModal {...{ ...props, popDialog: popDialog }} />);
+      pushDialog(
+        <CredentialsExternalTestModal {...{ ...props, popDialog: popDialog, alertToaster }} />
+      );
     } else {
       popDialog();
     }
-  }, [props, pushDialog, popDialog]);
+  }, [props, pushDialog, popDialog, alertToaster]);
 
   return setProps;
 }

--- a/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.cy.tsx
+++ b/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.cy.tsx
@@ -1,0 +1,297 @@
+import { CreateCredential, EditCredential } from '../CredentialForm';
+
+describe('CredentialsExternalTestModal.tsx', () => {
+  beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/v2/credential_types/*',
+      },
+      {
+        fixture: 'externalCredentialTypes.json',
+      }
+    );
+  });
+
+  it('External test modal opens when test button is selected in create credential form', () => {
+    cy.mount(<CreateCredential />);
+    cy.getByDataCy('name').type('foo');
+    cy.getByDataCy('credential_type').click();
+    cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
+    cy.getByDataCy('url').type('http://foo.com');
+    cy.getByDataCy('client-id').type('foo');
+    cy.getByDataCy('client-password').type('foo');
+    cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+    cy.contains('Test external credential').should('be.visible');
+  });
+
+  it('External test modal opens when test button is selected in edit credential form', () => {
+    cy.intercept('GET', '/api/v2/credentials/35/', { fixture: 'externalCredential.json' }).as(
+      'getCredential'
+    );
+    cy.mount(<EditCredential />, {
+      path: '/:id/',
+      initialEntries: ['/35'],
+    });
+    cy.wait('@getCredential');
+    cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+    cy.contains('Test external credential').should('be.visible');
+  });
+
+  it('Test button is disabled when required fields are not completed when creating a new credential', () => {
+    cy.mount(<CreateCredential />);
+    cy.getByDataCy('name').type('foo');
+    cy.getByDataCy('credential_type').click();
+    cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
+    cy.getByDataCy('url').type('http://foo.com');
+    cy.getByDataCy('client-id').type('foo');
+    cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('Test button is disabled when required fields are not completed when editing an existing credential', () => {
+    cy.intercept('GET', '/api/v2/credentials/35/', { fixture: 'externalCredential.json' }).as(
+      'getCredential'
+    );
+    cy.mount(<EditCredential />, {
+      path: '/:id/',
+      initialEntries: ['/35'],
+    });
+    cy.wait('@getCredential');
+    cy.getByDataCy('name').clear();
+    cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('Renders test button for all external credential types', () => {
+    const credentialTypes = [
+      'aws-secrets-manager-lookup',
+      'centrify-vault-credential-provider-lookup',
+      'cyberark-central-credential-provider-lookup',
+      'cyberark-conjur-secrets-manager-lookup',
+      'hashicorp-vault-secret-lookup',
+      'hashicorp-vault-signed-ssh',
+      'microsoft-azure-key-vault',
+      'thycotic-devops-secrets-vault',
+      'thycotic-secret-server',
+    ];
+    cy.mount(<CreateCredential />);
+    cy.getByDataCy('name').type('foo');
+    credentialTypes.forEach((type) => {
+      cy.getByDataCy('credential_type').click();
+      cy.getByDataCy(type).click();
+      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'true');
+    });
+  });
+
+  it('Renders correct fields in modal for each credential type', () => {
+    const credentialTypes = [
+      {
+        name: 'aws-secrets-manager-lookup',
+        inputs: {
+          fields: [
+            {
+              id: 'aws-access-key',
+              input: 'foo',
+            },
+            {
+              id: 'aws-secret-key',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['region-name', 'secret-name'],
+        },
+      },
+      {
+        name: 'centrify-vault-credential-provider-lookup',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'client-id',
+              input: 'foo',
+            },
+            {
+              id: 'client-password',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['account-name', 'system-name'],
+        },
+      },
+      {
+        name: 'cyberark-central-credential-provider-lookup',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'app-id',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['object-query', 'object-query-format', 'object-property', 'reason'],
+        },
+      },
+      {
+        name: 'cyberark-conjur-secrets-manager-lookup',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'api-key',
+              input: 'foo',
+            },
+            {
+              id: 'account',
+              input: 'foo',
+            },
+            {
+              id: 'username',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['secret-path', 'secret-version'],
+        },
+      },
+      {
+        name: 'hashicorp-vault-secret-lookup',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'api-version',
+              choice: 'v1',
+            },
+          ],
+          modal_fields: [
+            'secret-backend',
+            'secret-path',
+            'auth-path',
+            'secret-key',
+            'secret-version',
+          ],
+        },
+      },
+      {
+        name: 'hashicorp-vault-signed-ssh',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+          ],
+          modal_fields: ['public-key', 'secret-path', 'auth-path', 'role', 'valid-principals'],
+        },
+      },
+      {
+        name: 'microsoft-azure-key-vault',
+        inputs: {
+          fields: [
+            {
+              id: 'url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'client',
+              input: 'foo',
+            },
+            {
+              id: 'secret',
+              input: 'foo',
+            },
+            {
+              id: 'tenant',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['secret-field', 'secret-version'],
+        },
+      },
+      {
+        name: 'thycotic-devops-secrets-vault',
+        inputs: {
+          fields: [
+            {
+              id: 'tenant',
+              input: 'foo',
+            },
+            {
+              id: 'client-id',
+              input: 'foo',
+            },
+            {
+              id: 'client-secret',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['path', 'secret-field', 'secret-decoding'],
+        },
+      },
+      {
+        name: 'thycotic-secret-server',
+        inputs: {
+          fields: [
+            {
+              id: 'server-url',
+              input: 'http://foo.com',
+            },
+            {
+              id: 'username',
+              input: 'foo',
+            },
+            {
+              id: 'password',
+              input: 'foo',
+            },
+          ],
+          modal_fields: ['secret-id', 'secret-field'],
+        },
+      },
+    ];
+    cy.mount(<CreateCredential />);
+    cy.getByDataCy('name').type('foo');
+    credentialTypes.forEach((type) => {
+      cy.getByDataCy('credential_type').click();
+      cy.getByDataCy(type.name).click();
+      type.inputs.fields.map((field) => {
+        field.input && cy.getByDataCy(field.id).type(field.input);
+        field.choice &&
+          cy.getByDataCy(`${field.id}-form-group`).within(() => {
+            cy.get('.pf-v5-c-select__toggle-arrow').click({ force: true });
+            cy.getByDataCy(field.choice).click();
+          });
+      });
+      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+      type.inputs.modal_fields.map((field) => {
+        cy.getByDataCy(`${field}-form-group`).should('be.visible');
+      });
+      cy.clickModalButton('Cancel');
+    });
+  });
+
+  it('Handles error when required fields are not filled in modal', () => {
+    cy.mount(<CreateCredential />);
+    cy.getByDataCy('name').type('foo');
+    cy.getByDataCy('credential_type').click();
+    cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
+    cy.getByDataCy('url').type('http://foo.com');
+    cy.getByDataCy('client-id').type('foo');
+    cy.getByDataCy('client-password').type('foo');
+    cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+    cy.contains('Test external credential').should('be.visible');
+    cy.getByDataCy('account-name').type('foo');
+    cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
+    cy.contains('System name is required.').should('be.visible');
+  });
+});

--- a/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
+++ b/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
@@ -1,0 +1,136 @@
+import { AlertProps, Modal } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { AwxPageForm } from '../../../common/AwxPageForm';
+import { CredentialInputField, CredentialType } from '../../../interfaces/CredentialType';
+import {
+  PageFormSelect,
+  PageFormSubmitHandler,
+  PageFormTextArea,
+  PageFormTextInput,
+  usePageAlertToaster,
+} from '../../../../../framework';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { Credential } from '../../../interfaces/Credential';
+
+export interface CredentialsExternalTestModalProps {
+  credential?: Credential;
+  credentialType: CredentialType;
+}
+
+export interface CredentialsRetainInput {
+  field: {
+    id: number;
+  };
+}
+
+export function CredentialsExternalTestModal(
+  props: CredentialsExternalTestModalProps & { popDialog: () => void }
+) {
+  const { t } = useTranslation();
+  const postRequest = usePostRequest<CredentialsRetainInput>();
+  const alertToaster = usePageAlertToaster();
+  const alert: AlertProps = {
+    variant: 'success',
+    title: t('Test passed.'),
+    timeout: 2000,
+  };
+  const onSubmit: PageFormSubmitHandler<CredentialsRetainInput> = async (
+    retainInput: CredentialsRetainInput
+  ) => {
+    props.credential
+      ? await postRequest(awxAPI`/credentials/${String(props.credential.id)}/test/`, retainInput)
+          .then(() => {
+            alertToaster.addAlert(alert);
+          })
+          .catch((error) => {
+            alertToaster.replaceAlert(alert, {
+              variant: 'danger',
+              title: t('Something went wrong with the request to test this credential.'),
+              children: error instanceof Error && error.message,
+            });
+          })
+      : await postRequest(
+          awxAPI`/credential_types/${String(props.credentialType.id)}/test/`,
+          retainInput
+        )
+          .then(() => {
+            alertToaster.addAlert(alert);
+          })
+          .catch((error) => {
+            alertToaster.replaceAlert(alert, {
+              variant: 'danger',
+              title: t('Something went wrong with the request to test this credential.'),
+              children: error instanceof Error && error.message,
+            });
+          });
+  };
+  const onCancel = () => props.popDialog();
+
+  return (
+    <Modal
+      aria-label={t(`Test external credential`)}
+      variant="small"
+      position="default"
+      title={t`Test external credential`}
+      hasNoBodyWrapper
+      isOpen
+      onClose={() => props.popDialog()}
+    >
+      <AwxPageForm
+        submitText={t('Run')}
+        onSubmit={onSubmit}
+        cancelText={t('Cancel')}
+        onCancel={onCancel}
+        singleColumn
+      >
+        {props.credentialType.inputs.metadata.map((field: CredentialInputField) => {
+          const isRequired = props.credentialType.inputs?.required.includes(field.id);
+          if (field.type === 'string') {
+            if (field.choices) {
+              return (
+                <PageFormSelect
+                  key={`credential-${field.id}`}
+                  name={field.id}
+                  label={field.label}
+                  labelHelp={field.help_text}
+                  isRequired={isRequired}
+                  options={field.choices.map((choice) => ({
+                    value: choice,
+                    key: choice,
+                    label: choice,
+                  }))}
+                />
+              );
+            }
+
+            if (field.multiline) {
+              return (
+                <PageFormTextArea
+                  key={`credential-${field.id}`}
+                  name={field.id}
+                  label={field.label}
+                  labelHelp={field.help_text}
+                  isRequired={isRequired}
+                />
+              );
+            }
+
+            return (
+              <PageFormTextInput
+                key={`credential-${field.id}`}
+                name={field.id}
+                label={field.label}
+                labelHelp={field.help_text}
+                type="text"
+                isRequired={isRequired}
+              />
+            );
+          }
+
+          return null;
+        })}
+      </AwxPageForm>
+    </Modal>
+  );
+}

--- a/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
+++ b/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { AwxPageForm } from '../../../common/AwxPageForm';
 import { CredentialInputField, CredentialType } from '../../../interfaces/CredentialType';
 import {
+  IPageAlertToaster,
   PageFormSelect,
   PageFormSubmitHandler,
   PageFormTextArea,
   PageFormTextInput,
-  usePageAlertToaster,
 } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { usePostRequest } from '../../../../common/crud/usePostRequest';
@@ -25,26 +25,29 @@ export interface CredentialsRetainInput {
 }
 
 export function CredentialsExternalTestModal(
-  props: CredentialsExternalTestModalProps & { popDialog: () => void }
+  props: CredentialsExternalTestModalProps & { popDialog: () => void } & {
+    alertToaster: IPageAlertToaster;
+  }
 ) {
   const { t } = useTranslation();
   const postRequest = usePostRequest<CredentialsRetainInput>();
-  const alertToaster = usePageAlertToaster();
-  const alert: AlertProps = {
-    variant: 'success',
-    title: t('Test passed.'),
-    timeout: 2000,
-  };
+  const alertToaster = props.alertToaster;
+
   const onSubmit: PageFormSubmitHandler<CredentialsRetainInput> = async (
     retainInput: CredentialsRetainInput
   ) => {
+    const alert: AlertProps = {
+      variant: 'success',
+      title: t('Test passed.'),
+      timeout: 2000,
+    };
     props.credential
       ? await postRequest(awxAPI`/credentials/${String(props.credential.id)}/test/`, retainInput)
           .then(() => {
             alertToaster.addAlert(alert);
           })
           .catch((error) => {
-            alertToaster.replaceAlert(alert, {
+            alertToaster.addAlert({
               variant: 'danger',
               title: t('Something went wrong with the request to test this credential.'),
               children: error instanceof Error && error.message,
@@ -58,7 +61,7 @@ export function CredentialsExternalTestModal(
             alertToaster.addAlert(alert);
           })
           .catch((error) => {
-            alertToaster.replaceAlert(alert, {
+            alertToaster.addAlert({
               variant: 'danger',
               title: t('Something went wrong with the request to test this credential.'),
               children: error instanceof Error && error.message,

--- a/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
+++ b/frontend/awx/access/credentials/utils/CredentialsExternalTestModal.tsx
@@ -93,7 +93,7 @@ export function CredentialsExternalTestModal(
             if (field.choices) {
               return (
                 <PageFormSelect
-                  key={`credential-${field.id}`}
+                  key={field.id}
                   name={field.id}
                   label={field.label}
                   labelHelp={field.help_text}
@@ -110,7 +110,7 @@ export function CredentialsExternalTestModal(
             if (field.multiline) {
               return (
                 <PageFormTextArea
-                  key={`credential-${field.id}`}
+                  key={field.id}
                   name={field.id}
                   label={field.label}
                   labelHelp={field.help_text}
@@ -121,7 +121,7 @@ export function CredentialsExternalTestModal(
 
             return (
               <PageFormTextInput
-                key={`credential-${field.id}`}
+                key={field.id}
                 name={field.id}
                 label={field.label}
                 labelHelp={field.help_text}

--- a/frontend/awx/interfaces/CredentialType.ts
+++ b/frontend/awx/interfaces/CredentialType.ts
@@ -35,15 +35,7 @@ export interface CredentialType
   inputs: {
     fields: CredentialInputField[];
     required: string[];
-    metadata: {
-      id: string;
-      label: string;
-      type: string;
-      help_text: string;
-      choices?: string[];
-      multiline?: boolean;
-      default?: boolean | string;
-    }[];
+    metadata: CredentialInputField[];
   };
   related: {
     credentials: string;


### PR DESCRIPTION
This PR adds a 'test' button to the credentials edit and create pages when an external credential type is selected. This button opens a modal which asks for some additional fields (dynamic depending on the credential type that is selected) and has a run button to run the test. Running the test then displays either a success or error alert on the page. 

Jira issue: https://issues.redhat.com/browse/AAP-23162

![Screenshot 2024-05-03 at 12 44 48 PM](https://github.com/ansible/ansible-ui/assets/89094075/77a8a8af-0764-402b-affe-9e94e6441ab6)

**Steps to see a mock successful response:**
In AWX run:
```
DOCKER_HOST=`docker context inspect | jq -r ".[0].Endpoints.docker.Host"` VAULT=true COMPOSE_TAG=devel make docker-compose
``` 

Then, in a separate window (still in AWX): 
`ansible-playbook tools/docker-compose/ansible/plumb_vault.yml -e enable_ldap=false`
`ansible-playbook tools/docker-compose/ansible/unseal_vault.yml`

Open a new window, in ansible-ui:
Point frontend to local backend using 
`export AWX_SERVER=https://127.0.0.1:8043`
`Npm run awx`

In UI, go to credentials list
Vault lookup cred => edit => test button => 
Name of secret backend: my_engine
Path to secret: /my_root/my_folder
Key name: my_key