### PR TITLE
Avoid using only integers as keys when internally tracking selected items in the map

### DIFF
--- a/framework/PageTable/useTableItems.tsx
+++ b/framework/PageTable/useTableItems.tsx
@@ -104,7 +104,7 @@ export function useSelected<T extends object>(
   const [selectedMap, setSelectedMap] = useState<Record<string | number, T>>(() => {
     if (defaultSelection) {
       return defaultSelection.reduce<Record<string | number, T>>((selectedMap, item) => {
-        selectedMap[keyFn(item)] = item;
+        selectedMap[`item-${keyFn(item)}`] = item;
         return selectedMap;
       }, {});
     } else {
@@ -116,7 +116,7 @@ export function useSelected<T extends object>(
     setSelectedMap((selectedMap) => {
       let changed = false;
       items.forEach((item) => {
-        const key = keyFn(item);
+        const key = `item-${keyFn(item)}`;
         if (selectedMap[key] && selectedMap[key] !== item) {
           changed = true;
           selectedMap[key] = item;
@@ -129,7 +129,7 @@ export function useSelected<T extends object>(
   const selectItem = useCallback(
     (item: T) => {
       setSelectedMap((selectedMap) => {
-        const itemKey = keyFn(item);
+        const itemKey = `item-${keyFn(item)}`;
         const existing = selectedMap[itemKey];
         if (existing !== item) {
           selectedMap = { ...selectedMap };
@@ -144,7 +144,7 @@ export function useSelected<T extends object>(
   const unselectItem = useCallback(
     (item: T) => {
       setSelectedMap((selectedMap) => {
-        const itemKey = keyFn(item);
+        const itemKey = `item-${keyFn(item)}`;
         const existing = selectedMap[itemKey];
         if (existing) {
           selectedMap = { ...selectedMap };
@@ -158,7 +158,7 @@ export function useSelected<T extends object>(
 
   const isSelected = useCallback(
     (item: T) => {
-      const itemKey = keyFn(item);
+      const itemKey = `item-${keyFn(item)}`;
       return selectedMap[itemKey] !== undefined;
     },
     [keyFn, selectedMap]
@@ -169,7 +169,7 @@ export function useSelected<T extends object>(
       setSelectedMap((selectedMap) => {
         selectedMap = { ...selectedMap };
         for (const item of items) {
-          const itemKey = keyFn(item);
+          const itemKey = `item-${keyFn(item)}`;
           selectedMap[itemKey] = item;
         }
         return selectedMap;


### PR DESCRIPTION
When adding key/value pairs to an object in javascript, insert order is maintained as long as the keys are not integers (or stringified integers).  We're using stringified integers (id's) in almost all cases though: https://github.com/ansible/ansible-ui/blob/main/frontend/common/crud/Data.tsx#L106-L108.  By doing this, the order of selected items will always be ordered ascending by id rather than the order in which things were selected (or the order in which the API gives us previously selected items).

This isn't the most elegant solution but I believe it will work.  By adding a prefix to every key we can ensure that the key is a non-integer string and thus preserve the insert order.  As best as I can tell, this only impacts the internals of the hook and shouldn't impact anything that uses the hook.

Some blogs I found helpful for understanding how this works in JS:
https://darrinholst.com/blog/2021/09/25/object-keys/
https://dev.to/frehner/the-order-of-js-object-keys-458d