### PR TITLE
Bug fix: Page crash on changing resource type

### DIFF
--- a/frontend/awx/access/common/AwxRolesWizardSteps/AwxSelectResourceTypeStep.tsx
+++ b/frontend/awx/access/common/AwxRolesWizardSteps/AwxSelectResourceTypeStep.tsx
@@ -8,7 +8,7 @@ type ContentTypeOption = [string, string];
 
 export function AwxSelectResourceTypeStep() {
   const { t } = useTranslation();
-  const { setWizardData } = usePageWizard();
+  const { wizardData, setStepData, setWizardData } = usePageWizard();
   const { data, isLoading } = useOptions<{
     actions: { POST: { content_type: { choices: ContentTypeOption[] } } };
   }>(awxAPI`/role_definitions/`);
@@ -29,7 +29,13 @@ export function AwxSelectResourceTypeStep() {
           value,
           label: display_name,
         }))}
-      onChange={() => setWizardData({})}
+      onChange={(option?: string) => {
+        // Reset wizard/step data if the resource type selection was changed
+        if ((wizardData as { [key: string]: unknown })['resourceType'] !== option) {
+          setWizardData({});
+          setStepData({});
+        }
+      }}
       placeholderText={t('Select a resource type')}
       isRequired
     />

--- a/frontend/awx/common/useAwxMultiSelectListView.ts
+++ b/frontend/awx/common/useAwxMultiSelectListView.ts
@@ -27,6 +27,9 @@ export function useAwxMultiSelectListView<T extends { id: number }>(
 ) {
   const { setValue } = useFormContext();
   const { wizardData, stepData } = usePageWizard();
+  // console.log('onChange ResourcesStep: fieldName', fieldName);
+  // console.log('onChange ResourcesStep: wizardData', wizardData);
+  // console.log('onChange ResourcesStep: stepData', stepData);
 
   const view = useAwxView<T>({
     ...viewOptions,

--- a/frontend/awx/common/useAwxMultiSelectListView.ts
+++ b/frontend/awx/common/useAwxMultiSelectListView.ts
@@ -27,9 +27,6 @@ export function useAwxMultiSelectListView<T extends { id: number }>(
 ) {
   const { setValue } = useFormContext();
   const { wizardData, stepData } = usePageWizard();
-  // console.log('onChange ResourcesStep: fieldName', fieldName);
-  // console.log('onChange ResourcesStep: wizardData', wizardData);
-  // console.log('onChange ResourcesStep: stepData', stepData);
 
   const view = useAwxView<T>({
     ...viewOptions,

--- a/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
+++ b/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
@@ -11,7 +11,7 @@ interface ContentTypeOption {
 
 export function EdaSelectResourceTypeStep() {
   const { t } = useTranslation();
-  const { setWizardData } = usePageWizard();
+  const { wizardData, setWizardData, setStepData } = usePageWizard();
   const { data, isLoading } = useOptions<{
     actions: { POST: { content_type: { choices: ContentTypeOption[] } } };
   }>(edaAPI`/role_definitions/`);
@@ -38,7 +38,13 @@ export function EdaSelectResourceTypeStep() {
           value,
           label: display_name,
         }))}
-      onChange={() => setWizardData({})}
+      onChange={(option?: string) => {
+        // Reset wizard/step data if the resource type selection was changed
+        if ((wizardData as { [key: string]: unknown })['resourceType'] !== option) {
+          setWizardData({});
+          setStepData({});
+        }
+      }}
       placeholderText={t('Select a resource type')}
       isRequired
     />


### PR DESCRIPTION
The `User -> Roles -> Add roles` and `Team -> Roles -> Add roles` wizards in both AWX and EDA crash if the selected resource type is changed after making selections of resources/roles.
This was because the wizard data was not being reset correctly.

To test: See steps in [AAP-24843](https://issues.redhat.com/browse/AAP-24843) to recreate the issue.

