### PR TITLE
Back button doesn't work after redirect in JT notification tab link

### DIFF
--- a/frontend/awx/resources/notifications/hooks/useNotificationColumns.tsx
+++ b/frontend/awx/resources/notifications/hooks/useNotificationColumns.tsx
@@ -14,7 +14,7 @@ export function useNotificationsColumns(options?: {
   const pageNavigate = usePageNavigate();
   const nameClick = useCallback(
     (notificationTemplate: NotificationTemplate) => {
-      return pageNavigate(AwxRoute.NotificationTemplatePage, {
+      return pageNavigate(AwxRoute.NotificationTemplateDetails, {
         params: {
           id: notificationTemplate.id,
         },


### PR DESCRIPTION
No-Issue

Browser back button doesn't work when user clicks on notification link in the Job Template notification tab

before:
![chrome-capture-2024-5-20 (1)](https://github.com/ansible/ansible-ui/assets/19647757/674af63c-0f85-4549-9408-986bb8e25ed5)

after:
![chrome-capture-2024-5-20](https://github.com/ansible/ansible-ui/assets/19647757/51cde054-6245-4393-97ce-ad87068e9074)

