### PR TITLE
Limit height of social auth options on login

### DIFF
--- a/frontend/common/SocialAuthLogin.tsx
+++ b/frontend/common/SocialAuthLogin.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 const Container = styled.div`
+  max-block-size: 330px;
+  overflow: auto;
   margin-block-start: 40px;
   padding-block-start: 20px;
   border-block-start: 1px solid var(--pf-v5-global--BorderColor--light-100);


### PR DESCRIPTION
Restricts the height of the container when there is a long list of oauth login options (more than 4). Four options are visible, and the beginning of a fifth to help indicate scrolling is available.

![Screenshot 2024-05-03 at 9 07 48 AM](https://github.com/ansible/ansible-ui/assets/410794/422db4b0-c6fb-4bc9-a424-77c4461f954f)
