### PR TITLE
Add custom command to query for AWX role definitions

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -13,7 +13,6 @@ describe('Schedules - Create and Delete', function () {
   let jobTemplate: JobTemplate;
   let project: Project;
   let inventory: Inventory;
-  let inventorySource: InventorySource;
   let schedule: Schedule;
   const testSignature: string = randomString(5, undefined, { isLowercase: true });
   function generateScheduleName(): string {
@@ -31,9 +30,6 @@ describe('Schedules - Create and Delete', function () {
       organization = o;
       cy.createAwxInventory({ organization: organization.id }).then((i) => {
         inventory = i;
-        cy.createAwxInventorySource(i, project).then((invSrc) => {
-          inventorySource = invSrc;
-        });
       });
     });
     const schedName = 'E2E Schedule' + randomString(4);
@@ -50,7 +46,6 @@ describe('Schedules - Create and Delete', function () {
     cy.deleteAWXSchedule(schedule, { failOnStatusCode: false });
     cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
   });
 
   it('can create a simple schedule, navigate to schedule details, then delete the schedule from the details page', () => {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -31,6 +31,7 @@ import { WorkflowJobNode, WorkflowNode } from '../../frontend/awx/interfaces/Wor
 import { Spec } from '../../frontend/awx/interfaces/Survey';
 import { awxAPI } from './formatApiPathForAwx';
 import { Survey } from '../../frontend/awx/interfaces/Survey';
+import { RoleSerializerWithParentAccess } from '../../frontend/awx/interfaces/generated-from-swagger/api';
 
 //  AWX related custom command implementation
 
@@ -776,6 +777,15 @@ Cypress.Commands.add(
     }
   }
 );
+
+Cypress.Commands.add('getAwxRoles', () => {
+  cy.requestGet<AwxItemsResponse<RoleSerializerWithParentAccess>>(awxAPI`/role_definitions/`).then(
+    (response) => {
+      const awxRoles = response.results;
+      return awxRoles;
+    }
+  );
+});
 
 Cypress.Commands.add(
   'createAwxProject',

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -25,6 +25,7 @@ import { Schedule } from '../../frontend/awx/interfaces/Schedule';
 import { Survey } from '../../frontend/awx/interfaces/Survey';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { AwxUser } from '../../frontend/awx/interfaces/User';
+import { RoleSerializerWithParentAccess } from '../../frontend/awx/interfaces/generated-from-swagger/api';
 import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../frontend/awx/interfaces/WorkflowNode';
@@ -886,7 +887,10 @@ declare global {
       getAwxJobTemplateByName(awxJobTemplateName: string): Chainable<JobTemplate>;
       createAwxTeam(organization: Organization): Chainable<Team>;
       createAwxUser(organization: Organization): Chainable<AwxUser>;
-      createAwxInstanceGroup(instanceGroup?: Partial<InstanceGroup>): Chainable<InstanceGroup>;
+      getAwxRoles(): Chainable<RoleSerializerWithParentAccess>;
+      createAwxInstanceGroup(
+        instanceGroup?: Partial<Omit<InstanceGroup, 'id'>>
+      ): Chainable<InstanceGroup>;
       createAwxInstance(hostname: string, listener_port?: number): Chainable<Instance>;
       createAwxLabel(label: Partial<Omit<Label, 'id'>>): Chainable<Label>;
       createGlobalOrganization(): Chainable<void>;


### PR DESCRIPTION
This custom command queries the Controller API to return a list of role definitions, as shown below. This command will be useful once the role definitions feature is finished downstream.
![image](https://github.com/ansible/ansible-ui/assets/63685497/b88f9717-d295-45d0-b3a6-8948543714e4)
