### PR TITLE
Removes deprecated hook and replaces it with the current hook

### DIFF
--- a/framework/PageDialogs/BulkActionDialog.tsx
+++ b/framework/PageDialogs/BulkActionDialog.tsx
@@ -19,7 +19,7 @@ import { usePaged } from '../PageTable/useTableItems';
 import { pfDanger, pfInfo, pfSuccess } from '../components/pfcolors';
 import { useAbortController } from '../hooks/useAbortController';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
-import { usePageDialog } from './PageDialog';
+import { usePageDialogs } from './PageDialog';
 
 export interface BulkActionDialogProps<T extends object> {
   /** The title of the model.
@@ -99,7 +99,7 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
   const [error, setError] = useState('');
   const [statuses, setStatuses] = useState<Record<string | number, string | null | undefined>>();
   const abortController = useAbortController();
-  const [_, setDialog] = usePageDialog();
+  const { popDialog } = usePageDialogs();
 
   const onCancelClicked = useCallback(() => {
     setCanceled(true);
@@ -118,9 +118,9 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
   }, [abortController, items, keyFn, t]);
 
   const onCloseClicked = useCallback(() => {
-    setDialog(undefined);
+    popDialog();
     onClose?.();
-  }, [onClose, setDialog]);
+  }, [onClose, popDialog]);
 
   useEffect(() => {
     async function process() {
@@ -260,7 +260,6 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
               },
             ]}
             keyFn={keyFn}
-            // pagination={pagination}
             compact
             errorStateTitle=""
             emptyStateTitle={t('No items')}
@@ -310,7 +309,7 @@ export function BulkActionDialog<T extends object>(props: BulkActionDialogProps<
 export function useBulkActionDialog<T extends object>(
   defaultErrorAdapter: ErrorAdapter = genericErrorAdapter
 ) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog, popDialog } = usePageDialogs();
   const [props, setProps] = useState<BulkActionDialogProps<T>>();
   useEffect(() => {
     if (props) {
@@ -318,7 +317,7 @@ export function useBulkActionDialog<T extends object>(
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(
+      pushDialog(
         <BulkActionDialog<T>
           {...props}
           errorAdapter={props.errorAdapter ?? defaultErrorAdapter}
@@ -326,8 +325,8 @@ export function useBulkActionDialog<T extends object>(
         />
       );
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog, defaultErrorAdapter]);
+  }, [props, popDialog, pushDialog, defaultErrorAdapter]);
   return setProps;
 }

--- a/framework/PageDialogs/BulkConfirmationDialog.tsx
+++ b/framework/PageDialogs/BulkConfirmationDialog.tsx
@@ -19,7 +19,7 @@ import { usePaged } from '../PageTable/useTableItems';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { compareStrings } from '../utils/compare';
 import { BulkActionDialogProps, useBulkActionDialog } from './BulkActionDialog';
-import { usePageDialog } from './PageDialog';
+import { usePageDialogs } from './PageDialog';
 
 const ModalBodyDiv = styled.div`
   display: flex;
@@ -95,12 +95,12 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
     actionButtonText,
     isDanger,
   } = props;
-  const [_, setDialog] = usePageDialog();
+  const { popDialog } = usePageDialogs();
   const [translations] = useFrameworkTranslations();
   const onCloseClicked = useCallback(() => {
-    setDialog(undefined);
+    popDialog();
     onClose?.();
-  }, [onClose, setDialog]);
+  }, [onClose, popDialog]);
 
   // Non-actionable rows appear first
   const sortedItems = useMemo<T[]>(() => {
@@ -198,7 +198,6 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
               itemCount={items.length}
               tableColumns={modalColumns}
               keyFn={keyFn}
-              // pagination={pagination}
               compact
               errorStateTitle="Error"
               emptyStateTitle="No items"
@@ -225,7 +224,7 @@ function BulkConfirmationDialog<T extends object>(props: BulkConfirmationDialog<
 }
 
 function useBulkConfirmationDialog<T extends object>() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<BulkConfirmationDialog<T>>();
   useEffect(() => {
     if (props) {
@@ -233,11 +232,11 @@ function useBulkConfirmationDialog<T extends object>() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<BulkConfirmationDialog<T> {...props} onClose={onCloseHandler} />);
+      pushDialog(<BulkConfirmationDialog<T> {...props} onClose={onCloseHandler} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, popDialog, pushDialog]);
   return setProps;
 }
 

--- a/framework/PageDialogs/MultiSelectDialog.tsx
+++ b/framework/PageDialogs/MultiSelectDialog.tsx
@@ -5,7 +5,7 @@ import { ISelected } from '../PageTable/useTableItems';
 import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { IView } from '../useView';
-import { usePageDialog } from './PageDialog';
+import { usePageDialogs } from './PageDialog';
 import { PageMultiSelectList } from '../PageTable/PageMultiSelectList';
 
 export type MultiSelectDialogProps<T extends object> = {
@@ -40,8 +40,8 @@ export function MultiSelectDialog<T extends object>(props: MultiSelectDialogProp
     maxSelections,
     allowZeroSelections,
   } = props;
-  const [_, setDialog] = usePageDialog();
-  let onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog } = usePageDialogs();
+  let onClose = useCallback(() => popDialog(), [popDialog]);
   if (props.onClose) {
     onClose = props.onClose;
   }

--- a/framework/PageDialogs/PageDialog.tsx
+++ b/framework/PageDialogs/PageDialog.tsx
@@ -34,26 +34,26 @@ export function usePageDialogs() {
   return useContext(PageDialogContext);
 }
 
-/*
- * @deprecated Use usePageDialogs instead
- */
-export function usePageDialog(): [
-  dialog: ReactNode | undefined,
-  setDialog: (dialog: ReactNode | undefined) => void,
-] {
-  const { dialogs, clearDialogs, pushDialog } = usePageDialogs();
-  const dialog = useMemo(
-    () => (dialogs.length > 0 ? dialogs[dialogs.length - 1] : undefined),
-    [dialogs]
-  );
-  const setDialog = useCallback(
-    (dialog: ReactNode | undefined) => {
-      clearDialogs();
-      if (dialog !== undefined) {
-        pushDialog(dialog);
-      }
-    },
-    [clearDialogs, pushDialog]
-  );
-  return useMemo(() => [dialog, setDialog] as const, [dialog, setDialog]);
-}
+// /*
+//  * @deprecated Use usePageDialogs instead
+//  */
+// export function usePageDialog(): [
+//   dialog: ReactNode | undefined,
+//   setDialog: (dialog: ReactNode | undefined) => void,
+// ] {
+//   const { dialogs, clearDialogs, pushDialog } = usePageDialogs();
+//   const dialog = useMemo(
+//     () => (dialogs.length > 0 ? dialogs[dialogs.length - 1] : undefined),
+//     [dialogs]
+//   );
+//   const setDialog = useCallback(
+//     (dialog: ReactNode | undefined) => {
+//       clearDialogs();
+//       if (dialog !== undefined) {
+//         pushDialog(dialog);
+//       }
+//     },
+//     [clearDialogs, pushDialog]
+//   );
+//   return useMemo(() => [dialog, setDialog] as const, [dialog, setDialog]);
+// }

--- a/framework/PageDialogs/SingleSelectDialog.tsx
+++ b/framework/PageDialogs/SingleSelectDialog.tsx
@@ -6,8 +6,7 @@ import { ISelected } from '../PageTable/useTableItems';
 import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
 import { useFrameworkTranslations } from '../useFrameworkTranslations';
 import { IView } from '../useView';
-import { usePageDialog } from './PageDialog';
-
+import { usePageDialogs } from './PageDialog';
 export type SingleSelectDialogProps<T extends object> = {
   title: string;
   view: IView & ISelected<T> & { itemCount?: number; pageItems: T[] | undefined };
@@ -23,8 +22,8 @@ export type SingleSelectDialogProps<T extends object> = {
 
 export function SingleSelectDialog<T extends object>(props: SingleSelectDialogProps<T>) {
   const { title, view, tableColumns, toolbarFilters, confirmText, cancelText, onSelect } = props;
-  const [_, setDialog] = usePageDialog();
-  let onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog } = usePageDialogs();
+  let onClose = useCallback(() => popDialog(), [popDialog]);
   if (props.onClose) {
     onClose = props.onClose;
   }

--- a/framework/PageDialogs/useSelectDialog.tsx
+++ b/framework/PageDialogs/useSelectDialog.tsx
@@ -17,7 +17,7 @@ import { ISelected } from '../PageTable/useTableItems';
 import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
 import { Collapse } from '../components/Collapse';
 import { IView } from '../useView';
-import { usePageDialog } from './PageDialog';
+import { usePageDialogs } from './PageDialog';
 
 /**
  * @deprecated use SingleSelectDialog
@@ -47,10 +47,10 @@ export function useSelectDialog<
     setTitle(title ?? '');
     setOnSelect(() => onSelect);
   }, []);
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog, popDialog } = usePageDialogs();
   useEffect(() => {
     if (onSelect !== undefined) {
-      setDialog(
+      pushDialog(
         <SelectDialog<T, TMultiple>
           title={title}
           open
@@ -67,7 +67,7 @@ export function useSelectDialog<
         />
       );
     } else {
-      setDialog(undefined);
+      popDialog();
       view.unselectAll();
     }
   }, [
@@ -75,7 +75,8 @@ export function useSelectDialog<
     confirm,
     onSelect,
     selected,
-    setDialog,
+    popDialog,
+    pushDialog,
     tableColumns,
     title,
     toolbarFilters,

--- a/framework/components/useManagedItems.tsx
+++ b/framework/components/useManagedItems.tsx
@@ -1,9 +1,9 @@
 import { Button, Divider, Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../PageDialogs/PageDialog';
 import { useSelected } from '../PageTable/useTableItems';
 import { ReorderItems } from './ReorderItems';
+import { usePageDialogs } from '../PageDialogs/PageDialog';
 
 interface IManageItemColumn<ItemT extends object> {
   header: string;
@@ -61,7 +61,7 @@ export interface ManageItemsProps<ItemT extends object> {
  * - Display type
  */
 export function useManageItems<ItemT extends object>(options: ManageItemsProps<ItemT>) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const [keyFn] = useState(() => options.keyFn);
   const [saveFn] = useState(() => options.saveFn);
   const [loadFn] = useState(() => options.loadFn);
@@ -137,7 +137,7 @@ export function useManageItems<ItemT extends object>(options: ManageItemsProps<I
   );
 
   const openManageItems = () =>
-    setDialog(
+    pushDialog(
       <ManageItemsModal
         {...options}
         keyFn={keyFn}
@@ -159,8 +159,8 @@ export function ManageItemsModal<ItemT extends object>(
   const { t } = useTranslation();
   const { title, description, columns, onApplyChanges } = props;
   const [keyFn] = useState(() => props.keyFn);
-  const [_, setDialog] = usePageDialog();
-  const onClose = () => setDialog(undefined);
+  const { popDialog } = usePageDialogs();
+  const onClose = () => popDialog();
   const [items, setItems] = useState<ItemT[]>(() => props.items);
   const {
     selectedItems,
@@ -174,7 +174,7 @@ export function ManageItemsModal<ItemT extends object>(
 
   const onApply = () => {
     onApplyChanges(items, selectedItems);
-    setDialog(undefined);
+    popDialog();
   };
 
   return (

--- a/frontend/awx/access/common/DeleteRoleConfirmation.tsx
+++ b/frontend/awx/access/common/DeleteRoleConfirmation.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../framework';
+import { usePageDialogs } from '../../../../framework';
 import { AccessRole, AwxUser } from '../../interfaces/User';
 
 export interface DeleteRoleConfirmationProps {
@@ -20,13 +20,13 @@ export interface DeleteRoleConfirmationProps {
 
 export function DeleteRoleConfirmation(props: DeleteRoleConfirmationProps) {
   const { title, role, user, onConfirm, onClose } = props;
-  const [_, setDialog] = usePageDialog();
+  const { popDialog } = usePageDialogs();
   const { t } = useTranslation();
   const sourceOfRole = () => (typeof role.team_id !== 'undefined' ? t(`team`) : t(`user`));
   const onCloseClicked = useCallback(() => {
-    setDialog(undefined);
+    popDialog();
     onClose?.();
-  }, [onClose, setDialog]);
+  }, [onClose, popDialog]);
 
   return (
     <Modal
@@ -100,7 +100,7 @@ export function DeleteRoleConfirmation(props: DeleteRoleConfirmationProps) {
  * openDeleteRoleConfirmationDialog(...) // Pass DeleteRoleConfirmationProps
  */
 export function useDeleteRoleConfirmationDialog() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<DeleteRoleConfirmationProps>();
   useEffect(() => {
     if (props) {
@@ -108,10 +108,10 @@ export function useDeleteRoleConfirmationDialog() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<DeleteRoleConfirmation {...props} onClose={onCloseHandler} />);
+      pushDialog(<DeleteRoleConfirmation {...props} onClose={onCloseHandler} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, pushDialog, popDialog]);
   return setProps;
 }

--- a/frontend/awx/access/credentials/hooks/useSelectCredential.tsx
+++ b/frontend/awx/access/credentials/hooks/useSelectCredential.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IToolbarFilter, usePageDialog, useSelectDialog } from '../../../../../framework';
+import { IToolbarFilter, usePageDialogs, useSelectDialog } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import {
@@ -83,11 +83,11 @@ export function useSingleSelectCredential(
   title?: string,
   sourceType?: string
 ) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectCredential = useCallback(
     (onSelect: (credential: Credential) => void) => {
-      setDialog(
+      pushDialog(
         <SelectCredential
           title={title ? title : t('Select credential')}
           onSelect={onSelect}
@@ -96,7 +96,7 @@ export function useSingleSelectCredential(
         />
       );
     },
-    [credentialType, setDialog, t, title, sourceType]
+    [credentialType, pushDialog, t, title, sourceType]
   );
   return openSelectCredential;
 }

--- a/frontend/awx/access/organizations/hooks/useSelectOrganizations.tsx
+++ b/frontend/awx/access/organizations/hooks/useSelectOrganizations.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { MultiSelectDialog } from '../../../../../framework/PageDialogs/MultiSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -29,12 +29,12 @@ function SelectOrganizations(props: {
 }
 
 export function useSelectOrganizations() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const openSelectOrganizations = useCallback(
     (title: string, onSelect: (organizations: Organization[]) => void) => {
-      setDialog(<SelectOrganizations title={title} onSelect={onSelect} />);
+      pushDialog(<SelectOrganizations title={title} onSelect={onSelect} />);
     },
-    [setDialog]
+    [pushDialog]
   );
   return openSelectOrganizations;
 }

--- a/frontend/awx/access/teams/hooks/useSelectTeams.tsx
+++ b/frontend/awx/access/teams/hooks/useSelectTeams.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { MultiSelectDialog } from '../../../../../framework/PageDialogs/MultiSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -27,12 +27,12 @@ function SelectTeams(props: { title: string; onSelect: (teams: Team[]) => void }
 }
 
 export function useSelectTeams() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const openSelectTeams = useCallback(
     (title: string, onSelect: (teams: Team[]) => void) => {
-      setDialog(<SelectTeams title={title} onSelect={onSelect} />);
+      pushDialog(<SelectTeams title={title} onSelect={onSelect} />);
     },
-    [setDialog]
+    [pushDialog]
   );
   return openSelectTeams;
 }

--- a/frontend/awx/access/users/hooks/useSelectUsers.tsx
+++ b/frontend/awx/access/users/hooks/useSelectUsers.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { MultiSelectDialog } from '../../../../../framework/PageDialogs/MultiSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -39,7 +39,7 @@ function SelectUsers(props: {
 }
 
 export function useSelectUsers() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const openSelectUsers = useCallback(
     (
       title: string,
@@ -47,7 +47,7 @@ export function useSelectUsers() {
       confirmText?: string,
       accessUrl?: string
     ) => {
-      setDialog(
+      pushDialog(
         <SelectUsers
           accessUrl={accessUrl}
           title={title}
@@ -56,7 +56,7 @@ export function useSelectUsers() {
         />
       );
     },
-    [setDialog]
+    [pushDialog]
   );
   return openSelectUsers;
 }

--- a/frontend/awx/administration/activity-stream/hooks/useActivityStreamDialog.tsx
+++ b/frontend/awx/administration/activity-stream/hooks/useActivityStreamDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ActivityStream } from '../../../interfaces/ActivityStream';
 import { ActivityStreamInitiatedByCell } from '../components/ActivityStreamInitiatedByCell';
 import { ActivityDescription } from '../components/ActivityDescription';
-import { PageDetail, PageDetails, usePageDialog } from '../../../../../framework';
+import { PageDetail, PageDetails, usePageDialogs } from '../../../../../framework';
 import { PageDetailCodeEditor } from '../../../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../../../framework/utils/formatDateString';
 
@@ -15,8 +15,8 @@ export interface ActivityStreamModalProps {
 
 export function ActivityStreamDialog({ activity }: ActivityStreamModalProps) {
   const { t } = useTranslation();
-  const [_, setDialog] = usePageDialog();
-  const onClose = () => setDialog(undefined);
+  const { popDialog } = usePageDialogs();
+  const onClose = () => popDialog();
 
   return (
     <Modal
@@ -66,7 +66,7 @@ export function ActivityStreamDialog({ activity }: ActivityStreamModalProps) {
 }
 
 export function useActivityStreamDialog() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<ActivityStreamModalProps>();
   useEffect(() => {
     if (props) {
@@ -74,10 +74,10 @@ export function useActivityStreamDialog() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<ActivityStreamDialog {...props} onClose={onCloseHandler} />);
+      pushDialog(<ActivityStreamDialog {...props} onClose={onCloseHandler} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, popDialog, pushDialog]);
   return setProps;
 }

--- a/frontend/awx/administration/instances/hooks/useSelectPeers.tsx
+++ b/frontend/awx/administration/instances/hooks/useSelectPeers.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { Instance } from '../../../interfaces/Instance';
@@ -44,13 +44,13 @@ function SelectPeers(props: {
 }
 
 export function useMultiSelectPeer() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectPeers = useCallback(
     (onSelect: (instances: Instance[]) => void) => {
-      setDialog(<SelectPeers onSelect={onSelect} isLookup={true} title={t('Select peers')} />);
+      pushDialog(<SelectPeers onSelect={onSelect} isLookup={true} title={t('Select peers')} />);
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectPeers;
 }

--- a/frontend/awx/administration/management-jobs/hooks/useSelectManagementJobs.tsx
+++ b/frontend/awx/administration/management-jobs/hooks/useSelectManagementJobs.tsx
@@ -5,7 +5,7 @@ import { useAwxView } from '../../../common/useAwxView';
 import { useManagementJobColumns } from './useManagementJobColumns';
 import { useManagementJobFilters } from './useManagementJobFilters';
 import { useCallback } from 'react';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { SystemJobTemplate } from '../../../interfaces/SystemJobTemplate';
 
 function SelectManagementJob(props: {
@@ -31,13 +31,13 @@ function SelectManagementJob(props: {
 }
 
 export function useSelectManagementJobs() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectSystemJob = useCallback(
     (onSelect: (template: SystemJobTemplate) => void) => {
-      setDialog(<SelectManagementJob title={t('Select a system job')} onSelect={onSelect} />);
+      pushDialog(<SelectManagementJob title={t('Select a system job')} onSelect={onSelect} />);
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectSystemJob;
 }

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from 'react';
 import { FieldPath, FieldValues, PathValue, useFormContext, useWatch } from 'react-hook-form';
-import { ITableColumn, IToolbarFilter, MultiSelectDialog, usePageDialog } from '../../../framework';
+import {
+  ITableColumn,
+  IToolbarFilter,
+  MultiSelectDialog,
+  usePageDialogs,
+} from '../../../framework';
 import { PageFormAsyncMultiSelect } from '../../../framework/PageForm/Inputs/PageFormAsyncMultiSelect';
 import { PageAsyncSelectOptionsFn } from '../../../framework/PageInputs/PageAsyncSelectOptions';
 import { useID } from '../../../framework/hooks/useID';
@@ -82,13 +87,13 @@ export function PageFormMultiSelectAwxResource<
     [props.url, props.queryParams]
   );
 
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
 
   const { setValue } = useFormContext<FormData>();
   const value = useWatch<FormData>({ name: props.name }) as Value[];
   const openSelectDialog = useCallback(
     (onSelect: (resources: Resource[]) => void) => {
-      setDialog(
+      pushDialog(
         <SelectResource<Resource>
           title={props.label}
           url={props.url}
@@ -111,7 +116,7 @@ export function PageFormMultiSelectAwxResource<
       props.tableColumns,
       props.toolbarFilters,
       props.url,
-      setDialog,
+      pushDialog,
       value,
       props.queryParams,
     ]

--- a/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormSingleSelectAwxResource.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { FieldPath, FieldValues, PathValue, useFormContext, useWatch } from 'react-hook-form';
-import { ITableColumn, IToolbarFilter, usePageDialog } from '../../../framework';
+import { ITableColumn, IToolbarFilter, usePageDialogs } from '../../../framework';
 import { SingleSelectDialog } from '../../../framework/PageDialogs/SingleSelectDialog';
 import { PageFormAsyncSingleSelect } from '../../../framework/PageForm/Inputs/PageFormAsyncSingleSelect';
 import { PageAsyncSelectOptionsFn } from '../../../framework/PageInputs/PageAsyncSelectOptions';
@@ -83,13 +83,13 @@ export function PageFormSingleSelectAwxResource<
     [props.url, props.queryParams]
   );
 
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
 
   const { setValue } = useFormContext<FormData>();
   const value = useWatch<FormData>({ name: props.name });
   const openSelectDialog = useCallback(
     (onSelect: (resource: Resource) => void) => {
-      setDialog(
+      pushDialog(
         <SelectResource<Resource>
           title={props.label}
           url={props.url}
@@ -106,7 +106,7 @@ export function PageFormSingleSelectAwxResource<
       props.tableColumns,
       props.toolbarFilters,
       props.url,
-      setDialog,
+      pushDialog,
       value,
       props.queryParams,
     ]

--- a/frontend/awx/overview/AwxOverview.tsx
+++ b/frontend/awx/overview/AwxOverview.tsx
@@ -4,7 +4,7 @@ import { CogIcon, InfoCircleIcon } from '@patternfly/react-icons';
 import { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
-import { PageHeader, PageLayout, usePageDialog } from '../../../framework';
+import { PageHeader, PageLayout, usePageDialogs } from '../../../framework';
 import { PageDashboard } from '../../../framework/PageDashboard/PageDashboard';
 import { awxAPI } from '../common/api/awx-utils';
 import { useAwxConfig } from '../common/useAwxConfig';
@@ -24,7 +24,7 @@ export function AwxOverview() {
   const { openManageDashboard, managedResources } = useManagedAwxDashboard();
   const product: string = process.env.PRODUCT ?? t('AWX');
   const config = useAwxConfig();
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const welcomeMessageSetting = localStorage.getItem(HIDE_WELCOME_MESSAGE);
   const hideWelcomeMessage = welcomeMessageSetting ? welcomeMessageSetting === 'true' : false;
   function renderCustomizeControls() {
@@ -36,9 +36,9 @@ export function AwxOverview() {
   }
   useEffect(() => {
     if (config?.ui_next && !hideWelcomeMessage) {
-      setDialog(<WelcomeModal />);
+      pushDialog(<WelcomeModal />);
     }
-  }, [config?.ui_next, hideWelcomeMessage, setDialog]);
+  }, [config?.ui_next, hideWelcomeMessage, pushDialog]);
 
   return (
     <PageLayout>

--- a/frontend/awx/overview/WelcomeModal.tsx
+++ b/frontend/awx/overview/WelcomeModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Modal, ModalVariant, TextContent } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../framework';
+import { usePageDialogs } from '../../../framework';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
@@ -11,11 +11,11 @@ const CheckboxDiv = styled.div`
 const HIDE_WELCOME_MESSAGE = 'hide-welcome-message';
 
 export function WelcomeModal() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog } = usePageDialogs();
   const { t } = useTranslation();
   const onClose = useCallback(() => {
-    setDialog(undefined);
-  }, [setDialog]);
+    popDialog();
+  }, [popDialog]);
   const [isChecked, setIsChecked] = useState<boolean>(false);
 
   const handleChange = (checked: boolean) => {

--- a/frontend/awx/resources/groups/hooks/useDeleteGroups.tsx
+++ b/frontend/awx/resources/groups/hooks/useDeleteGroups.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { InventoryGroup } from '../../../interfaces/InventoryGroup';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import {
   Button,
   HelperText,
@@ -137,10 +137,10 @@ function DeleteGroupsDialog(props: {
 }
 
 export function useDeleteGroups(onDelete: () => void) {
-  const [_, setDialog] = usePageDialog();
-  const onClose = () => setDialog(undefined);
+  const { popDialog, pushDialog } = usePageDialogs();
+  const onClose = () => popDialog();
   const deleteGroups = (groups: InventoryGroup[]) => {
-    setDialog(<DeleteGroupsDialog groups={groups} onClose={onClose} onDelete={onDelete} />);
+    pushDialog(<DeleteGroupsDialog groups={groups} onClose={onClose} onDelete={onDelete} />);
   };
   return deleteGroups;
 }

--- a/frontend/awx/resources/groups/hooks/useRelatedGroupsEmptyStateActions.tsx
+++ b/frontend/awx/resources/groups/hooks/useRelatedGroupsEmptyStateActions.tsx
@@ -5,7 +5,7 @@ import {
   PageActionSelection,
   PageActionType,
   usePageAlertToaster,
-  usePageDialog,
+  usePageDialogs,
   usePageNavigate,
 } from '../../../../../framework';
 import { useCallback, useMemo } from 'react';
@@ -20,7 +20,7 @@ import { ButtonVariant } from '@patternfly/react-core';
 import { IAwxView } from '../../../common/useAwxView';
 
 export function useRelatedGroupsEmptyStateActions(view: IAwxView<InventoryGroup>) {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const params = useParams<{ id: string; inventory_type: string; group_id: string }>();
@@ -48,9 +48,9 @@ export function useRelatedGroupsEmptyStateActions(view: IAwxView<InventoryGroup>
           });
         }
       }
-      setDialog(undefined);
+      popDialog();
     },
-    [setDialog, params.group_id, alertToaster, t, view]
+    [popDialog, params.group_id, alertToaster, t, view]
   );
 
   return useMemo<IPageAction<InventoryGroup>[]>(() => {
@@ -66,7 +66,7 @@ export function useRelatedGroupsEmptyStateActions(view: IAwxView<InventoryGroup>
         label: t('Existing group'),
         isPinned: true,
         onClick: () =>
-          setDialog(
+          pushDialog(
             <GroupSelectDialog
               groupId={params.group_id as string}
               onSelectedGroups={onSelectedGroups}
@@ -102,7 +102,7 @@ export function useRelatedGroupsEmptyStateActions(view: IAwxView<InventoryGroup>
     params.group_id,
     params.id,
     params.inventory_type,
-    setDialog,
+    pushDialog,
     t,
   ]);
 }

--- a/frontend/awx/resources/groups/hooks/useRelatedGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/groups/hooks/useRelatedGroupsToolbarActions.tsx
@@ -7,7 +7,7 @@ import {
   PageActionSelection,
   PageActionType,
   usePageAlertToaster,
-  usePageDialog,
+  usePageDialogs,
   usePageNavigate,
 } from '../../../../../framework';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
@@ -23,7 +23,7 @@ import { usePostRequest } from '../../../../common/crud/usePostRequest';
 import { useRunCommandAction } from '../../inventories/hooks/useInventoriesGroupsToolbarActions';
 
 export function useRelatedGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const disassociateGroups = useDisassociateGroups(view.unselectItemsAndRefresh);
@@ -61,9 +61,9 @@ export function useRelatedGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
           });
         }
       }
-      setDialog(undefined);
+      popDialog();
     },
-    [setDialog, postRequest, params.group_id, view, alertToaster, t]
+    [popDialog, postRequest, params.group_id, view, alertToaster, t]
   );
 
   return useMemo<IPageAction<InventoryGroup>[]>(() => {
@@ -83,7 +83,7 @@ export function useRelatedGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
             selection: PageActionSelection.None,
             label: t('Add existing group'),
             onClick: () =>
-              setDialog(
+              pushDialog(
                 <GroupSelectDialog
                   groupId={params.group_id as string}
                   onSelectedGroups={onSelectedGroups}
@@ -141,7 +141,7 @@ export function useRelatedGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
     view.selectedItems.length,
     params.group_id,
     onSelectedGroups,
-    setDialog,
+    pushDialog,
     isConstructed,
   ]);
 }

--- a/frontend/awx/resources/hosts/hooks/useHostsEmptyStateActions.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostsEmptyStateActions.tsx
@@ -6,7 +6,7 @@ import {
   PageActionSelection,
   PageActionType,
   usePageAlertToaster,
-  usePageDialog,
+  usePageDialogs,
   usePageNavigate,
 } from '../../../../../framework';
 import { ButtonVariant } from '@patternfly/react-core';
@@ -20,7 +20,7 @@ import { postRequest } from '../../../../common/crud/Data';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
 export function useHostsEmptyStateActions(view: IAwxView<AwxHost>) {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const params = useParams<{
     id: string;
@@ -51,9 +51,9 @@ export function useHostsEmptyStateActions(view: IAwxView<AwxHost>) {
           });
         }
       }
-      setDialog(undefined);
+      popDialog();
     },
-    [setDialog, params.group_id, alertToaster, t, view]
+    [popDialog, params.group_id, alertToaster, t, view]
   );
 
   return useMemo<IPageAction<AwxHost>[]>(
@@ -65,7 +65,7 @@ export function useHostsEmptyStateActions(view: IAwxView<AwxHost>) {
         label: t('Add existing host'),
         isPinned: true,
         onClick: () =>
-          setDialog(
+          pushDialog(
             <HostSelectDialog
               inventoryId={params.id as string}
               groupId={params.group_id as string}
@@ -104,7 +104,7 @@ export function useHostsEmptyStateActions(view: IAwxView<AwxHost>) {
       params.group_id,
       params.id,
       params.inventory_type,
-      setDialog,
+      pushDialog,
       t,
     ]
   );

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
@@ -9,7 +9,7 @@ import {
   PageActionSelection,
   usePageNavigate,
   usePageAlertToaster,
-  usePageDialog,
+  usePageDialogs,
 } from '../../../../../framework';
 import { useOptions } from '../../../../common/crud/useOptions';
 import { awxAPI } from '../../../common/api/awx-utils';
@@ -23,7 +23,7 @@ import { HostSelectDialog } from '../../hosts/hooks/useHostSelectDialog';
 import { useRunCommandAction } from './useInventoriesGroupsToolbarActions';
 
 export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>) {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const disassociateHosts = useDisassociateHosts(view.unselectItemsAndRefresh);
@@ -54,9 +54,9 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
           });
         }
       }
-      setDialog(undefined);
+      popDialog();
     },
-    [setDialog, params.group_id, view, alertToaster, t]
+    [popDialog, params.group_id, view, alertToaster, t]
   );
 
   return useMemo<IPageAction<AwxHost>[]>(() => {
@@ -75,7 +75,7 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
             selection: PageActionSelection.None,
             label: t('Add existing host'),
             onClick: () =>
-              setDialog(
+              pushDialog(
                 <HostSelectDialog
                   inventoryId={params.id as string}
                   groupId={params.group_id as string}
@@ -125,7 +125,7 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
     t,
     disassociateHosts,
     view.selectedItems.length,
-    setDialog,
+    pushDialog,
     params.id,
     params.group_id,
     params.inventory_type,

--- a/frontend/awx/resources/inventories/hooks/useSelectInventory.tsx
+++ b/frontend/awx/resources/inventories/hooks/useSelectInventory.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -28,13 +28,13 @@ function SelectInventory(props: { title: string; onSelect: (inventory: Inventory
 }
 
 export function useSelectInventory() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (inventory: Inventory) => void) => {
-      setDialog(<SelectInventory title={t('Select inventory')} onSelect={onSelect} />);
+      pushDialog(<SelectInventory title={t('Select inventory')} onSelect={onSelect} />);
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectInventory;
 }

--- a/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
+++ b/frontend/awx/resources/inventories/hooks/useSelectInventorySource.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -37,11 +37,11 @@ function SelectInventorySource(props: {
 }
 
 export function useSelectInventorySource(inventoryId?: number) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (inventory: InventorySource) => void) => {
-      setDialog(
+      pushDialog(
         <SelectInventorySource
           title={t('Select inventory source')}
           inventoryId={inventoryId}
@@ -49,7 +49,7 @@ export function useSelectInventorySource(inventoryId?: number) {
         />
       );
     },
-    [setDialog, inventoryId, t]
+    [pushDialog, inventoryId, t]
   );
   return openSelectInventory;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
@@ -1,6 +1,6 @@
 import { t } from 'i18next';
 import { useState, useEffect } from 'react';
-import { MultiSelectDialog, usePageDialog } from '../../../../../framework';
+import { MultiSelectDialog, usePageDialogs } from '../../../../../framework';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { InventoryGroup } from '../../../interfaces/InventoryGroup';
@@ -42,14 +42,14 @@ export function InventoryHostGroupsAddModal(props: {
 }
 
 export function useInventoryHostGroupsAddModal() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<InventoryHostGroupsAddModalProps>();
   useEffect(() => {
     if (props) {
-      setDialog(<InventoryHostGroupsAddModal {...props} />);
+      pushDialog(<InventoryHostGroupsAddModal {...props} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, popDialog, pushDialog]);
   return setProps;
 }

--- a/frontend/awx/resources/projects/hooks/useSelectProject.tsx
+++ b/frontend/awx/resources/projects/hooks/useSelectProject.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -28,13 +28,13 @@ function SelectProject(props: { title: string; onSelect: (project: Project) => v
 }
 
 export function useSelectProject() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (project: Project) => void) => {
-      setDialog(<SelectProject title={t('Select project')} onSelect={onSelect} />);
+      pushDialog(<SelectProject title={t('Select project')} onSelect={onSelect} />);
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectInventory;
 }

--- a/frontend/awx/resources/templates/hooks/useDeleteSurveyDialog.tsx
+++ b/frontend/awx/resources/templates/hooks/useDeleteSurveyDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { Button, Checkbox, Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core';
-import { usePageDialog, PageTable, usePageAlertToaster } from '../../../../../framework';
+import { usePageDialogs, PageTable, usePageAlertToaster } from '../../../../../framework';
 import { usePaged } from '../../../../../framework/PageTable/useTableItems';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { useDeleteSurvey } from './useDeleteSurvey';
@@ -25,7 +25,7 @@ const ConfirmBoxDiv = styled.div`
 
 export function useDeleteSurveyDialog(onComplete: (questions: Spec[]) => void) {
   const { t } = useTranslation();
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog, popDialog } = usePageDialogs();
   const alertToaster = usePageAlertToaster();
 
   const onError = (error: unknown) => {
@@ -43,10 +43,10 @@ export function useDeleteSurveyDialog(onComplete: (questions: Spec[]) => void) {
   };
 
   const deleteSurveyDialog = (questions: Spec[]) => {
-    setDialog(
+    pushDialog(
       <DeleteSurveyDialog
         questions={questions}
-        onClose={() => setDialog(undefined)}
+        onClose={() => popDialog()}
         onComplete={onComplete}
         onError={onError}
       />

--- a/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectJobTemplate.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IToolbarFilter, usePageDialog } from '../../../../../framework';
+import { IToolbarFilter, usePageDialogs } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -45,13 +45,13 @@ function SelectJobTemplate(props: { title: string; onSelect: (template: JobTempl
 }
 
 export function useSelectJobTemplate() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectTemplate = useCallback(
     (onSelect: (template: JobTemplate) => void) => {
-      setDialog(<SelectJobTemplate title={t('Select job template')} onSelect={onSelect} />);
+      pushDialog(<SelectJobTemplate title={t('Select job template')} onSelect={onSelect} />);
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectTemplate;
 }

--- a/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useSelectWorkflowJobTemplate.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IToolbarFilter, usePageDialog } from '../../../../../framework';
+import { IToolbarFilter, usePageDialogs } from '../../../../../framework';
 import { SingleSelectDialog } from '../../../../../framework/PageDialogs/SingleSelectDialog';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -48,15 +48,15 @@ function SelectWorkflowJobTemplate(props: {
 }
 
 export function useSelectWorkflowJobTemplate() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectInventory = useCallback(
     (onSelect: (template: WorkflowJobTemplate) => void) => {
-      setDialog(
+      pushDialog(
         <SelectWorkflowJobTemplate title={t('Select workflow job template')} onSelect={onSelect} />
       );
     },
-    [setDialog, t]
+    [pushDialog, t]
   );
   return openSelectInventory;
 }

--- a/frontend/common/AboutModal.tsx
+++ b/frontend/common/AboutModal.tsx
@@ -1,20 +1,20 @@
 import { AboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usePageDialog } from '../../framework';
+import { usePageDialogs } from '../../framework';
 
 export interface AnsibleAboutModalProps {
   onClose?: () => void;
 }
 
 function AnsibleAboutModal(props: AnsibleAboutModalProps) {
-  const [_dialog, setDialog] = usePageDialog();
+  const { popDialog } = usePageDialogs();
   const { t } = useTranslation();
   return (
     <AboutModal
       isOpen
       onClose={() => {
-        setDialog(undefined);
+        popDialog();
         props.onClose?.();
       }}
       trademark={t(`Copyright {{fullYear}} Red Hat, Inc.`, { fullYear: new Date().getFullYear() })}
@@ -33,7 +33,7 @@ function AnsibleAboutModal(props: AnsibleAboutModalProps) {
 }
 
 export function useAnsibleAboutModal() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<AnsibleAboutModalProps>();
   useEffect(() => {
     if (props) {
@@ -41,10 +41,10 @@ export function useAnsibleAboutModal() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<AnsibleAboutModal {...props} onClose={onCloseHandler} />);
+      pushDialog(<AnsibleAboutModal {...props} onClose={onCloseHandler} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, pushDialog, popDialog]);
   return setProps;
 }

--- a/frontend/common/access/hooks/useManageOrgRolesDialog.tsx
+++ b/frontend/common/access/hooks/useManageOrgRolesDialog.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-co
 import { OrgRolesList, OrgRolesListProps } from '../components/OrgRolesList';
 import { Trans, useTranslation } from 'react-i18next';
 import { useCallback, useState } from 'react';
-import { usePageDialog } from '../../../../framework';
+import { usePageDialogs } from '../../../../framework';
 import { CogIcon } from '@patternfly/react-icons';
 
 type ViewOrgRolesProps = {
@@ -14,8 +14,8 @@ type ViewOrgRolesProps = {
 export function ManageOrgRoles(props: ViewOrgRolesProps) {
   const { t } = useTranslation();
   const { orgListsOptions, onManageRolesClick, userOrTeamName } = props;
-  const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog } = usePageDialogs();
+  const onClose = useCallback(() => popDialog(), [popDialog]);
   const [orgListIsEmpty, setOrgListIsEmpty] = useState<boolean[]>(
     orgListsOptions.map((_) => false)
   );
@@ -73,14 +73,14 @@ export function ManageOrgRoles(props: ViewOrgRolesProps) {
 }
 
 export function useManageOrgRoles() {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const openManageOrgRoles = useCallback(
     (manageOrgRolesOptions: {
       orgListsOptions: OrgRolesListProps[];
       onManageRolesClick: () => void;
       userOrTeamName: string;
     }) => {
-      setDialog(
+      pushDialog(
         <ManageOrgRoles
           orgListsOptions={manageOrgRolesOptions.orgListsOptions}
           onManageRolesClick={manageOrgRolesOptions.onManageRolesClick}
@@ -88,7 +88,7 @@ export function useManageOrgRoles() {
         />
       );
     },
-    [setDialog]
+    [pushDialog]
   );
   return openManageOrgRoles;
 }

--- a/frontend/eda/access/credentials/hooks/useSelectCredentials.tsx
+++ b/frontend/eda/access/credentials/hooks/useSelectCredentials.tsx
@@ -5,14 +5,14 @@ import { useCredentialFilters } from './useCredentialFilters';
 import { useCredentialColumns } from './useCredentialColumns';
 import { EdaCredential } from '../../../interfaces/EdaCredential';
 import { useEdaView } from '../../../common/useEventDrivenView';
-import { MultiSelectDialog, usePageDialog } from '../../../../../framework';
+import { MultiSelectDialog, usePageDialogs } from '../../../../../framework';
 
 export function useSelectCredentials(credentialKinds?: string[], title?: string) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectCredentials = useCallback(
     (onSelect: (credentials: EdaCredential[]) => void) => {
-      setDialog(
+      pushDialog(
         <SelectEdaCredentials
           title={t(title ? title : 'Select credential')}
           onSelect={onSelect}
@@ -20,7 +20,7 @@ export function useSelectCredentials(credentialKinds?: string[], title?: string)
         />
       );
     },
-    [credentialKinds, setDialog, t, title]
+    [credentialKinds, pushDialog, t, title]
   );
   return openSelectCredentials;
 }

--- a/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
+++ b/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
@@ -2,7 +2,7 @@ import { Spinner } from '@patternfly/react-core';
 import { useCallback } from 'react';
 import { FieldPath, FieldValues, PathValue, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ITableColumn, IToolbarFilter, usePageDialog } from '../../../framework';
+import { ITableColumn, IToolbarFilter, usePageDialogs } from '../../../framework';
 import { SingleSelectDialog } from '../../../framework/PageDialogs/SingleSelectDialog';
 import { PageFormAsyncSingleSelect } from '../../../framework/PageForm/Inputs/PageFormAsyncSingleSelect';
 import { PageAsyncSelectOptionsFn } from '../../../framework/PageInputs/PageAsyncSelectOptions';
@@ -61,12 +61,12 @@ export function PageFormSingleSelectEdaResource<
     [props.url]
   );
 
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { setValue } = useFormContext<FormData>();
   const value = useWatch<FormData>({ name: props.name });
   const openSelectDialog = useCallback(
     (onSelect: (resource: Resource) => void) => {
-      setDialog(
+      pushDialog(
         <SelectResource<Resource>
           title={props.label}
           url={props.url}
@@ -77,7 +77,7 @@ export function PageFormSingleSelectEdaResource<
         />
       );
     },
-    [props.label, props.tableColumns, props.toolbarFilters, props.url, setDialog, value]
+    [props.label, props.tableColumns, props.toolbarFilters, props.url, pushDialog, value]
   );
 
   const queryLabel = useCallback(

--- a/frontend/eda/rule-audit/EventPayloadDialog.tsx
+++ b/frontend/eda/rule-audit/EventPayloadDialog.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageDetail, PageDetails, Scrollable, usePageDialog } from '../../../framework';
+import { PageDetail, PageDetails, Scrollable, usePageDialogs } from '../../../framework';
 import { PageDetailCodeEditor } from '../../../framework/PageDetails/PageDetailCodeEditor';
 import { formatDateString } from '../../../framework/utils/formatDateString';
 import { EdaRuleAuditEvent } from '../interfaces/EdaRuleAuditEvent';
@@ -13,8 +13,8 @@ export interface EventPayloadModalProps {
 
 export function EventPayloadDialog(props: EventPayloadModalProps) {
   const { t } = useTranslation();
-  const [_, setDialog] = usePageDialog();
-  const onClose = () => setDialog(undefined);
+  const { popDialog } = usePageDialogs();
+  const onClose = () => popDialog();
 
   return (
     <Modal
@@ -54,7 +54,7 @@ export function EventPayloadDialog(props: EventPayloadModalProps) {
 }
 
 export function useEventPayloadDialog() {
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const [props, setProps] = useState<EventPayloadModalProps>();
   useEffect(() => {
     if (props) {
@@ -62,10 +62,10 @@ export function useEventPayloadDialog() {
         setProps(undefined);
         props.onClose?.();
       };
-      setDialog(<EventPayloadDialog {...props} onClose={onCloseHandler} />);
+      pushDialog(<EventPayloadDialog {...props} onClose={onCloseHandler} />);
     } else {
-      setDialog(undefined);
+      popDialog();
     }
-  }, [props, setDialog]);
+  }, [props, popDialog, pushDialog]);
   return setProps;
 }

--- a/frontend/eda/webhooks/hooks/useSelectWebhooks.tsx
+++ b/frontend/eda/webhooks/hooks/useSelectWebhooks.tsx
@@ -5,14 +5,14 @@ import { useWebhookFilters } from './useWebhookFilters';
 import { useWebhookColumns } from './useWebhookColumns';
 import { EdaWebhook } from '../../interfaces/EdaWebhook';
 import { useEdaView } from '../../common/useEventDrivenView';
-import { MultiSelectDialog, usePageDialog } from '../../../../framework';
+import { MultiSelectDialog, usePageDialogs } from '../../../../framework';
 
 export function useSelectWebhooks(webhookType?: number, title?: string) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const { t } = useTranslation();
   const openSelectWebhooks = useCallback(
     (onSelect: (webhooks: EdaWebhook[]) => void) => {
-      setDialog(
+      pushDialog(
         <SelectEdaWebhooks
           title={t(title ? title : 'Select webhook')}
           onSelect={onSelect}
@@ -20,7 +20,7 @@ export function useSelectWebhooks(webhookType?: number, title?: string) {
         />
       );
     },
-    [webhookType, setDialog, t, title]
+    [webhookType, pushDialog, t, title]
   );
   return openSelectWebhooks;
 }

--- a/frontend/hub/administration/repositories/hooks/useSyncRepositories.tsx
+++ b/frontend/hub/administration/repositories/hooks/useSyncRepositories.tsx
@@ -5,7 +5,7 @@ import {
   PageFormSwitch,
   errorToAlertProps,
   usePageAlertToaster,
-  usePageDialog,
+  usePageDialogs,
 } from '../../../../../framework';
 import { HubPageForm } from '../../../common/HubPageForm';
 import { pulpAPI } from '../../../common/api/formatPath';
@@ -20,15 +20,15 @@ interface SyncFormProps {
 
 export function useSyncRepositories() {
   const { t } = useTranslation();
-  const [_, setDialog] = usePageDialog();
+  const { popDialog, pushDialog } = usePageDialogs();
   const alertToaster = usePageAlertToaster();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const onClose = useCallback(() => popDialog(), [popDialog]);
   const syncFormValues: SyncFormProps = {
     mirror: true,
     optimize: true,
   };
   return (repository: Repository) => {
-    setDialog(
+    pushDialog(
       <Modal
         title={t(`Sync repository ${repository.name}`)}
         aria-label={t(`Sync repository ${repository.name}`)}

--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -13,15 +13,15 @@ import { PulpItemsResponse, HubItemsResponse, useHubView } from '../../common/us
 import { AnsibleAnsibleRepositoryResponse } from '../../interfaces/generated/AnsibleAnsibleRepositoryResponse';
 import { SigningServiceResponse } from '../../interfaces/generated/SigningServiceResponse';
 import { CollectionVersionSearch } from '../Collection';
-import { usePageDialog } from './../../../../framework';
+import { usePageDialogs } from './../../../../framework';
 import { PageTable } from './../../../../framework/PageTable/PageTable';
 import { requestGet } from './../../../common/crud/Data';
 import { useGetRequest } from './../../../common/crud/useGet';
 import { TFunction } from 'i18next';
 
 export function useCopyToRepository(refresh: (collections: CollectionVersionSearch[]) => void) {
-  const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog, pushDialog } = usePageDialogs();
+  const onClose = useCallback(() => popDialog(), [popDialog]);
   const context = useHubContext();
 
   return (
@@ -29,7 +29,7 @@ export function useCopyToRepository(refresh: (collections: CollectionVersionSear
     operation: 'approve' | 'copy',
     displayDefaultError?: string
   ) => {
-    setDialog(
+    pushDialog(
       <CopyToRepositoryModal
         collection={collection}
         onClose={() => {

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -6,7 +6,7 @@ import {
   ITableColumn,
   MultiSelectDialog,
   TextCell,
-  usePageDialog,
+  usePageDialogs,
 } from '../../../../framework';
 import { hubAPI } from '../../common/api/formatPath';
 import { collectionKeyFn } from '../../common/api/hub-api-utils';
@@ -98,7 +98,7 @@ export function CollectionMultiSelectDialog(props: {
 }
 
 export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSearch[]) {
-  const [_, setDialog] = usePageDialog();
+  const { pushDialog } = usePageDialogs();
   const openSelectCollectionsDialog = useCallback(
     (
       title: string,
@@ -109,7 +109,7 @@ export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSe
         allowZeroSelections?: boolean;
       }
     ) => {
-      setDialog(
+      pushDialog(
         <CollectionMultiSelectDialog
           title={title}
           description={description}
@@ -120,7 +120,7 @@ export function useSelectCollectionsDialog(defaultSelection: CollectionVersionSe
         />
       );
     },
-    [defaultSelection, setDialog]
+    [defaultSelection, pushDialog]
   );
   return openSelectCollectionsDialog;
 }

--- a/frontend/hub/collections/hooks/useUploadSignature.tsx
+++ b/frontend/hub/collections/hooks/useUploadSignature.tsx
@@ -1,5 +1,5 @@
 import { CollectionVersionSearch } from '../Collection';
-import { LoadingPage, usePageDialog } from './../../../../framework';
+import { LoadingPage, usePageDialogs } from './../../../../framework';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useState, useCallback } from 'react';
@@ -13,12 +13,12 @@ import { TaskResponse } from '../../administration/tasks/Task';
 import { parseTaskResponse } from '../../common/api/hub-api-utils';
 
 export function useUploadSignature() {
-  const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog, pushDialog } = usePageDialogs();
+  const onClose = useCallback(() => popDialog(), [popDialog]);
   const context = useHubContext();
 
   return (collection: CollectionVersionSearch) => {
-    setDialog(
+    pushDialog(
       <UploadSignatureDialog collection={collection} onClose={onClose} context={context} />
     );
   };

--- a/frontend/hub/common/ToolbarAsyncSelectFilterBuilder.tsx
+++ b/frontend/hub/common/ToolbarAsyncSelectFilterBuilder.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { ISelected, ITableColumn, IToolbarFilter, usePageDialog } from '../../../framework';
+import { ISelected, ITableColumn, IToolbarFilter, usePageDialogs } from '../../../framework';
 import { MultiSelectDialog } from '../../../framework/PageDialogs/MultiSelectDialog';
 import { SingleSelectDialog } from '../../../framework/PageDialogs/SingleSelectDialog';
 import { IView, ViewExtendedOptions } from '../../../framework/useView';
@@ -24,15 +24,15 @@ export type AsyncSelectFilterBuilderProps<T extends object> = {
 export function useAsyncSingleSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  let [, setDialog] = usePageDialog();
+  let { pushDialog } = usePageDialogs();
   if (props.multiDialogs?.pushDialog) {
-    setDialog = props.multiDialogs.pushDialog;
+    pushDialog = props.multiDialogs.pushDialog;
   }
 
   return {
     openBrowse: useCallback(
       (onSelect: (value: T) => void, defaultSelection?: T) => {
-        setDialog(
+        pushDialog(
           <SelectFilter<T>
             defaultSelection={defaultSelection}
             onSelect={onSelect}
@@ -41,7 +41,7 @@ export function useAsyncSingleSelectFilterBuilder<T extends object>(
           />
         );
       },
-      [setDialog, props]
+      [pushDialog, props]
     ),
   };
 }
@@ -49,15 +49,15 @@ export function useAsyncSingleSelectFilterBuilder<T extends object>(
 export function useAsyncMultiSelectFilterBuilder<T extends object>(
   props: AsyncSelectFilterBuilderProps<T>
 ) {
-  let [, setDialog] = usePageDialog();
+  let { pushDialog } = usePageDialogs();
   if (props.multiDialogs?.pushDialog) {
-    setDialog = props.multiDialogs.pushDialog;
+    pushDialog = props.multiDialogs.pushDialog;
   }
 
   return {
     openBrowse: useCallback(
       (onSelect: (value: T[]) => void, defaultSelection?: T[]) => {
-        setDialog(
+        pushDialog(
           <SelectFilter<T>
             defaultSelection={defaultSelection}
             onMultiSelect={onSelect}
@@ -66,7 +66,7 @@ export function useAsyncMultiSelectFilterBuilder<T extends object>(
           />
         );
       },
-      [setDialog, props]
+      [pushDialog, props]
     ),
   };
 }

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentManageTags.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentManageTags.tsx
@@ -15,7 +15,7 @@ import {
 import { ExecutionEnvironment } from '../../ExecutionEnvironment';
 import { ExecutionEnvironmentImage } from '../ExecutionEnvironmentImage';
 import { ExecutionEnvironmentTag } from '../../ExecutionEnvironmentTag';
-import { usePageDialog } from '../../../../../framework';
+import { usePageDialogs } from '../../../../../framework';
 import { PageFormGroup } from '../../../../../framework/PageForm/Inputs/PageFormGroup';
 import { LoadingState } from '../../../../../framework/components/LoadingState';
 import { TagLabel } from '../components/ImageLabels';
@@ -30,11 +30,11 @@ import { Task } from '../../../administration/tasks/Task';
 const VALID_TAG_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 export function useExecutionEnvironmentManageTags(onComplete?: () => void) {
-  const [_, setDialog] = usePageDialog();
-  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+  const { popDialog, pushDialog } = usePageDialogs();
+  const onClose = useCallback(() => popDialog(), [popDialog]);
 
   return (ee: ExecutionEnvironment, image: ExecutionEnvironmentImage) => {
-    setDialog(<ManageTagsModal ee={ee} image={image} onClose={onClose} onComplete={onComplete} />);
+    pushDialog(<ManageTagsModal ee={ee} image={image} onClose={onClose} onComplete={onComplete} />);
   };
 }
 


### PR DESCRIPTION
This removes a deprecated usePagDialog hook and replaces it with usePageDialogs.  no functionality should change.  

In an effort to clean up our code base and remove deprecated items in order to improve our QOL and improve our testing issues I think this PR is pertinent.