### PR TITLE
Add file upload option & password fields to settings

### DIFF
--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -12,6 +12,7 @@ import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 import { AwxPageForm } from '../../common/AwxPageForm';
 import { awxAPI } from '../../common/api/awx-utils';
 import { PageFormFileUpload } from '../../../../framework/PageForm/Inputs/PageFormFileUpload';
+import { useTranslation } from 'react-i18next';
 
 export interface AwxSettingsOptionsResponse {
   actions: {
@@ -169,8 +170,9 @@ export function AwxSettingsForm(props: {
 
 export function OptionActionsFormInput(props: { name: string; option: AwxSettingsOptionsAction }) {
   const option = props.option;
+  const { t } = useTranslation();
 
-  if (option.label.endsWith('Secret')) {
+  if (option.label.includes(t('Secret'))) {
     return (
       <PageFormTextInput
         label={option.label}

--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -11,6 +11,7 @@ import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSe
 import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 import { AwxPageForm } from '../../common/AwxPageForm';
 import { awxAPI } from '../../common/api/awx-utils';
+import { PageFormFileUpload } from '../../../../framework/PageForm/Inputs/PageFormFileUpload';
 
 export interface AwxSettingsOptionsResponse {
   actions: {
@@ -168,6 +169,38 @@ export function AwxSettingsForm(props: {
 
 export function OptionActionsFormInput(props: { name: string; option: AwxSettingsOptionsAction }) {
   const option = props.option;
+
+  if (option.label.endsWith('Secret')) {
+    return (
+      <PageFormTextInput
+        label={option.label}
+        name={props.name}
+        labelHelpTitle={option.label}
+        labelHelp={option.help_text}
+        isRequired={option.required}
+        type="password"
+      />
+    );
+  }
+
+  if (
+    option.label.includes('SAML Service Provider Public Certificate') ||
+    option.label.includes('SAML Service Provider Private Key')
+  ) {
+    return (
+      <PageFormFileUpload
+        label={option.label}
+        name={props.name}
+        type="text"
+        labelHelpTitle={option.label}
+        labelHelp={option.help_text}
+        isRequired={option.required}
+        allowEditingUploadedText={true}
+        isReadOnly={false}
+      />
+    );
+  }
+
   switch (option.type) {
     case 'string':
     case 'field':

--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -170,9 +170,8 @@ export function AwxSettingsForm(props: {
 
 export function OptionActionsFormInput(props: { name: string; option: AwxSettingsOptionsAction }) {
   const option = props.option;
-  const { t } = useTranslation();
 
-  if (option.label.includes(t('Secret'))) {
+  if (props.name.endsWith('SECRET')) {
     return (
       <PageFormTextInput
         label={option.label}
@@ -186,8 +185,8 @@ export function OptionActionsFormInput(props: { name: string; option: AwxSetting
   }
 
   if (
-    option.label.includes('SAML Service Provider Public Certificate') ||
-    option.label.includes('SAML Service Provider Private Key')
+    props.name.includes('SOCIAL_AUTH_SAML_SP_PUBLIC_CERT') ||
+    props.name.includes('SOCIAL_AUTH_SAML_SP_PRIVATE_KEY')
   ) {
     return (
       <PageFormSection singleColumn>

--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -12,7 +12,6 @@ import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 import { AwxPageForm } from '../../common/AwxPageForm';
 import { awxAPI } from '../../common/api/awx-utils';
 import { PageFormFileUpload } from '../../../../framework/PageForm/Inputs/PageFormFileUpload';
-import { useTranslation } from 'react-i18next';
 
 export interface AwxSettingsOptionsResponse {
   actions: {

--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -190,16 +190,18 @@ export function OptionActionsFormInput(props: { name: string; option: AwxSetting
     option.label.includes('SAML Service Provider Private Key')
   ) {
     return (
-      <PageFormFileUpload
-        label={option.label}
-        name={props.name}
-        type="text"
-        labelHelpTitle={option.label}
-        labelHelp={option.help_text}
-        isRequired={option.required}
-        allowEditingUploadedText={true}
-        isReadOnly={false}
-      />
+      <PageFormSection singleColumn>
+        <PageFormFileUpload
+          label={option.label}
+          name={props.name}
+          type="text"
+          labelHelpTitle={option.label}
+          labelHelp={option.help_text}
+          isRequired={option.required}
+          allowEditingUploadedText={true}
+          isReadOnly={false}
+        />
+      </PageFormSection>
     );
   }
 


### PR DESCRIPTION
This PR is for AAP-24760 and AAP-24670. It adds a password field to all secrets in the settings forms and adds fileupload forms to the SAML settings section