### PR TITLE
useGet*: do nothing for falsy urls

### DIFF
--- a/frontend/common/crud/useGet.tsx
+++ b/frontend/common/crud/useGet.tsx
@@ -11,7 +11,10 @@ export function useGet<T>(
 ) {
   const getRequest = useGetRequest<T>();
 
-  url += normalizeQueryString(query);
+  if (url) {
+    url += normalizeQueryString(query);
+  }
+
   const response = useSWR<T>(url, getRequest, {
     dedupingInterval: 0,
     ...swrConfiguration,
@@ -39,8 +42,11 @@ export function useGetItem<T = unknown>(
   id?: string | number,
   swrOptions?: SWRConfiguration
 ) {
-  if (url.endsWith('/')) url = url.slice(0, url.length - 1);
-  return useGet<T>(id ? `${url}/${id}/` : undefined, undefined, swrOptions);
+  if (url?.endsWith('/')) {
+    url = url.slice(0, url.length - 1);
+  }
+
+  return useGet<T>(url && id ? `${url}/${id}/` : undefined, undefined, swrOptions);
 }
 
 export function useGetRequest<ResponseBody>() {
@@ -54,8 +60,12 @@ export function useGetRequest<ResponseBody>() {
     query?: Record<string, string | number | boolean>,
     signal?: AbortSignal
   ) => {
+    if (url) {
+      url += normalizeQueryString(query);
+    }
+
     const response: Response = await requestCommon({
-      url: url + normalizeQueryString(query),
+      url,
       method: 'GET',
       signal,
     });


### PR DESCRIPTION
`useGet`, `useGetItem`, `useGetRequest` end up passing the url to `useSWR` which can handle `undefined` and do nothing,
but `undefined` gets mangled along the way, stringified when adding url params.

Add explicit logic to support `undefined` url.

---

This should get rid of the `undefined?page=...` GET request from `HubMasthead`.