### PR TITLE
[AAP-24645] Instance Details Switch

### DIFF
--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -112,7 +112,7 @@ describe('Instances: Add/Edit', () => {
     });
   });
 
-  it.only('can uncheck the Enable Instance checkbox on the edit form, save form, and see the toggle is off', () => {
+  it('can uncheck the Enable Instance checkbox on the edit form, save form, and see the toggle is off', () => {
     cy.filterTableBySingleSelect('hostname', instance.hostname);
     cy.clickTableRowLink('name', instance.hostname, { disableFilter: true });
     cy.url().then((currentUrl) => {

--- a/cypress/e2e/awx/administration/instances.cy.ts
+++ b/cypress/e2e/awx/administration/instances.cy.ts
@@ -112,13 +112,13 @@ describe('Instances: Add/Edit', () => {
     });
   });
 
-  it('can uncheck the Enable Instance checkbox on the edit form, save form, and see the toggle is off', () => {
+  it.only('can uncheck the Enable Instance checkbox on the edit form, save form, and see the toggle is off', () => {
     cy.filterTableBySingleSelect('hostname', instance.hostname);
     cy.clickTableRowLink('name', instance.hostname, { disableFilter: true });
     cy.url().then((currentUrl) => {
       expect(currentUrl.includes(`/infrastructure/instances/${instance.id}/details`)).to.be.true;
     });
-    cy.get('input[aria-label="Click to disable instance"]').should('exist');
+    cy.get('input[aria-label="Enabled"]').should('exist');
     cy.getByDataCy('actions-dropdown').click();
     cy.getByDataCy('edit-instance').click();
     cy.getByDataCy('enabled').uncheck();
@@ -132,7 +132,7 @@ describe('Instances: Add/Edit', () => {
       .then((response: Instance) => {
         expect(response.enabled).to.be.false;
       });
-    cy.get('input[aria-label="Click to enable instance"]').should('exist');
+    cy.get('input[aria-label="Disabled"]').should('exist');
   });
 });
 

--- a/frontend/awx/administration/instances/InstanceDetails.cy.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.cy.tsx
@@ -91,7 +91,7 @@ describe('Instance Details', () => {
       });
   });
 
-  it.only('Enabled/Disabled switch is enabled if user has right permissions', () => {
+  it('Enabled/Disabled switch is enabled if user has right permissions', () => {
     cy.mount(<InstanceDetails />);
     cy.wait('@getInstance')
       .its('response.body')

--- a/frontend/awx/administration/instances/InstanceDetails.cy.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.cy.tsx
@@ -81,4 +81,22 @@ describe('Instance Details', () => {
         cy.get('.pf-v5-c-slider__thumb').should('have.attr', 'aria-disabled', 'true');
       });
   });
+
+  it('Enabled/Disabled switch is disabled if user does not have the right permissions', () => {
+    cy.mount(<InstanceDetails />, undefined, 'normalUser');
+    cy.wait('@getInstance')
+      .its('response.body')
+      .then(() => {
+        cy.get('.pf-v5-c-switch__input').should('be.disabled');
+      });
+  });
+
+  it.only('Enabled/Disabled switch is enabled if user has right permissions', () => {
+    cy.mount(<InstanceDetails />);
+    cy.wait('@getInstance')
+      .its('response.body')
+      .then(() => {
+        cy.get('.pf-v5-c-switch__input').should('not.be.disabled');
+      });
+  });
 });

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -28,6 +28,7 @@ import { useNodeTypeTooltip } from './hooks/useNodeTypeTooltip';
 import { InstanceForksSlider } from './components/InstanceForksSlider';
 import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 import { InstanceSwitch } from './components/InstanceSwitch';
+import { Unavailable } from '../../../../framework/components/Unavailable';
 
 export function InstanceDetails() {
   const params = useParams<{ id?: string; instance_id?: string }>();
@@ -132,7 +133,7 @@ export function InstanceDetailsTab(props: {
         {instance.enabled ? (
           <Progress value={Math.round(100 - instance.percent_capacity_remaining)} />
         ) : (
-          t('Unavailable')
+          <Unavailable>{t('Unavailable')}</Unavailable>
         )}
       </PageDetail>
       <PageDetail label={t('Running jobs')} data-cy="running-jobs">

--- a/frontend/awx/administration/instances/InstanceDetails.tsx
+++ b/frontend/awx/administration/instances/InstanceDetails.tsx
@@ -27,6 +27,7 @@ import { useInstanceActions } from './hooks/useInstanceActions';
 import { useNodeTypeTooltip } from './hooks/useNodeTypeTooltip';
 import { InstanceForksSlider } from './components/InstanceForksSlider';
 import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
+import { InstanceSwitch } from './components/InstanceSwitch';
 
 export function InstanceDetails() {
   const params = useParams<{ id?: string; instance_id?: string }>();
@@ -153,11 +154,16 @@ export function InstanceDetailsTab(props: {
         {formatDateString(instance.created)}
       </PageDetail>
       <LastModifiedPageDetail value={instance.modified} data-cy="modified" />
-      {instance.node_type !== 'hop' ? (
-        <PageDetail label={t('Forks')} data-cy="forks">
-          {instanceForks > 0 ? <InstanceForksSlider instance={instance} /> : undefined}
-        </PageDetail>
-      ) : undefined}
+      <PageDetail
+        label={t('Forks')}
+        data-cy="forks"
+        isEmpty={instance.node_type === 'hop' || instanceForks <= 0}
+      >
+        <InstanceForksSlider instance={instance} />
+      </PageDetail>
+      <PageDetail label={t('Enabled')} data-cy="enabled">
+        <InstanceSwitch instance={instance} />
+      </PageDetail>
       <PageDetailCodeEditor
         value={instance.errors}
         label={t('Errors')}

--- a/frontend/awx/administration/instances/InstancesPage.cy.tsx
+++ b/frontend/awx/administration/instances/InstancesPage.cy.tsx
@@ -27,7 +27,6 @@ describe('Instances Page', () => {
     cy.getByDataCy('remove-instance').should('have.attr', 'aria-disabled', 'false');
     cy.getByDataCy('run-health-check').should('be.visible');
     cy.getByDataCy('run-health-check').should('have.attr', 'aria-disabled', 'false');
-    cy.getByDataCy('toggle-switch').should('be.visible');
   });
 
   it('edit instance button should be hidden for non-k8s system', () => {
@@ -167,14 +166,5 @@ describe('Instances Page', () => {
     cy.mount(<InstancePage />);
     cy.getByDataCy('instances-listener-addresses-tab').should('be.visible');
     cy.getByDataCy('instances-listener-addresses-tab').should('be.enabled');
-  });
-
-  it('Enabled/Disabled switch is disabled if user does not have the right permissions', () => {
-    cy.mount(<InstancePage />, undefined, 'normalUser');
-    cy.wait('@getInstance')
-      .its('response.body')
-      .then(() => {
-        cy.get('.pf-v5-c-switch__input').should('be.disabled');
-      });
   });
 });

--- a/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
+++ b/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
@@ -19,7 +19,7 @@ export function InstanceForksSlider(props: { instance: Instance }) {
         min={instance.cpu_capacity}
         value={instanceForks}
         onChange={(_event: SliderOnChangeEvent, value: number) =>
-          void handleInstanceForksSlider(instance, value)
+          void handleInstanceForksSlider(value)
         }
         isDisabled={
           !(

--- a/frontend/awx/administration/instances/components/InstanceSwitch.tsx
+++ b/frontend/awx/administration/instances/components/InstanceSwitch.tsx
@@ -1,24 +1,34 @@
-import { Switch } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { PageActionSwitch } from '../../../../../framework/PageActions/PageActionSwitch';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { Instance } from '../../../interfaces/Instance';
 import { useInstanceActions } from '../hooks/useInstanceActions';
+import {
+  IPageActionSwitchSingle,
+  PageActionSelection,
+  PageActionType,
+} from '../../../../../framework';
+import { useTranslation } from 'react-i18next';
 
 export function InstanceSwitch(props: { instance: Instance }) {
+  const { t } = useTranslation();
   const { instance } = props;
   const { handleToggleInstance } = useInstanceActions(String(props.instance.id));
   const { activeAwxUser } = useAwxActiveUser();
 
-  return (
-    <Switch
-      id="enable-instance"
-      isDisabled={!activeAwxUser?.is_superuser}
-      label={t('Enabled')}
-      labelOff={t('Disabled')}
-      isChecked={instance?.enabled}
-      onChange={() => {
-        void handleToggleInstance(!instance?.enabled);
-      }}
-    />
-  );
+  const action: IPageActionSwitchSingle<Instance> = {
+    type: PageActionType.Switch,
+    onToggle: () => {
+      void handleToggleInstance(!instance?.enabled);
+    },
+    isSwitchOn: () => instance?.enabled,
+    isDisabled: (_instance) =>
+      !activeAwxUser?.is_superuser
+        ? t('You do not have permissions to toggle this instance')
+        : undefined,
+    ariaLabel: (isEnabled: boolean) => (isEnabled ? t('Enabled') : t('Disabled')),
+    selection: PageActionSelection.Single,
+    label: '',
+  };
+
+  return <PageActionSwitch action={action} selectedItem={instance} />;
 }

--- a/frontend/awx/administration/instances/components/InstanceSwitch.tsx
+++ b/frontend/awx/administration/instances/components/InstanceSwitch.tsx
@@ -1,0 +1,24 @@
+import { Switch } from '@patternfly/react-core';
+import { t } from 'i18next';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { Instance } from '../../../interfaces/Instance';
+import { useInstanceActions } from '../hooks/useInstanceActions';
+
+export function InstanceSwitch(props: { instance: Instance }) {
+  const { instance } = props;
+  const { handleToggleInstance } = useInstanceActions(String(props.instance.id));
+  const { activeAwxUser } = useAwxActiveUser();
+
+  return (
+    <Switch
+      id="enable-instance"
+      isDisabled={!activeAwxUser?.is_superuser}
+      label={t('Enabled')}
+      labelOff={t('Disabled')}
+      isChecked={instance?.enabled}
+      onChange={() => {
+        void handleToggleInstance(!instance?.enabled);
+      }}
+    />
+  );
+}

--- a/frontend/awx/administration/topology/Sidebar.tsx
+++ b/frontend/awx/administration/topology/Sidebar.tsx
@@ -3,12 +3,13 @@ import { Instance } from '../../interfaces/Instance';
 import { InstanceGroup } from '../../interfaces/InstanceGroup';
 import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { useInstanceActions } from '../instances/hooks/useInstanceActions';
+import { useGetItem } from '../../../common/crud/useGet';
+import { awxAPI } from '../../common/api/awx-utils';
 
 export function InstanceDetailInner(props: {
   instance: Instance;
   instanceGroups: AwxItemsResponse<InstanceGroup> | undefined;
   instanceForks: number;
-  handleInstanceForksSlider: (instance: Instance, value: number) => Promise<void>;
 }) {
   const { instance, instanceGroups, instanceForks } = props;
   return (
@@ -23,14 +24,13 @@ export function InstanceDetailInner(props: {
 
 export function InstanceDetailSidebar(props: { selectedId: string }) {
   const { selectedId } = props;
-  const { instance, instanceGroups, handleInstanceForksSlider, instanceForks } =
-    useInstanceActions(selectedId);
+  const { data: instance } = useGetItem<Instance>(awxAPI`/instances/`, selectedId);
+  const { instanceGroups, instanceForks } = useInstanceActions(selectedId);
 
   return instance ? (
     <InstanceDetailInner
       instance={instance}
       instanceGroups={instanceGroups ? instanceGroups : undefined}
-      handleInstanceForksSlider={handleInstanceForksSlider}
       instanceForks={instanceForks}
     />
   ) : null;


### PR DESCRIPTION
Moved instance switch to instance details section so topology view side bar has access to it. Customers can enable and disable an instance from the instances list, instance detail page and topology sidebar now (Just added).
Related JIRA: AAP-24645