### PR TITLE
Add GCE Upload component to CredentialsForm.

### DIFF
--- a/framework/PageForm/Inputs/PageFormFileUpload.tsx
+++ b/framework/PageForm/Inputs/PageFormFileUpload.tsx
@@ -1,5 +1,5 @@
 import { FileUpload, FileUploadProps } from '@patternfly/react-core';
-import { useCallback, useState } from 'react';
+import { ReactNode, useCallback, useState } from 'react';
 import { Controller, FieldPathByValue, FieldValues, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useID } from '../../hooks/useID';
@@ -14,6 +14,7 @@ export type PageFormFileUploadProps<
   placeholder?: string;
   validate?: (value: File) => string | undefined;
   onInputChange?: (file: File) => Promise<void>;
+  additionalHelperText?: ReactNode;
 } & PageFormGroupProps &
   Omit<FileUploadProps, 'id'>;
 
@@ -102,6 +103,7 @@ export function PageFormFileUpload<
             {props.icon && props.icon !== undefined ? (
               <div style={{ display: 'grid', gridTemplateColumns: '10fr 1fr' }}>
                 <FileUpload
+                  dropzoneProps={props.dropzoneProps}
                   id={id}
                   data-cy={id}
                   type={props.type || 'dataURL'}
@@ -126,28 +128,35 @@ export function PageFormFileUpload<
                   isClearButtonDisabled={props.isClearButtonDisabled}
                 />
                 {props.icon}
+                {props.additionalHelperText ? props.additionalHelperText : null}
               </div>
             ) : (
-              <FileUpload
-                id={id}
-                data-cy={id}
-                type={props.type || 'dataURL'}
-                value={value as string}
-                hideDefaultPreview={props.hideDefaultPreview}
-                filename={isLoading ? t('loading...') : filename}
-                filenamePlaceholder={props.placeholder}
-                onFileInputChange={handleFileInputChange}
-                onDataChange={(_event, value: string) => handleTextOrDataChange(value)}
-                onTextChange={(_event, value: string) => handleTextOrDataChange(value)}
-                onReadStarted={(_event, _fileHandle: File) => handleFileReadStarted(_fileHandle)}
-                onReadFinished={(_event, _fileHandle: File) => handleFileReadFinished(_fileHandle)}
-                onClearClick={handleClear}
-                // isLoading={isLoading}
-                allowEditingUploadedText={props.allowEditingUploadedText || false}
-                // browseButtonText={t('Upload')}
-                isReadOnly={props.isReadOnly || isSubmitting}
-                validated={error ? 'error' : undefined}
-              />
+              <>
+                <FileUpload
+                  dropzoneProps={props.dropzoneProps}
+                  id={id}
+                  data-cy={id}
+                  type={props.type || 'dataURL'}
+                  value={value as string}
+                  hideDefaultPreview={props.hideDefaultPreview}
+                  filename={isLoading ? t('loading...') : filename}
+                  filenamePlaceholder={props.placeholder}
+                  onFileInputChange={handleFileInputChange}
+                  onDataChange={(_event, value: string) => handleTextOrDataChange(value)}
+                  onTextChange={(_event, value: string) => handleTextOrDataChange(value)}
+                  onReadStarted={(_event, _fileHandle: File) => handleFileReadStarted(_fileHandle)}
+                  onReadFinished={(_event, _fileHandle: File) =>
+                    handleFileReadFinished(_fileHandle)
+                  }
+                  onClearClick={handleClear}
+                  // isLoading={isLoading}
+                  allowEditingUploadedText={props.allowEditingUploadedText || false}
+                  // browseButtonText={t('Upload')}
+                  isReadOnly={props.isReadOnly || isSubmitting}
+                  validated={error ? 'error' : undefined}
+                />
+                {props.additionalHelperText ? props.additionalHelperText : null}
+              </>
             )}
           </PageFormGroup>
         );

--- a/framework/PageForm/Inputs/PageFormFileUpload.tsx
+++ b/framework/PageForm/Inputs/PageFormFileUpload.tsx
@@ -69,7 +69,9 @@ export function PageFormFileUpload<
           ? validate && isValidating
             ? t('Validating...')
             : error?.message
