### PR TITLE
Hub ExternalLink: update classnames to v5, fix missing children

### DIFF
--- a/frontend/hub/common/ExternalLink.tsx
+++ b/frontend/hub/common/ExternalLink.tsx
@@ -1,13 +1,11 @@
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
-import { ReactNode, CSSProperties, useMemo } from 'react';
+import { type ReactNode, type CSSProperties, useMemo } from 'react';
 
 interface IProps {
   children: ReactNode;
   'data-cy'?: string;
   href: string;
   variant?: 'default' | 'download' | 'menu' | 'nav';
-  target?: string;
-  rel?: string;
 }
 
 const getIconStyle = (variant: string): CSSProperties => {
@@ -22,8 +20,8 @@ const getIconStyle = (variant: string): CSSProperties => {
 };
 
 const classNames = {
-  nav: 'pf-c-nav__link',
-  menu: 'pf-c-dropdown__menu-item',
+  nav: 'pf-v5-c-nav__link',
+  menu: 'pf-v5-c-dropdown__menu-item',
   default: undefined,
   download: undefined,
 };
@@ -50,7 +48,7 @@ export const ExternalLink = ({
       rel="nofollow noopener noreferrer"
       target="_blank"
     >
-      {children && <ExternalLinkAltIcon style={iconStyle} />}
+      {children} <ExternalLinkAltIcon style={iconStyle} />
     </a>
   );
 };

--- a/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCLI.tsx
+++ b/frontend/hub/namespaces/HubNamespacePage/HubNamespaceCLI.tsx
@@ -13,11 +13,7 @@ export function HubNamespaceCLI() {
         <Trans>
           <b>Note:</b> Use this URL to configure ansible-galaxy to upload collections to this
           namespace. More information on ansible-galaxy configurations can be found{' '}
-          <ExternalLink
-            href="https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client"
-            target="_blank"
-            rel="noreferrer"
-          >
+          <ExternalLink href="https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client">
             here.
           </ExternalLink>
         </Trans>


### PR DESCRIPTION
`ExternalLink` ignores `target` and `rel` props (as it should), remove from props.
Change patternfly classnames to their v5 variants.
Show `children`, instead of only showing the external link icon when children exist.