### PR TITLE
[AAP-25091] Uses resource id for edit schedule instead of params

### DIFF
--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -55,7 +55,7 @@ export const useProcessSchedule = () => {
         if (params.schedule_id && params.id) {
           return updateSchedule(awxAPI`/schedules/${params.schedule_id.toString()}/`, {
             ...payload,
-            unified_job_template: parseInt(params?.id, 10),
+            unified_job_template: resource.id,
           });
         }
         return postSchedule(endPoint, payload);


### PR DESCRIPTION
This resolves AAP-25091.  Instead of relying on the params to get the resource ID we get that information from the form.