### PR TITLE
Allow passing create route and info message to EDA controller tokens component

### DIFF
--- a/frontend/eda/access/users/CreateControllerToken.tsx
+++ b/frontend/eda/access/users/CreateControllerToken.tsx
@@ -52,7 +52,7 @@ export function CreateControllerToken() {
 
   const onSubmit: PageFormSubmitHandler<EdaControllerTokenCreate> = async (token) => {
     await postRequest(edaAPI`/users/me/awx-tokens/`, token);
-    pageNavigate(EdaRoute.MyTokens);
+    pageNavigate(EdaRoute.MyTokens, { params: { id: activeEdaUser?.id } });
   };
   const onCancel = () => navigate(-1);
 
@@ -65,13 +65,13 @@ export function CreateControllerToken() {
       label: activeEdaUser?.username ?? '',
       to: canViewUsers
         ? getPageUrl(EdaRoute.UserPage, { params: { id: activeEdaUser?.id } })
-        : getPageUrl(EdaRoute.MyPage),
+        : getPageUrl(EdaRoute.MyPage, { params: { id: activeEdaUser?.id } }),
     },
     {
       label: t('Controller tokens'),
       to: canViewUsers
         ? getPageUrl(EdaRoute.UserTokens, { params: { id: activeEdaUser?.id } })
-        : getPageUrl(EdaRoute.MyTokens),
+        : getPageUrl(EdaRoute.MyTokens, { params: { id: activeEdaUser?.id } }),
     },
     { label: activeEdaUser?.username ?? '' },
   ];

--- a/frontend/eda/access/users/UserPage/ControllerTokens.tsx
+++ b/frontend/eda/access/users/UserPage/ControllerTokens.tsx
@@ -8,20 +8,23 @@ import { useControllerTokenActions } from '../hooks/useControllerTokenActions';
 import { useControllerTokensActions } from '../hooks/useControllerTokensActions';
 import { useControllerTokensColumns } from '../hooks/useControllerTokensColumns';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { DetailInfo } from '../../../../../framework/components/DetailInfo';
 
-export function ControllerTokens() {
+export function ControllerTokens(props: { createTokenRoute?: string; infoMessage?: string }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const tableColumns = useControllerTokensColumns();
+  const createRoute = props.createTokenRoute || EdaRoute.CreateControllerToken;
 
   const view = useEdaView<EdaControllerToken>({
     url: edaAPI`/users/me/awx-tokens/`,
     tableColumns,
   });
-  const toolbarActions = useControllerTokensActions(view);
+  const toolbarActions = useControllerTokensActions(view, createRoute);
   const rowActions = useControllerTokenActions(view);
   return (
     <PageLayout>
+      {props.infoMessage && <DetailInfo title={t(props.infoMessage)}></DetailInfo>}
       <PageTable
         id="eda-controller-tokens-table"
         tableColumns={tableColumns}
@@ -34,7 +37,7 @@ export function ControllerTokens() {
         )}
         emptyStateButtonIcon={<PlusCircleIcon />}
         emptyStateButtonText={t('Create controller token')}
-        emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateControllerToken)}
+        emptyStateButtonClick={() => pageNavigate(createRoute)}
         {...view}
         defaultSubtitle={t('Controller tokens')}
       />

--- a/frontend/eda/access/users/hooks/useControllerTokensActions.tsx
+++ b/frontend/eda/access/users/hooks/useControllerTokensActions.tsx
@@ -13,9 +13,13 @@ import { EdaControllerToken } from '../../../interfaces/EdaControllerToken';
 import { EdaRoute } from '../../../main/EdaRoutes';
 import { useDeleteControllerTokens } from './useDeleteControllerTokens';
 
-export function useControllerTokensActions(view: IEdaView<EdaControllerToken>) {
+export function useControllerTokensActions(
+  view: IEdaView<EdaControllerToken>,
+  createTokenRoute?: string
+) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
+  const createRoute = createTokenRoute || EdaRoute.CreateControllerToken;
   const deleteControllerTokens = useDeleteControllerTokens(view.unselectItemsAndRefresh);
   return useMemo<IPageAction<EdaControllerToken>[]>(
     () => [
@@ -26,7 +30,7 @@ export function useControllerTokensActions(view: IEdaView<EdaControllerToken>) {
         isPinned: true,
         icon: PlusCircleIcon,
         label: t('Create controller token'),
-        onClick: () => pageNavigate(EdaRoute.CreateControllerToken),
+        onClick: () => pageNavigate(createRoute),
       },
       {
         type: PageActionType.Button,
@@ -38,6 +42,6 @@ export function useControllerTokensActions(view: IEdaView<EdaControllerToken>) {
         isDanger: true,
       },
     ],
-    [deleteControllerTokens, pageNavigate, t]
+    [deleteControllerTokens, pageNavigate, t, createRoute]
   );
 }


### PR DESCRIPTION
This PR adds **optional** properties for EDA tokens component in order to allow integration of the component into unified ansible UI.
Also, the routes used to navigate away from creating a token (upon submitting or cancelling) have user id added as a parameter because the unified ansible UI does not have the user specific routes (with "/me" in the path).