### PR TITLE
GitHub Action Update Success Job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -138,8 +138,8 @@ jobs:
     needs: 
       - checks
       - component-tests
-      - awx-e2e
-      - eda-e2e
-      - hub-e2e      
+      # - awx-e2e
+      # - eda-e2e
+      # - hub-e2e
     steps:
       - run: echo Success


### PR DESCRIPTION
We need to cut our Cypress costs.
Part of that is to stop using the Cypress dashboard for component tests.
This will save ~75% in costs.
There is a new job  as part of the pipeline that indicates if that pipeline was success.
This makes it easier to have that as the only required check for PRs.
Since the team has decided that E2E are not required, this removes the requirement of E2E from the success job.