### PR TITLE
Add Sync All Button for inventory sources

### DIFF
--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -28,7 +28,7 @@ export function InventorySources() {
     tableColumns,
   });
 
-  const toolbarActions = useInventoriesSourcesToolbarActions(view);
+  const toolbarActions = useInventoriesSourcesToolbarActions(view, params.id || '');
   const rowActions = useInventorySourceActions({
     onInventorySourcesDeleted: view.unselectItemsAndRefresh,
   });

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -30,7 +30,8 @@ export function InventorySources() {
 
   const toolbarActions = useInventoriesSourcesToolbarActions(view, params.id || '');
   const rowActions = useInventorySourceActions({
-    unselectAndRefresh: view.unselectItemsAndRefresh,
+    onDelete: view.unselectItemsAndRefresh,
+    onSync: () => void view.refresh(),
   });
 
   const sourceOptions = useOptions<OptionsResponse<ActionsResponse>>(

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -30,7 +30,7 @@ export function InventorySources() {
 
   const toolbarActions = useInventoriesSourcesToolbarActions(view, params.id || '');
   const rowActions = useInventorySourceActions({
-    onInventorySourcesDeleted: view.unselectItemsAndRefresh,
+    unselectAndRefresh: view.unselectItemsAndRefresh,
   });
 
   const sourceOptions = useOptions<OptionsResponse<ActionsResponse>>(

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -92,7 +92,7 @@ export function useInventoriesSourcesToolbarActions(
         type: PageActionType.Button,
         selection: PageActionSelection.None,
         isPinned: false,
-        label: t('Sync All'),
+        label: t('Launch inventory update'),
         onClick: syncAll,
         isDisabled: () => cannotLaunchInventorySourcesUpdate,
       },

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -91,7 +91,7 @@ export function useInventoriesSourcesToolbarActions(
       {
         type: PageActionType.Button,
         selection: PageActionSelection.None,
-        isPinned: false,
+        icon: RocketIcon,
         label: t('Launch inventory update'),
         onClick: syncAll,
         isDisabled: () => cannotLaunchInventorySourcesUpdate,

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -97,6 +97,7 @@ function useSyncAll(inventory_id : string, refresh : () => void ) {
   const url = awxAPI`/inventories/${inventory_id}/update_inventory_sources/`;
   const postRequest = usePostRequest();
   const alertToaster = usePageAlertToaster();
+  const {t} = useTranslation();
 
   return () => {
     (async () => {
@@ -105,9 +106,15 @@ function useSyncAll(inventory_id : string, refresh : () => void ) {
       {
         await postRequest(url, {});
         refresh();
-      }catch(err)
+      }catch(error)
       {
-        alertToaster.addAlert({ title : (err as Object)?.toString(), variant : 'danger' });      }
+        alertToaster.addAlert({
+          variant: 'danger',
+          title: t('Failed to sync all inventory sources'),
+          children: error instanceof Error && error.message,
+          timeout: 5000,
+        });     
+      }
     })();
   };
 }

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -27,6 +27,8 @@ export function useInventoriesSourcesToolbarActions(view: IAwxView<InventorySour
   const sourceOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventory_sources/`
   ).data;
+
+  debugger;
   const canCreateSource = Boolean(
     sourceOptions && sourceOptions.actions && sourceOptions.actions['POST']
   );
@@ -60,6 +62,14 @@ export function useInventoriesSourcesToolbarActions(view: IAwxView<InventorySour
         onClick: deleteSources,
         isDanger: true,
         isDisabled: (sources: InventorySource[]) => cannotDeleteResources(sources, t),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.None,
+        isPinned: true,
+        label: t('Sync all'),
+        onClick: () => {},
+        isDisabled: () => '',
       },
     ],
     [t, deleteSources, pageNavigate, params.inventory_type, params.id, canCreateSource]

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -91,8 +91,8 @@ export function useInventoriesSourcesToolbarActions(
       {
         type: PageActionType.Button,
         selection: PageActionSelection.None,
-        isPinned: true,
-        label: t('Sync all'),
+        isPinned: false,
+        label: t('Sync All'),
         onClick: syncAll,
         isDisabled: () => cannotLaunchInventorySourcesUpdate,
       },

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -48,7 +48,7 @@ export function useInventoriesSourcesToolbarActions(view: IAwxView<InventorySour
       cannotLaunchInventorySourcesUpdate = t(`The inventory source cannot be updated due to insufficient permission`);
     }
 
-  const syncAll = useSyncAll(inventory_id);
+  const syncAll = useSyncAll(inventory_id, view.refresh);
 
   return useMemo<IPageAction<InventorySource>[]>(
     () => [
@@ -93,7 +93,7 @@ export function useInventoriesSourcesToolbarActions(view: IAwxView<InventorySour
   );
 }
 
-function useSyncAll(inventory_id : string) {
+function useSyncAll(inventory_id : string, refresh : () => void ) {
   const url = awxAPI`/inventories/${inventory_id}/update_inventory_sources/`;
   const postRequest = usePostRequest();
   const alertToaster = usePageAlertToaster();
@@ -104,6 +104,7 @@ function useSyncAll(inventory_id : string) {
       try
       {
         await postRequest(url, {});
+        refresh();
       }catch(err)
       {
         alertToaster.addAlert({ title : (err as Object)?.toString(), variant : 'danger' });      }

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -18,15 +18,15 @@ import { AwxRoute } from '../../../main/AwxRoutes';
 import { useDeleteInventorySources } from './useDeleteInventorySources';
 
 type InventorySourceActionOptions = {
-  onInventorySourcesDeleted: (inventorySources: InventorySource[]) => void;
+  unselectAndRefresh: (inventorySources: InventorySource[]) => void;
 };
 
 export function useInventorySourceActions({
-  onInventorySourcesDeleted,
+  unselectAndRefresh,
 }: InventorySourceActionOptions) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const deleteInventorySources = useDeleteInventorySources(onInventorySourcesDeleted);
+  const deleteInventorySources = useDeleteInventorySources(unselectAndRefresh);
   const params = useParams<{ inventory_type: string }>();
 
   const { activeAwxUser } = useAwxActiveUser();
@@ -37,6 +37,7 @@ export function useInventorySourceActions({
     async (invSrc: InventorySource) => {
       try {
         await postRequest(awxAPI`/inventory_sources/${invSrc.id.toString()}/update/`, {});
+        unselectAndRefresh([]);
       } catch (error) {
         alertToaster.addAlert({
           variant: 'danger',

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -21,9 +21,7 @@ type InventorySourceActionOptions = {
   unselectAndRefresh: (inventorySources: InventorySource[]) => void;
 };
 
-export function useInventorySourceActions({
-  unselectAndRefresh,
-}: InventorySourceActionOptions) {
+export function useInventorySourceActions({ unselectAndRefresh }: InventorySourceActionOptions) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const deleteInventorySources = useDeleteInventorySources(unselectAndRefresh);
@@ -47,7 +45,7 @@ export function useInventorySourceActions({
         });
       }
     },
-    [alertToaster, postRequest, t]
+    [alertToaster, postRequest, t, unselectAndRefresh]
   );
 
   return useMemo<IPageAction<InventorySource>[]>(() => {

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -18,13 +18,14 @@ import { AwxRoute } from '../../../main/AwxRoutes';
 import { useDeleteInventorySources } from './useDeleteInventorySources';
 
 type InventorySourceActionOptions = {
-  unselectAndRefresh: (inventorySources: InventorySource[]) => void;
+  onDelete: (inventorySources: InventorySource[]) => void;
+  onSync: () => void;
 };
 
-export function useInventorySourceActions({ unselectAndRefresh }: InventorySourceActionOptions) {
+export function useInventorySourceActions({ onDelete, onSync }: InventorySourceActionOptions) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const deleteInventorySources = useDeleteInventorySources(unselectAndRefresh);
+  const deleteInventorySources = useDeleteInventorySources(onDelete);
   const params = useParams<{ inventory_type: string }>();
 
   const { activeAwxUser } = useAwxActiveUser();
@@ -35,7 +36,7 @@ export function useInventorySourceActions({ unselectAndRefresh }: InventorySourc
     async (invSrc: InventorySource) => {
       try {
         await postRequest(awxAPI`/inventory_sources/${invSrc.id.toString()}/update/`, {});
-        unselectAndRefresh([]);
+        onSync();
       } catch (error) {
         alertToaster.addAlert({
           variant: 'danger',
@@ -45,7 +46,7 @@ export function useInventorySourceActions({ unselectAndRefresh }: InventorySourc
         });
       }
     },
-    [alertToaster, postRequest, t, unselectAndRefresh]
+    [alertToaster, postRequest, t, onSync]
   );
 
   return useMemo<IPageAction<InventorySource>[]>(() => {

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
@@ -28,10 +28,11 @@ export function InventorySourcePage() {
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
   const itemActions = useInventorySourceActions({
-    unselectAndRefresh: () =>
+    onDelete: () =>
       pageNavigate(AwxRoute.InventorySources, {
         params: { id: params.id, inventory_type: params.inventory_type },
       }),
+    onSync: refresh,
   });
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!inventorySource) return <LoadingPage breadcrumbs tabs />;

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
@@ -28,7 +28,7 @@ export function InventorySourcePage() {
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
   const itemActions = useInventorySourceActions({
-    onInventorySourcesDeleted: () =>
+    unselectAndRefresh: () =>
       pageNavigate(AwxRoute.InventorySources, {
         params: { id: params.id, inventory_type: params.inventory_type },
       }),


### PR DESCRIPTION
Adds Sync All buttons in Inventories -> Detail -> Tab Sources -> Sources list

Sync all is calling single API, so its not classic bulk action which calls multiple API calls for every item. It calls single API endpoint that starts syncing for all items.

Also row action to launch sync (and in detail) is now much more responsive because it immediately calls refresh of the page instead of waiting for periodic reload, which may happen somewhere from 0 to 5 seconds.