### PR TITLE
Hide client secret field if client type is public

### DIFF
--- a/frontend/awx/administration/applications/ApplicationPage/ApplicationClientSecretModal.tsx
+++ b/frontend/awx/administration/applications/ApplicationPage/ApplicationClientSecretModal.tsx
@@ -8,6 +8,7 @@ export function ApplicationClientSecretModal(props: {
   onClose: (value: SetStateAction<Application | undefined>) => void;
   applicationModalSource: Application;
 }) {
+  const { applicationModalSource } = props;
   return (
     <Modal
       aria-label={t`Application information`}
@@ -22,15 +23,18 @@ export function ApplicationClientSecretModal(props: {
         alertPrompts={[t`This is the only time the client secret will be shown.`]}
         numberOfColumns="single"
       >
-        <PageDetail label={t`Name`}>{props.applicationModalSource.name}</PageDetail>
+        <PageDetail label={t`Name`}>{applicationModalSource.name}</PageDetail>
         <PageDetail label={t`Client ID`}>
           <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
-            {props.applicationModalSource.client_id}
+            {applicationModalSource.client_id}
           </ClipboardCopy>
         </PageDetail>
-        <PageDetail label={t`Client Secret`}>
+        <PageDetail
+          label={t`Client Secret`}
+          isEmpty={applicationModalSource.client_type === 'public'}
+        >
           <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
-            {props.applicationModalSource.client_secret}
+            {applicationModalSource.client_secret}
           </ClipboardCopy>
         </PageDetail>
       </PageDetails>


### PR DESCRIPTION
This PR fixes an issue where the client secret modal displays a client secret field for an application with a `public` client type. The empty field throws an error when attempting to use the copy button for the field. More info can be found here https://github.com/ansible/aap-ui/pull/297