### PR TITLE
[AAP-22567] Workaround for setValue for the 'Generate extra vars' button

### DIFF
--- a/frontend/eda/access/credential-types/CredentialTypeForm.cy.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.cy.tsx
@@ -1,0 +1,107 @@
+import { CreateCredentialType, EditCredentialType } from './CredentialTypeForm';
+import { EdaCredentialType } from '../../interfaces/EdaCredentialType';
+import { edaAPI } from '../../common/eda-utils';
+describe('CredentialTypeForm.cy.ts', () => {
+  const credentialType = {
+    name: 'Sample Credential Type',
+    description: 'This is a sample credential',
+    id: 1,
+    inputs: {
+      fields: [
+        {
+          id: 'name',
+          type: 'string',
+          label: 'Name',
+        },
+      ],
+      required: ['name'],
+    },
+    injectors: {},
+  };
+
+  describe('Create Credential Type', () => {
+    it('should validate required fields on save', () => {
+      cy.mount(<CreateCredentialType />);
+      cy.clickButton(/^Create credential type$/);
+      cy.contains('Name is required.').should('be.visible');
+    });
+
+    it('should create credential type', () => {
+      cy.intercept('POST', edaAPI`/credential-types`, {
+        statusCode: 201,
+        body: credentialType,
+      }).as('createCredentialType');
+      cy.mount(<CreateCredentialType />);
+      cy.get('[data-cy="name"]').type('New Credential Type');
+      cy.get('[data-cy="description"]').type('New credential description');
+      cy.clickButton(/^Create credential type$/);
+      cy.wait('@createCredentialType')
+        .its('request.body')
+        .then((createdCredentialType: EdaCredentialType) => {
+          expect(createdCredentialType).to.deep.equal({
+            name: 'New Credential Type',
+            description: 'New credential description',
+            inputs: {},
+            injectors: {},
+          });
+        });
+    });
+  });
+
+  describe('Edit Credential Type', () => {
+    beforeEach(() => {
+      cy.intercept(
+        { method: 'GET', url: edaAPI`/credential-types/*` },
+        { statusCode: 200, body: credentialType }
+      );
+    });
+
+    it('should preload the form with current values', () => {
+      cy.mount(<EditCredentialType />);
+      cy.verifyPageTitle('Edit Credential Type');
+      cy.get('[data-cy="name"]').should('have.value', 'Sample Credential Type');
+      cy.get('[data-cy="description"]').should('have.value', 'This is a sample credential');
+      cy.dataEditorShouldContain('[data-cy="inputs"]', credentialType.inputs);
+      cy.dataEditorShouldContain('[data-cy="injectors"]', credentialType.injectors);
+    });
+
+    it('should edit credential type', () => {
+      cy.intercept('PATCH', edaAPI`/credential-types/*`, {
+        statusCode: 201,
+        body: credentialType,
+      }).as('editCredentialType');
+      cy.mount(<EditCredentialType />);
+      cy.get('[data-cy="name"]').should('have.value', 'Sample Credential Type');
+      cy.get('[data-cy="name"]').clear();
+      cy.get('[data-cy="name"]').type('Modified Credential Type');
+      cy.clickButton(/^Save credential type$/);
+      cy.wait('@editCredentialType')
+        .its('request.body')
+        .then((editedCredentialType: EdaCredentialType) => {
+          expect(editedCredentialType.name).to.equal('Modified Credential Type');
+          expect(editedCredentialType.description).to.equal('This is a sample credential');
+          expect(editedCredentialType.inputs).to.deep.equal({
+            fields: [
+              {
+                id: 'name',
+                type: 'string',
+                label: 'Name',
+              },
+            ],
+            required: ['name'],
+          });
+        });
+    });
+
+    it('should generate extra vars', () => {
+      cy.mount(<EditCredentialType />);
+      cy.get('[data-cy="name"]').type('Sample Credential Type');
+      cy.get('[data-cy="description"]').type('This is a sample credential');
+      cy.clickButton(/^Generate extra vars$/);
+      cy.dataEditorShouldContain(
+        '[data-cy="injectors-g"]',
+        '{"extra_vars": { "name" : "{{name}}"}}'
+      );
+    });
+  });
+});

--- a/frontend/eda/access/credential-types/CredentialTypeForm.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.tsx
@@ -133,7 +133,6 @@ function CredentialTypeInputs() {
       extraVarFields += `"${field.id}" : "{{${field.id}}}"`;
     });
     const extraVars = `{"extra_vars": { ${extraVarFields}}}`;
-    //setValue('injectors', JSON.parse(extraVars), { shouldValidate: true });
     setValue('injectors_g', extraVars);
     setValue('injectors', undefined);
     setInjectorGenerated(true);

--- a/frontend/eda/access/credential-types/CredentialTypeForm.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   PageFormDataEditor,
+  PageFormTextArea,
   PageHeader,
   PageLayout,
   useGetPageUrl,
