### PR TITLE
Persist default values in re-enabling webhook and provisioning callback 

### DIFF
--- a/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
+++ b/frontend/awx/resources/templates/JobTemplateFormHelpers.ts
@@ -5,8 +5,7 @@ import { InstanceGroup } from '../../interfaces/InstanceGroup';
 export function getJobTemplateDefaultValues(
   t: (string: string) => string,
   template?: JobTemplate,
-  instanceGroups?: InstanceGroup[],
-  webhookKey?: string
+  instanceGroups?: InstanceGroup[]
 ): JobTemplateForm | undefined {
   if (!template) return undefined;
   return {
@@ -57,10 +56,7 @@ export function getJobTemplateDefaultValues(
     webhook_url: template.related?.webhook_receiver
       ? `${document.location.origin}${template.related.webhook_receiver}`
       : t('a new webhook url will be generated on save.').toUpperCase(),
-    webhook_key:
-      template.webhook_key ||
-      webhookKey ||
-      t('a new webhook key will be generated on save.').toUpperCase(),
+    webhook_key: t('a new webhook key will be generated on save.').toUpperCase(),
     webhook_credential: template.summary_fields?.webhook_credential,
 
     isProvisioningCallbackEnabled: Boolean(template.related?.callback),

--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -36,7 +36,7 @@ const acceptableCredentialKinds = [
 export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
   const { jobtemplate } = props;
   const { t } = useTranslation();
-  const { setValue } = useFormContext<JobTemplateForm>();
+  const { setValue, getValues, reset } = useFormContext<JobTemplateForm>();
   const [playbookOptions, setPlaybookOptions] = useState<string[]>();
   const projectPath = useWatch({
     name: 'project',
@@ -55,6 +55,10 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
   const organization = useWatch<JobTemplateForm>({ name: 'organization' });
   const organizationId: string | undefined =
     organization?.toString() ?? projectPath?.organization?.toString();
+
+  useEffect(() => {
+    reset(getValues());
+  }, [isProvisioningCallbackEnabled, reset, getValues]);
 
   useEffect(() => {
     async function handleFetchPlaybooks() {

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -47,22 +47,10 @@ export function EditJobTemplate() {
   } = useGet<AwxItemsResponse<InstanceGroup>>(
     awxAPI`/job_templates/${id.toString()}/instance_groups/`
   );
-  const {
-    data: whkData,
-    isLoading: isWhkDataLoading,
-    error: whkDataError,
-    refresh: whkDataRefresh,
-  } = useGet<{ webhook_key: string }>(awxAPI`/job_templates/${id.toString()}/webhook_key/`);
 
   const defaultValues = useMemo(
-    () =>
-      getJobTemplateDefaultValues(
-        t,
-        jobTemplate,
-        instanceGroups?.results ?? [],
-        whkData?.webhook_key
-      ),
-    [t, jobTemplate, instanceGroups, whkData]
+    () => getJobTemplateDefaultValues(t, jobTemplate, instanceGroups?.results ?? []),
+    [t, jobTemplate, instanceGroups]
   );
   const { cache } = useSWRConfig();
   const onSubmit: PageFormSubmitHandler<JobTemplateForm> = async (values: JobTemplateForm) => {
@@ -101,22 +89,16 @@ export function EditJobTemplate() {
 
   const getPageUrl = useGetPageUrl();
 
-  const jobTemplateFormError = jobTemplateError || instanceGroupsError || whkDataError;
+  const jobTemplateFormError = jobTemplateError || instanceGroupsError;
   if (jobTemplateFormError instanceof Error) {
     return (
       <AwxError
         error={jobTemplateFormError}
-        handleRefresh={
-          jobTemplateError
-            ? jobTemplateRefresh
-            : instanceGroupsError
-              ? instanceGroupRefresh
-              : whkDataRefresh
-        }
+        handleRefresh={jobTemplateError ? jobTemplateRefresh : instanceGroupRefresh}
       />
     );
   }
-  if (isJobTemplateLoading || isInstanceGroupsLoading || isWhkDataLoading) return <LoadingPage />;
+  if (isJobTemplateLoading || isInstanceGroupsLoading) return <LoadingPage />;
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
@@ -42,14 +42,6 @@ export function EditWorkflowJobTemplate() {
     refresh: wfjtRefresh,
     isLoading: isWfjtLoading,
   } = useGet<WorkflowJobTemplate>(awxAPI`/workflow_job_templates/${id.toString()}/`);
-  const {
-    data: whkData,
-    isLoading: isWhkDataLoading,
-    error: whkDataError,
-    refresh: whkDataRefresh,
-  } = useGet<{ webhook_key: string }>(
-    awxAPI`/workflow_job_templates/${id.toString()}/webhook_key/`
-  );
 
   const onSubmit: PageFormSubmitHandler<WorkflowJobTemplateForm> = async (
     values: WorkflowJobTemplateForm
@@ -94,28 +86,20 @@ export function EditWorkflowJobTemplate() {
       scm_branch: workflowJobTemplate.scm_branch || '',
       skip_tags: parseStringToTagArray(workflowJobTemplate.job_tags || ''),
       webhook_credential: workflowJobTemplate.summary_fields.webhook_credential || null,
-      webhook_key:
-        whkData?.webhook_key || t('a new webhook key will be generated on save.').toUpperCase(),
+      webhook_key: t('a new webhook key will be generated on save.').toUpperCase(),
       webhook_url: workflowJobTemplate.related?.webhook_receiver
         ? `${document.location.origin}${workflowJobTemplate.related.webhook_receiver}`
         : t('a new webhook url will be generated on save.').toUpperCase(),
       webhook_receiver: workflowJobTemplate.related.webhook_receiver,
       webhook_service: workflowJobTemplate.webhook_service || '',
     };
-  }, [t, workflowJobTemplate, whkData]);
+  }, [t, workflowJobTemplate]);
   const { cache } = useSWRConfig();
 
-  const wfjtFormError = wfjtError || whkDataError;
-
-  if (wfjtFormError instanceof Error) {
-    return (
-      <AwxError
-        error={wfjtFormError}
-        handleRefresh={wfjtFormError ? wfjtRefresh : whkDataRefresh}
-      />
-    );
+  if (wfjtError instanceof Error) {
+    return <AwxError error={wfjtError} handleRefresh={wfjtRefresh} />;
   }
-  if (isWfjtLoading || isWhkDataLoading) return <LoadingPage />;
+  if (isWfjtLoading) return <LoadingPage />;
   return (
     <PageLayout>
       <PageHeader

--- a/frontend/awx/resources/templates/components/WebhookSubForm.tsx
+++ b/frontend/awx/resources/templates/components/WebhookSubForm.tsx
@@ -44,14 +44,14 @@ export function WebhookSubForm(props: {
       const whkData = await requestGet<WebhookKey>(
         awxAPI`/${templateType}/${params.id ?? ''}/webhook_key/`
       );
-      setValue('webhook_key', whkData.webhook_key || webhookKey);
+      reset({
+        ...getValues(),
+        webhook_key: whkData.webhook_key || webhookKey || (getValues('webhook_key') as string),
+      });
     }
     if (!pathname.endsWith('/create')) void handleFetchWebhookKey();
-  }, [params.id, setValue, pathname, templateType, webhookKey]);
-
-  useEffect(() => {
-    reset(getValues());
-  }, [reset, getValues]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (webhookService)


### PR DESCRIPTION
Re-enabling `webhook_key` subform option or provisioning callback subform causes default values to be empty.

before:
![chrome-capture-2024-5-14 (1)](https://github.com/ansible/ansible-ui/assets/19647757/3d544600-911a-42fa-9076-4c928893b25a)


after:
![chrome-capture-2024-5-14](https://github.com/ansible/ansible-ui/assets/19647757/a523ec0a-4177-4493-b762-106e7634fba9)
