### PR TITLE
[AAP-24931] Add ID column to job lists

### DIFF
--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useInstanceGroupJobsColumns.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useInstanceGroupJobsColumns.tsx
@@ -26,6 +26,19 @@ export function useInstanceGroupJobsColumns(options?: {
   const pageNavigate = usePageNavigate();
   const { t } = useTranslation();
 
+  const IDColumns = useMemo<ITableColumn<UnifiedJob>>(
+    () => ({
+      header: t('ID'),
+      cell: (job: UnifiedJob) => job.id,
+      sort: 'id',
+      card: 'hidden',
+      list: 'hidden',
+      dashboard: 'hidden',
+      minWidth: 0,
+    }),
+    [t]
+  );
+
   const jobPaths = useMemo<{ [key: string]: string }>(
     () => ({
       project_update: 'project',
@@ -102,6 +115,7 @@ export function useInstanceGroupJobsColumns(options?: {
 
   const tableColumns = useMemo<ITableColumn<UnifiedJob>[]>(() => {
     const displayColumns = [
+      IDColumns,
       nameColumn,
       statusColumn,
       typeColumn,
@@ -118,6 +132,7 @@ export function useInstanceGroupJobsColumns(options?: {
     ];
     return displayColumns;
   }, [
+    IDColumns,
     nameColumn,
     statusColumn,
     typeColumn,

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsJobsColumns.tsx
@@ -21,6 +21,19 @@ export function useHostsJobsColumns(options?: { disableSort?: boolean; disableLi
   const pageNavigate = usePageNavigate();
   const { t } = useTranslation();
 
+  const IDColumns = useMemo<ITableColumn<UnifiedJob>>(
+    () => ({
+      header: t('ID'),
+      cell: (job: UnifiedJob) => job.id,
+      sort: 'id',
+      card: 'hidden',
+      list: 'hidden',
+      dashboard: 'hidden',
+      minWidth: 0,
+    }),
+    [t]
+  );
+
   const jobPaths = useMemo<{ [key: string]: string }>(
     () => ({
       project_update: 'project',
@@ -95,6 +108,7 @@ export function useHostsJobsColumns(options?: { disableSort?: boolean; disableLi
 
   const tableColumns = useMemo<ITableColumn<UnifiedJob>[]>(() => {
     const displayColumns = [
+      IDColumns,
       nameColumn,
       statusColumn,
       startTimeColumn,
@@ -109,6 +123,7 @@ export function useHostsJobsColumns(options?: { disableSort?: boolean; disableLi
     ];
     return displayColumns;
   }, [
+    IDColumns,
     nameColumn,
     statusColumn,
     startTimeColumn,


### PR DESCRIPTION
Issue: [AAP-24931](https://issues.redhat.com/browse/AAP-24931)

Add ID columns to job list screens:
- `Host > Jobs`
- `Inventories > Hosts > Jobs`
- `Inventories > Jobs`
- `Instance groups > Jobs`
