### PR TITLE
[AAP-24675] Add download button for jobs output

### DIFF
--- a/frontend/awx/views/jobs/hooks/useDownloadJobOutput.tsx
+++ b/frontend/awx/views/jobs/hooks/useDownloadJobOutput.tsx
@@ -1,0 +1,18 @@
+import { downloadTextFile } from '../../../../../framework/utils/download-file';
+import { requestCommon } from '../../../../common/crud/requestCommon';
+import { createRequestError } from '../../../../common/crud/RequestError';
+import { UnifiedJob } from '../../../interfaces/UnifiedJob';
+
+export function useDownloadJobOutput() {
+  const downloadJobOutput = async (job: UnifiedJob) => {
+    const url = `${job.related.stdout}?format=txt_download`;
+    const result = await requestCommon({ url: url, method: 'GET' });
+    if (!result.ok) {
+      throw await createRequestError(result);
+    }
+    const content = await result.text();
+    downloadTextFile(job.name, content);
+  };
+
+  return downloadJobOutput;
+}

--- a/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
+import { DownloadIcon, MinusCircleIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IPageAction, PageActionSelection, PageActionType } from '../../../../../framework';
@@ -9,6 +9,7 @@ import { useCancelJobs } from './useCancelJobs';
 import { useDeleteJobs } from './useDeleteJobs';
 import { useRelaunchJob } from './useRelaunchJob';
 import { TFunction } from 'i18next';
+import { useDownloadJobOutput } from './useDownloadJobOutput';
 
 export const cannotCancelJob = (job: UnifiedJob, t: TFunction<'translation', undefined>) => {
   if (!isJobRunning(job.status)) return t(`The job cannot be canceled because it is not running`);
@@ -21,6 +22,7 @@ export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
   const { t } = useTranslation();
   const cancelJobs = useCancelJobs(onComplete);
   const deleteJobs = useDeleteJobs(onComplete);
+  const downloadJobOutput = useDownloadJobOutput();
   const relaunchJob = useRelaunchJob();
 
   return useMemo<IPageAction<UnifiedJob>[]>(() => {
@@ -70,7 +72,16 @@ export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
         ouiaId: 'job-detail-delete-button',
         isDanger: true,
       },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: DownloadIcon,
+        label: t(`Download Output`),
+        onClick: (job: UnifiedJob) => downloadJobOutput(job),
+        ouiaId: 'job-detail-download-button',
+        isHidden: (job: UnifiedJob) => !job.related.stdout,
+      },
     ];
     return actions;
-  }, [cancelJobs, deleteJobs, relaunchJob, t]);
+  }, [cancelJobs, deleteJobs, relaunchJob, downloadJobOutput, t]);
 }

--- a/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobHeaderActions.tsx
@@ -58,7 +58,16 @@ export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
         onClick: (job: UnifiedJob) => cancelJobs([job]),
       },
       { type: PageActionType.Seperator },
-
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: DownloadIcon,
+        label: t(`Download Output`),
+        onClick: (job: UnifiedJob) => downloadJobOutput(job),
+        ouiaId: 'job-detail-download-button',
+        isHidden: (job: UnifiedJob) => !job.related.stdout,
+      },
+      { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -71,15 +80,6 @@ export function useJobHeaderActions(onComplete: (jobs: UnifiedJob[]) => void) {
         },
         ouiaId: 'job-detail-delete-button',
         isDanger: true,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: DownloadIcon,
-        label: t(`Download Output`),
-        onClick: (job: UnifiedJob) => downloadJobOutput(job),
-        ouiaId: 'job-detail-download-button',
-        isHidden: (job: UnifiedJob) => !job.related.stdout,
       },
     ];
     return actions;


### PR DESCRIPTION
This PR addresses AAP-24675. Users should now be able to download logs from a job page where possible. This download button is in the kebab menu and is hidden if there is no `related.stdout` value for a job
