### PR TITLE
Allow write-in values for async single selects

### DIFF
--- a/framework/PageForm/Inputs/PageFormAsyncSingleSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormAsyncSingleSelect.tsx
@@ -38,6 +38,7 @@ export type PageFormAsyncSingleSelectProps<
   | 'queryErrorText'
   | 'onBrowse'
   | 'queryLabel'
+  | 'writeInOption'
 > &
   Pick<
     PageFormGroupProps,
@@ -101,6 +102,7 @@ export function PageFormAsyncSingleSelect<
               queryLabel={props.queryLabel}
               disableAutoSelect
               isRequired={props.isRequired}
+              writeInOption={props.writeInOption}
             />
           </PageFormGroup>
         );

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -21,6 +21,8 @@ export interface PageAsyncSingleSelectProps<ValueT>
   queryErrorText?: PageAsyncQueryErrorText;
 
   onBrowse?: () => void;
+
+  writeInOption?: (query: string) => PageSelectOption<ValueT>;
 }
 
 /**
@@ -47,7 +49,7 @@ export function PageAsyncSingleSelect<
 >(props: PageAsyncSingleSelectProps<ValueT>) {
   const { t } = useTranslation();
 
-  const { queryOptions } = props;
+  const { queryOptions, writeInOption } = props;
   const [loading, setLoading] = useState(false);
   const [allLoaded, setAllLoaded] = useState(false);
   const [loadingError, setLoadingError] = useState<Error>();
@@ -116,6 +118,9 @@ export function PageAsyncSingleSelect<
               onSelect(newOptions[0].value);
             }
             setTotal(result.remaining + newOptions.length);
+            if (writeInOption && result.remaining + newOptions.length === 0) {
+              newOptions.push(writeInOption(searchValue));
+            }
             return newOptions;
           });
         })
@@ -130,7 +135,7 @@ export function PageAsyncSingleSelect<
       return true;
     });
     return () => abortController.abort();
-  }, [onSelect, queryOptions, searchValue, t]);
+  }, [onSelect, queryOptions, searchValue, t, writeInOption]);
 
   const onLoadMore = useCallback(
     (e: React.MouseEvent) => {


### PR DESCRIPTION
Adds a new `writeInOption` prop for async single select. If given, this callback can create an on-the-fly select option based on the user's search query