### PR TITLE
Access control for managing/adding roles to users and teams

### DIFF
--- a/frontend/awx/access/teams/TeamPage/AwxTeamRoles.tsx
+++ b/frontend/awx/access/teams/TeamPage/AwxTeamRoles.tsx
@@ -1,15 +1,41 @@
 import { useParams } from 'react-router-dom';
 import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { LoadingPage } from '../../../../../framework';
+import { useTranslation } from 'react-i18next';
 
 export function AwxTeamRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
+  const { t } = useTranslation();
+
+  const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
+    awxAPI`/teams/${params.id ?? ''}/`
+  );
+
+  const canEditTeam = Boolean(
+    data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
+  );
+
+  if (isLoadingOptions) {
+    return <LoadingPage />;
+  }
+
   return (
     <ResourceAccess
       service={'awx'}
       id={props.id || params.id || ''}
       type="team-roles"
       addRolesRoute={props.addRolesRoute || AwxRoute.AddRolesToTeam}
+      disableAddRoles={
+        canEditTeam
+          ? undefined
+          : t(
+              'You do not have permission to add roles to this team. Please contact your system administrator if there is an issue with your access.'
+            )
+      }
     />
   );
 }

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -5,16 +5,23 @@ import { useOptions } from '../../../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useTranslation } from 'react-i18next';
+import { LoadingPage } from '../../../../../framework';
 
 export function UserRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
   const { t } = useTranslation();
 
-  const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/users/${params.id ?? ''}/`);
+  const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
+    awxAPI`/users/${params.id ?? ''}/`
+  );
 
   const canEditUser = Boolean(
     data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
   );
+
+  if (isLoadingOptions) {
+    return <LoadingPage />;
+  }
 
   return (
     <ResourceAccess

--- a/frontend/awx/access/users/UserPage/UserRoles.tsx
+++ b/frontend/awx/access/users/UserPage/UserRoles.tsx
@@ -1,15 +1,34 @@
 import { useParams } from 'react-router-dom';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { useTranslation } from 'react-i18next';
 
 export function UserRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
+  const { t } = useTranslation();
+
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/users/${params.id ?? ''}/`);
+
+  const canEditUser = Boolean(
+    data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
+  );
+
   return (
     <ResourceAccess
       service="awx"
       id={props.id || params.id || ''}
       type="user-roles"
       addRolesRoute={props.addRolesRoute || AwxRoute.AddRolesToUser}
+      disableAddRoles={
+        canEditUser
+          ? undefined
+          : t(
+              'You do not have permission to add roles to this user. Please contact your system administrator if there is an issue with your access.'
+            )
+      }
     />
   );
 }

--- a/frontend/common/access/components/Access.tsx
+++ b/frontend/common/access/components/Access.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../../framework';
 import { useCallback, useMemo } from 'react';
 import { ButtonVariant } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { CubesIcon, MinusCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { idKeyFn } from '../../../common/utils/nameKeyFn';
 import { requestDelete } from '../../../common/crud/Data';
 import { Assignment } from '../interfaces/Assignment';
@@ -48,6 +48,7 @@ type AccessProps<T extends Assignment> = {
   addRoleButtonText?: string;
   removeRoleText?: string;
   removeConfirmationText?: (count: number) => string;
+  disableAddRoles?: string;
 };
 
 export function Access<T extends Assignment>(props: AccessProps<T>) {
@@ -208,6 +209,7 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
         isPinned: true,
         icon: PlusCircleIcon,
         label: props.addRoleButtonText ?? t('Add roles'),
+        isDisabled: props.disableAddRoles,
         href: getPageUrl(props.addRolesRoute ?? '', { params: { id: params.id } }),
       },
       {
@@ -219,7 +221,15 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
         isDanger: true,
       },
     ],
