### PR TITLE
Fix Inventory hosts groups missing run command button

### DIFF
--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -32,7 +32,12 @@ export function InventoryHostGroups(props: { page: string }) {
     tableColumns,
   });
 
-  const toolbarActions = useHostsGroupsToolbarActions(view, inventoryId, hostId, isHostPage ? 'standaloneHost' : 'inventoryHost');
+  const toolbarActions = useHostsGroupsToolbarActions(
+    view,
+    inventoryId,
+    hostId,
+    isHostPage ? 'standaloneHost' : 'inventoryHost'
+  );
   const rowActions = useHostsGroupsActions(inventoryId);
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -32,7 +32,7 @@ export function InventoryHostGroups(props: { page: string }) {
     tableColumns,
   });
 
-  const toolbarActions = useHostsGroupsToolbarActions(view, inventoryId, hostId);
+  const toolbarActions = useHostsGroupsToolbarActions(view, inventoryId, hostId, isHostPage ? 'standaloneHost' : 'inventoryHost');
   const rowActions = useHostsGroupsActions(inventoryId);
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -18,7 +18,7 @@ export function useHostsGroupsToolbarActions(
   view: IAwxView<InventoryGroup>,
   inventoryId: string,
   hostId: string,
-  type : 'standaloneHost' | 'inventoryHost',
+  type: 'standaloneHost' | 'inventoryHost'
 ) {
   const { t } = useTranslation();
 
@@ -35,64 +35,59 @@ export function useHostsGroupsToolbarActions(
   const params = useParams<{ id: string; inventory_type: string }>();
   const runCommandAction = useRunCommandAction<InventoryGroup>(params);
 
-  return useMemo<IPageAction<InventoryGroup>[]>(
-    () => {
-      
-      let arr : IPageAction<InventoryGroup>[] = [];
+  return useMemo<IPageAction<InventoryGroup>[]>(() => {
+    const arr: IPageAction<InventoryGroup>[] = [];
 
-      arr.push({
-        type: PageActionType.Button,
-        selection: PageActionSelection.None,
-        variant: ButtonVariant.primary,
-        isPinned: true,
-        icon: PlusCircleIcon,
-        label: t('Associate'),
-        onClick: () =>
-          openInventoryHostsGroupsAddModal({
-            onAdd: associateGroups,
-            inventoryId: inventoryId ?? '',
-            hostId: hostId ?? '',
-          }),
-        isDisabled: () =>
-          canCreateGroup
-            ? undefined
-            : t(
-                'You do not have permission to create a host. Please contact your organization administrator if there is an issue with your access.'
-              ),
-      });
+    arr.push({
+      type: PageActionType.Button,
+      selection: PageActionSelection.None,
+      variant: ButtonVariant.primary,
+      isPinned: true,
+      icon: PlusCircleIcon,
+      label: t('Associate'),
+      onClick: () =>
+        openInventoryHostsGroupsAddModal({
+          onAdd: associateGroups,
+          inventoryId: inventoryId ?? '',
+          hostId: hostId ?? '',
+        }),
+      isDisabled: () =>
+        canCreateGroup
+          ? undefined
+          : t(
+              'You do not have permission to create a host. Please contact your organization administrator if there is an issue with your access.'
+            ),
+    });
 
-      arr.push({ type: PageActionType.Seperator });
-    
-      if (type === 'inventoryHost')
-      {
-        arr.push(runCommandAction);
-      }
+    arr.push({ type: PageActionType.Seperator });
 
-      arr.push({ type: PageActionType.Seperator });
+    if (type === 'inventoryHost') {
+      arr.push(runCommandAction);
+    }
 
-      arr.push({
-        type: PageActionType.Button,
-        selection: PageActionSelection.Multiple,
-        label: t('Disassociate'),
-        isDisabled:
-          view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
-        onClick: disassociateGroups,
-        isPinned: true,
-      });
+    arr.push({ type: PageActionType.Seperator });
 
-      return arr;
-    },
-    [
-      t,
-      view.selectedItems.length,
-      disassociateGroups,
-      openInventoryHostsGroupsAddModal,
-      associateGroups,
-      canCreateGroup,
-      hostId,
-      inventoryId,
-      runCommandAction,
-      type
-    ]
-  );
+    arr.push({
+      type: PageActionType.Button,
+      selection: PageActionSelection.Multiple,
+      label: t('Disassociate'),
+      isDisabled:
+        view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
+      onClick: disassociateGroups,
+      isPinned: true,
+    });
+
+    return arr;
+  }, [
+    t,
+    view.selectedItems.length,
+    disassociateGroups,
+    openInventoryHostsGroupsAddModal,
+    associateGroups,
+    canCreateGroup,
+    hostId,
+    inventoryId,
+    runCommandAction,
+    type,
+  ]);
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -17,7 +17,8 @@ import { useParams } from 'react-router-dom';
 export function useHostsGroupsToolbarActions(
   view: IAwxView<InventoryGroup>,
   inventoryId: string,
-  hostId: string
+  hostId: string,
+  type : 'standaloneHost' | 'inventoryHost',
 ) {
   const { t } = useTranslation();
 
@@ -35,8 +36,11 @@ export function useHostsGroupsToolbarActions(
   const runCommandAction = useRunCommandAction<InventoryGroup>(params);
 
   return useMemo<IPageAction<InventoryGroup>[]>(
-    () => [
-      {
+    () => {
+      
+      let arr : IPageAction<InventoryGroup>[] = [];
+
+      arr.push({
         type: PageActionType.Button,
         selection: PageActionSelection.None,
         variant: ButtonVariant.primary,
@@ -55,11 +59,18 @@ export function useHostsGroupsToolbarActions(
             : t(
                 'You do not have permission to create a host. Please contact your organization administrator if there is an issue with your access.'
               ),
-      },
-      { type: PageActionType.Seperator },
-      runCommandAction,
-      { type: PageActionType.Seperator },
+      });
+
+      arr.push({ type: PageActionType.Seperator });
+    
+      if (type === 'inventoryHost')
       {
+        arr.push(runCommandAction);
+      }
+
+      arr.push({ type: PageActionType.Seperator });
+
+      arr.push({
         type: PageActionType.Button,
         selection: PageActionSelection.Multiple,
         label: t('Disassociate'),
@@ -67,8 +78,10 @@ export function useHostsGroupsToolbarActions(
           view.selectedItems.length === 0 ? t('Select at least one item from the list') : undefined,
         onClick: disassociateGroups,
         isPinned: true,
-      },
-    ],
+      });
+
+      return arr;
+    },
     [
       t,
       view.selectedItems.length,
@@ -78,6 +91,8 @@ export function useHostsGroupsToolbarActions(
       canCreateGroup,
       hostId,
       inventoryId,
+      runCommandAction,
+      type
     ]
   );
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -11,6 +11,8 @@ import { IAwxView } from '../../../../common/useAwxView';
 import { useDisassociateGroups } from './useDisassociateGroups';
 import { useInventoryHostGroupsAddModal } from '../InventoryHostGroupsModal';
 import { useAssociateGroupsToHost } from './useAssociateGroupsToHost';
+import { useRunCommandAction } from '../../hooks/useInventoriesGroupsToolbarActions';
+import { useParams } from 'react-router-dom';
 
 export function useHostsGroupsToolbarActions(
   view: IAwxView<InventoryGroup>,
@@ -28,6 +30,9 @@ export function useHostsGroupsToolbarActions(
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();
   const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh, hostId);
+
+  const params = useParams<{ id: string; inventory_type: string }>();
+  const runCommandAction = useRunCommandAction<InventoryGroup>(params);
 
   return useMemo<IPageAction<InventoryGroup>[]>(
     () => [
@@ -51,6 +56,8 @@ export function useHostsGroupsToolbarActions(
                 'You do not have permission to create a host. Please contact your organization administrator if there is an issue with your access.'
               ),
       },
+      { type: PageActionType.Seperator },
+      runCommandAction,
       { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,


### PR DESCRIPTION
The run command button was missing in inventories -> detail -> hosts -> detail -> groups.

Note that the groups are showing only in normal inventories, not smart or constructed.