### PR TITLE
fix inventory type and id in hosts -> groups navigation

### DIFF
--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -18,10 +18,26 @@ import { useGetHost } from '../../hosts/hooks/useGetHost';
 
 export function InventoryHostGroups(props: { page: string }) {
   const { t } = useTranslation();
-  const tableColumns = useHostsGroupsColumns();
+
   const isHostPage: boolean = props.page === 'host';
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const { host } = useGetHost(isHostPage ? params.id ?? '' : params.host_id ?? '');
+
+  let inventory_type = '';
+  
+  if (host?.summary_fields.inventory?.kind === '') {
+    inventory_type = 'inventory';
+  };
+
+  if (host?.summary_fields.inventory?.kind === 'smart') {
+    inventory_type = 'smart_inventory';
+  }
+
+  if (host?.summary_fields.inventory?.kind === 'constructed') {
+    inventory_type = 'constructed_inventory';
+  }
+
+  const tableColumns = useHostsGroupsColumns({ inventory_type });
 
   const inventoryId = String(host?.inventory) ?? '';
   const hostId = isHostPage ? params.id ?? '' : params.host_id ?? '';

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -18,27 +18,10 @@ import { useGetHost } from '../../hosts/hooks/useGetHost';
 
 export function InventoryHostGroups(props: { page: string }) {
   const { t } = useTranslation();
-
+  const tableColumns = useHostsGroupsColumns({useGroupInventory : true});
   const isHostPage: boolean = props.page === 'host';
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const { host } = useGetHost(isHostPage ? params.id ?? '' : params.host_id ?? '');
-
-  let inventory_type = '';
-
-  if (host?.summary_fields.inventory?.kind === '') {
-    inventory_type = 'inventory';
-  }
-
-  if (host?.summary_fields.inventory?.kind === 'smart') {
-    inventory_type = 'smart_inventory';
-  }
-
-  if (host?.summary_fields.inventory?.kind === 'constructed') {
-    inventory_type = 'constructed_inventory';
-  }
-
-  const tableColumns = useHostsGroupsColumns({ inventory_type });
-
   const inventoryId = String(host?.inventory) ?? '';
   const hostId = isHostPage ? params.id ?? '' : params.host_id ?? '';
 

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -18,7 +18,7 @@ import { useGetHost } from '../../hosts/hooks/useGetHost';
 
 export function InventoryHostGroups(props: { page: string }) {
   const { t } = useTranslation();
-  const tableColumns = useHostsGroupsColumns({useGroupInventory : true});
+  const tableColumns = useHostsGroupsColumns({ useGroupInventory: true });
   const isHostPage: boolean = props.page === 'host';
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const { host } = useGetHost(isHostPage ? params.id ?? '' : params.host_id ?? '');

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -24,10 +24,10 @@ export function InventoryHostGroups(props: { page: string }) {
   const { host } = useGetHost(isHostPage ? params.id ?? '' : params.host_id ?? '');
 
   let inventory_type = '';
-  
+
   if (host?.summary_fields.inventory?.kind === '') {
     inventory_type = 'inventory';
-  };
+  }
 
   if (host?.summary_fields.inventory?.kind === 'smart') {
     inventory_type = 'smart_inventory';

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
@@ -5,19 +5,21 @@ import { useNameColumn } from '../../../../../common/columns';
 import { InventoryGroup } from '../../../../interfaces/InventoryGroup';
 import { AwxRoute } from '../../../../main/AwxRoutes';
 
-export function useHostsGroupsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
+export function useHostsGroupsColumns(options?: { disableSort?: boolean; disableLinks?: boolean, inventory_type?: string}) {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string }>();
+  const inventory_type = options?.inventory_type || params.inventory_type;
+
   const nameClick = useCallback(
     (group: InventoryGroup) =>
       pageNavigate(AwxRoute.InventoryGroupDetails, {
         params: {
           id: params.id,
           group_id: group.id,
-          inventory_type: params.inventory_type,
+          inventory_type,
         },
       }),
-    [pageNavigate, params.id, params.inventory_type]
+    [pageNavigate, params.id, inventory_type]
   );
   const nameColumn = useNameColumn({
     ...options,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
@@ -5,7 +5,11 @@ import { useNameColumn } from '../../../../../common/columns';
 import { InventoryGroup } from '../../../../interfaces/InventoryGroup';
 import { AwxRoute } from '../../../../main/AwxRoutes';
 
-export function useHostsGroupsColumns(options?: { disableSort?: boolean; disableLinks?: boolean, inventory_type?: string}) {
+export function useHostsGroupsColumns(options?: {
+  disableSort?: boolean;
+  disableLinks?: boolean;
+  inventory_type?: string;
+}) {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string }>();
   const inventory_type = options?.inventory_type || params.inventory_type;

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
@@ -8,7 +8,7 @@ import { AwxRoute } from '../../../../main/AwxRoutes';
 export function useHostsGroupsColumns(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
-  useGroupInventory? : boolean;
+  useGroupInventory?: boolean;
 }) {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string }>();
@@ -19,10 +19,14 @@ export function useHostsGroupsColumns(options?: {
         params: {
           id: options?.useGroupInventory === true ? group.summary_fields.inventory.id : params.id,
           group_id: group.id,
-          inventory_type : options?.useGroupInventory === true ? kindToInventoryType(group.summary_fields.inventory.kind) : params.inventory_type,
+          inventory_type:
+            options?.useGroupInventory === true
+              ? kindToInventoryType(group.summary_fields.inventory.kind)
+              : params.inventory_type,
         },
-      })},
-    [pageNavigate, params.id, params.inventory_type]
+      });
+    },
+    [pageNavigate, params.id, params.inventory_type, options?.useGroupInventory]
   );
   const nameColumn = useNameColumn({
     ...options,
@@ -34,8 +38,7 @@ export function useHostsGroupsColumns(options?: {
   return tableColumns;
 }
 
-function kindToInventoryType(kind : string)
-{
+function kindToInventoryType(kind: string) {
   let inventory_type = '';
 
   if (kind === '') {
@@ -50,5 +53,5 @@ function kindToInventoryType(kind : string)
     inventory_type = 'constructed_inventory';
   }
 
-  return inventory_type
+  return inventory_type;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsColumns.tsx
@@ -8,22 +8,21 @@ import { AwxRoute } from '../../../../main/AwxRoutes';
 export function useHostsGroupsColumns(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
-  inventory_type?: string;
+  useGroupInventory? : boolean;
 }) {
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string }>();
-  const inventory_type = options?.inventory_type || params.inventory_type;
 
   const nameClick = useCallback(
-    (group: InventoryGroup) =>
+    (group: InventoryGroup) => {
       pageNavigate(AwxRoute.InventoryGroupDetails, {
         params: {
-          id: params.id,
+          id: options?.useGroupInventory === true ? group.summary_fields.inventory.id : params.id,
           group_id: group.id,
-          inventory_type,
+          inventory_type : options?.useGroupInventory === true ? kindToInventoryType(group.summary_fields.inventory.kind) : params.inventory_type,
         },
-      }),
-    [pageNavigate, params.id, inventory_type]
+      })},
+    [pageNavigate, params.id, params.inventory_type]
   );
   const nameColumn = useNameColumn({
     ...options,
@@ -33,4 +32,23 @@ export function useHostsGroupsColumns(options?: {
   const tableColumns = useMemo<ITableColumn<InventoryGroup>[]>(() => [nameColumn], [nameColumn]);
 
   return tableColumns;
+}
+
+function kindToInventoryType(kind : string)
+{
+  let inventory_type = '';
+
+  if (kind === '') {
+    inventory_type = 'inventory';
+  }
+
+  if (kind === 'smart') {
+    inventory_type = 'smart_inventory';
+  }
+
+  if (kind === 'constructed') {
+    inventory_type = 'constructed_inventory';
+  }
+
+  return inventory_type
 }


### PR DESCRIPTION
Navigation was broken in Hosts -> Groups -> click the group link that will navigate it to inventories -> groups. Now the hosts does not have inventory_type param and it uses hook for columns that get this missing param. I added props to the hook so the params is get from host summary inventory field.