### PR TITLE
URL cleanup

### DIFF
--- a/cypress/e2e/awx/administration/instanceGroups.cy.ts
+++ b/cypress/e2e/awx/administration/instanceGroups.cy.ts
@@ -74,8 +74,7 @@ instanceGroupTypes.forEach((igType) => {
       cy.verifyPageTitle(name);
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes(`infrastructure/instance_groups/${igType.toLowerCase()}-group`))
-          .to.be.true;
+        expect(currentUrl.includes(`infrastructure/instance-groups`)).to.be.true;
       });
       if (igType === 'Instance') {
         cy.getByDataCy('policy-instance-minimum').should('have.text', '1');
@@ -270,8 +269,7 @@ instanceGroupTypes.forEach((igType) => {
       cy.get('[data-cy="name-column-cell"]').click();
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes(`infrastructure/instance_groups/${igType.toLowerCase()}-group`))
-          .to.be.true;
+        expect(currentUrl.includes(`infrastructure/instance-groups`)).to.be.true;
       });
       cy.getByDataCy(`edit-${igType.toLowerCase()}-group`).click();
       cy.get('[data-cy="name"]').clear();
@@ -323,8 +321,7 @@ instanceGroupTypes.forEach((igType) => {
       cy.get('[data-cy="name-column-cell"]').click();
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes(`infrastructure/instance_groups/${igType.toLowerCase()}-group`))
-          .to.be.true;
+        expect(currentUrl.includes(`infrastructure/instance-groups`)).to.be.true;
       });
       cy.clickPageAction(`delete-${igType.toLowerCase()}-group`);
       cy.intercept('DELETE', awxAPI`/instance_groups/*/`).as('deleteInstanceGroup');
