### PR TITLE
[Analytics] Add check there's HOST_METRIC_SUMMARY_TASK_LAST_TS

### DIFF
--- a/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx
+++ b/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx
@@ -71,9 +71,10 @@ export function SubscriptionUsage() {
               <FlexItem>
                 <Text component="small">
                   Last recalculation date:{' '}
-                  {systemData.data !== undefined
+                  {systemData.data !== undefined &&
+                  !!systemData.data.HOST_METRIC_SUMMARY_TASK_LAST_TS
                     ? systemData.data.HOST_METRIC_SUMMARY_TASK_LAST_TS.slice(0, 10)
-                    : null}
+                    : t('None')}
                 </Text>
               </FlexItem>
             </Flex>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-23754

Before:
dev. env. shows bunch of errrors
<img width="963" alt="Screenshot 2024-05-13 at 14 16 58" src="https://github.com/ansible/ansible-ui/assets/9210860/8a5d769a-4289-4bb1-a3f4-cded5bdfde1e">
prod. env. shows empty page
After:
<img width="1434" alt="Screenshot 2024-05-13 at 14 16 19" src="https://github.com/ansible/ansible-ui/assets/9210860/4e2482a3-3b38-4d1d-ad3e-31408f82cdf4">

How to reproduce:
- mock missing `HOST_METRIC_SUMMARY_TASK_LAST_TS`
```diff
diff --git a/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx b/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx
index 63e58373..e8d368f4 100644
--- a/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx
+++ b/frontend/awx/analytics/subscription-usage/SubscriptionUsage.tsx
@@ -72,7 +72,7 @@ export function SubscriptionUsage() {
                 <Text component="small">
                   Last recalculation date:{' '}
                   {systemData.data !== undefined
-                    ? systemData.data.HOST_METRIC_SUMMARY_TASK_LAST_TS.slice(0, 10)
+                    ? systemData.data.HOST_METRIC_SUMMARY_TASK_LAST_S.slice(0, 10)
                     : null}
                 </Text>
               </FlexItem>
```
