### PR TITLE
[AAP-23770] Fix `Provisioning callback` and `Enable webhook` options in WFJT/JT create/edit forms 

### DIFF
--- a/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
+++ b/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
@@ -5,7 +5,8 @@ import { InstanceGroup } from '../../interfaces/InstanceGroup';
 export function getJobTemplateDefaultValues(
   t: (string: string) => string,
   template?: JobTemplate,
-  instanceGroups?: InstanceGroup[]
+  instanceGroups?: InstanceGroup[],
+  webhookKey?: string
 ): JobTemplateForm | undefined {
   if (!template) return undefined;
   return {
@@ -57,7 +58,9 @@ export function getJobTemplateDefaultValues(
       ? `${document.location.origin}${template.related.webhook_receiver}`
       : t('a new webhook url will be generated on save.').toUpperCase(),
     webhook_key:
-      template.webhook_key || t('a new webhook key will be generated on save.').toUpperCase(),
+      template.webhook_key ||
+      webhookKey ||
+      t('a new webhook key will be generated on save.').toUpperCase(),
     webhook_credential: template.summary_fields?.webhook_credential,
 
     isProvisioningCallbackEnabled: Boolean(template.related?.callback),

--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -319,7 +319,7 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
           />
         </FormSection>
       ) : null}
-      {isWebhookEnabled ? <WebhookSubForm /> : null}
+      {isWebhookEnabled ? <WebhookSubForm templateType="job_templates" /> : null}
     </>
   );
 }

--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -314,7 +314,7 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
           <PageFormTextInput<JobTemplateForm>
             name="host_config_key"
             placeholder={t('Add a host config key')}
