### PR TITLE
Add remaining columns missing from jobs details page.

### DIFF
--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -15,6 +15,7 @@ import { StatusCell } from '../../../common/Status';
 import { AwxRoute } from '../../main/AwxRoutes';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
 import { Job } from '../../interfaces/Job';
+import { useVerbosityString } from '../../common/useVerbosityString';
 
 export function JobDetails() {
   const { t } = useTranslation();
@@ -22,14 +23,6 @@ export function JobDetails() {
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const { job } = useOutletContext<{ job: Job }>();
-  const verbosity = [
-    '0 (Normal)',
-    '1 (Verbose)',
-    '2 (More Verbose)',
-    '3 (Debug)',
-    '4 (Connection Debug)',
-    '5 (WinRM Debug)',
-  ];
 
   const verbosityHelpText = t`Control the level of output ansible will produce as the playbook executes.`;
   const forksHelpText = t`The number of parallel or simultaneous processes to use while executing the playbook. 

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -24,12 +24,7 @@ export function JobDetails() {
   const pageNavigate = usePageNavigate();
   const { job } = useOutletContext<{ job: Job }>();
 
-  const verbosityHelpText = t`Control the level of output ansible will produce as the playbook executes.`;
-  const forksHelpText = t`The number of parallel or simultaneous processes to use while executing the playbook. 
-  An empty value, or a value less than 1 will use the Ansible default which is usually 5. The default number of 
-  forks can be overwritten with a change to ansible.cfg. Refer to the Ansible documentation for details about the 
-  configuration file.`;
-  const timeoutHelpText = t`The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout.`;
+  const verbosity = useVerbosityString(job.verbosity || 0);
   const timeoutDefaultText = t`No timeout specified`;
 
   return (
@@ -91,7 +86,12 @@ export function JobDetails() {
           {job.summary_fields?.instance_group?.name}
         </Link>
       </PageDetail>
-      <PageDetail label={t('Forks')} helpText={forksHelpText}>
+      <PageDetail
+        label={t('Forks')}
+        helpText={t(
+          'The number of parallel or simultaneous processes to use while executing the playbook. An empty value, or a value less than 1 will use the Ansible default which is usually 5. The default number of forks can be overwritten with a change to ansible.cfg. Refer to the Ansible documentation for details about the configuration file.'
+        )}
+      >
         {job.forks}
       </PageDetail>
       <PageDetail
@@ -106,7 +106,7 @@ export function JobDetails() {
         label={t('Verbosity')}
         helpText={t('Control the level of output ansible will produce as the playbook executes.')}
       >
-        {job.verbosity}
+        {verbosity}
       </PageDetail>
       <PageDetail
         label={t('Job tags')}

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -22,6 +22,22 @@ export function JobDetails() {
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const { job } = useOutletContext<{ job: Job }>();
+  const verbosity = [
+    '0 (Normal)',
+    '1 (Verbose)',
+    '2 (More Verbose)',
+    '3 (Debug)',
+    '4 (Connection Debug)',
+    '5 (WinRM Debug)',
+  ];
+
+  const verbosityHelpText = t`Control the level of output ansible will produce as the playbook executes.`;
+  const forksHelpText = t`The number of parallel or simultaneous processes to use while executing the playbook. 
+  An empty value, or a value less than 1 will use the Ansible default which is usually 5. The default number of 
+  forks can be overwritten with a change to ansible.cfg. Refer to the Ansible documentation for details about the 
+  configuration file.`;
+  const timeoutHelpText = t`The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout.`;
+  const timeoutDefaultText = t`No timeout specified`;
 
   return (
     <PageDetails>
@@ -82,20 +98,18 @@ export function JobDetails() {
           {job.summary_fields?.instance_group?.name}
         </Link>
       </PageDetail>
-      <PageDetail isEmpty={!job.forks} label={t('Forks')}>
+      <PageDetail label={t('Forks')} helpText={forksHelpText}>
         {job.forks}
       </PageDetail>
       <PageDetail
-        isEmpty={!job.timeout}
         label={t('Timeout')}
         helpText={t(
           'The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout.'
         )}
       >
-        {job.timeout}
+        {job.timeout === 0 ? timeoutDefaultText : job.timeout}
       </PageDetail>
       <PageDetail
-        isEmpty={!job.verbosity}
         label={t('Verbosity')}
         helpText={t('Control the level of output ansible will produce as the playbook executes.')}
       >


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-24307

This adds the last few remaining columns that were not showing in the jobs details page. Removing the isEmpty from the PageDetails for Forks, Timeout, and Verbosity allow them to be shown even when empty. Also adds helpText and default text for when the field isn't defined or equals 0.

Before:
![Screenshot 2024-06-05 at 2 16 38 PM](https://github.com/ansible/ansible-ui/assets/14355897/e48cac03-bcea-4e34-a572-8248a750dd55)

After:
![Screenshot 2024-06-05 at 2 16 28 PM](https://github.com/ansible/ansible-ui/assets/14355897/630d5e48-7979-4127-b958-9c6cc1e4a179)