-          : undefined;
+          : inputError?.message
+            ? inputError.message
+            : undefined;
         const handleClear = props.onClearClick
           ? props.onClearClick
           : (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/framework/PageForm/Inputs/PageFormFileUpload.tsx
+++ b/framework/PageForm/Inputs/PageFormFileUpload.tsx
@@ -72,12 +72,13 @@ export function PageFormFileUpload<
           : inputError?.message
             ? inputError.message
             : undefined;
-        const handleClear = props.onClearClick
-          ? props.onClearClick
-          : (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-              setFilename('');
-              onChange(undefined);
-            };
+        const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+          setFilename('');
+          onChange(undefined);
+          if (props.onClearClick) {
+            props.onClearClick(_event);
+          }
+        };
         const handleFileReadFinished = (_fileHandle: File) => {
           setIsLoading(false);
           onChange(_fileHandle);

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -645,6 +645,7 @@ function CredentialSubForm({
 
   return hasFields ? (
     <PageFormSection title={t('Type Details')}>
+      {credentialType?.namespace === 'gce' && <GCEUploadField />}
       {stringFields.length > 0 &&
         stringFields.map((field) => {
           if (field?.multiline) {
@@ -720,7 +721,6 @@ function CredentialSubForm({
             labelHelp={field.help_text}
           />
         ))}
-      {credentialType?.namespace === 'gce' && <GCEUploadField />}
     </PageFormSection>
   ) : null;
 }

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -39,6 +39,7 @@ import { CredentialInputSource } from '../../interfaces/CredentialInputSource';
 import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { useSWRConfig } from 'swr';
 import { useCredentialsTestModal } from './hooks/useCredentialsTestModal';
+import { GCEUploadField } from './components/GCEUploadField';
 
 interface CredentialForm extends Credential {
   user?: number;
@@ -719,6 +720,7 @@ function CredentialSubForm({
             labelHelp={field.help_text}
           />
         ))}
+      {credentialType?.namespace === 'gce' && <GCEUploadField />}
     </PageFormSection>
   ) : null;
 }

--- a/frontend/awx/access/credentials/components/GCEUploadField.tsx
+++ b/frontend/awx/access/credentials/components/GCEUploadField.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { FormHelperText, HelperTextItem } from '@patternfly/react-core';
 
 interface GCEFileContents {
   project_id?: string;
@@ -14,12 +15,16 @@ export function GCEUploadField() {
   const { setValue, clearErrors } = useFormContext();
   const [GCEFileContents, setGCEFileContents] = useState<GCEFileContents>({});
   const [uploadError, setUploadError] = useState<Error | undefined>(undefined);
+  const [isRejected, setIsRejected] = useState(false);
   const onClear = () => {
     setGCEFileContents({});
     setUploadError(undefined);
     setValue('project', '');
     setValue('username', '');
     setValue('ssh_key_data', '');
+  };
+  const handleFileRejected = () => {
+    setIsRejected(true);
   };
 
   useEffect(() => {
@@ -49,7 +54,6 @@ export function GCEUploadField() {
         helperText={t(
           'Select a JSON formatted service account key to autopopulate the following fields.'
         )}
-        accept=".json"
         validated={uploadError ? 'error' : 'default'}
         onInputChange={async (file) => {
           try {
@@ -60,6 +64,17 @@ export function GCEUploadField() {
             setUploadError(error as Error);
           }
         }}
+        dropzoneProps={{
+          accept: { 'text/json': ['.json'] },
+          onDropRejected: handleFileRejected,
+        }}
+        additionalHelperText={
+          <FormHelperText>
+            <HelperTextItem variant={isRejected ? 'error' : 'default'}>
+              {isRejected ? t('File upload rejected. Please select a single .json file.') : null}
+            </HelperTextItem>
+          </FormHelperText>
+        }
       />
     </>
   );

--- a/frontend/awx/access/credentials/components/GCEUploadField.tsx
+++ b/frontend/awx/access/credentials/components/GCEUploadField.tsx
@@ -14,8 +14,7 @@ export function GCEUploadField() {
   const { setValue, clearErrors } = useFormContext();
   const [GCEFileContents, setGCEFileContents] = useState<GCEFileContents>({});
   const [uploadError, setUploadError] = useState<Error | undefined>(undefined);
-
-  const handleClear = () => {
+  const onClear = () => {
     setGCEFileContents({});
     setUploadError(undefined);
     setValue('project', '');
@@ -42,6 +41,8 @@ export function GCEUploadField() {
   return (
     <>
       <PageFormFileUpload
+        onClearClick={onClear}
+        key="credential-gce-file"
         name="credential-gce-file"
         fieldId="credential-gce-file"
         label={t('Service account JSON file')}
@@ -59,7 +60,6 @@ export function GCEUploadField() {
             setUploadError(error as Error);
           }
         }}
-        onClearClick={handleClear}
       />
     </>
   );

--- a/frontend/awx/access/credentials/components/GCEUploadField.tsx
+++ b/frontend/awx/access/credentials/components/GCEUploadField.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next';
+import { PageFormFileUpload } from '../../../../../framework/PageForm/Inputs/PageFormFileUpload';
+import { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+interface GCEFileContents {
+  project_id?: string;
+  client_email?: string;
+  private_key?: string;
+}
+
+export function GCEUploadField() {
+  const { t } = useTranslation();
+  const { setValue, clearErrors } = useFormContext();
+  const [GCEFileContents, setGCEFileContents] = useState<GCEFileContents>({});
+  const [uploadError, setUploadError] = useState<Error | undefined>(undefined);
+
+  useEffect(() => {
+    // Loop through JSON object and set the relevant fields
+    if (GCEFileContents.project_id) {
+      setValue('project', GCEFileContents.project_id);
+      clearErrors('project');
+    }
+    if (GCEFileContents.client_email) {
+      setValue('username', GCEFileContents.client_email);
+      clearErrors('username');
+    }
+    if (GCEFileContents.private_key) {
+      setValue('ssh_key_data', GCEFileContents.private_key);
+      clearErrors('ssh_key_data');
+    }
+  }, [GCEFileContents, setValue, clearErrors]);
+
+  return (
+    <>
+      <PageFormFileUpload
+        name="credential-gce-file"
+        fieldId="credential-gce-file"
+        label={t('Service account JSON file')}
+        helperText={t(
+          'Select a JSON formatted service account key to autopopulate the following fields.'
+        )}
+        accept=".json"
+        validated={uploadError ? 'error' : 'default'}
+        onInputChange={async (file) => {
+          try {
+            const fileText = await file.text();
+            const fileJSON = JSON.parse(fileText) as GCEFileContents;
+            setGCEFileContents(fileJSON);
+          } catch (error) {
+            setUploadError(error as Error);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/awx/access/credentials/components/GCEUploadField.tsx
+++ b/frontend/awx/access/credentials/components/GCEUploadField.tsx
@@ -15,6 +15,14 @@ export function GCEUploadField() {
   const [GCEFileContents, setGCEFileContents] = useState<GCEFileContents>({});
   const [uploadError, setUploadError] = useState<Error | undefined>(undefined);
 
+  const handleClear = () => {
+    setGCEFileContents({});
+    setUploadError(undefined);
+    setValue('project', '');
+    setValue('username', '');
+    setValue('ssh_key_data', '');
+  };
+
   useEffect(() => {
     // Loop through JSON object and set the relevant fields
     if (GCEFileContents.project_id) {
@@ -51,6 +59,7 @@ export function GCEUploadField() {
             setUploadError(error as Error);
           }
         }}
+        onClearClick={handleClear}
       />
     </>
   );


### PR DESCRIPTION
This PR adds the GCE Upload component to the Credentials form for Google Compute Engine type credentials. When a user selects a JSON file to upload it should auto-populate the relevant fields with the values from the JSON file.
![Screenshot 2024-06-07 at 9 39 34 AM](https://github.com/ansible/ansible-ui/assets/2293210/8ef2b4ae-16e8-4829-9e1e-a9db588c40b7)

You can test by creating a local JSON file to use with the following entries:
{
  "client_email": "test@mail.com",
  "project_id": "barrrr",
  "private_key": "123"
}
Note private_key corresponds to an RSA input field - the sample JSON does not contain a valid RSA string. You can generate one here: https://phpseclib.com/docs/rsa-keys