### PR TITLE
Add Cancel Sync Inventory Option

### DIFF
--- a/frontend/awx/resources/inventories/hooks/useCancelInventoryUpdate.tsx
+++ b/frontend/awx/resources/inventories/hooks/useCancelInventoryUpdate.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings } from '../../../../../framework';
+import { useNameColumn } from '../../../../common/columns';
+import { getItemKey } from '../../../../common/crud/Data';
+import { usePostRequest } from '../../../../common/crud/usePostRequest';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
+import { InventorySource } from '../../../interfaces/InventorySource';
+import { useInventorySourceColumns } from './useInventorySourceColumns';
+
+export function useCancelIventoryUpdate(onComplete: (inventorySources: InventorySource[]) => void) {
+  const { t } = useTranslation();
+  const bulkAction = useAwxBulkConfirmation<InventorySource>();
+  const requestPost = usePostRequest();
+  const confirmationColumns = useInventorySourceColumns({ disableLinks: true });
+  const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
+
+  const cancelInventoryUpdate = (inventorySources: InventorySource[]) => {
+    bulkAction({
+      title: t('Cancel Inventory Update'),
+      confirmText: t('Yes, I confirm that I want to cancel inventory update.'),
+      actionButtonText: t('Cancel Update'),
+      items: inventorySources.sort((l, r) => compareStrings(l.name, r.name)),
+      keyFn: getItemKey,
+      isDanger: true,
+      confirmationColumns,
+      actionColumns,
+      onComplete,
+      actionFn: (inventorySource, signal) => {
+        let job;
+        if (inventorySource.summary_fields?.current_job) {
+          job = inventorySource.summary_fields.current_job;
+        } else if (inventorySource.summary_fields?.last_job) {
+          job = inventorySource.summary_fields.last_job;
+        }
+        return requestPost(awxAPI`/inventory_updates/${String(job?.id)}/cancel/`, signal);
+      },
+    });
+  };
+
+  return cancelInventoryUpdate;
+}

--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PencilAltIcon, RocketIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -15,17 +15,21 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { InventorySource } from '../../../interfaces/InventorySource';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useCancelIventoryUpdate } from './useCancelInventoryUpdate';
 import { useDeleteInventorySources } from './useDeleteInventorySources';
 
 type InventorySourceActionOptions = {
-  onDelete: (inventorySources: InventorySource[]) => void;
-  onSync: () => void;
+  onInventorySourcesDeleted: (inventorySources: InventorySource[]) => void;
+  onInvUpdateCanceled: (inventorySources: InventorySource[]) => void;
 };
 
-export function useInventorySourceActions({ onDelete, onSync }: InventorySourceActionOptions) {
+export function useInventorySourceActions({
+  onInventorySourcesDeleted,
+  onInvUpdateCanceled,
+}: InventorySourceActionOptions) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
-  const deleteInventorySources = useDeleteInventorySources(onDelete);
+  const deleteInventorySources = useDeleteInventorySources(onInventorySourcesDeleted);
   const params = useParams<{ inventory_type: string }>();
 
   const { activeAwxUser } = useAwxActiveUser();
@@ -36,7 +40,6 @@ export function useInventorySourceActions({ onDelete, onSync }: InventorySourceA
     async (invSrc: InventorySource) => {
       try {
         await postRequest(awxAPI`/inventory_sources/${invSrc.id.toString()}/update/`, {});
-        onSync();
       } catch (error) {
         alertToaster.addAlert({
           variant: 'danger',
@@ -46,8 +49,10 @@ export function useInventorySourceActions({ onDelete, onSync }: InventorySourceA
         });
       }
     },
-    [alertToaster, postRequest, t, onSync]
+    [alertToaster, postRequest, t]
   );
+
+  const cancelInventoryUpdate = useCancelIventoryUpdate(onInvUpdateCanceled);
 
   return useMemo<IPageAction<InventorySource>[]>(() => {
     const cannotDeleteInventorySource = (inventorySource: InventorySource): string => {
@@ -101,11 +106,49 @@ export function useInventorySourceActions({ onDelete, onSync }: InventorySourceA
         icon: RocketIcon,
         label: t('Launch inventory update'),
         isPinned: true,
-        isHidden: (inventorySource: InventorySource) =>
-          !inventorySource?.summary_fields.user_capabilities.start,
+        isHidden: (inventorySource: InventorySource) => {
+          const startPerms = inventorySource?.summary_fields.user_capabilities.start;
+          let job;
+          let unlaunchableStatus;
+          if (inventorySource.summary_fields?.current_job) {
+            job = inventorySource.summary_fields.current_job;
+          } else if (inventorySource.summary_fields?.last_job) {
+            job = inventorySource.summary_fields.last_job;
+          }
+          if (job) {
+            unlaunchableStatus = ['new', 'running', 'pending', 'waiting'].includes(job?.status);
+          }
+
+          return !startPerms || unlaunchableStatus ? true : false;
+        },
         isDisabled: (inventorySource: InventorySource) =>
           cannotLaunchInventorySourceUpdate(inventorySource),
         onClick: (inventorySource) => handleUpdate(inventorySource),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: MinusCircleIcon,
+        label: t('Cancel inventory update'),
+        isPinned: true,
+        isHidden: (inventorySource: InventorySource) => {
+          const startPerms = inventorySource?.summary_fields.user_capabilities.start;
+          let job;
+          let unlaunchableStatus;
+          if (inventorySource.summary_fields?.current_job) {
+            job = inventorySource.summary_fields.current_job;
+          } else if (inventorySource.summary_fields?.last_job) {
+            job = inventorySource.summary_fields.last_job;
+          }
+          if (job) {
+            unlaunchableStatus = ['new', 'running', 'pending', 'waiting'].includes(job?.status);
+          }
+
+          return !startPerms || !unlaunchableStatus ? true : false;
+        },
+        isDisabled: (inventorySource: InventorySource) =>
+          cannotLaunchInventorySourceUpdate(inventorySource),
+        onClick: (inventorySource) => cancelInventoryUpdate([inventorySource]),
       },
       {
         type: PageActionType.Button,
@@ -119,5 +162,13 @@ export function useInventorySourceActions({ onDelete, onSync }: InventorySourceA
       },
     ];
     return itemActions;
-  }, [deleteInventorySources, pageNavigate, handleUpdate, activeAwxUser, t, params.inventory_type]);
+  }, [
+    deleteInventorySources,
+    pageNavigate,
+    handleUpdate,
+    cancelInventoryUpdate,
+    activeAwxUser,
+    t,
+    params.inventory_type,
+  ]);
 }

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourcePage.tsx
@@ -28,11 +28,11 @@ export function InventorySourcePage() {
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
   const itemActions = useInventorySourceActions({
-    onDelete: () =>
+    onInventorySourcesDeleted: () =>
       pageNavigate(AwxRoute.InventorySources, {
         params: { id: params.id, inventory_type: params.inventory_type },
       }),
-    onSync: refresh,
+    onInvUpdateCanceled: refresh,
   });
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!inventorySource) return <LoadingPage breadcrumbs tabs />;


### PR DESCRIPTION
This PR addresses AAP-24920. It adds the option to cancel an inventory sync when one is running. In addition, websockets are used to track status changes of the inventory sync jobs.