### PR TITLE
Fix error when creating credential with custom type without input

### DIFF
--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -46,6 +46,25 @@ describe('Credentials', () => {
   });
 
   describe('Credentials: List View', () => {
+    it('create credential using custom credential type', () => {
+      cy.createAwxCredentialType().then((credType) => {
+        const credentialName = 'E2E Credential ' + randomString(4);
+        cy.navigateTo('awx', 'credentials');
+        cy.clickButton(/^Create credential$/);
+        cy.get('[data-cy="name"]').type(credentialName);
+        cy.singleSelectBy('[data-cy="credential_type"]', credType.name, true);
+        cy.clickButton(/^Create credential$/);
+        cy.verifyPageTitle(credentialName);
+        cy.get('[data-cy="name"]').contains(credentialName);
+        //delete created credential
+        cy.clickPageAction('delete-credential');
+        cy.get('#confirm').click();
+        cy.clickButton(/^Delete credential/);
+        cy.verifyPageTitle('Credentials');
+        cy.deleteAwxCredentialType(credType);
+      });
+    });
+
     it('vault id field can not be edited for Vault credential type', () => {
       const credentialName = 'E2E Credential ' + randomString(4);
       cy.navigateTo('awx', 'credentials');

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -577,10 +577,10 @@ function CredentialSubForm({
   const { t } = useTranslation();
   const openCredentialPluginsModal = useCredentialPluginsModal();
   const requiredFields = credentialType?.inputs?.required || [];
-  const requiredFieldsInSubForm = credentialType.inputs.fields.filter((field) =>
+  const requiredFieldsInSubForm = credentialType?.inputs?.fields?.filter((field) =>
     requiredFields.includes(field.id)
   );
-  const subFormFields = credentialType.inputs.fields.map((field) => field.id);
+  const subFormFields = credentialType?.inputs?.fields?.map((field) => field.id);
 
   const watchedRequiredFields = useWatch({
     name: requiredFields,


### PR DESCRIPTION
Fix error when creating credential with custom type without input. Also, add test.

To test: 

1. Create a custom credential type without inputs
2. Create a credential using the previous item
3. No error should be raised