### PR TITLE
Fix infinite credential type requests in InventoryRunCommand test

### DIFF
--- a/cypress/fixtures/machine_credential_type.json
+++ b/cypress/fixtures/machine_credential_type.json
@@ -1,6 +1,6 @@
 {
   "count": 1,
-  "next": "/api/v2/credential_types/?order_by=-managed&page=2&page_size=10",
+  "next": null,
   "previous": null,
   "results": [
     {

--- a/frontend/awx/resources/inventories/InventoryRunCommand.cy.tsx
+++ b/frontend/awx/resources/inventories/InventoryRunCommand.cy.tsx
@@ -32,7 +32,7 @@ describe('Run command wizard', () => {
       }
     );
   });
-  it('reveiw step has correct values', () => {
+  it('review step has correct values', () => {
     cy.mount(<InventoryRunCommand />);
     cy.selectDropdownOptionByResourceName('module-name', 'shell');
     cy.getByDataCy('module-args-form-group').type('argument');
@@ -59,11 +59,8 @@ describe('Run command wizard', () => {
       cy.clickButton(/^Confirm/);
     });
     cy.clickButton(/^Next$/);
-    cy.getByDataCy('credential-select-form-group').within(() => {
-      cy.getBy('[aria-label="Options menu"]').click();
-    });
-    cy.selectTableRowByCheckbox('name', 'Demo Credential');
-    cy.clickButton(/^Confirm$/);
+    cy.get('#credential-select').type('Demo Credential');
+
     cy.clickButton(/^Next$/);
     cy.getByDataCy('module').should('contain', 'shell');
     cy.getByDataCy('arguments').should('contain', 'argument');


### PR DESCRIPTION
* Update test fixture value to `"next": null` to prevent `useAwxGetAllPages` from making additional requests
* Type credential value instead of selecting from flakey popup modal


_Screenshot of failing test_
<img width="1239" alt="Screenshot 2024-05-15 at 3 50 41 PM" src="https://github.com/ansible/ansible-ui/assets/15881645/e08603d6-74fb-4d76-ae2c-075048970f77">