@@ -23,7 +24,7 @@ import {
 import { EdaPageForm } from '../../common/EdaPageForm';
 import { Button } from '@patternfly/react-core';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export function CreateCredentialType() {
   const { t } = useTranslation();
@@ -32,8 +33,12 @@ export function CreateCredentialType() {
 
   const postRequest = usePostRequest<EdaCredentialType, EdaCredentialType>();
 
-  const onSubmit: PageFormSubmitHandler<EdaCredentialType> = async (credentialType) => {
-    const newCredentialType = await postRequest(edaAPI`/credential-types/`, credentialType);
+  const onSubmit: PageFormSubmitHandler<IEdaCredentialType> = async (credentialType) => {
+    const credentialTypeInput =
+      !credentialType.injectors && credentialType.injectors_g
+        ? { ...credentialType, injectors: JSON.parse(credentialType.injectors_g) as never }
+        : credentialType;
+    const newCredentialType = await postRequest(edaAPI`/credential-types/`, credentialTypeInput);
     pageNavigate(EdaRoute.CredentialTypePage, { params: { id: newCredentialType.id } });
   };
 
@@ -71,8 +76,15 @@ export function EditCredentialType() {
 
   const patchRequest = usePatchRequest<EdaCredentialType, EdaCredentialType>();
 
-  const handleSubmit: PageFormSubmitHandler<EdaCredentialType> = async (editedCredentialType) => {
-    await patchRequest(edaAPI`/credential-types/` + `${params?.id}/`, editedCredentialType);
+  const handleSubmit: PageFormSubmitHandler<IEdaCredentialType> = async (editedCredentialType) => {
+    const editedCredentialTypeInput =
+      !editedCredentialType.injectors && editedCredentialType.injectors_g
+        ? {
+            ...editedCredentialType,
+            injectors: JSON.parse(editedCredentialType.injectors_g) as never,
+          }
+        : editedCredentialType;
+    await patchRequest(edaAPI`/credential-types/` + `${params?.id}/`, editedCredentialTypeInput);
     pageNavigate(EdaRoute.CredentialTypeDetails, { params: { id: params?.id } });
   };
 
@@ -104,16 +116,12 @@ export function EditCredentialType() {
 function CredentialTypeInputs() {
   const { t } = useTranslation();
   const { setValue } = useFormContext();
+  const [injectorGenerated, setInjectorGenerated] = useState<boolean>(false);
 
   const credentialInputs = useWatch<EdaCredentialTypeCreate>({
     name: 'inputs',
     defaultValue: undefined,
   }) as EdaCredentialTypeInputs;
-
-  const credentialInjectors = useWatch<EdaCredentialTypeCreate>({
-    name: 'injectors',
-    defaultValue: undefined,
-  }) as EdaCredentialTypeCreate;
 
   const setInjectorsExtraVars = useCallback(() => {
     const fields = credentialInputs?.fields;
@@ -125,8 +133,16 @@ function CredentialTypeInputs() {
       extraVarFields += `"${field.id}" : "{{${field.id}}}"`;
     });
     const extraVars = `{"extra_vars": { ${extraVarFields}}}`;
-    setValue('injectors', JSON.parse(extraVars), { shouldValidate: true });
+    //setValue('injectors', JSON.parse(extraVars), { shouldValidate: true });
+    setValue('injectors_g', extraVars);
+    setValue('injectors', undefined);
+    setInjectorGenerated(true);
   }, [credentialInputs, setValue]);
+
+  const clearInjectorsExtraVars = useCallback(() => {
+    setValue('injectors_g', undefined);
+    setInjectorGenerated(false);
+  }, [setValue]);
 
   return (
     <>
@@ -153,34 +169,49 @@ function CredentialTypeInputs() {
           format="object"
         />
       </PageFormSection>
-      {credentialInputs &&
-        Object.keys(credentialInputs).length !== 0 &&
-        (!credentialInjectors ||
-          (credentialInjectors && Object.keys(credentialInjectors).length === 0)) && (
-          <PageFormSection>
-            <Button
-              id={'generate-injector'}
-              variant={'primary'}
-              size={'sm'}
-              style={{ maxWidth: 150 }}
-              onClick={() => setInjectorsExtraVars()}
-            >
-              {t('Generate extra vars')}
-            </Button>
-          </PageFormSection>
-        )}
-      <PageFormSection singleColumn>
-        <PageFormDataEditor
-          name="injectors"
-          label={t('Injector configuration')}
-          labelHelpTitle={t('Injector configuration')}
-          labelHelp={t(
-            `Enter injectors using either JSON or YAML syntax. Refer to the Ansible Controller documentation for example syntax.`
-          )}
-          isRequired
-          format="object"
-        />
-      </PageFormSection>
+      {credentialInputs && Object.keys(credentialInputs).length !== 0 && (
+        <PageFormSection>
+          <Button
+            id={'generate-injector'}
+            variant={'primary'}
+            size={'sm'}
+            style={{ maxWidth: 150 }}
+            onClick={() =>
+              injectorGenerated ? clearInjectorsExtraVars() : setInjectorsExtraVars()
+            }
+          >
+            {injectorGenerated ? t('Enter extra vars') : t('Generate extra vars')}
+          </Button>
+        </PageFormSection>
+      )}
+      {!injectorGenerated && (
+        <PageFormSection singleColumn>
+          <PageFormDataEditor
+            name="injectors"
+            label={t('Injector configuration')}
+            labelHelpTitle={t('Injector configuration')}
+            labelHelp={t(
+              `Enter injectors using either JSON or YAML syntax. Refer to the Ansible Controller documentation for example syntax.`
+            )}
+            isRequired
+            format="object"
+          />
+        </PageFormSection>
+      )}
+      {injectorGenerated && (
+        <PageFormSection singleColumn>
+          <PageFormTextArea
+            name="injectors_g"
+            label={t('Injector configuration')}
+            labelHelpTitle={t('Injector configuration')}
+            labelHelp={t(
+              `Enter injectors using either JSON or YAML syntax. Refer to the Ansible Controller documentation for example syntax.`
+            )}
+            isReadOnly
+            isRequired
+          />
+        </PageFormSection>
+      )}
     </>
   );
 }
@@ -191,3 +222,7 @@ function getInitialFormValues(credentialType?: EdaCredentialType) {
   }
   return credentialType;
 }
+
+type IEdaCredentialType = EdaCredentialType & {
+  injectors_g?: string;
+};

--- a/frontend/eda/access/credential-types/CredentialTypeForm.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.tsx
@@ -124,7 +124,7 @@ function CredentialTypeInputs() {
   }) as EdaCredentialTypeInputs;
 
   const setInjectorsExtraVars = useCallback(() => {
-    const fields = credentialInputs?.fields;
+    const fields = Array.isArray(credentialInputs?.fields) ? credentialInputs?.fields : [];
     let extraVarFields = '';
     fields?.map((field, idx) => {
       if (idx > 0) {

--- a/frontend/eda/access/credential-types/CredentialTypeForm.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.tsx
@@ -176,11 +176,9 @@ function CredentialTypeInputs() {
             variant={'secondary'}
             size={'sm'}
             style={{ maxWidth: 150 }}
-            onClick={() =>
-              injectorGenerated ? clearInjectorsExtraVars() : setInjectorsExtraVars()
-            }
+            onClick={() => setInjectorsExtraVars()}
           >
-            {injectorGenerated ? t('Clear extra vars') : t('Generate extra vars')}
+            {t('Generate extra vars')}
           </Button>
         </PageFormSection>
       )}
@@ -210,6 +208,17 @@ function CredentialTypeInputs() {
             isReadOnly
             isRequired
           />
+          <PageFormSection>
+            <Button
+              id={'generate-injector'}
+              variant={'secondary'}
+              size={'sm'}
+              style={{ maxWidth: 150 }}
+              onClick={() => clearInjectorsExtraVars()}
+            >
+              {t('Clear extra vars')}
+            </Button>
+          </PageFormSection>
         </PageFormSection>
       )}
     </>

--- a/frontend/eda/access/credential-types/CredentialTypeForm.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypeForm.tsx
@@ -173,14 +173,14 @@ function CredentialTypeInputs() {
         <PageFormSection>
           <Button
             id={'generate-injector'}
-            variant={'primary'}
+            variant={'secondary'}
             size={'sm'}
             style={{ maxWidth: 150 }}
             onClick={() =>
               injectorGenerated ? clearInjectorsExtraVars() : setInjectorsExtraVars()
             }
           >
-            {injectorGenerated ? t('Enter extra vars') : t('Generate extra vars')}
+            {injectorGenerated ? t('Clear extra vars') : t('Generate extra vars')}
           </Button>
         </PageFormSection>
       )}


### PR DESCRIPTION
The Generate extra vars button will generate a read only value for the injectors, or the user can click the relabeled button 'Enter extra vars' to type their value:

![Screenshot from 2024-06-11 18-00-25](https://github.com/ansible/ansible-ui/assets/12769982/89ddbe58-59e1-4156-adfd-3317bcef4ea6)

![Screenshot from 2024-06-11 18-00-35](https://github.com/ansible/ansible-ui/assets/12769982/d7d2c172-5124-4ca7-9352-c1e8533ce33a)

![Screenshot from 2024-06-11 18-16-29](https://github.com/ansible/ansible-ui/assets/12769982/fb3c7e31-a34e-48a1-9141-7255f783e12c)
