### PR TITLE
Mask template launch survey passwords on review step

### DIFF
--- a/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
@@ -16,7 +16,7 @@ import { jsonToYaml, yamlToJson } from '../../../../../../framework/utils/codeEd
 import { WorkflowJobTemplate } from '../../../../interfaces/WorkflowJobTemplate';
 import { Survey } from '../../../../interfaces/Survey';
 
-function getRelatedResourceUrl(template: JobTemplate | WorkflowJobTemplate) {
+function getSurveySpecUrl(template: JobTemplate | WorkflowJobTemplate) {
   if (!template) return '';
   switch (template?.type) {
     case 'job_template':
@@ -89,7 +89,7 @@ export function TemplateLaunchReviewStep(props: { template: JobTemplate }) {
     verbosity,
     survey,
   } = wizardData as TemplateLaunch;
-  const { data: surveyConfig } = useGet<Survey>(getRelatedResourceUrl(template));
+  const { data: surveyConfig } = useGet<Survey>(getSurveySpecUrl(template));
 
   let extraVarDetails = extra_vars || '{}';
   if (survey) {


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-25113

Show survey passwords as `$encrypted$` in the prompt on launch review step. 

![Screenshot 2024-06-07 at 3 02 44 PM](https://github.com/ansible/ansible-ui/assets/15881645/94e639a7-f374-4ca9-925b-04402fa817a2)
