### PR TITLE
Header updates for Roles list/details pages

### DIFF
--- a/framework/PageHeader.tsx
+++ b/framework/PageHeader.tsx
@@ -114,8 +114,11 @@ export function PageHeader(props: PageHeaderProps) {
 
   const pageBreadcrumbs = useMemo(() => {
     const pageBreadcrumbs = [];
-    if (props.breadcrumbs) pageBreadcrumbs.push(...props.breadcrumbs);
-    if (tabBreadcrumb) pageBreadcrumbs.push(tabBreadcrumb);
+    if (props.breadcrumbs) {
+      pageBreadcrumbs.push(...props.breadcrumbs);
+      if (tabBreadcrumb) pageBreadcrumbs.push(tabBreadcrumb);
+    }
+
     return pageBreadcrumbs;
   }, [props.breadcrumbs, tabBreadcrumb]);
 

--- a/frontend/awx/access/roles/AwxRolePage.tsx
+++ b/frontend/awx/access/roles/AwxRolePage.tsx
@@ -7,7 +7,10 @@ import { AwxRoute } from '../../main/AwxRoutes';
 import { AwxRole } from './AwxRoles';
 import { useAwxRoles } from './useAwxRoles';
 
-export function AwxRolePage() {
+export function AwxRolePage(props: {
+  breadcrumbLabelForPreviousPage?: string;
+  backTabLabel?: string;
+}) {
   const params = useParams<{ id: string; resourceType: string }>();
   const awxRoles = useAwxRoles();
   const role: AwxRole = {
@@ -24,11 +27,17 @@ export function AwxRolePage() {
     <PageLayout>
       <PageHeader
         title={role?.name}
-        breadcrumbs={[{ label: t('Roles'), to: getPageUrl(AwxRoute.Roles) }, { label: role?.name }]}
+        breadcrumbs={[
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(AwxRoute.Roles),
+          },
+          { label: role?.name },
+        ]}
       />
       <PageRoutedTabs
         backTab={{
-          label: t('Back to Roles'),
+          label: props.backTabLabel || t('Back to Roles'),
           page: AwxRoute.Roles,
           persistentFilterKey: 'awx-roles',
         }}

--- a/frontend/eda/access/roles/EdaRolePage.tsx
+++ b/frontend/eda/access/roles/EdaRolePage.tsx
@@ -21,7 +21,10 @@ import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useDeleteEdaRoles } from './hooks/useDeleteEdaRoles';
 import { useEdaActiveUser } from '../../common/useEdaActiveUser';
 
-export function EdaRolePage() {
+export function EdaRolePage(props: {
+  breadcrumbLabelForPreviousPage?: string;
+  backTabLabel?: string;
+}) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { activeEdaUser } = useEdaActiveUser();
@@ -82,7 +85,13 @@ export function EdaRolePage() {
     <PageLayout>
       <PageHeader
         title={role?.name}
-        breadcrumbs={[{ label: t('Roles'), to: getPageUrl(EdaRoute.Roles) }, { label: role?.name }]}
+        breadcrumbs={[
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(EdaRoute.Roles),
+          },
+          { label: role?.name },
+        ]}
         headerActions={
           <PageActions<EdaRbacRole>
             actions={itemActions}
@@ -93,7 +102,7 @@ export function EdaRolePage() {
       />
       <PageRoutedTabs
         backTab={{
-          label: t('Back to Roles'),
+          label: props.backTabLabel || t('Back to Roles'),
           page: EdaRoute.Roles,
           persistentFilterKey: 'eda-roles',
         }}

--- a/frontend/eda/access/roles/RoleForm.tsx
+++ b/frontend/eda/access/roles/RoleForm.tsx
@@ -22,7 +22,7 @@ import { PageFormMultiSelect } from '../../../../framework/PageForm/Inputs/PageF
 import { PageFormHidden } from '../../../../framework/PageForm/Utils/PageFormHidden';
 import { useWatch } from 'react-hook-form';
 
-export function CreateRole() {
+export function CreateRole(props: { breadcrumbLabelForPreviousPage?: string }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
@@ -43,7 +43,10 @@ export function CreateRole() {
       <PageHeader
         title={t('Create Role')}
         breadcrumbs={[
-          { label: t('Roles'), to: getPageUrl(EdaRoute.Roles) },
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(EdaRoute.Roles),
+          },
           { label: t('Create Role') },
         ]}
       />
@@ -59,7 +62,7 @@ export function CreateRole() {
   );
 }
 
-export function EditRole() {
+export function EditRole(props: { breadcrumbLabelForPreviousPage?: string }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const pageNavigate = usePageNavigate();
@@ -90,7 +93,10 @@ export function EditRole() {
         <PageLayout>
           <PageHeader
             breadcrumbs={[
-              { label: t('Roles'), to: getPageUrl(EdaRoute.Roles) },
+              {
+                label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+                to: getPageUrl(EdaRoute.Roles),
+              },
               { label: t('Edit Role') },
             ]}
           />
@@ -102,7 +108,10 @@ export function EditRole() {
           <PageHeader
             title={t('Edit Role')}
             breadcrumbs={[
-              { label: t('Roles'), to: getPageUrl(EdaRoute.Roles) },
+              {
+                label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+                to: getPageUrl(EdaRoute.Roles),
+              },
               { label: t('Edit Role') },
             ]}
           />

--- a/frontend/hub/access/roles/RolePage/RoleForm.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleForm.tsx
@@ -31,7 +31,7 @@ export interface RoleInput extends Omit<Role, 'pulp_href' | 'pulp_created' | 'lo
 
 export type RoleRequestBody = Omit<Role, 'pulp_href' | 'pulp_created' | 'locked'>;
 
-export function CreateRole() {
+export function CreateRole(props: { breadcrumbLabelForPreviousPage?: string }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const navigate = useNavigate();
@@ -53,7 +53,10 @@ export function CreateRole() {
       <PageHeader
         title={t('Create Role')}
         breadcrumbs={[
-          { label: t('Roles'), to: getPageUrl(HubRoute.Roles) },
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(HubRoute.Roles),
+          },
           { label: t('Create Role') },
         ]}
       />
@@ -69,7 +72,7 @@ export function CreateRole() {
   );
 }
 
-export function EditRole() {
+export function EditRole(props: { breadcrumbLabelForPreviousPage?: string }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const navigate = useNavigate();
@@ -100,9 +103,12 @@ export function EditRole() {
     return (
       <PageLayout>
         <PageHeader
-          title={t('Edit Role')}
+          title={props.breadcrumbLabelForPreviousPage || t('Edit Role')}
           breadcrumbs={[
-            { label: t('Roles'), to: getPageUrl(HubRoute.Roles) },
+            {
+              label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+              to: getPageUrl(HubRoute.Roles),
+            },
             { label: t('Edit Role') },
           ]}
         />
@@ -115,7 +121,10 @@ export function EditRole() {
       <PageHeader
         title={t('Edit Role')}
         breadcrumbs={[
-          { label: t('Roles'), to: getPageUrl(HubRoute.Roles) },
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(HubRoute.Roles),
+          },
           { label: t('Edit Role') },
         ]}
       />

--- a/frontend/hub/access/roles/RolePage/RolePage.tsx
+++ b/frontend/hub/access/roles/RolePage/RolePage.tsx
@@ -18,7 +18,10 @@ import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { PageRoutedTabs } from '../../../../../framework/PageTabs/PageRoutedTabs';
 import { PulpItemsResponse } from '../../../common/useHubView';
 
-export function RolePage() {
+export function RolePage(props: {
+  breadcrumbLabelForPreviousPage?: string;
+  backTabLabel?: string;
+}) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { data, error, refresh } = useGet<PulpItemsResponse<Role>>(
@@ -36,7 +39,13 @@ export function RolePage() {
     <PageLayout>
       <PageHeader
         title={role?.name}
-        breadcrumbs={[{ label: t('Roles'), to: getPageUrl(HubRoute.Roles) }, { label: role?.name }]}
+        breadcrumbs={[
+          {
+            label: props.breadcrumbLabelForPreviousPage || t('Roles'),
+            to: getPageUrl(HubRoute.Roles),
+          },
+          { label: role?.name },
+        ]}
         headerActions={
           <PageActions<Role>
             actions={actions}
@@ -47,7 +56,7 @@ export function RolePage() {
       />
       <PageRoutedTabs
         backTab={{
-          label: t('Back to Roles'),
+          label: props.backTabLabel || t('Back to Roles'),
           page: HubRoute.Roles,
           persistentFilterKey: 'hub-roles',
         }}


### PR DESCRIPTION
Framework update:
- `PageHeader` updated so that the active tab is only added to breadcrumbs if the PageHeader was initialized with the `breadcrumbs` prop.

Roles Details/form UIs:
- Accept label for the "Back to <>" tab in the routed tabs and breadcrumb label for the previous page as props so that these can be configured while setting up the routes.