### PR TITLE
Fixes flake in credentials and some job e2e tests

### DIFF
--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -596,7 +596,6 @@ Cypress.Commands.add('clickPageAction', (dataCy: string) => {
   cy.getByDataCy(dataCy).click();
 });
 
-// Resources for testing AWX
 Cypress.Commands.add('createAwxOrganization', (orgName?: string, failOnStatusCode?: boolean) => {
   cy.requestPost<Pick<Organization, 'name'>, Organization>(
     awxAPI`/organizations/`,
@@ -604,7 +603,6 @@ Cypress.Commands.add('createAwxOrganization', (orgName?: string, failOnStatusCod
     failOnStatusCode
   );
 });
-
 Cypress.Commands.add(
   'createAWXCredential',
   (credential: SetRequired<Partial<Credential>, 'organization' | 'kind' | 'credential_type'>) => {
@@ -623,7 +621,6 @@ Cypress.Commands.add(
   (
     credential: Credential,
     options?: {
-      /** Whether to fail on response codes other than 2xx and 3xx */
       failOnStatusCode?: boolean;
     }
   ) => {


### PR DESCRIPTION
One goal for this pr, within the jobs tests, is to rely less on the api to finish a job before we can act on it...delete it.  To do this I moved some tests out of the e2e test file and into a component test file and to focus less on what the api returns to us, and more on what the user can do.  In those tests we assert that a user can delete a job.  This is an improvement IMO because we no longer have to wait for the job to finish.  We can use stubbed data to load the table with completed jobs, and we can assert that the user can go through the steps necessary to delete a job.  