### PR TITLE
Management jobs notifications list

### DIFF
--- a/frontend/awx/main/routes/useAwxManagementJobsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxManagementJobsRoutes.tsx
@@ -12,6 +12,7 @@ import { SchedulesList } from '../../views/schedules/SchedulesList';
 import { awxAPI } from '../../common/api/awx-utils';
 import { SchedulePage } from '../../views/schedules/SchedulePage/SchedulePage';
 import { ScheduleDetails } from '../../views/schedules/SchedulePage/ScheduleDetails';
+import { ResourceNotifications } from '../../resources/notifications/ResourceNotifications';
 
 export function useAwxManagementJobsRoutes() {
   const { t } = useTranslation();
@@ -76,7 +77,7 @@ export function useAwxManagementJobsRoutes() {
             {
               id: AwxRoute.ManagementJobNotifications,
               path: 'notifications',
-              element: <PageNotImplemented />,
+              element: <ResourceNotifications resourceType="job_templates" />,
             },
             {
               path: '',

--- a/frontend/awx/main/routes/useAwxManagementJobsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxManagementJobsRoutes.tsx
@@ -77,7 +77,7 @@ export function useAwxManagementJobsRoutes() {
             {
               id: AwxRoute.ManagementJobNotifications,
               path: 'notifications',
-              element: <ResourceNotifications resourceType="job_templates" />,
+              element: <ResourceNotifications resourceType="system_job_templates" />,
             },
             {
               path: '',

--- a/frontend/awx/resources/notifications/ResourceNotifications.tsx
+++ b/frontend/awx/resources/notifications/ResourceNotifications.tsx
@@ -59,7 +59,9 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
   >(awxAPI`/${resourceType}/${resourceId ?? ''}/notification_templates_error/`);
 
   const approvalUrl =
-    resourceType === 'system_job_templates'
+    resourceType === 'system_job_templates' ||
+    resourceType === 'job_templates' ||
+    resourceType === 'projects'
       ? ''
       : awxAPI`/${resourceType}/${resourceId ?? ''}/notification_templates_approvals/`;
 
@@ -93,6 +95,7 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
 
   return (
     <PageLayout>
+      {resourceType}
       <PageTable<NotificationTemplate>
         id="awx-inventory-sources-table"
         toolbarFilters={toolbarFilters}

--- a/frontend/awx/resources/notifications/ResourceNotifications.tsx
+++ b/frontend/awx/resources/notifications/ResourceNotifications.tsx
@@ -18,6 +18,7 @@ interface ResourceTypeMapper {
   job_templates?: string;
   workflow_job_templates?: string;
   organizations?: string;
+  system_job_templates?: string;
 }
 
 export function ResourceNotifications({ resourceType }: { resourceType: string }) {
@@ -30,6 +31,7 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
     job_templates: 'id',
     workflow_job_templates: 'id',
     organizations: 'id',
+    system_job_templates: 'id',
   };
 
   const resourceToErrorMsg: ResourceTypeMapper = {
@@ -38,6 +40,7 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
     job_templates: 'job template',
     workflow_job_templates: 'workflow job template',
     organizations: 'organization',
+    system_job_templates: 'system job templates',
   };
 
   const params = useParams();
@@ -55,9 +58,12 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
     AwxItemsResponse<NotificationTemplate>
   >(awxAPI`/${resourceType}/${resourceId ?? ''}/notification_templates_error/`);
 
-  const approval = useGet<AwxItemsResponse<NotificationTemplate>>(
-    awxAPI`/${resourceType}/${resourceId ?? ''}/notification_templates_approvals/`
-  );
+  const approvalUrl =
+    resourceType === 'system_job_templates'
+      ? ''
+      : awxAPI`/${resourceType}/${resourceId ?? ''}/notification_templates_approvals/`;
+
+  const approval = useGet<AwxItemsResponse<NotificationTemplate>>(approvalUrl);
   const { data: notificationApproval, refresh: notificationApprovalRefresh } =
     resourceType === 'organizations'
       ? approval

--- a/frontend/awx/resources/notifications/ResourceNotifications.tsx
+++ b/frontend/awx/resources/notifications/ResourceNotifications.tsx
@@ -95,7 +95,6 @@ export function ResourceNotifications({ resourceType }: { resourceType: string }
 
   return (
     <PageLayout>
-      {resourceType}
       <PageTable<NotificationTemplate>
         id="awx-inventory-sources-table"
         toolbarFilters={toolbarFilters}


### PR DESCRIPTION
![image](https://github.com/ansible/ansible-ui/assets/23277791/cb6cc6d7-3219-41df-8497-e7228894a335)

Also fixed the loading of approvals query /notification_templates_approvals/ that was sent also in notification list types that old application did not send and those requests failed. Now it does not sends the approvals requests for:

  resourceType === 'system_job_templates' ||
    resourceType === 'job_templates' ||
    resourceType === 'projects'