### PR TITLE
github actions add success step

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -132,3 +132,14 @@ jobs:
       HUB_PROJECT_ID: ${{ secrets.HUB_PROJECT_ID }}
       HUB_RECORD_KEY: ${{ secrets.HUB_RECORD_KEY }}
       
+  success:
+    name: Success
+    runs-on: ubuntu-latest
+    needs: 
+      - checks
+      - component-tests
+      - awx-e2e
+      - eda-e2e
+      - hub-e2e      
+    steps:
+      - run: echo Success


### PR DESCRIPTION
Adds a success job to the github action for PRs.  This will make it easier to have a required successful step, vs requiring a bunch of steps for a PR.

This will also make it easier to move to the newer more cost effective cypress component testing without disrupting PRs.