### PR TITLE
Adds help text to job details

### DIFF
--- a/framework/PageDetails/PageDetailsFromColumns.tsx
+++ b/framework/PageDetails/PageDetailsFromColumns.tsx
@@ -48,7 +48,11 @@ export function PageDetailsFromColumns<T extends object>(props: {
     <>
       {firstColumns.map((column) => {
         return (
-          <PageDetail key={column.id ?? column.header} label={column.header}>
+          <PageDetail
+            key={column.id ?? column.header}
+            helpText={column.helpText}
+            label={column.header}
+          >
             <TableColumnCell column={column} item={item} />
           </PageDetail>
         );

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -79,6 +79,9 @@ interface ITableColumnCommon<T extends object> {
   /** Header for the column in the table. */
   header: string;
 
+  /** This is the help text that will appear on the details view when that details view uses <PageDetailsFromColumns> */
+  helpText?: string;
+
   /** MinWidth for the column. */
   minWidth?: number;
 

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -44,10 +44,17 @@ export function JobDetails() {
       <PageDetail isEmpty={!job.controller_node} label={t('Controller node')}>
         {job.controller_node}
       </PageDetail>
-      <PageDetail isEmpty={!job.execution_node} label={t('Execution node')}>
+      <PageDetail
+        isEmpty={!job.execution_node}
+        label={t('Execution node')}
+        helpText={t(
+          'The execution environment that will be used when launching this job template. The resolved execution environment can be overridden by explicitly assigning a different one to this job template.'
+        )}
+      >
         {job.execution_node}
       </PageDetail>
       <PageDetail
+        helpText={t('Instance group used on this job run.')}
         isEmpty={!job.summary_fields.instance_group?.is_container_group}
         label={t('Instance group')}
       >
@@ -78,18 +85,36 @@ export function JobDetails() {
       <PageDetail isEmpty={!job.forks} label={t('Forks')}>
         {job.forks}
       </PageDetail>
-      <PageDetail isEmpty={!job.timeout} label={t('Timeout')}>
+      <PageDetail
+        isEmpty={!job.timeout}
+        label={t('Timeout')}
+        helpText={t(
+          'The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout.'
+        )}
+      >
         {job.timeout}
       </PageDetail>
-      <PageDetail isEmpty={!job.verbosity} label={t('Verbosity')}>
+      <PageDetail
+        isEmpty={!job.verbosity}
+        label={t('Verbosity')}
+        helpText={t('Control the level of output ansible will produce as the playbook executes.')}
+      >
         {job.verbosity}
       </PageDetail>
-      <PageDetail label={t('Job tags')} isEmpty={!job.job_tags}>
+      <PageDetail
+        label={t('Job tags')}
+        helpText={t('Job tags used during this job.')}
+        isEmpty={!job.job_tags}
+      >
         <LabelGroup>
           {job.job_tags?.split(',')?.map((tag) => <Label key={tag}>{tag}</Label>)}
         </LabelGroup>
       </PageDetail>
-      <PageDetail label={t('Skip tags')} isEmpty={!job.skip_tags}>
+      <PageDetail
+        helpText={t('Skip tags used during this job.')}
+        label={t('Skip tags')}
+        isEmpty={!job.skip_tags}
+      >
         <LabelGroup>
           {job.skip_tags?.split(',')?.map((tag) => <Label key={tag}>{tag}</Label>)}
         </LabelGroup>
@@ -119,6 +144,9 @@ export function JobDetails() {
       />
       <PageDetailCodeEditor
         label={t`Extra Variables`}
+        helpText={t(
+          'Extra Variables used on this job.  This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax.'
+        )}
         showCopyToClipboard
         data-cy="inventory-source-detail-variables"
         value={job.extra_vars ?? ''}

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -234,6 +234,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
             {job.summary_fields?.inventory?.name}
           </Link>
         ),
+        helpText: t('Inventory used on this job'),
         value: (job: UnifiedJob) => job.summary_fields?.inventory?.name,
         table: ColumnTableOption.expanded,
         card: 'hidden',
@@ -244,6 +245,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Project'),
+        helpText: t('The project containing the playbook this job will execute.'),
         cell: (job: UnifiedJob) => (
           <Link
             to={getPageUrl(AwxRoute.ProjectDetails, {
@@ -263,6 +265,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Execution environment'),
+        helpText: t('The execution environment that was be used when launching this job template.'),
         cell: (job: UnifiedJob) => (
           <Link
             to={getPageUrl(AwxRoute.ExecutionEnvironmentDetails, {
@@ -285,6 +288,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Credentials'),
+        helpText: t('Credential(s) used to access the nodes this job will be ran against.'),
         cell: (job: UnifiedJob) => (
           <LabelGroup
             numLabels={5}
@@ -310,6 +314,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Labels'),
+        helpText: t('Labels used to describe job.'),
         cell: (job: UnifiedJob) => (
           <ChipGroup
             numChips={5}
@@ -349,6 +354,9 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Job slice'),
+        helpText: t(
+          'Divide the work done by this job template into the specified number of job slices, each running the same tasks against a portion of the inventory.'
+        ),
         cell: (job: UnifiedJob) => (
           <span>{`${job.job_slice_number ?? 0}/${(job.job_slice_count ?? 0).toString()}`}</span>
         ),


### PR DESCRIPTION
This addresses AAP-24726.

It also adds a helpText property to `ITableColumnCommon` so that we can define help text on each column and then <PageDetailsFromColumns> can consume, and render the help text in the details views