-    [t, getPageUrl, props.addRolesRoute, props.addRoleButtonText, params.id, removeRoles]
+    [
+      props.addRoleButtonText,
+      props.disableAddRoles,
+      props.addRolesRoute,
+      t,
+      getPageUrl,
+      params.id,
+      removeRoles,
+    ]
   );
   const emptyStateTitle = useMemo(() => {
     let title: string;
@@ -261,11 +271,13 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
       toolbarFilters={toolbarFilters}
       rowActions={rowActions}
       errorStateTitle={t('Error loading access data.')}
-      emptyStateTitle={emptyStateTitle}
-      emptyStateDescription={t('Add a role by clicking the button below.')}
-      emptyStateButtonIcon={<PlusCircleIcon />}
+      emptyStateTitle={props.disableAddRoles ?? emptyStateTitle}
+      emptyStateDescription={
+        props.disableAddRoles ? undefined : t('Add a role by clicking the button below.')
+      }
+      emptyStateIcon={props.disableAddRoles ? CubesIcon : undefined}
       emptyStateButtonText={props.addRoleButtonText ?? t('Add roles')}
-      emptyStateActions={toolbarActions.slice(0, 1)}
+      emptyStateActions={props.disableAddRoles ? undefined : toolbarActions.slice(0, 1)}
       {...view}
     />
   );

--- a/frontend/common/access/components/ResourceAccess.tsx
+++ b/frontend/common/access/components/ResourceAccess.tsx
@@ -20,8 +20,9 @@ export function ResourceAccess(props: {
   id: string;
   type: 'user-roles' | 'team-roles';
   addRolesRoute?: string;
+  disableAddRoles?: string;
 }) {
-  const { id, type, addRolesRoute, service } = props;
+  const { id, type, addRolesRoute, disableAddRoles, service } = props;
   const { t } = useTranslation();
   const getDisplayName = useMapContentTypeToDisplayName();
   const roleDefinitionsURL =
@@ -85,6 +86,7 @@ export function ResourceAccess(props: {
       url={type === 'user-roles' ? roleUserAssignmentsURL : roleTeamAssignmentsURL}
       id={id}
       addRolesRoute={addRolesRoute}
+      disableAddRoles={disableAddRoles}
       accessListType={type}
     />
   );

--- a/frontend/common/access/hooks/useManageOrgRolesDialog.tsx
+++ b/frontend/common/access/hooks/useManageOrgRolesDialog.tsx
@@ -7,7 +7,7 @@ import { CogIcon } from '@patternfly/react-icons';
 
 type ViewOrgRolesProps = {
   orgListsOptions: OrgRolesListProps[];
-  onManageRolesClick: () => void;
+  onManageRolesClick?: () => void;
   userOrTeamName: string;
 };
 
@@ -27,19 +27,23 @@ export function ManageOrgRoles(props: ViewOrgRolesProps) {
       isOpen
       onClose={onClose}
       actions={[
-        <Button
-          ouiaId="manage-roles-modal-manage-roles-button"
-          key="manage-roles"
-          variant={ButtonVariant.primary}
-          icon={<CogIcon />}
-          onClick={() => {
-            onManageRolesClick();
-            onClose();
-          }}
-          aria-label={t`Close`}
-        >
-          {t(`Manage roles`)}
-        </Button>,
+        ...(onManageRolesClick
+          ? [
+              <Button
+                ouiaId="manage-roles-modal-manage-roles-button"
+                key="manage-roles"
+                variant={ButtonVariant.primary}
+                icon={<CogIcon />}
+                onClick={() => {
+                  onManageRolesClick();
+                  onClose();
+                }}
+                aria-label={t`Close`}
+              >
+                {t(`Manage roles`)}
+              </Button>,
+            ]
+          : []),
         <Button
           ouiaId="manage-roles-modal-close-button"
           key="close"
@@ -62,12 +66,17 @@ export function ManageOrgRoles(props: ViewOrgRolesProps) {
           listId={index}
         />
       ))}
-      {orgListIsEmpty.every((isEmpty) => isEmpty === true) && (
-        <Trans>
-          <b>{userOrTeamName}</b> has no organization roles. To add roles to <b>{userOrTeamName}</b>{' '}
-          click on the button below.
-        </Trans>
-      )}
+      {orgListIsEmpty.every((isEmpty) => isEmpty === true) &&
+        (onManageRolesClick ? (
+          <Trans>
+            <b>{userOrTeamName}</b> has no organization roles. To add roles to{' '}
+            <b>{userOrTeamName}</b> click on the button below.
+          </Trans>
+        ) : (
+          <Trans>
+            <b>{userOrTeamName}</b> has no organization roles.
+          </Trans>
+        ))}
     </Modal>
   );
 }
@@ -77,8 +86,8 @@ export function useManageOrgRoles() {
   const openManageOrgRoles = useCallback(
     (manageOrgRolesOptions: {
       orgListsOptions: OrgRolesListProps[];
-      onManageRolesClick: () => void;
       userOrTeamName: string;
+      onManageRolesClick?: () => void;
     }) => {
       setDialog(
         <ManageOrgRoles

--- a/frontend/eda/access/teams/TeamPage/EdaTeamRoles.tsx
+++ b/frontend/eda/access/teams/TeamPage/EdaTeamRoles.tsx
@@ -1,15 +1,41 @@
 import { useParams } from 'react-router-dom';
 import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
 import { EdaRoute } from '../../../main/EdaRoutes';
+import { useTranslation } from 'react-i18next';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
+import { edaAPI } from '../../../common/eda-utils';
+import { LoadingPage } from '../../../../../framework';
 
 export function EdaTeamRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
+  const { t } = useTranslation();
+
+  const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
+    edaAPI`/teams/${params.id ?? ''}/`
+  );
+
+  const canEditTeam = Boolean(
+    data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
+  );
+
+  if (isLoadingOptions) {
+    return <LoadingPage />;
+  }
+
   return (
     <ResourceAccess
       service={'eda'}
       id={props.id || params.id || ''}
       type="team-roles"
       addRolesRoute={props.addRolesRoute || EdaRoute.TeamAddRoles}
+      disableAddRoles={
+        canEditTeam
+          ? undefined
+          : t(
+              'You do not have permission to add roles to this team. Please contact your system administrator if there is an issue with your access.'
+            )
+      }
     />
   );
 }

--- a/frontend/eda/access/users/UserPage/EdaUserRoles.tsx
+++ b/frontend/eda/access/users/UserPage/EdaUserRoles.tsx
@@ -1,15 +1,32 @@
 import { useParams } from 'react-router-dom';
 import { EdaRoute } from '../../../main/EdaRoutes';
 import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
+import { edaAPI } from '../../../common/eda-utils';
+import { OptionsResponse, ActionsResponse } from '../../../interfaces/OptionsResponse';
+import { useOptions } from '../../../../common/crud/useOptions';
+import { useTranslation } from 'react-i18next';
 
 export function EdaUserRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(edaAPI`/users/${params.id ?? ''}/`);
+  const { t } = useTranslation();
+
+  const canEditUser = Boolean(
+    data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
+  );
   return (
     <ResourceAccess
       service="eda"
       id={props.id || params.id || ''}
       type="user-roles"
       addRolesRoute={props.addRolesRoute || EdaRoute.UserAddRoles}
+      disableAddRoles={
+        canEditUser
+          ? undefined
+          : t(
+              'You do not have permission to add roles to this user. Please contact your system administrator if there is an issue with your access.'
+            )
+      }
     />
   );
 }

--- a/frontend/eda/access/users/UserPage/EdaUserRoles.tsx
+++ b/frontend/eda/access/users/UserPage/EdaUserRoles.tsx
@@ -5,15 +5,23 @@ import { edaAPI } from '../../../common/eda-utils';
 import { OptionsResponse, ActionsResponse } from '../../../interfaces/OptionsResponse';
 import { useOptions } from '../../../../common/crud/useOptions';
 import { useTranslation } from 'react-i18next';
+import { LoadingPage } from '../../../../../framework';
 
 export function EdaUserRoles(props: { id?: string; addRolesRoute?: string }) {
   const params = useParams<{ id: string }>();
-  const { data } = useOptions<OptionsResponse<ActionsResponse>>(edaAPI`/users/${params.id ?? ''}/`);
+  const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
+    edaAPI`/users/${params.id ?? ''}/`
+  );
   const { t } = useTranslation();
 
   const canEditUser = Boolean(
     data && data.actions && (data.actions['PUT'] || data.actions['PATCH'])
   );
+
+  if (isLoadingOptions) {
+    return <LoadingPage />;
+  }
+
   return (
     <ResourceAccess
       service="eda"


### PR DESCRIPTION
- `Add roles` for a team is enabled if the logged in user has edit permissions on the team.
- `Add roles` for a user is enabled if the logged in user has edit permissions on the user.
- The `Manage (org) roles` dialog hides the "Manage roles" action if the logged in user does not have permissions to edit the organization.
