### PR TITLE
Removal of unnecessary TODO

### DIFF
--- a/frontend/awx/access/common/useRemoveUserFromResource.tsx
+++ b/frontend/awx/access/common/useRemoveUserFromResource.tsx
@@ -37,7 +37,6 @@ export function useRemoveUsersFromResource() {
       const titleMap: { [key: string]: string } = {
         organization: 'Remove user from organization',
         team: 'Remove user from team',
-        // TODO: Expand map for other resource types
       };
       const title = resource.type ? titleMap[resource.type] : 'Remove user';
 

--- a/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
@@ -50,19 +50,6 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
         label: t('Add users to selected teams'),
         onClick: () => selectUsersAddTeams(view.selectedItems),
       },
-      /**
-       * TODO: This feature is being hidden for the time being as it is not implemented accurately
-       * at the moment. It is also not a feature in the awx UI.
-       * With each team having its own access_list of users, we will need to design an experience
-       * and implementation to handle removal of users from multiple teams.
-       */
-      // {
-      //   type: PageActionType.Button,
-      // selection: PageActionSelection.Multiple,
-      //   icon: MinusCircleIcon,
-      //   label: t('Remove users from selected teams'),
-      //   onClick: () => selectUsersRemoveTeams(view.selectedItems), // This hook has been repurposed as useSelectAndRemoveUsersFromTeam to handle removing users from a single team
-      // },
       {
         type: PageActionType.Button,
         selection: PageActionSelection.None,


### PR DESCRIPTION
[AAP-24151](https://issues.redhat.com/browse/AAP-24151)
Re: the toolbar action `Remove users from selected teams` for removing multiple users from multiple teams -- This TODO will not be applicable when we update the Controller Access Management UI upstream. It is not a feature of the Access Management UI mockups (or even the existing AWX UI). 

[AAP-24146](https://issues.redhat.com/browse/AAP-24146)
[AAP-24147](https://issues.redhat.com/browse/AAP-24147)
The other TODOs in `ResourceAccessList` and `useRemoveUserFromResource` will also become obsolete in the future when we're ready to replace ResourceAccessList with the updated UI/endpoints for handling team access upstream.

Update -> `ResourceAccessList` (obsolete) was removed in https://github.com/ansible/ansible-ui/pull/2362