-            isRequired
+            isRequired={!!isProvisioningCallbackEnabled}
             label={t('Host config key')}
           />
         </FormSection>

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -54,7 +54,16 @@ export function EditJobTemplate() {
   );
   const { cache } = useSWRConfig();
   const onSubmit: PageFormSubmitHandler<JobTemplateForm> = async (values: JobTemplateForm) => {
-    const { credentials, labels, instance_groups, webhook_key, webhook_url, ...rest } = values;
+    const {
+      credentials,
+      labels,
+      instance_groups,
+      webhook_key,
+      webhook_url,
+      isProvisioningCallbackEnabled,
+      host_config_key,
+      ...rest
+    } = values;
     const formValues = {
       ...rest,
       project: values.project.id,
@@ -63,8 +72,8 @@ export function EditJobTemplate() {
       job_tags: stringifyTags(values.job_tags) ?? '',
       skip_tags: stringifyTags(values.skip_tags) ?? '',
       webhook_credential: values.webhook_credential?.id || null,
+      host_config_key: isProvisioningCallbackEnabled ? host_config_key : null,
     };
-
     await requestPatch<JobTemplateForm>(awxAPI`/job_templates/${id.toString()}/`, formValues);
     (cache as unknown as { clear: () => void }).clear?.();
     const promises = [];

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -47,10 +47,22 @@ export function EditJobTemplate() {
   } = useGet<AwxItemsResponse<InstanceGroup>>(
     awxAPI`/job_templates/${id.toString()}/instance_groups/`
   );
+  const {
+    data: whkData,
+    isLoading: isWhkDataLoading,
+    error: whkDataError,
+    refresh: whkDataRefresh,
+  } = useGet<{ webhook_key: string }>(awxAPI`/job_templates/${id.toString()}/webhook_key/`);
 
   const defaultValues = useMemo(
-    () => getJobTemplateDefaultValues(t, jobTemplate, instanceGroups?.results ?? []),
-    [t, jobTemplate, instanceGroups]
+    () =>
+      getJobTemplateDefaultValues(
+        t,
+        jobTemplate,
+        instanceGroups?.results ?? [],
+        whkData?.webhook_key
+      ),
+    [t, jobTemplate, instanceGroups, whkData]
   );
   const { cache } = useSWRConfig();
   const onSubmit: PageFormSubmitHandler<JobTemplateForm> = async (values: JobTemplateForm) => {
@@ -61,6 +73,7 @@ export function EditJobTemplate() {
       webhook_key,
       webhook_url,
       isProvisioningCallbackEnabled,
+      isWebhookEnabled,
       host_config_key,
       ...rest
     } = values;
@@ -72,6 +85,7 @@ export function EditJobTemplate() {
       job_tags: stringifyTags(values.job_tags) ?? '',
       skip_tags: stringifyTags(values.skip_tags) ?? '',
       webhook_credential: values.webhook_credential?.id || null,
+      webhook_service: isWebhookEnabled ? values.webhook_service : null,
       host_config_key: isProvisioningCallbackEnabled ? host_config_key : null,
     };
     await requestPatch<JobTemplateForm>(awxAPI`/job_templates/${id.toString()}/`, formValues);
@@ -87,16 +101,22 @@ export function EditJobTemplate() {
 
   const getPageUrl = useGetPageUrl();
 
-  const jobTemplateFormError = jobTemplateError || instanceGroupsError;
+  const jobTemplateFormError = jobTemplateError || instanceGroupsError || whkDataError;
   if (jobTemplateFormError instanceof Error) {
     return (
       <AwxError
         error={jobTemplateFormError}
-        handleRefresh={jobTemplateError ? jobTemplateRefresh : instanceGroupRefresh}
+        handleRefresh={
+          jobTemplateError
+            ? jobTemplateRefresh
+            : instanceGroupsError
+              ? instanceGroupRefresh
+              : whkDataRefresh
+        }
       />
     );
   }
-  if (isJobTemplateLoading || isInstanceGroupsLoading) return <LoadingPage />;
+  if (isJobTemplateLoading || isInstanceGroupsLoading || isWhkDataLoading) return <LoadingPage />;
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/awx/resources/templates/WorkflowJobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateInputs.tsx
@@ -127,7 +127,7 @@ export function WorkflowJobTemplateInputs(props: {
         />
       </PageFormSection>
 
-      {isWebhookEnabled ? <WebhookSubForm /> : null}
+      {isWebhookEnabled ? <WebhookSubForm templateType="workflow_job_templates" /> : null}
     </>
   );
 }

--- a/frontend/awx/resources/templates/components/WebhookSubForm.tsx
+++ b/frontend/awx/resources/templates/components/WebhookSubForm.tsx
@@ -15,13 +15,16 @@ import { CredentialType } from '../../../interfaces/CredentialType';
 import { JobTemplateForm } from '../../../interfaces/JobTemplateForm';
 import { WorkflowJobTemplateForm } from '../../../interfaces/WorkflowJobTemplate';
 
-export function WebhookSubForm() {
+export function WebhookSubForm(props: {
+  templateType: 'job_templates' | 'workflow_job_templates';
+}) {
   const { t } = useTranslation();
   const params = useParams<{ id?: string }>();
   const { setValue } = useFormContext<JobTemplateForm | WorkflowJobTemplateForm>();
   const webhookKey = useWatch({ name: 'webhook_key' }) as string;
   const webhookService = useWatch({ name: 'webhook_service' }) as string;
   const isWebhookEnabled = useWatch({ name: 'isWebhookEnabled' }) as boolean;
+  const { templateType } = props;
 
   const { pathname } = useLocation();
 
@@ -35,13 +38,13 @@ export function WebhookSubForm() {
   const handleGenerateWebhookKey = useCallback(async () => {
     if (isWebhookEnabled && params.id) {
       const { webhook_key: webhookKey } = await postRequest<{ webhook_key: string }>(
-        awxAPI`/job_templates/${params.id}/webhook_key/`,
+        awxAPI`/${templateType}/${params.id}/webhook_key/`,
         {}
       );
       setValue('webhook_key', webhookKey);
       return;
     }
-  }, [isWebhookEnabled, setValue, params]);
+  }, [isWebhookEnabled, setValue, params, templateType]);
 
   useGet<AwxItemsResponse<CredentialType>>(
     awxAPI`/credential_types/?namespace=${webhookService}_token`
@@ -53,7 +56,7 @@ export function WebhookSubForm() {
       'related.webhook_receiver',
       pathname.endsWith('/create')
         ? t`a new webhook url will be generated on save.`.toUpperCase()
-        : `${document.location.origin}${awxAPI`/job_template/`}${
+        : `${document.location.origin}${awxAPI`/${templateType}/`}${
             params.id as string
           }/${webhookService}/`
     );
@@ -63,7 +66,7 @@ export function WebhookSubForm() {
         'related.webhook_key',
         t`a new webhook key will be generated on save.`.toUpperCase()
       );
-  }, [webhookService, setValue, pathname, params.id, t]);
+  }, [webhookService, setValue, pathname, params.id, t, templateType]);
 
   const isUpdateKeyDisabled =
     pathname.endsWith('/create') || webhookKey === 'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.';

--- a/frontend/awx/resources/templates/components/WebhookSubForm.tsx
+++ b/frontend/awx/resources/templates/components/WebhookSubForm.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
 import { PageFormSelect, PageFormTextInput } from '../../../../../framework';
 import { PageFormSection } from '../../../../../framework/PageForm/Utils/PageFormSection';
-import { requestGet } from '../../../../common/crud/Data';
+import { postRequest } from '../../../../common/crud/Data';
 import { useGet } from '../../../../common/crud/useGet';
 import { PageFormCredentialSelect } from '../../../access/credentials/components/PageFormCredentialSelect';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
@@ -21,7 +21,7 @@ export function WebhookSubForm() {
   const { setValue } = useFormContext<JobTemplateForm | WorkflowJobTemplateForm>();
   const webhookKey = useWatch({ name: 'webhook_key' }) as string;
   const webhookService = useWatch({ name: 'webhook_service' }) as string;
-  const isWebhookEnabled = useWatch({ name: 'enable_webhook' }) as boolean;
+  const isWebhookEnabled = useWatch({ name: 'isWebhookEnabled' }) as boolean;
 
   const { pathname } = useLocation();
 
@@ -32,9 +32,12 @@ export function WebhookSubForm() {
     }
   );
 
-  const handleFetchWebhookKey = useCallback(async () => {
+  const handleGenerateWebhookKey = useCallback(async () => {
     if (isWebhookEnabled && params.id) {
-      const webhookKey = await requestGet<string>(awxAPI`/job_template/${params.id}/webhook_key`);
+      const { webhook_key: webhookKey } = await postRequest<{ webhook_key: string }>(
+        awxAPI`/job_templates/${params.id}/webhook_key/`,
+        {}
+      );
       setValue('webhook_key', webhookKey);
       return;
     }
@@ -48,12 +51,18 @@ export function WebhookSubForm() {
     if (!webhookService) return;
     setValue(
       'related.webhook_receiver',
-      pathname.endsWith('/creat')
+      pathname.endsWith('/create')
         ? t`a new webhook url will be generated on save.`.toUpperCase()
         : `${document.location.origin}${awxAPI`/job_template/`}${
             params.id as string
           }/${webhookService}/`
     );
+
+    if (pathname.endsWith('/create'))
+      setValue(
+        'related.webhook_key',
+        t`a new webhook key will be generated on save.`.toUpperCase()
+      );
   }, [webhookService, setValue, pathname, params.id, t]);
 
   const isUpdateKeyDisabled =
@@ -74,11 +83,13 @@ export function WebhookSubForm() {
         name="related.webhook_receiver"
         isDisabled={!params.id || !webhookService}
         label={t('Webhook URL')}
+        isReadOnly
         placeholder={t('Select a webhook service')}
       />
       <PageFormTextInput<JobTemplateForm>
         name="webhook_key"
         label={t('Webhook key')}
+        isReadOnly
         button={
           <Button
             ouiaId="update-webhook-key-button"
@@ -86,7 +97,7 @@ export function WebhookSubForm() {
             variant="tertiary"
             aria-label={t`Update webhook key`}
             onClick={() => {
-              void handleFetchWebhookKey();
+              void handleGenerateWebhookKey();
             }}
           >
             <SyncAltIcon />


### PR DESCRIPTION
Issue: [AAP-23770](https://issues.redhat.com/browse/AAP-23770)

Also fixes
- fix default values in webhook forms
- fix re-generating `webhook_key` in edit template
- incorrect `webhook_url` for workflow job templates

