### PR TITLE
Update PageActionDropdown to use PF5 Dropdown

### DIFF
--- a/framework/PageActions/PageActions.tsx
+++ b/framework/PageActions/PageActions.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { ButtonVariant, Flex, FlexItem } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import {
   ComponentClass,
@@ -40,6 +40,8 @@ interface PageActionProps<T extends object> {
 
   /** Called when a dropdown is opened, allowing the parent to handle the z-index needed */
   onOpen?: (open: boolean) => void;
+
+  variant?: ButtonVariant;
 }
 
 /**

--- a/framework/PageActions/PageActionsPinned.tsx
+++ b/framework/PageActions/PageActionsPinned.tsx
@@ -1,5 +1,4 @@
 import { Split } from '@patternfly/react-core';
-import { DropdownPosition } from '@patternfly/react-core/deprecated';
 import { ComponentClass, FunctionComponent } from 'react';
 import { IPageAction, PageActionType } from './PageAction';
 import { PageActionButton } from './PageActionButton';
@@ -116,7 +115,6 @@ export function PageActionPinned<T extends object>(props: PageActionPinnedProps<
           selectedItem={selectedItem}
           selectedItems={selectedItems}
           iconOnly={props.iconOnly}
-          position={DropdownPosition.right}
           tooltip={tooltip}
           isDisabled={isDisabled}
           variant={action.variant}


### PR DESCRIPTION
Updates the PageActionDropdown to use the newer PF5 Dropdown and not the deprecated PF4 dropdown.
This dropdown works much better and the menus that open do not get clipped off the screen anymore.

This is needed for some other work going on.
This breaks tests because of the tests looking for specific pf classes. :( 