### PR TITLE
AAP-23534 `Management Jobs` tests

### DIFF
--- a/cypress/e2e/awx/administration/management-jobs.cy.ts
+++ b/cypress/e2e/awx/administration/management-jobs.cy.ts
@@ -1,6 +1,6 @@
 import { SystemJobTemplate } from '../../../../frontend/awx/interfaces/SystemJobTemplate';
 
-describe('Management Jobs - List, Launch ', () => {
+describe('Management Jobs Page - List and Launch Jobs', () => {
   beforeEach(() => {
     cy.awxLogin();
   });
@@ -88,7 +88,7 @@ describe('Management Jobs - List, Launch ', () => {
   const managementJobsWithModal = ['Cleanup Activity Stream', 'Cleanup Job Details'];
   const rententionDays = '4';
   managementJobsWithModal.forEach((jobName) => {
-    it(`admin can launch management job: ${jobName}`, () => {
+    it(`admin can launch management job: ${jobName} with retention days`, () => {
       cy.intercept('GET', 'api/v2/system_job_templates/?order_by=name&page=1&page_size=10').as(
         'getManagementJobsListPage'
       );

--- a/cypress/e2e/awx/administration/management-jobs.cy.ts
+++ b/cypress/e2e/awx/administration/management-jobs.cy.ts
@@ -52,18 +52,10 @@ describe('Management Jobs Page - List and Launch Jobs', () => {
               .then((jobId: string) => {
                 cy.verifyPageTitle(jobName);
                 cy.url().should('include', `/jobs/management/${jobId}/output`);
-                cy.waitForManagementJobStatus(jobId).then((response: SystemJobTemplate) => {
-                  const status = response.status;
-                  let resultStatus;
-                  if (status === 'successful') {
-                    resultStatus = 'Success';
-                  }
+                cy.waitForManagementJobStatus(jobId).then(() => {
                   cy.contains('a[role="tab"]', 'Details').click();
                   cy.get('[data-cy="id"]').should('have.text', jobId).should('be.visible');
                   cy.get('[data-cy="name"]').should('have.text', jobName).should('be.visible');
-                  cy.get('[data-cy="status"]')
-                    .should('have.text', resultStatus)
-                    .should('be.visible');
                   cy.get('[data-cy="type"]')
                     .should('have.text', 'Management job')
                     .should('be.visible');
@@ -112,18 +104,10 @@ describe('Management Jobs Page - List and Launch Jobs', () => {
               .then((jobId: string) => {
                 cy.verifyPageTitle(jobName);
                 cy.url().should('include', `/jobs/management/${jobId}/output`);
-                cy.waitForManagementJobStatus(jobId).then((response: SystemJobTemplate) => {
-                  const status = response.status;
-                  let resultStatus;
-                  if (status === 'successful') {
-                    resultStatus = 'Success';
-                  }
+                cy.waitForManagementJobStatus(jobId).then(() => {
                   cy.contains('a[role="tab"]', 'Details').click();
                   cy.get('[data-cy="id"]').should('have.text', jobId).should('be.visible');
                   cy.get('[data-cy="name"]').should('have.text', jobName).should('be.visible');
-                  cy.get('[data-cy="status"]')
-                    .should('have.text', resultStatus)
-                    .should('be.visible');
                   cy.get('[data-cy="type"]')
                     .should('have.text', 'Management job')
                     .should('be.visible');

--- a/cypress/e2e/awx/administration/management-jobs.cy.ts
+++ b/cypress/e2e/awx/administration/management-jobs.cy.ts
@@ -1,15 +1,37 @@
 import { SystemJobTemplate } from '../../../../frontend/awx/interfaces/SystemJobTemplate';
 
-describe('Management Jobs', () => {
-  describe('Management Jobs: List View', () => {
-    it('render the management jobs list page, assert the management jobs listed', () => {
-      const managementJobsList = [
-        'Cleanup Activity Stream',
-        'Cleanup Expired OAuth 2 Tokens',
-        'Cleanup Expired Sessions',
-        'Cleanup Job Details',
-      ];
-      cy.awxLogin();
+describe('Management Jobs - List, Launch ', () => {
+  beforeEach(() => {
+    cy.awxLogin();
+  });
+
+  it('render the management jobs list page, assert the management jobs listed', () => {
+    const managementJobsList = [
+      'Cleanup Activity Stream',
+      'Cleanup Expired OAuth 2 Tokens',
+      'Cleanup Expired Sessions',
+      'Cleanup Job Details',
+    ];
+    cy.intercept('GET', 'api/v2/system_job_templates/?order_by=name&page=1&page_size=10').as(
+      'getManagementJobsListPage'
+    );
+    cy.navigateTo('awx', 'management-jobs');
+    cy.verifyPageTitle('Management Jobs');
+    cy.wait('@getManagementJobsListPage')
+      .its('response.body.results')
+      .then((results: SystemJobTemplate[]) => {
+        const responseJobsList = results?.map((job: SystemJobTemplate) => job.name);
+        expect(responseJobsList).to.have.members(managementJobsList);
+        cy.get('.pf-v5-c-table__tbody tr').should('have.length', responseJobsList.length);
+        cy.get('.pf-v5-c-table__tbody tr').each(($row, index) => {
+          cy.wrap($row).find('td').eq(0).should('contain', responseJobsList[index]);
+        });
+      });
+  });
+
+  const managementJobs = ['Cleanup Expired OAuth 2 Tokens', 'Cleanup Expired Sessions'];
+  managementJobs.forEach((jobName) => {
+    it(`admin can launch management job: ${jobName}`, () => {
       cy.intercept('GET', 'api/v2/system_job_templates/?order_by=name&page=1&page_size=10').as(
         'getManagementJobsListPage'
       );
@@ -18,128 +40,107 @@ describe('Management Jobs', () => {
       cy.wait('@getManagementJobsListPage')
         .its('response.body.results')
         .then((results: SystemJobTemplate[]) => {
-          const responseJobsList = results?.map((job: SystemJobTemplate) => job.name);
-          expect(responseJobsList).to.have.members(managementJobsList);
-          cy.get('.pf-v5-c-table__tbody tr').should('have.length', responseJobsList.length);
-          cy.get('.pf-v5-c-table__tbody tr').each(($row, index) => {
-            cy.wrap($row).find('td').eq(0).should('contain', responseJobsList[index]);
-          });
+          const jobId = results.find((job) => job.name === jobName)?.id;
+          if (jobId) {
+            cy.intercept('POST', `/api/v2/system_job_templates/${jobId}/launch/`).as('launchJob');
+            cy.clickTableRowAction('name', jobName, 'launch-management-job', {
+              inKebab: false,
+              disableFilter: true,
+            });
+            cy.wait('@launchJob')
+              .its('response.body.id')
+              .then((jobId: string) => {
+                cy.verifyPageTitle(jobName);
+                cy.url().should('include', `/jobs/management/${jobId}/output`);
+                cy.waitForManagementJobStatus(jobId).then((response: SystemJobTemplate) => {
+                  const status = response.status;
+                  let resultStatus;
+                  if (status === 'successful') {
+                    resultStatus = 'Success';
+                  }
+                  cy.contains('a[role="tab"]', 'Details').click();
+                  cy.get('[data-cy="id"]').should('have.text', jobId).should('be.visible');
+                  cy.get('[data-cy="name"]').should('have.text', jobName).should('be.visible');
+                  cy.get('[data-cy="status"]')
+                    .should('have.text', resultStatus)
+                    .should('be.visible');
+                  cy.get('[data-cy="type"]')
+                    .should('have.text', 'Management job')
+                    .should('be.visible');
+                  cy.get('[data-cy="id"]').should('have.text', jobId).should('be.visible');
+                  cy.intercept('DELETE', `api/v2/system_jobs/${jobId}/`).as('deleteMgtJob');
+                  cy.clickPageAction('delete-job');
+                  cy.get('#confirm').click();
+                  cy.clickButton(/^Delete job/);
+                  cy.wait('@deleteMgtJob')
+                    .its('response')
+                    .then((response) => {
+                      expect(response?.statusCode).to.eql(204);
+                    });
+                });
+              });
+          }
         });
-    });
-
-    it.skip('only allows an admin user to view the management job tab', () => {
-      //Assert that admin is the currently logged in user
-      //Create a normal user in this test, or in the beforeEach block
-      //Log out and log back in as normal user, assert that it is the normal user
-      //Assert that the normal user cannot see management jobs
+      cy.navigateTo('awx', 'management-jobs');
     });
   });
 
-  describe('Management Jobs: Cleanup Expired OAuth 2 Tokens', () => {
-    it.skip('can manually launch a job, verify redirect to output screen, and verify job details', () => {
-      //Assert that the user is looking at the expected job
-      //Assert the launch
-      //Assert the redirect to output screen
-      //Assert viewable job details
-    });
-  });
-  describe('Management Jobs: Cleanup Expired Sessions', () => {
-    it.skip('can manually launch a job, verify redirect to output screen, and verify job details', () => {
-      //Assert that the user is looking at the expected job
-      //Assert the launch
-      //Assert the redirect to output screen
-      //Assert viewable job details
-    });
-  });
-  describe('Management Jobs: Cleanup Activity Stream', () => {
-    it.skip('can manually launch a job, view a modal to set # of days, verify redirect to output screen, and verify job details', () => {
-      //Assert that the user is looking at the expected job
-      //Assert the launch
-      //Assert the redirect to output screen
-      //Assert viewable job details
-    });
-  });
-  describe('Management Jobs: Cleanup Job Details', () => {
-    it.skip('can manually launch a job, view a modal to set # of days, verify redirect to output screen, and verify job details', () => {
-      //Assert that the user is looking at the expected job
-      //Assert the launch
-      //Assert the redirect to output screen
-      //Assert viewable job details
-    });
-  });
+  const managementJobsWithModal = ['Cleanup Activity Stream', 'Cleanup Job Details'];
+  const rententionDays = '4';
+  managementJobsWithModal.forEach((jobName) => {
+    it(`admin can launch management job: ${jobName}`, () => {
+      cy.intercept('GET', 'api/v2/system_job_templates/?order_by=name&page=1&page_size=10').as(
+        'getManagementJobsListPage'
+      );
+      cy.navigateTo('awx', 'management-jobs');
+      cy.verifyPageTitle('Management Jobs');
+      cy.wait('@getManagementJobsListPage')
+        .its('response.body.results')
+        .then((results: SystemJobTemplate[]) => {
+          const jobId = results.find((job) => job.name === jobName)?.id;
+          if (jobId) {
+            cy.intercept('POST', `/api/v2/system_job_templates/${jobId}/launch/`).as('launchJob');
+            cy.clickTableRowAction('name', jobName, 'launch-management-job', {
+              inKebab: false,
+              disableFilter: true,
+            });
+            cy.get('[data-cy="extra-vars-days"]').clear().type(rententionDays);
+            cy.clickButton(/^Launch/);
 
-  describe('Management Jobs: Schedules Tab', () => {
-    it.skip('can click the Cleanup Activity Stream link on the list view and verify the details of the automatically generated schedule', () => {
-      //Assert schedule presence on list view
-      //Assert info on the schedule details page, including the fact that it is automatically generated
-    });
-
-    it.skip('can make multiple edits to the Cleanup Activity Stream schedule, save, disable schedule, and reenable', () => {
-      //Assert the edit form showing
-      //Assert that the edits made were saved
-      //Assert the disabling of the schedule
-      //Assert the reenabling of the schedule
-    });
-
-    it.skip('can click the Cleanup Expired OAuth 2 Tokens link on the list view and verify the details of the automatically generated schedule', () => {
-      //Assert schedule presence on list view
-      //Assert info on the schedule details page, including the fact that it is automatically generated
-    });
-
-    it.skip('can make multiple edits to the Cleanup Expired OAuth 2 Tokens schedule, save, disable schedule, and reenable', () => {
-      //Assert the edit form showing
-      //Assert that the edits made were saved
-      //Assert the disabling of the schedule
-      //Assert the reenabling of the schedule
-    });
-
-    it.skip('can click the Cleanup Expired Sessions link on the list view and verify the details of the automatically generated schedule', () => {
-      //Assert schedule presence on list view
-      //Assert info on the schedule details page, including the fact that it is automatically generated
-    });
-
-    it.skip('can make multiple edits to the Cleanup Expired Sessions schedule, save, disable schedule, and reenable', () => {
-      //Assert the edit form showing
-      //Assert that the edits made were saved
-      //Assert the disabling of the schedule
-      //Assert the reenabling of the schedule
-    });
-
-    it.skip('can click the Cleanup Job Details link on the list view and verify the details of the automatically generated schedule', () => {
-      //Assert schedule presence on list view
-      //Assert info on the schedule details page, including the fact that it is automatically generated
-    });
-
-    it.skip('can make multiple edits to the Cleanup Job Details schedule, save, disable schedule, and reenable', () => {
-      //Assert the edit form showing
-      //Assert that the edits made were saved
-      //Assert the disabling of the schedule
-      //Assert the reenabling of the schedule
-    });
-  });
-
-  describe('Management Jobs: Notifications Tab', () => {
-    it.skip('can navigate to the Management Jobs -> Notifications list and then to the details page of the Notification', () => {
-      //Assert the navigation to the notifications tab of the Management Job
-      //Assert the navigation to the details page of the notification
-    });
-
-    it.skip('can toggle the Management Jobs -> Notification on and off for job start', () => {
-      //Assert the navigation to the notifications tab of the Management Job
-      //Assert the start toggling on
-      //Assert the start toggling off
-    });
-
-    it.skip('can toggle the Management Jobs -> Notification on and off for job success', () => {
-      //Assert the navigation to the notifications tab of the Management Job
-      //Assert the success toggling on
-      //Assert the success toggling off
-    });
-
-    it.skip('can toggle the Management Jobs -> Notification on and off for job failure', () => {
-      //Assert the navigation to the notifications tab of the Management Job
-      //Assert the failure toggling on
-      //Assert the failure toggling off
+            cy.wait('@launchJob')
+              .its('response.body.id')
+              .then((jobId: string) => {
+                cy.verifyPageTitle(jobName);
+                cy.url().should('include', `/jobs/management/${jobId}/output`);
+                cy.waitForManagementJobStatus(jobId).then((response: SystemJobTemplate) => {
+                  const status = response.status;
+                  let resultStatus;
+                  if (status === 'successful') {
+                    resultStatus = 'Success';
+                  }
+                  cy.contains('a[role="tab"]', 'Details').click();
+                  cy.get('[data-cy="id"]').should('have.text', jobId).should('be.visible');
+                  cy.get('[data-cy="name"]').should('have.text', jobName).should('be.visible');
+                  cy.get('[data-cy="status"]')
+                    .should('have.text', resultStatus)
+                    .should('be.visible');
+                  cy.get('[data-cy="type"]')
+                    .should('have.text', 'Management job')
+                    .should('be.visible');
+                  cy.intercept('DELETE', `api/v2/system_jobs/${jobId}/`).as('deleteMgtJob');
+                  cy.clickPageAction('delete-job');
+                  cy.get('#confirm').click();
+                  cy.clickButton(/^Delete job/);
+                  cy.wait('@deleteMgtJob')
+                    .its('response')
+                    .then((response) => {
+                      expect(response?.statusCode).to.eql(204);
+                    });
+                });
+              });
+          }
+        });
+      cy.navigateTo('awx', 'management-jobs');
     });
   });
 });

--- a/cypress/e2e/awx/administration/management-jobs.cy.ts
+++ b/cypress/e2e/awx/administration/management-jobs.cy.ts
@@ -88,7 +88,7 @@ describe('Management Jobs Page - List and Launch Jobs', () => {
   const managementJobsWithModal = ['Cleanup Activity Stream', 'Cleanup Job Details'];
   const rententionDays = '4';
   managementJobsWithModal.forEach((jobName) => {
-    it(`admin can launch management job: ${jobName} with retention days`, () => {
+    it(`admin can launch management job: ${jobName} with the retention days set`, () => {
       cy.intercept('GET', 'api/v2/system_job_templates/?order_by=name&page=1&page_size=10').as(
         'getManagementJobsListPage'
       );

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1336,20 +1336,15 @@ Cypress.Commands.add('waitForManagementJobStatus', (jobID: string) => {
   cy.requestGet<SystemJobTemplate>(`api/v2/system_jobs/${jobID}/`).then(
     (response: SystemJobTemplate) => {
       const status = response.status;
-      if (!status) {
-        cy.log('Status is null or undefined, retrying...');
-        cy.wait(100).then(() => cy.waitForManagementJobStatus(jobID));
-      } else {
-        switch (status) {
-          case 'failed':
-          case 'successful':
-            cy.log('management job launch status: ' + status);
-            cy.wrap(status);
-            break;
-          default:
-            cy.wait(100).then(() => cy.waitForManagementJobStatus(jobID));
-            break;
-        }
+      switch (status) {
+        case 'failed':
+        case 'successful':
+          cy.log('management job launch status: ' + status);
+          cy.wrap(status);
+          break;
+        default:
+          cy.wait(100).then(() => cy.waitForManagementJobStatus(jobID));
+          break;
       }
     }
   );

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -76,6 +76,7 @@ import {
   HubQueryRolesOptions,
   HubRequestOptions,
 } from './hub-commands';
+import { SystemJobTemplate } from '../../frontend/awx/interfaces/SystemJobTemplate';
 
 declare global {
   namespace Cypress {
@@ -1073,6 +1074,7 @@ declare global {
       ): Chainable<WorkflowApproval>;
 
       waitForTemplateStatus(jobID: string): Chainable<AwxItemsResponse<JobEvent>>;
+      waitForManagementJobStatus(jobID: string): Chainable<SystemJobTemplate>;
       waitForJobToProcessEvents(jobID: string, retries?: number): Chainable<Job>;
       waitForWorkflowJobStatus(jobID: string): Chainable<Job>;
 


### PR DESCRIPTION
## Description
## [This PR is for ticket](https://issues.redhat.com/browse/AAP-23534) 

**More tests for tabs are to be written in separate PRs**

## [Acceptance Criteria](https://issues.redhat.com/browse/AAP-21394)

**Custom Commands**

- [x] Custom command for the Management Job launch that polls until the job execution is completed running `waitForManagementJobStatus`

**Tests**
- [x] admin can launch management job: Cleanup Expired OAuth 2 Tokens
- [x] admin can launch management job: Cleanup Expired Sessions
- [x] admin can launch management job: Cleanup Activity Stream with the retention days set
- [x] admin can launch management job: Cleanup Job Details with the retention days set
