### PR TITLE
Schedules with survey submit failure fix

### DIFF
--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -50,7 +50,8 @@ export const useProcessSchedule = () => {
   const updateSchedule = usePatchRequest<CreateSchedulePayload, Schedule>();
   return useCallback(
     async (payloadData: StandardizedFormData) => {
-      const { resource, prompt, schedule_days_to_keep, ...rest } = payloadData;
+      const { resource, prompt, schedule_days_to_keep, survey, ...rest } = payloadData;
+
       const request = (endPoint: string, payload: CreateSchedulePayload) => {
         if (params.schedule_id && params.id) {
           return updateSchedule(awxAPI`/schedules/${params.schedule_id.toString()}/`, {
@@ -67,13 +68,18 @@ export const useProcessSchedule = () => {
         job_tags,
         skip_tags,
         inventory,
+
         ...restOfPrompt
       } = prompt || { execution_environment: null, job_tags: '', skip_tags: '' };
       const { type, id } = resource;
       let schedule: Schedule;
       const hasJobTags = job_tags && job_tags?.length > 0;
       const hasSkipTags = prompt && prompt?.skip_tags && prompt?.skip_tags?.length > 0;
-      const extraDataObject = schedule_days_to_keep ? { days: schedule_days_to_keep } : {};
+      let extraDataObject: { [key: string]: string | number | boolean } = {};
+      if (schedule_days_to_keep) extraDataObject.days = schedule_days_to_keep;
+
+      extraDataObject = { ...extraDataObject, ...survey };
+
       const payload = {
         ...rest,
         ...restOfPrompt,
@@ -82,7 +88,7 @@ export const useProcessSchedule = () => {
         skip_tags: hasSkipTags ? stringifyTags(prompt?.skip_tags) : undefined,
         job_tags: hasJobTags ? stringifyTags(job_tags) : undefined,
         enabled: true,
-        extra_data: extraDataObject,
+        extra_data: { ...extraDataObject },
       };
       switch (type) {
         case 'inventory_source':

--- a/frontend/awx/views/schedules/types.ts
+++ b/frontend/awx/views/schedules/types.ts
@@ -55,6 +55,7 @@ export interface ScheduleFormWizard {
   launch_config: LaunchConfiguration | null;
   prompt: PromptFormValues;
   schedule_days_to_keep: number;
+  survey: { [key: string]: string | number | boolean };
 }
 
 export type ScheduleResourceType =


### PR DESCRIPTION
I just found this bug.

To test on main:
1) Create a job template.
2) On the JT create a survey with at least 1 required value and enable the survey
3) On the same JT create a schedule and attempt to submit it.

Notice the validation failure.  

This PR fixes that.