### PR TITLE
Fix Flaky tests

### DIFF
--- a/cypress/e2e/awx/administration/instanceGroups.cy.ts
+++ b/cypress/e2e/awx/administration/instanceGroups.cy.ts
@@ -637,30 +637,19 @@ describe('Instance Groups: Jobs Tab', () => {
     });
     cy.clickTab(/^Jobs$/, true);
     cy.filterTableBySingleSelect('name', job_template.name);
-    cy.getBy('tbody').within(() => {
-      cy.get('[data-cy="cancel-job"]', { timeout: 60000 }).should('not.exist');
-      cy.clickKebabAction('actions-dropdown', 'delete-job');
-    });
-
     cy.intercept('DELETE', awxAPI`/jobs/*/`).as('deleted');
 
-    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-      cy.get('header').contains('Permanently delete job');
-      cy.get('button').contains('Delete job').should('have.attr', 'aria-disabled', 'true');
-      cy.getByDataCy('name-column-cell').should('have.text', job_template.name);
-      cy.get('input[id="confirm"]').click();
-      cy.get('button').contains('Delete job').click();
-    });
+    cy.clickTableRowKebabAction(job_template.name, 'delete-job', false);
+    cy.clickModalConfirmCheckbox();
+    cy.clickModalButton('Delete job');
+    cy.assertModalSuccess();
     cy.wait('@deleted')
       .its('response')
       .then((response) => {
         expect(response?.statusCode).to.eql(204);
       });
-    cy.clickModalButton('Close');
-    cy.get('.pf-v5-c-empty-state__title-text').contains(/^No results found/);
-    cy.get('.pf-v5-c-empty-state__body').contains(
-      /^No results match this filter criteria. Clear all filters and try again./
-    );
+    cy.clickButton(/^Close$/);
+    cy.clickButton(/^Clear all filters$/);
   });
 });
 

--- a/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
@@ -123,6 +123,7 @@ function testNotification(type: string) {
   cy.createAwxOrganization(orgName).then(() => {
     cy.getByDataCy(`awx-notification-templates`).click({ force: true });
     cy.get(`[data-cy="add-notifier"]`).click();
+    cy.verifyPageTitle('Add notifier');
 
     fillBasicData(notificationName, type);
     fillNotificationType(type);

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -63,10 +63,13 @@ describe('Inventory Sources', () => {
       cy.selectDropdownOptionByResourceName('source_control_type', 'Sourced from a Project');
       cy.selectDropdownOptionByResourceName('project', project.name);
       cy.selectDropdownOptionByResourceName('inventory', 'Dockerfile');
-      cy.getBy('.pf-v5-c-input-group > .pf-v5-c-button').click();
-      cy.getBy('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-        cy.searchAndDisplayResource(credentialName);
-        cy.getBy('[data-cy="checkbox-column-cell"] > label').click();
+      cy.get('[data-cy="credential-select-form-group"]')
+        .click()
+        .within(() => {
+          cy.get('button[aria-label="Options menu"]').click();
+        });
+      cy.getModal().within(() => {
+        cy.selectTableRowByCheckbox('name', credentialName);
         cy.getBy('#submit').click();
       });
       cy.getBy('[data-cy="host-filter"]').type('/^test$/');

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -422,7 +422,7 @@ describe('Job Templates Tests', function () {
       cy.getByDataCy('enabled-options').contains('Provisioning Callbacks').should('not.exist');
     });
 
-    it.skip('can edit a job template to enable webhook, regenerate webhook key and set webhook credentials', function () {
+    it('can edit a job template to enable webhook, regenerate webhook key and set webhook credentials', function () {
       cy.createAWXCredential({
         kind: 'github_token',
         organization: (this.globalOrganization as Organization).id,
@@ -432,7 +432,13 @@ describe('Job Templates Tests', function () {
         let webhookKey: string;
         cy.intercept('GET', awxAPI`/credential_types/*`).as('getCredTypes');
 
-        cy.visit(`templates/job_template/${jobTemplate.id}/edit`);
+        cy.navigateTo('awx', 'templates');
+        cy.verifyPageTitle('Templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.clickTableRowAction('name', jobTemplate.name, 'edit-template', {
+          inKebab: false,
+          disableFilter: true,
+        });
 
         cy.getByDataCy('isWebhookEnabled').click();
         cy.selectDropdownOptionByResourceName('webhook-service', 'GitHub');
@@ -442,7 +448,6 @@ describe('Job Templates Tests', function () {
         // modal is closed instanly, possible cause: https://issues.redhat.com/browse/AAP-23766
         cy.get('[data-ouia-component-id="lookup-webhook_credential.name-button"]').click();
         cy.get('[data-ouia-component-id="lookup-webhook_credential.name-button"]').click();
-
         cy.wait('@getCredType');
 
         cy.getModal().within(() => {


### PR DESCRIPTION

## Description
This PR fixes these tests [Cypress Dashboard](https://cloud.cypress.io/projects/77sud6/analytics/flaky-tests) 

- [x] Notifications: List View tests
- [x] can visit the instance group -> jobs tab, trigger a job, let the job finish,
 then view the job on the jobs list tab of the IG and delete the job
- [x] can navigate to the Create Source form, create a new source,
 and verify all expected info shown on the details page
- [x] can edit a job template to enable webhook, 
regenerate webhook key and set webhook credentials