@@ -390,8 +387,7 @@ instanceGroupTypes.forEach((igType) => {
       });
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes(`infrastructure/instance_groups/${igType.toLowerCase()}-group`))
-          .to.be.true;
+        expect(currentUrl.includes(`infrastructure/instance-groups`)).to.be.true;
       });
       cy.clickTab(/^Team access$/, true);
       cy.get('.pf-v5-c-empty-state__title-text').contains(
@@ -400,7 +396,7 @@ instanceGroupTypes.forEach((igType) => {
       cy.get('.pf-v5-c-empty-state__body').contains(/^Add a role by clicking the button below./);
       cy.getByDataCy('add-roles').click();
       cy.url().then((currentUrl) => {
-        expect(currentUrl.includes('infrastructure/instance_groups/')).to.be.true;
+        expect(currentUrl.includes('infrastructure/instance-groups/')).to.be.true;
         expect(currentUrl.includes('instance-groups/teams/add-teams')).to.be.true;
       });
       cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select team(s)');
@@ -438,9 +434,7 @@ instanceGroupTypes.forEach((igType) => {
         .then((response) => {
           expect(response?.statusCode).to.eql(201);
         });
-      cy.visit(
-        `/infrastructure/instance_groups/${igType.toLowerCase()}-groups/${instanceGroup.id}/team-access`
-      );
+      cy.visit(`/infrastructure/instance-groups/${instanceGroup.id}/team-access`);
       cy.verifyPageTitle(instanceGroup.name);
       cy.get('[data-cy="text-input"]').find('input').type(team.name);
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
@@ -508,8 +502,7 @@ instanceGroupTypes.forEach((igType) => {
       });
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes(`infrastructure/instance_groups/${igType.toLowerCase()}-group`))
-          .to.be.true;
+        expect(currentUrl.includes(`infrastructure/instance-groups`)).to.be.true;
       });
       cy.clickTab(/^User access$/, true);
       cy.get('.pf-v5-c-empty-state__title-text').contains(
@@ -518,7 +511,7 @@ instanceGroupTypes.forEach((igType) => {
       cy.get('.pf-v5-c-empty-state__body').contains(/^Add a role by clicking the button below./);
       cy.getByDataCy('add-roles').click();
       cy.url().then((currentUrl) => {
-        expect(currentUrl.includes('infrastructure/instance_groups/')).to.be.true;
+        expect(currentUrl.includes('infrastructure/instance-groups/')).to.be.true;
         expect(currentUrl.includes('instance-groups/users/add-users')).to.be.true;
       });
       cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select user(s)');
@@ -555,9 +548,7 @@ instanceGroupTypes.forEach((igType) => {
         .then((response) => {
           expect(response?.statusCode).to.eql(201);
         });
-      cy.visit(
-        `/infrastructure/instance_groups/${igType.toLowerCase()}-groups/${instanceGroup.id}/user-access`
-      );
+      cy.visit(`/infrastructure/instance-groups/${instanceGroup.id}/user-access`);
       cy.verifyPageTitle(instanceGroup.name);
       cy.get('[data-cy="text-input"]').find('input').type(user.username);
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
@@ -633,7 +624,7 @@ describe('Instance Groups: Jobs Tab', () => {
     });
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups/container-group')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
     cy.clickTab(/^Jobs$/, true);
     cy.filterTableBySingleSelect('name', job_template.name);
@@ -689,7 +680,7 @@ describe('Instance Groups: Instances Tab', () => {
     cy.get('[data-cy="name-column-cell"]').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
 
     cy.clickTab(/^Instances$/, true);
@@ -753,7 +744,7 @@ describe('Instance Groups: Instances Tab', () => {
       cy.get('[data-cy="name-column-cell"]').click();
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+        expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
       });
       cy.clickTab(/^Instances$/, true);
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
@@ -801,7 +792,7 @@ describe('Instance Groups: Instances Tab', () => {
     cy.get('[data-cy="name-column-cell"]').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
     cy.clickTab(/^Instances$/, true);
     cy.get('button').contains('Run health check').should('have.attr', 'aria-disabled', 'true');
@@ -838,7 +829,7 @@ describe('Instance Groups: Instances Tab', () => {
     cy.get('[data-cy="name-column-cell"]').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
     cy.clickTab(/^Instances$/, true);
     cy.get('[data-ouia-component-id="simple-table"]').within(() => {
@@ -862,7 +853,7 @@ describe('Instance Groups: Instances Tab', () => {
     cy.get('[data-cy="name-column-cell"]').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
     cy.clickTab(/^Instances$/, true);
     cy.get('[data-ouia-component-id="simple-table"]').within(() => {
@@ -872,7 +863,7 @@ describe('Instance Groups: Instances Tab', () => {
     cy.get('[data-cy="name-column-cell"]').click();
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes('details')).to.be.true;
-      expect(currentUrl.includes('infrastructure/instance_groups')).to.be.true;
+      expect(currentUrl.includes('infrastructure/instance-groups')).to.be.true;
     });
     cy.verifyPageTitle(instance.hostname);
     cy.contains('nav[aria-label="Breadcrumb"]', 'Instance groups').should('exist');

--- a/cypress/e2e/awx/administration/topology-view.cy.ts
+++ b/cypress/e2e/awx/administration/topology-view.cy.ts
@@ -66,7 +66,7 @@ describe('Topology view', () => {
           .then((instanceGroups: InstanceGroup[]) => {
             cy.clickLink(`${instanceGroups[0].name}`);
             // TODO Instance groups detail page not yet implemented; check URL for now
-            cy.url().should('contain', `/instance_groups/instance-group/${instanceGroups[0].id}`);
+            cy.url().should('contain', `/instance-groups/${instanceGroups[0].id}`);
           });
       });
   });

--- a/cypress/e2e/awx/administration/workflowApproval.cy.ts
+++ b/cypress/e2e/awx/administration/workflowApproval.cy.ts
@@ -143,9 +143,9 @@ describe.skip('Workflow Approvals - List View', () => {
   // TODO: Launch template using the API
   // cy.intercept(
   //   'POST',
-  //   awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/launch`
+  //   awxAPI`/workflow-job-templates/${workflowJobTemplate.id.toString()}/launch`
   // ).as('launchWFJT');
-  // cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id.toString()}/details`);
+  // cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id.toString()}/details`);
   // cy.getByDataCy('launch-template').click();
   // });
 
@@ -181,7 +181,7 @@ describe.skip('Workflow Approvals - List View', () => {
       'POST',
       awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/launch`
     ).as('launchWFJT');
-    cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id.toString()}/details`);
+    cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id.toString()}/details`);
     cy.getByDataCy('launch-template').click();
     cy.wait('@launchWFJT')
       .its('response.body')
@@ -198,7 +198,7 @@ describe.skip('Workflow Approvals - List View', () => {
       'POST',
       awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/launch`
     ).as('launchWFJT');
-    cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id.toString()}/details`);
+    cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id.toString()}/details`);
     cy.getByDataCy('launch-template').click();
     cy.wait('@launchWFJT')
       .its('response.body')
@@ -215,7 +215,7 @@ describe.skip('Workflow Approvals - List View', () => {
       'POST',
       awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/launch`
     ).as('launchWFJT');
-    cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id.toString()}/details`);
+    cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id.toString()}/details`);
     cy.getByDataCy('launch-template').click();
     cy.wait('@launchWFJT')
       .its('response.body')

--- a/cypress/e2e/awx/resources/jobTemplateSurveys.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplateSurveys.cy.ts
@@ -36,7 +36,7 @@ describe('Job Templates Surveys', function () {
             jobTemplate = jT;
             reusableTemplateSurveyTestSuite = new ReusableTemplateSurveyTestSuite(jobTemplate);
 
-            cy.visit(`/templates/job_template/${jobTemplate.id}/survey`);
+            cy.visit(`/templates/job-template/${jobTemplate.id}/survey`);
           });
         }
       );
@@ -74,7 +74,7 @@ describe('Job Templates Surveys', function () {
             jobTemplate = jT;
             reusableTemplateSurveyTestSuite = new ReusableTemplateSurveyTestSuite(jobTemplate);
 
-            cy.visit(`/templates/job_template/${jobTemplate.id}/survey`);
+            cy.visit(`/templates/job-template/${jobTemplate.id}/survey`);
           });
         }
       );

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -318,7 +318,7 @@ describe('Job Templates Tests', function () {
         (inv) => {
           inventory2 = inv;
 
-          cy.visit(`templates/job_template/${jobTemplate.id}/details`);
+          cy.visit(`templates/job-template/${jobTemplate.id}/details`);
           cy.contains(jobTemplate.name);
           cy.getByDataCy('inventory').contains(jobTemplate.summary_fields.inventory.name).click();
 
@@ -330,7 +330,7 @@ describe('Job Templates Tests', function () {
           cy.clickModalButton('Delete inventory');
           cy.wait('@deleteInventory');
 
-          cy.visit(`templates/job_template/${jobTemplate.id}/details`);
+          cy.visit(`templates/job-template/${jobTemplate.id}/details`);
           cy.contains(jobTemplate.name);
           cy.getByDataCy('inventory').contains('Deleted');
           cy.clickLink('Edit template');
@@ -345,10 +345,10 @@ describe('Job Templates Tests', function () {
       );
     });
 
-    it('can edit a job template to enable provisioning callback and and enable webhook, then edit again to disable those options', function () {
+    it('can edit a job template to enable provisioning callback and enable webhook, then edit again to disable those options', function () {
       const jtURL = document.location.origin + awxAPI`/job_templates/${jobTemplate.id.toString()}`;
 
-      cy.visit(`templates/job_template/${jobTemplate.id}/details`);
+      cy.visit(`templates/job-template/${jobTemplate.id}/details`);
       cy.get('[data-cy="enabled-options"]').should('not.exist');
       cy.clickLink('Edit template');
 
@@ -577,7 +577,7 @@ describe('Job Templates Tests', function () {
     });
 
     it('can copy an existing job template from the details page', function () {
-      cy.visit(`/templates/job_template/${jobTemplate.id.toString()}/details`);
+      cy.visit(`/templates/job-template/${jobTemplate.id.toString()}/details`);
       cy.intercept('POST', awxAPI`/job_templates/${jobTemplate.id.toString()}/copy/`).as(
         'copyTemplate'
       );
@@ -586,7 +586,7 @@ describe('Job Templates Tests', function () {
       cy.wait('@copyTemplate')
         .its('response.body')
         .then(({ id, name }: { id: number; name: string }) => {
-          cy.visit(`/templates/job_template/${id}/details`);
+          cy.visit(`/templates/job-template/${id}/details`);
           cy.contains(name);
         });
     });

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -625,7 +625,7 @@ describe('Projects', () => {
           cy.clickTab('Job templates', true);
           cy.url().should(
             'contain',
-            `/projects/${thisProject.id}/job_templates?page=1&perPage=10&sort=name`
+            `/projects/${thisProject.id}/job-templates?page=1&perPage=10&sort=name`
           );
           cy.filterTableByMultiSelect('name', [jobTemplate.name]);
           cy.getTableRow('name', jobTemplate.name, { disableFilter: true }).should('be.visible');

--- a/cypress/e2e/awx/resources/workflowJobTemplateSurveys.cy.ts
+++ b/cypress/e2e/awx/resources/workflowJobTemplateSurveys.cy.ts
@@ -36,7 +36,7 @@ describe('Workflow Job Templates Surveys', function () {
               workflowJobTemplate
             );
 
-            cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id}/survey`);
+            cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id}/survey`);
           });
         }
       );
@@ -75,7 +75,7 @@ describe('Workflow Job Templates Surveys', function () {
               workflowJobTemplate
             );
 
-            cy.visit(`/templates/workflow_job_template/${workflowJobTemplate.id}/survey`);
+            cy.visit(`/templates/workflow-job-template/${workflowJobTemplate.id}/survey`);
           });
         }
       );

--- a/cypress/e2e/awx/resources/workflowVisualizerCRUD.cy.ts
+++ b/cypress/e2e/awx/resources/workflowVisualizerCRUD.cy.ts
@@ -112,7 +112,7 @@ describe('Workflow Visualizer', () => {
     });
 
     it('Adds a new node linked to an existing node with always status, and save the visualizer.', function () {
-      cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+      cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
       cy.contains('Workflow Visualizer').should('be.visible');
       cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
         force: true,
@@ -144,7 +144,7 @@ describe('Workflow Visualizer', () => {
     });
 
     it('Adds a new node specifically linked to an already existing node.', function () {
-      cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+      cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
       cy.contains('Workflow Visualizer').should('be.visible');
       cy.get(`g[data-id="${projectNode.id}"]`)
         .should('be.visible')
@@ -192,7 +192,7 @@ describe('Workflow Visualizer', () => {
                 cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
               })
               .then(() => {
-                cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+                cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
                 cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
                   force: true,
                 });
@@ -234,7 +234,7 @@ describe('Workflow Visualizer', () => {
           });
         })
         .then(() => {
-          cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+          cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
           cy.contains('Workflow Visualizer').should('be.visible');
           cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).should(
             'have.text',
@@ -252,7 +252,7 @@ describe('Workflow Visualizer', () => {
     });
 
     it('Create a job template node using a JT with multiple dependencies and then edit the node to use a different resource', function () {
-      cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+      cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
       cy.contains('Workflow Visualizer').should('be.visible');
       cy.clickButton('Add step');
       cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
@@ -291,7 +291,7 @@ describe('Workflow Visualizer', () => {
           });
         })
         .then(() => {
-          cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+          cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
           cy.contains('Workflow Visualizer').should('be.visible');
           cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
             force: true,
@@ -348,7 +348,7 @@ describe('Workflow Visualizer', () => {
                 cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
               })
               .then(() => {
-                cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+                cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
                 cy.get('[data-cy="wf-vzr-name"]')
                   .should('contain', `${workflowJobTemplate.name}`)
                   .should('be.visible');
@@ -396,7 +396,7 @@ describe('Workflow Visualizer', () => {
               }
             );
           });
-          cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+          cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
           cy.get('[data-cy="wf-vzr-name"]')
             .should('contain', `${workflowJobTemplate.name}`)
             .should('be.visible');
@@ -411,7 +411,7 @@ describe('Workflow Visualizer', () => {
       cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then((projNode) => {
         projectNode = projNode;
         cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then(() => {
-          cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+          cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
           cy.contains('Workflow Visualizer').should('be.visible');
           cy.get('[data-kind="node"]').should('have.length', 3);
           cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
@@ -455,7 +455,7 @@ describe('Workflow Visualizer', () => {
           });
         })
         .then(() => {
-          cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+          cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
           cy.contains('Workflow Visualizer').should('be.visible');
           cy.contains('Run on fail').should('be.visible');
           cy.get(`g[data-id="${projectNode.id}-${workflowJtNode.id}"]`).within(() => {

--- a/cypress/e2e/awx/resources/workflowVisualizerOutput.cy.ts
+++ b/cypress/e2e/awx/resources/workflowVisualizerOutput.cy.ts
@@ -141,7 +141,7 @@ describe.skip('Workflow Visualizer', () => {
     });
 
     it.skip('can view the details pages of related job on a WFJT either by clicking the job nodes or by toggling the Workflow Jobs dropdown', function () {
-      cy.visit(`/templates/workflow_job_template/${workflowJobTemplate?.id}/visualizer`);
+      cy.visit(`/templates/workflow-job-template/${workflowJobTemplate?.id}/visualizer`);
       cy.contains('Workflow Visualizer').should('be.visible');
       cy.getBy('[data-cy="workflow-visualizer-toolbar-kebab"]').click();
       cy.intercept(

--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -478,7 +478,7 @@ describe.skip('Schedules - Create and Delete', function () {
       cy.verifyPageTitle(`${scheduleName}`);
       cy.url().then((currentUrl) => {
         expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes('/templates/job_template/')).to.be.true;
+        expect(currentUrl.includes('/templates/job-template/')).to.be.true;
       });
       cy.getByDataCy('name').should('have.text', scheduleName);
       cy.getByDataCy('time-zone').should('have.text', 'America/Mexico_City');

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1088,7 +1088,7 @@ Cypress.Commands.add(
         )
           .as('newVisualizerView')
           .then(() => {
-            cy.visit(`/templates/workflow_job_template/${results.id}/visualizer`);
+            cy.visit(`/templates/workflow-job-template/${results.id}/visualizer`);
           });
       });
   }
@@ -1814,7 +1814,9 @@ Cypress.Commands.add(
       'required' | 'min' | 'max' | 'new_question' | 'choices'
     >
   ) => {
-    cy.visit(`/templates/${template.type}/${template.id}/survey/add`);
+    cy.visit(
+      `/templates/${template.type === 'job_template' ? 'job-template' : 'workflow-job-template'}/${template.id}/survey/add`
+    );
 
     cy.getByDataCy('question-name').type(spec.question_name ?? '');
     cy.getByDataCy('question-description').type(spec?.question_description ?? '');

--- a/frontend/awx/access/organizations/OrganizationPage/OrganizationDetails.tsx
+++ b/frontend/awx/access/organizations/OrganizationPage/OrganizationDetails.tsx
@@ -77,7 +77,6 @@ export function OrganizationDetails() {
                   to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                     params: {
                       id: ig.id,
-                      instanceType: ig.is_container_group ? 'container-group' : 'instance-group',
                     },
                   })}
                 >

--- a/frontend/awx/access/roles/AwxRoleDetails.tsx
+++ b/frontend/awx/access/roles/AwxRoleDetails.tsx
@@ -8,7 +8,7 @@ import { awxAPI } from '../../common/api/awx-utils';
 
 export function AwxRoleDetails() {
   const columns = useAwxRoleColumns();
-  const params = useParams<{ id: string; resourceType: string }>();
+  const params = useParams<{ id: string }>();
   const {
     data: role,
     error,

--- a/frontend/awx/access/roles/AwxRolePage.tsx
+++ b/frontend/awx/access/roles/AwxRolePage.tsx
@@ -44,7 +44,7 @@ export function AwxRolePage(props: {
           persistentFilterKey: 'awx-roles',
         }}
         tabs={[{ label: t('Details'), page: AwxRoute.RoleDetails }]}
-        params={{ id: params.id ?? '', resourceType: params.resourceType ?? '' }}
+        params={{ id: params.id ?? '' }}
       />
     </PageLayout>
   );

--- a/frontend/awx/access/roles/useAwxRoleColumns.tsx
+++ b/frontend/awx/access/roles/useAwxRoleColumns.tsx
@@ -24,7 +24,7 @@ export function useAwxRoleColumns(options?: { disableSort?: boolean; disableLink
               options?.disableLinks
                 ? undefined
                 : getPageUrl(AwxRoute.RoleDetails, {
-                    params: { id: role.id, resourceType: role.content_type || 'null' },
+                    params: { id: role.id },
                   })
             }
             text={role.name}

--- a/frontend/awx/administration/instance-groups/ContainerGroupForm.cy.tsx
+++ b/frontend/awx/administration/instance-groups/ContainerGroupForm.cy.tsx
@@ -28,7 +28,7 @@ describe('Create Edit Container Group Form', () => {
         { fixture: 'credentials.json' }
       );
       cy.mount(<CreateContainerGroup />, {
-        path: '/instance_groups/:instanceType/create',
+        path: '/instance_groups/container-group/create',
         initialEntries: [`/instance_groups/container-group/create`],
       });
       cy.get('[data-cy="name"]').type('Test name');
@@ -73,7 +73,7 @@ describe('Create Edit Container Group Form', () => {
 
     it('should preload the form with current values', () => {
       cy.mount(<EditContainerGroup />, {
-        path: '/instance-groups/:instancetype/:id/edit',
+        path: '/instance-groups/container-group/:id/edit',
         initialEntries: [`/instance-groups/container-group/1/edit`],
       });
       cy.verifyPageTitle('Edit Container Group');
@@ -84,7 +84,7 @@ describe('Create Edit Container Group Form', () => {
 
     it('should pass correct request body after editing ee', () => {
       cy.mount(<EditContainerGroup />, {
-        path: '/instance_groups/:instanceType/:id/edit',
+        path: '/instance_groups/container-group/:id/edit',
         initialEntries: [`/instance_groups/container-group/1/edit`],
       });
       cy.get('[data-cy="name"]').clear();

--- a/frontend/awx/administration/instance-groups/ContainerGroupForm.cy.tsx
+++ b/frontend/awx/administration/instance-groups/ContainerGroupForm.cy.tsx
@@ -28,8 +28,8 @@ describe('Create Edit Container Group Form', () => {
         { fixture: 'credentials.json' }
       );
       cy.mount(<CreateContainerGroup />, {
-        path: '/instance_groups/container-group/create',
-        initialEntries: [`/instance_groups/container-group/create`],
+        path: '/instance-groups/container-group/create',
+        initialEntries: [`/instance-groups/container-group/create`],
       });
       cy.get('[data-cy="name"]').type('Test name');
       cy.get('[data-cy="credential-select"]').type('E2E Credential ARWM');

--- a/frontend/awx/administration/instance-groups/ContainerGroupForm.tsx
+++ b/frontend/awx/administration/instance-groups/ContainerGroupForm.tsx
@@ -62,7 +62,7 @@ export function CreateContainerGroup() {
       is_container_group: true,
     });
     pageNavigate(AwxRoute.InstanceGroupDetails, {
-      params: { instanceType: 'container-group', id: containerGroup.id },
+      params: { id: containerGroup.id },
     });
   };
   if (isLoading) {
@@ -143,7 +143,7 @@ export function EditContainerGroup() {
       }
     );
     pageNavigate(AwxRoute.InstanceGroupDetails, {
-      params: { instanceType: 'container-group', id: updateContainerGroup.id },
+      params: { id: updateContainerGroup.id },
     });
   };
   return (

--- a/frontend/awx/administration/instance-groups/InstanceGroupAddTeams.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupAddTeams.tsx
@@ -118,11 +118,8 @@ export function InstanceGroupAddTeams() {
           resolve();
         },
         onClose: () => {
-          const instanceType = instanceGroup.is_container_group
-            ? 'container-group'
-            : 'instance-group';
           pageNavigate(AwxRoute.InstanceGroupTeamAccess, {
-            params: { id: instanceGroup.id.toString(), instanceType },
+            params: { id: instanceGroup.id.toString() },
           });
         },
       });
@@ -140,9 +137,6 @@ export function InstanceGroupAddTeams() {
             to: getPageUrl(AwxRoute.InstanceGroupDetails, {
               params: {
                 id: instanceGroup?.id,
-                instanceType: instanceGroup?.is_container_group
-                  ? 'container-group'
-                  : 'instance-group',
               },
             }),
           },

--- a/frontend/awx/administration/instance-groups/InstanceGroupAddUsers.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupAddUsers.tsx
@@ -119,11 +119,8 @@ export function InstanceGroupAddUsers() {
           resolve();
         },
         onClose: () => {
-          const instanceType = instanceGroup.is_container_group
-            ? 'container-group'
-            : 'instance-group';
           pageNavigate(AwxRoute.InstanceGroupUserAccess, {
-            params: { id: instanceGroup.id.toString(), instanceType },
+            params: { id: instanceGroup.id.toString() },
           });
         },
       });
@@ -141,9 +138,6 @@ export function InstanceGroupAddUsers() {
             to: getPageUrl(AwxRoute.InstanceGroupDetails, {
               params: {
                 id: instanceGroup?.id,
-                instanceType: instanceGroup?.is_container_group
-                  ? 'container-group'
-                  : 'instance-group',
               },
             }),
           },
@@ -152,9 +146,6 @@ export function InstanceGroupAddUsers() {
             to: getPageUrl(AwxRoute.InstanceGroupUserAccess, {
               params: {
                 id: instanceGroup?.id,
-                instanceType: instanceGroup?.is_container_group
-                  ? 'container-group'
-                  : 'instance-group',
               },
             }),
           },

--- a/frontend/awx/administration/instance-groups/InstanceGroupForm.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupForm.cy.tsx
@@ -67,8 +67,8 @@ describe('Create Edit Instance Group Form', () => {
 
     it('should pass correct request body after editing ee', () => {
       cy.mount(<EditInstanceGroup />, {
-        path: '/instance_groups/:id/edit',
-        initialEntries: [`/instance_groups/1/edit`],
+        path: '/instance-groups/:id/edit',
+        initialEntries: [`/instance-groups/1/edit`],
       });
       cy.get('[data-cy="name"]').clear();
       cy.get('[data-cy="name"]').type('Test name- edited');
@@ -99,8 +99,8 @@ describe('Create Edit Instance Group Form', () => {
 
     it('should validate required fields on save', () => {
       cy.mount(<EditInstanceGroup />, {
-        path: '/instance_groups/:id/edit',
-        initialEntries: [`/instance_groups/1/edit`],
+        path: '/instance-groups/:id/edit',
+        initialEntries: [`/instance-groups/1/edit`],
       });
       cy.get('[data-cy="name"]').clear();
       cy.clickButton(/^Save Instance Group$/);

--- a/frontend/awx/administration/instance-groups/InstanceGroupForm.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupForm.tsx
@@ -39,7 +39,6 @@ export function CreateInstanceGroup() {
     pageNavigate(AwxRoute.InstanceGroupDetails, {
       params: {
         id: instanceGroup.id,
-        instanceType: instanceGroup?.is_container_group ? 'container-group' : 'instance-group',
       },
     });
   };
@@ -103,7 +102,6 @@ export function EditInstanceGroup() {
     pageNavigate(AwxRoute.InstanceGroupDetails, {
       params: {
         id: updateInstanceGroup.id,
-        instanceType: instanceGroup?.is_container_group ? 'container-group' : 'instance-group',
       },
     });
   };

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupDetails.cy.tsx
@@ -9,8 +9,8 @@ describe('Instance Group Details', () => {
       { fixture: 'instance_group.json' }
     );
     cy.mount(<InstanceGroupDetails />, {
-      path: 'instance_groups/:id/details',
-      initialEntries: ['/instance_groups/1/details'],
+      path: 'instance-groups/:id/details',
+      initialEntries: ['/instance-groups/1/details'],
     });
     cy.fixture('instance_group').then((instance_group: InstanceGroup) => {
       cy.get('[data-cy="name"]').should('have.text', instance_group.name);
@@ -42,8 +42,8 @@ describe('Instance Group Details', () => {
       { fixture: 'container_group.json' }
     );
     cy.mount(<InstanceGroupDetails />, {
-      path: 'instance_groups/:id/details',
-      initialEntries: ['/instance_groups/2/details'],
+      path: 'instance-groups/:id/details',
+      initialEntries: ['/instance-groups/2/details'],
     });
     cy.fixture('container_group').then((container_group: InstanceGroup) => {
       cy.get('[data-cy="name"]').should('have.text', container_group.name);

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupPage.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupPage.tsx
@@ -33,8 +33,6 @@ export function InstanceGroupPage() {
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!instanceGroup) return <LoadingPage breadcrumbs tabs />;
 
-  const instanceType = instanceGroup.is_container_group ? 'container-group' : 'instance-group';
-
   return (
     <PageLayout>
       <PageHeader
@@ -78,7 +76,7 @@ export function InstanceGroupPage() {
                 { label: t('Jobs'), page: AwxRoute.InstanceGroupJobs },
               ]
         }
-        params={{ id: instanceGroup.id, instanceType }}
+        params={{ id: instanceGroup.id }}
       />
     </PageLayout>
   );

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupTeamAccess.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupTeamAccess.cy.tsx
@@ -46,8 +46,8 @@ describe('InstanceGroupTeamAccess', () => {
   });
 
   it('should render team assignments', () => {
-    const path = '/instance_groups/instance_group/:id/team-access';
-    const initialEntries = ['/instance_groups/instance_group/1/team-access'];
+    const path = '/instance-groups/instance_group/:id/team-access';
+    const initialEntries = ['/instance-groups/instance_group/1/team-access'];
     const params = {
       path,
       initialEntries,

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupTeamAccess.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupTeamAccess.cy.tsx
@@ -46,8 +46,8 @@ describe('InstanceGroupTeamAccess', () => {
   });
 
   it('should render team assignments', () => {
-    const path = '/instance-groups/instance_group/:id/team-access';
-    const initialEntries = ['/instance-groups/instance_group/1/team-access'];
+    const path = '/instance-groups/:id/team-access';
+    const initialEntries = ['/instance-groups/1/team-access'];
     const params = {
       path,
       initialEntries,

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupUserAccess.cy.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/InstanceGroupUserAccess.cy.tsx
@@ -46,8 +46,8 @@ describe('InstanceGroupUserAccess', () => {
   });
 
   it('should render user assignments', () => {
-    const path = '/instance_groups/instance_group/:id/user-access';
-    const initialEntries = ['/instance_groups/instance_group/1/user-access'];
+    const path = '/instance-groups/:id/user-access';
+    const initialEntries = ['/instance-groups/1/user-access'];
     const params = {
       path,
       initialEntries,

--- a/frontend/awx/administration/instance-groups/hooks/useInstanceGroupColumns.tsx
+++ b/frontend/awx/administration/instance-groups/hooks/useInstanceGroupColumns.tsx
@@ -27,9 +27,6 @@ export function useInstanceGroupsColumns(options?: {
                 ? undefined
                 : getPageUrl(AwxRoute.InstanceGroupDetails, {
                     params: {
-                      instanceType: instanceGroup.is_container_group
-                        ? 'container-group'
-                        : 'instance-group',
                       id: instanceGroup.id,
                     },
                   })

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -97,7 +97,7 @@ export function InstanceDetailsTab(props: {
             <Label color="blue" style={{ marginRight: '10px' }} key={instance.id}>
               <Link
                 to={getPageUrl(AwxRoute.InstanceGroupDetails, {
-                  params: { instanceType: 'instance-group', id: instance.id },
+                  params: { id: instance.id },
                 })}
               >
                 {instance.name}

--- a/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
@@ -29,7 +29,7 @@ export function useAwxInstanceGroupsRoutes() {
     () => ({
       id: AwxRoute.InstanceGroups,
       label: t('Instance Groups'),
-      path: 'instance_groups',
+      path: 'instance-groups',
       children: [
         {
           id: AwxRoute.CreateContainerGroup,

--- a/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInstanceGroupsRoutes.tsx
@@ -53,7 +53,7 @@ export function useAwxInstanceGroupsRoutes() {
         },
         {
           id: AwxRoute.InstanceGroupPage,
-          path: ':instanceType/:id/',
+          path: ':id',
           element: <InstanceGroupPage />,
           children: [
             {

--- a/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxInventoryRoutes.tsx
@@ -133,7 +133,7 @@ export function useAwxInventoryRoutes() {
         },
         {
           id: AwxRoute.InventoryGroupRelatedGroupsCreate,
-          path: ':inventory_type/:id/groups/:group_id/nested_groups/add',
+          path: ':inventory_type/:id/groups/:group_id/nested-groups/add',
           element: <CreateRelatedGroup />,
         },
         {
@@ -153,19 +153,19 @@ export function useAwxInventoryRoutes() {
             },
             {
               id: AwxRoute.InventoryGroupRelatedGroups,
-              path: 'nested_groups',
+              path: 'nested-groups',
               element: <GroupRelatedGroups />,
             },
             {
               id: AwxRoute.InventoryGroupHost,
-              path: 'nested_hosts',
+              path: 'nested-hosts',
               element: <GroupHosts />,
             },
           ],
         },
         {
           id: AwxRoute.InventoryGroupHostAdd,
-          path: ':inventory_type/:id/group/:group_id/nested_hosts/add',
+          path: ':inventory_type/:id/group/:group_id/nested-hosts/add',
           element: <CreateHost />,
         },
         {
@@ -264,12 +264,12 @@ export function useAwxInventoryRoutes() {
         },
         {
           id: AwxRoute.CreateSmartInventory,
-          path: 'smart_inventory/create',
+          path: 'smart-inventory/create',
           element: <CreateInventory inventoryKind="smart" />,
         },
         {
           id: AwxRoute.CreateConstructedInventory,
-          path: 'constructed_inventory/create',
+          path: 'constructed-inventory/create',
           element: <CreateInventory inventoryKind="constructed" />,
         },
         {

--- a/frontend/awx/main/routes/useAwxProjectRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxProjectRoutes.tsx
@@ -90,7 +90,7 @@ export function useAwxProjectRoutes() {
             },
             {
               id: AwxRoute.ProjectJobTemplates,
-              path: 'job_templates',
+              path: 'job-templates',
               element: <ProjectJobTemplates />,
             },
             {

--- a/frontend/awx/main/routes/useAwxTemplateRoutes.tsx
+++ b/frontend/awx/main/routes/useAwxTemplateRoutes.tsx
@@ -45,7 +45,7 @@ export function useAwxTemplateRoutes() {
       path: 'templates',
       children: [
         {
-          path: 'job_template',
+          path: 'job-template',
           children: [
             {
               id: AwxRoute.CreateJobTemplate,
@@ -172,7 +172,7 @@ export function useAwxTemplateRoutes() {
           ],
         },
         {
-          path: 'workflow_job_template',
+          path: 'workflow-job-template',
           children: [
             {
               id: AwxRoute.CreateWorkflowJobTemplate,
@@ -256,7 +256,7 @@ export function useAwxTemplateRoutes() {
                 },
                 {
                   id: AwxRoute.WorkflowJobTemplateJobs,
-                  path: 'workflow_jobs',
+                  path: 'workflow-jobs',
                   element: <TemplateJobs resourceType="workflow_job_templates" />,
                 },
                 {

--- a/frontend/awx/main/useAwxNavigation.tsx
+++ b/frontend/awx/main/useAwxNavigation.tsx
@@ -171,7 +171,7 @@ export function useAwxNavigation() {
           children: [
             {
               id: AwxRoute.Role,
-              path: ':resourceType/:id',
+              path: ':id',
               element: <AwxRolePage />,
               children: [
                 {

--- a/frontend/awx/resources/groups/GroupHosts.cy.tsx
+++ b/frontend/awx/resources/groups/GroupHosts.cy.tsx
@@ -38,11 +38,11 @@ describe('GroupHosts', () => {
   const kinds = ['', 'constructed'];
 
   kinds.forEach((kind) => {
-    const path = '/inventories/:inventory_type/:id/groups/:group_id/nested_hosts';
+    const path = '/inventories/:inventory_type/:id/groups/:group_id/nested-hosts';
     const initialEntries =
       kind === ''
-        ? ['/inventories/inventory/1/groups/176/nested_hosts']
-        : ['/inventories/constructed_inventory/1/groups/176/nested_hosts'];
+        ? ['/inventories/inventory/1/groups/176/nested-hosts']
+        : ['/inventories/constructed_inventory/1/groups/176/nested-hosts'];
 
     it(`renders group hosts (${kind === '' ? 'inventory' : kind})`, () => {
       cy.mount(<GroupHosts />, {

--- a/frontend/awx/resources/groups/GroupRelatedGroups.cy.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.cy.tsx
@@ -5,8 +5,8 @@ const inventories = ['inventory', 'constructed_inventory'];
 
 inventories.forEach((inventory) => {
   describe(`GroupRelatedGroups (${inventory})`, () => {
-    const path = '/inventories/:inventory_type/:id/groups/:group_id/nested_groups';
-    const initialEntries = [`/inventories/${inventory}/1/groups/176/nested_groups`];
+    const path = '/inventories/:inventory_type/:id/groups/:group_id/nested-groups';
+    const initialEntries = [`/inventories/${inventory}/1/groups/176/nested-groups`];
 
     beforeEach(() => {
       cy.intercept(

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.tsx
@@ -182,7 +182,6 @@ export function InventoryDetailsInner(props: { inventory: InventoryWithSource })
                 to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                   params: {
                     id: ig.id,
-                    instanceType: ig.is_container_group ? 'container-group' : 'instance-group',
                   },
                 })}
               >

--- a/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateDetails.tsx
@@ -159,7 +159,6 @@ export function TemplateDetails(props: { templateId?: string; disableScroll?: bo
                 to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                   params: {
                     id: ig.id,
-                    instanceType: ig.is_container_group ? 'container-group' : 'instance-group',
                   },
                 })}
               >

--- a/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
@@ -135,10 +135,6 @@ export function TemplateLaunchReviewStep(props: { template: JobTemplate }) {
                 to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                   params: {
                     id: ig.id,
-                    instanceType:
-                      'is_container_group' in ig && ig.is_container_group
-                        ? 'container-group'
-                        : 'instance-group',
                   },
                 })}
               >

--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
@@ -248,8 +248,8 @@ describe('Empty state', () => {
       { fixture: 'workflowJobTemplate.json' }
     );
     cy.mount(<WorkflowVisualizer />, {
-      path: '/templates/workflow_job_template/:id/visualizer',
-      initialEntries: ['/templates/workflow_job_template/123/visualizer'],
+      path: '/templates/workflow-job-template/:id/visualizer',
+      initialEntries: ['/templates/workflow-job-template/123/visualizer'],
     });
     cy.get('h4.pf-v5-c-empty-state__title-text').should(
       'have.text',
@@ -281,8 +281,8 @@ describe('Empty state', () => {
       { fixture: 'jobTemplates.json' }
     );
     cy.mount(<WorkflowVisualizer />, {
-      path: '/templates/workflow_job_template/:id/visualizer',
-      initialEntries: ['/templates/workflow_job_template/123/visualizer'],
+      path: '/templates/workflow-job-template/:id/visualizer',
+      initialEntries: ['/templates/workflow-job-template/123/visualizer'],
     });
     cy.get('div.pf-v5-c-empty-state__actions').within(() => {
       cy.get('[data-cy="add-node-button"]').click();

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
@@ -385,10 +385,6 @@ function InstanceGroupsDetail({
               to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                 params: {
                   id: ig.id,
-                  instanceType:
-                    'is_container_group' in ig && ig.is_container_group
-                      ? 'container-group'
-                      : 'instance-group',
                 },
               })}
             >

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.tsx
@@ -151,10 +151,6 @@ export function PromptReviewDetails() {
                 to={getPageUrl(AwxRoute.InstanceGroupDetails, {
                   params: {
                     id: ig.id,
-                    instanceType:
-                      'is_container_group' in ig && ig.is_container_group
-                        ? 'container-group'
-                        : 'instance-group',
                   },
                 })}
               >

--- a/frontend/awx/resources/templates/hooks/useDeleteSurvey.tsx
+++ b/frontend/awx/resources/templates/hooks/useDeleteSurvey.tsx
@@ -16,10 +16,10 @@ export function useDeleteSurvey(props: {
   const deleteRequest = useDeleteRequest();
 
   const jobTemplateSurveyId = useMatch(
-    '/templates/job_template/:id/survey'
+    '/templates/job-template/:id/survey'
   )?.params?.id?.toString();
   const workflowTemplateSurveyId = useMatch(
-    '/templates/workflow_job_template/:id/survey'
+    '/templates/workflow-job-template/:id/survey'
   )?.params?.id?.toString();
 
   const surveySpecEndpoint = jobTemplateSurveyId

--- a/frontend/awx/resources/templates/hooks/useSurveyToolbarActions.tsx
+++ b/frontend/awx/resources/templates/hooks/useSurveyToolbarActions.tsx
@@ -25,9 +25,9 @@ export function useSurveyToolbarActions(view: ISurveyView) {
   const { id } = useParams<{ id: string }>();
   const deleteQuestions = useDeleteSurveyDialog(view.unselectItemsAndRefresh);
 
-  const jobTemplateSurvey = useMatch('/templates/job_template/:id/survey')?.params?.id?.toString();
+  const jobTemplateSurvey = useMatch('/templates/job-template/:id/survey')?.params?.id?.toString();
   const workflowTemplateSurvey = useMatch(
-    '/templates/workflow_job_template/:id/survey'
+    '/templates/workflow-job-template/:id/survey'
   )?.params?.id?.toString();
 
   const { openManageQuestionOrder } = useManageSurveyQuestions(jobTemplateSurvey);

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -60,9 +60,6 @@ export function JobDetails() {
           to={getPageUrl(AwxRoute.InstanceGroupDetails, {
             params: {
               id: job.summary_fields?.instance_group?.id,
-              instanceType: job.summary_fields?.instance_group?.is_container_group
-                ? 'container-group'
-                : 'instance-group',
             },
           })}
         >
@@ -77,9 +74,6 @@ export function JobDetails() {
           to={getPageUrl(AwxRoute.InstanceGroupDetails, {
             params: {
               id: job.summary_fields?.instance_group?.id,
-              instanceType: job.summary_fields?.instance_group?.is_container_group
-                ? 'container-group'
-                : 'instance-group',
             },
           })}
         >

--- a/frontend/awx/views/jobs/jobUtils.tsx
+++ b/frontend/awx/views/jobs/jobUtils.tsx
@@ -68,7 +68,7 @@ export function getScheduleUrl(job: UnifiedJob) {
           : '';
         break;
       case 'job':
-        scheduleUrl = `/templates/job_template/${templateId}/schedules/${scheduleId}/details`;
+        scheduleUrl = `/templates/job-template/${templateId}/schedules/${scheduleId}/details`;
         break;
       case 'project_update':
         scheduleUrl = `/projects/${templateId}/schedules/${scheduleId}/details`;
@@ -77,7 +77,7 @@ export function getScheduleUrl(job: UnifiedJob) {
         scheduleUrl = `/management_jobs/${templateId}/schedules/${scheduleId}/details`;
         break;
       case 'workflow_job':
-        scheduleUrl = `/templates/workflow_job_template/${templateId}/schedules/${scheduleId}/details`;
+        scheduleUrl = `/templates/workflow-job-template/${templateId}/schedules/${scheduleId}/details`;
         break;
       default:
         break;
@@ -112,9 +112,9 @@ export function getLaunchedByDetails(job: UnifiedJob) {
     case 'webhook':
       value = 'Webhook';
       link = jobTemplate
-        ? `/templates/job_template/${jobTemplate.id}/details`
+        ? `/templates/job-template/${jobTemplate.id}/details`
         : workflowJT
-          ? `/templates/workflow_job_template/${workflowJT.id}/details`
+          ? `/templates/workflow-job-template/${workflowJT.id}/details`
           : undefined;
       break;
     case 'scheduled':

--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.cy.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.cy.tsx
@@ -104,8 +104,8 @@ describe('ScheduleEditWizard', () => {
 
     it('Should render the correct steps on initial ', () => {
       cy.mount(<ScheduleEditWizard />, {
-        initialEntries: ['/templates/job_template/7/schedules/1/edit'],
-        path: '/templates/job_template/:id/schedules/:schedule_id/edit',
+        initialEntries: ['/templates/job-template/7/schedules/1/edit'],
+        path: '/templates/job-template/:id/schedules/:schedule_id/edit',
       });
 
       cy.get('[data-cy="wizard-nav"]').within(() => {
@@ -120,8 +120,8 @@ describe('ScheduleEditWizard', () => {
 
     it('Should not go to next step due to failed validation', () => {
       cy.mount(<ScheduleEditWizard />, {
-        initialEntries: ['/templates/job_template/7/schedules/1/edit'],
-        path: '/templates/job_template/:id/schedules/:schedule_id/edit',
+        initialEntries: ['/templates/job-template/7/schedules/1/edit'],
+        path: '/templates/job-template/:id/schedules/:schedule_id/edit',
       });
 
       cy.get('[data-cy="name"]').clear();
@@ -139,8 +139,8 @@ describe('ScheduleEditWizard', () => {
       cy.intercept('/api/v2/job_templates/100/', { id: 100, name: 'Mock Job Template' });
       cy.intercept('/api/v2/job_templates/100/launch/', {});
       cy.mount(<ScheduleEditWizard />, {
-        initialEntries: ['/templates/job_template/7/schedules/1/edit'],
-        path: '/templates/job_template/:id/schedules/:schedule_id/edit',
+        initialEntries: ['/templates/job-template/7/schedules/1/edit'],
+        path: '/templates/job-template/:id/schedules/:schedule_id/edit',
       });
 
       cy.get('[data-cy="wizard-nav"]').within(() => {
@@ -227,8 +227,8 @@ describe('ScheduleEditWizard', () => {
     });
     it('Should be able to add rules while editing a schedule.', () => {
       cy.mount(<ScheduleEditWizard />, {
-        initialEntries: ['/templates/job_template/7/schedules/1/edit'],
-        path: '/templates/job_template/:id/schedules/:schedule_id/edit',
+        initialEntries: ['/templates/job-template/7/schedules/1/edit'],
+        path: '/templates/job-template/:id/schedules/:schedule_id/edit',
       });
 
       cy.clickButton(/^Next$/);


### PR DESCRIPTION
* removes unused `:instanceType` param from instance group URLs
* removes unused `:resourceType` param from role URLs
* changes underscores in URLs to hyphens for consistency with the rest of the app

Note: after a closer look, I decided the `:inventory_type` param is still needed in the inventories page, so I left it in place. A constructed inventory can be fetched from the API at `/inventories/:id`, but using the URL param to fetch from `/constructed_inventories/:id` instead returns a few extra fields