### PR TITLE
Expandable list in the roles review step should have at least one item in it

### DIFF
--- a/frontend/common/access/RolesWizard/steps/RoleAssignmentsReviewStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/RoleAssignmentsReviewStep.tsx
@@ -185,6 +185,10 @@ function ReviewExpandableList<
     tableColumns,
   });
 
+  if (view?.itemCount === 0) {
+    return null;
+  }
+
   return (
     <ExpandableSection
       data-cy={`expandable-section-${fieldName}`}


### PR DESCRIPTION
Fix for the momentary empty state that appears in the Role assignment review step:

![image (31)](https://github.com/ansible/ansible-ui/assets/43621546/4ab8306a-9a59-47ef-8e10-d2127fe861c9)
