### PR TITLE
[AAP-23726] Fix multiselect payload value in launch template

### DIFF
--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -42,8 +42,7 @@ const addSurveyQuestionsToExtraVars = (
   config.variables_needed_to_start.forEach((key, index) => {
     const value = formValues.survey[key];
     if (Array.isArray(value)) {
-      const variableNames: { name: string }[] = value as { name: string }[];
-      const outputString = variableNames.reduce((acc, { name }) => `${acc},'${name}'`, '').slice(1);
+      const outputString = value.join(',');
       stringValue += `${key}: [${outputString}]`;
     } else {
       stringValue += `${key}: ${formValues.survey[key] as string}`;
@@ -98,7 +97,7 @@ export interface TemplateLaunch {
   skip_tags: { name: string }[];
   timeout: number;
   verbosity: number;
-  survey: { [key: string]: string | string[] | { name: string }[] };
+  survey: { [key: string]: string | string[] };
 }
 
 interface LaunchPayload {
@@ -106,7 +105,7 @@ interface LaunchPayload {
   credential_passwords: { [key: string]: string };
   diff_mode: boolean;
   execution_environment: number;
-  extra_vars: string | { [key: string]: string | string[] | { name: string }[] };
+  extra_vars: string | { [key: string]: string | string[] };
   forks: number;
   instance_groups: number[];
   inventory: number;
@@ -229,14 +228,6 @@ export function TemplateLaunchWizard({ jobType }: { jobType: string }) {
 
         if (jobType === 'workflow_job_templates') {
           const extraVarsObj = extra_vars ? (JSON.parse(yamlToJson(extra_vars)) as object) : {};
-
-          Object.keys(formValues.survey).forEach((key) => {
-            const value = formValues.survey[key];
-            if (Array.isArray(value)) {
-              const variableNames: { name: string }[] = value as { name: string }[];
-              formValues.survey[key] = variableNames.map((k) => k.name);
-            }
-          });
 
           payload = {
             ...payload,


### PR DESCRIPTION
Issue: [AAP-23726](https://issues.redhat.com/browse/AAP-23726)

I have forgotten to update the payload body in https://github.com/ansible/ansible-ui/pull/2223 and it breaks the template launch with 
```
{
    "variables_needed_to_start": [
        "Value undefined for 'test' expected to be one of ['test', 'test1', 'test2'].",
        "Value undefined for 'test' expected to be one of ['test', 'test1', 'test2'].",
        "Value undefined for 'test' expected to be one of ['test', 'test1', 'test2']."
    ]
}
```