### PR TITLE
Updates organization interface to appropriately handle the related field and various summary_fields

### DIFF
--- a/cypress/fixtures/organization.json
+++ b/cypress/fixtures/organization.json
@@ -119,6 +119,10 @@
       "job_templates": 3,
       "admins": 0,
       "projects": 1
+    },
+    "resource": {
+      "ansible_id": "12345678-1234-1234-1234-123456789012",
+      "resource_type": "shared.organization"
     }
   },
   "created": "2023-05-11T15:14:40.438725Z",

--- a/frontend/awx/common/ExecutionEnvironmentDetail.tsx
+++ b/frontend/awx/common/ExecutionEnvironmentDetail.tsx
@@ -25,7 +25,7 @@ const ExclamationTrianglePopover = styled(PFExclamationTriangleIcon)`
 ExclamationTrianglePopover.displayName = 'ExclamationTrianglePopover';
 
 function ExecutionEnvironmentDetail(props: {
-  executionEnvironment: ExecutionEnvironment | SummaryFieldsExecutionEnvironment;
+  executionEnvironment: ExecutionEnvironment | SummaryFieldsExecutionEnvironment | undefined;
   isDefaultEnvironment: boolean;
   virtualEnvironment?: string;
   verifyMissingVirtualEnv?: boolean;

--- a/frontend/awx/interfaces/Organization.ts
+++ b/frontend/awx/interfaces/Organization.ts
@@ -5,9 +5,13 @@ import {
   SummaryFieldsExecutionEnvironment,
 } from './summary-fields/summary-fields';
 
-export interface Organization extends Omit<SwaggerOrganization, 'id' | 'summary_fields'> {
+export interface Organization
+  extends Omit<SwaggerOrganization, 'id' | 'related' | 'summary_fields'> {
   id: number;
   name: string;
+  related: {
+    [key: string]: string;
+  };
   summary_fields: {
     resource: {
       ansible_id: string;
@@ -41,10 +45,10 @@ export interface Organization extends Omit<SwaggerOrganization, 'id' | 'summary_
       job_templates: number;
       admins: number;
       projects: number;
-      hosts: number;
+      hosts?: number;
     };
-    default_environment: SummaryFieldsExecutionEnvironment;
+    default_environment?: SummaryFieldsExecutionEnvironment;
   };
 }
 
-export type AwxOrganizationCreate = Omit<Organization, 'id' | 'summary_fields'>;
+export type AwxOrganizationCreate = Omit<Organization, 'id' | 'related' | 'summary_fields'>;


### PR DESCRIPTION
The `related` field on an organization is an object of key/value pairs where the value is a string.  The swagger version of awx's organization looks like:

`related?: string`

which is incorrect and makes it difficult to get the typing right when mocking out an organization and passing it through as a prop where the prop is type checked.

Additionally, I noticed that `hosts` was missing from `related_field_counts` in the `summary_fields`.  It looks like this is optionally provided by the API (not sure if that's intentional since a lot of the other fields are included even if the value is 0.

Lastly, `default_environment` is only included in the summary_fields if a default_environment is actually set, otherwise it is not present in the response.