### PR TITLE
Hub: Show gateway landing page banner linking the other UI

### DIFF
--- a/frontend/hub/overview/HubOverview.tsx
+++ b/frontend/hub/overview/HubOverview.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable i18next/no-literal-string */
-import { Bullseye, Button, ButtonVariant } from '@patternfly/react-core';
+import { Banner, Bullseye, Button, ButtonVariant, Flex, FlexItem } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
-import { CogIcon } from '@patternfly/react-icons';
+import { CogIcon, InfoCircleIcon } from '@patternfly/react-icons';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   PageActionSelection,
   PageActionType,
@@ -13,6 +13,7 @@ import {
   PageLayout,
 } from '../../../framework';
 import { EmptyStateNoData } from '../../../framework/components/EmptyStateNoData';
+import { ExternalLink } from '../common/ExternalLink';
 import { CollectionCategoryCarousel } from './CollectionCategories';
 import { CategorizedCollections } from './CollectionCategory';
 import { useCategorizeCollections } from './hooks/useCategorizeCollections';
@@ -31,6 +32,20 @@ export function HubOverview() {
 
   return (
     <PageLayout>
+      <Banner variant="blue">
+        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <InfoCircleIcon />
+          </FlexItem>
+          <FlexItem>
+            <Trans>
+              You are currently viewing a tech preview of the new Ansible Automation Platform user
+              interface. To return to the original interface, click{' '}
+              <ExternalLink href="/ui/">here</ExternalLink>.
+            </Trans>
+          </FlexItem>
+        </Flex>
+      </Banner>
       <PageHeader
         title={t('Welcome to Automation Hub')}
         description={t(


### PR DESCRIPTION
Issue: [AAP-23475](https://issues.redhat.com/browse/AAP-23475)
Design: [figma](https://www.figma.com/proto/8pjK0LL5LxF7mz1gwVh3Pb/Hub-Landing-Page---Banner?page-id=0%3A1&type=design&node-id=12-12855&viewport=381%2C432%2C0.14&t=HYpwT5wDfhcJdUo4-1&scaling=scale-down)
mirrors https://github.com/ansible/ansible-hub-ui/pull/5029

* [x] Banner

![20240509150326](https://github.com/ansible/ansible-ui/assets/289743/a75b9ba4-3c49-4a53-af78-fc350ec0ca82)

* [ ] Modal

Depends on https://github.com/ansible/ansible-ui/pull/2302 for the external link to work right.

---

wip paused pending AAP-23475 refinement