### PR TITLE
Show missing job data in workflow approval job details tab

### DIFF
--- a/frontend/awx/interfaces/WorkflowApproval.ts
+++ b/frontend/awx/interfaces/WorkflowApproval.ts
@@ -27,7 +27,7 @@ export interface WorkflowApproval
       delete: boolean;
       start: boolean;
     };
-    source_workflow_job: SummaryFieldJob | object;
+    source_workflow_job: SummaryFieldJob;
   };
   status:
     | 'new'


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-24939

Pass workflow job to componentParams in order for JobDetails to retrieve the job from useOutletContext 

![Screenshot 2024-06-06 at 3 49 48 PM](https://github.com/ansible/ansible-ui/assets/15881645/1a752e57-5e4c-45bd-9bad-d41992aa536e)
