### PR TITLE
[UXD][AAP-23702] Update cred type button to primary

### DIFF
--- a/frontend/awx/access/credential-types/hooks/useCredentialTypeActions.tsx
+++ b/frontend/awx/access/credential-types/hooks/useCredentialTypeActions.tsx
@@ -14,6 +14,7 @@ import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsRes
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { useDeleteCredentialTypes } from './useDeleteCredentialTypes';
 import { CredentialType } from '../../../interfaces/CredentialType';
+import { ButtonVariant } from '@patternfly/react-core';
 
 export function useCredentialTypeToolbarActions(
   onCredentialTypesDeleted: (credentialType: CredentialType[]) => void
@@ -29,7 +30,7 @@ export function useCredentialTypeToolbarActions(
       {
         type: PageActionType.Link,
         selection: PageActionSelection.None,
-        // variant: ButtonVariant.primary,
+        variant: ButtonVariant.primary,
         isPinned: true,
         icon: PlusCircleIcon,
         label: t('Create credential type'),


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-23702
Updated the "Create credential type" button to primary from secondary.
<img width="1818" alt="Screenshot 2024-05-03 at 2 53 40 PM" src="https://github.com/ansible/ansible-ui/assets/98424339/c8486475-6957-48c2-ba0b-60bfb00c5552">
