### PR TITLE
flaky tests -> teams

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -1,57 +1,45 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Team } from '../../../../frontend/awx/interfaces/Team';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
-describe('teams', function () {
-  let team: Team;
-  let user1: AwxUser;
-  let user2: AwxUser;
+describe('Teams: Create', () => {
+  let organization: Organization;
 
-  before(function () {
+  before(() => {
     cy.awxLogin();
   });
 
-  beforeEach(function () {
-    cy.createAwxUser(this.globalOrganization as Organization).then((user) => {
-      user1 = user;
-      cy.createAwxTeam(this.globalOrganization as Organization).then((createdTeam) => {
-        team = createdTeam;
-        cy.giveUserTeamAccess(team.name, user1.id, 'Read');
-      });
+  beforeEach(() => {
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
     });
-    cy.createAwxUser(this.globalOrganization as Organization).then((user) => {
-      user2 = user;
-    });
-  });
-
-  this.afterEach(function () {
-    cy.deleteAwxUser(user1, { failOnStatusCode: false });
-    cy.deleteAwxUser(user2, { failOnStatusCode: false });
-    cy.deleteAwxTeam(team, { failOnStatusCode: false });
-  });
-
-  it('can render the teams list page', function () {
     cy.navigateTo('awx', 'teams');
     cy.verifyPageTitle('Teams');
   });
 
-  it('can create a basic team', function () {
+  afterEach(() => {
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  });
+
+  it('can create a basic team, assert details page and then delete team', () => {
     const teamName = 'E2E Team ' + randomString(4);
     cy.intercept('POST', awxAPI`/teams/`).as('newTeam');
-    cy.navigateTo('awx', 'teams');
     cy.containsBy('a', /^Create team$/).click();
     cy.getByDataCy('name').type(teamName);
-    cy.singleSelectByDataCy('organization', (this.globalOrganization as Organization).name);
+    cy.singleSelectByDataCy('organization', organization.name);
     cy.getByDataCy('Submit').click();
     cy.wait('@newTeam')
       .its('response.body')
-      .then((team: Team) => {
-        cy.verifyPageTitle(team.name);
-        cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+      .then((thisTeam: Team) => {
+        cy.url().then((currentUrl) => {
+          expect(currentUrl.includes(`/access/teams/${thisTeam.id.toString()}/details`)).to.be.true;
+        });
+        cy.verifyPageTitle(thisTeam.name);
+        cy.hasDetail('Name', thisTeam.name);
+        cy.hasDetail('Organization', organization.name);
+        cy.intercept('DELETE', awxAPI`/teams/${thisTeam.id.toString()}/`).as('deleted');
         cy.selectDetailsPageKebabAction('delete-team');
         cy.wait('@deleted')
           .its('response')
@@ -60,19 +48,147 @@ describe('teams', function () {
           });
       });
   });
+});
 
-  it('can remove users from the team via the teams list row item', function () {
-    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
-    });
-    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
+describe('Teams: Edit and Delete', () => {
+  let team: Team;
+  let organization: Organization;
+
+  before(() => {
+    cy.awxLogin();
+  });
+
+  beforeEach(() => {
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
+      cy.createAwxTeam(organization).then((createdTeam) => {
+        team = createdTeam;
+      });
     });
 
     cy.navigateTo('awx', 'teams');
+    cy.verifyPageTitle('Teams');
+  });
+
+  afterEach(() => {
+    cy.deleteAwxTeam(team, { failOnStatusCode: false });
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  });
+
+  it('can edit a team from the details page', () => {
+    cy.filterTableBySingleSelect('name', team.name);
+    cy.clickTableRowLink('name', team.name, { disableFilter: true });
+    cy.verifyPageTitle(team.name);
+    cy.hasDetail('Name', team.name);
+    cy.hasDetail('Organization', organization.name);
+    cy.clickButton(/^Edit team$/);
+    cy.verifyPageTitle('Edit Team');
+    cy.get('[data-cy="name"]')
+      .clear()
+      .type(team.name + '-edited');
+
+    cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
+    cy.clickButton(/^Save team$/);
+    cy.wait('@editTeam')
+      .its('response.statusCode')
+      .then((statusCode) => {
+        expect(statusCode).to.eql(200);
+      });
+    cy.verifyPageTitle(`${team.name}-edited`);
+  });
+
+  it('can navigate to the edit form from the team list row item', () => {
+    cy.filterTableBySingleSelect('name', team.name);
+    cy.clickTableRowAction('name', team.name, 'edit-team', { disableFilter: true });
+    cy.verifyPageTitle('Edit Team');
+    cy.get('[data-cy="name"]')
+      .clear()
+      .type(team.name + '-edited');
+
+    cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
+    cy.clickButton(/^Save team$/);
+    cy.wait('@editTeam')
+      .its('response.statusCode')
+      .then((statusCode) => {
+        expect(statusCode).to.eql(200);
+      });
+    cy.clearAllFilters();
+    cy.filterTableBySingleSelect('name', `${team.name}-edited`);
+  });
+
+  it('can delete a team from the details page', () => {
+    cy.filterTableBySingleSelect('name', team.name);
+    cy.clickTableRowLink('name', team.name, { disableFilter: true });
+    cy.verifyPageTitle(team.name);
+    cy.clickPageAction('delete-team');
+    cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+    cy.get('#confirm').click();
+    cy.clickButton(/^Delete team/);
+    cy.wait('@deleted')
+      .its('response')
+      .then((response) => {
+        expect(response?.statusCode).to.eql(204);
+        cy.verifyPageTitle('Teams');
+      });
+  });
+
+  it('can delete a team from the teams list row item', () => {
+    cy.filterTableBySingleSelect('name', team.name);
+    cy.clickTableRowAction('name', team.name, 'delete-team', {
+      disableFilter: true,
+      inKebab: true,
+    });
+    cy.get('#confirm').click();
+    cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+    cy.clickButton(/^Delete team/);
+    cy.wait('@deleted')
+      .its('response')
+      .then((response) => {
+        expect(response?.statusCode).to.eql(204);
+        cy.contains(/^Success$/);
+        cy.clickButton(/^Close$/);
+        cy.clearAllFilters();
+      });
+  });
+});
+
+describe('Teams: Add and Remove users', () => {
+  let team: Team;
+  let user1: AwxUser;
+  let organization: Organization;
+
+  before(() => {
+    cy.awxLogin();
+  });
+
+  beforeEach(() => {
+    cy.createAwxOrganization().then((o) => {
+      organization = o;
+      cy.createAwxUser(organization).then((user) => {
+        user1 = user;
+        cy.createAwxTeam(organization).then((createdTeam) => {
+          team = createdTeam;
+          cy.giveUserTeamAccess(team.name, user1.id, 'Read');
+        });
+      });
+    });
+    cy.navigateTo('awx', 'teams');
+    cy.verifyPageTitle('Teams');
+  });
+
+  afterEach(() => {
+    cy.deleteAwxUser(user1, { failOnStatusCode: false });
+    cy.deleteAwxTeam(team, { failOnStatusCode: false });
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  });
+
+  it('can remove users from the team via the teams list row item', () => {
+    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+      id: team.summary_fields.object_roles.member_role.id,
+    });
 
     // Remove users
-    cy.filterTableByMultiSelect('name', [team.name]);
+    cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowAction('name', team.name, 'remove-users', {
       inKebab: true,
       disableFilter: true,
@@ -81,7 +197,6 @@ describe('teams', function () {
     // Select users
     cy.getModal().within(() => {
       cy.selectTableRowByCheckbox('username', user1.username);
-      cy.selectTableRowByCheckbox('username', user2.username);
       cy.get('#submit').click();
     });
 
@@ -97,37 +212,13 @@ describe('teams', function () {
     cy.getModal().should('not.exist');
   });
 
-  it('can render the team details page', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickTab(/^Details$/, true);
-    cy.hasDetail('Name', team.name);
-  });
-
-  it('can edit a team from the details page', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.clickButton(/^Edit team$/);
-    cy.verifyPageTitle('Edit Team');
-    cy.get('[data-cy="name"]')
-      .clear()
-      .type(team.name + 'a');
-    cy.clickButton(/^Save team$/);
-    cy.verifyPageTitle(`${team.name}a`);
-  });
-
-  // FLAKY_06_14_2024
-  it.skip('can add users to the team via the team access tab toolbar', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
+  it('can add users to the team via the team access tab toolbar', () => {
+    cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowLink('name', team.name, { disableFilter: true });
     cy.verifyPageTitle(team.name);
     cy.clickTab(/^Users$/, true);
     cy.get('[data-cy="add-users"]').click();
-    cy.getTableRow('username', `${user2.username}`).within(() => {
+    cy.getTableRow('username', `${user1.username}`).within(() => {
       cy.get('input[type="checkbox"]').click({ force: true });
     });
     cy.clickButton(/^Next$/);
@@ -140,31 +231,18 @@ describe('teams', function () {
     cy.clickButton(/^Next$/);
     cy.clickButton(/^Finish$/);
     cy.clickModalButton('Close');
-    cy.getTableRow('username', user2.username, {
+    cy.getTableRow('username', user1.username, {
       disableFilter: true,
       disableFilterSelection: true,
     }).should('be.visible');
-
-    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
-      disassociate: true,
-    });
-    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
-      disassociate: true,
-    });
   });
 
-  // FLAKY_06_14_2024
-  it.skip('can remove users from the team via the team access tab toolbar', function () {
+  it('can remove users from the team via the team access tab toolbar', () => {
     cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
       id: team.summary_fields.object_roles.member_role.id,
     });
-    cy.requestPost<AwxUser>(awxAPI`/users/${user2.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
-    });
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
+
+    cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowLink('name', team.name, { disableFilter: true });
     cy.verifyPageTitle(team.name);
     cy.clickTab(/^Users$/, true);
@@ -180,9 +258,8 @@ describe('teams', function () {
     cy.get(`tr[data-cy=row-id-${user1.id}]`).should('not.exist');
   });
 
-  it('can remove a role from a user via the team access tab row action', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
+  it('can remove a role from a user via the team access tab row action', () => {
+    cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowLink('name', team.name, { disableFilter: true });
     cy.verifyPageTitle(team.name);
     cy.clickTab(/^Users$/, true);
@@ -197,90 +274,52 @@ describe('teams', function () {
       cy.get('tr').should('not.have.length');
     });
   });
+});
 
-  it('can render the team roles page', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickTab(/^Roles$/, true);
-    cy.url().should('contain', '/roles');
+describe('Teams: Bulk delete', () => {
+  let team: Team;
+  let organization: Organization;
+  const arrayOfElementText: string[] = [];
+
+  before(() => {
+    cy.awxLogin();
   });
 
-  it('can navigate to the edit form from the team details page', function () {
+  beforeEach(() => {
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
+      for (let i = 0; i < 5; i++) {
+        cy.createAwxTeam(organization).then((createdTeam) => {
+          team = createdTeam;
+          arrayOfElementText.push(team.name);
+        });
+      }
+    });
+
     cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickButton(/^Edit team$/);
-    cy.verifyPageTitle('Edit Team');
+    cy.verifyPageTitle('Teams');
   });
 
-  it('can delete a team from the details page', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickPageAction('delete-team');
-    cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+  afterEach(() => {
+    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  });
+
+  it('can bulk delete teams from the teams list toolbar', () => {
+    cy.filterTableByMultiSelect('name', arrayOfElementText);
+    cy.get('tbody tr').should('have.length', 5);
+    cy.getByDataCy('select-all').click();
+    cy.clickToolbarKebabAction('delete-selected-teams');
+
     cy.get('#confirm').click();
+    cy.intercept('DELETE', awxAPI`/teams/*/`).as('deleted');
     cy.clickButton(/^Delete team/);
     cy.wait('@deleted')
       .its('response')
       .then((response) => {
         expect(response?.statusCode).to.eql(204);
-        cy.verifyPageTitle('Teams');
+        cy.contains(/^Success$/);
+        cy.clickButton(/^Close$/);
+        cy.clearAllFilters();
       });
-  });
-
-  // FLAKY_06_13_2024
-  it.skip('can navigate to the edit form from the team list row item', function () {
-    cy.navigateTo('awx', 'teams');
-    cy.filterTableByMultiSelect('name', [team.name]);
-    cy.clickTableRowAction('name', team.name, 'edit-team', { disableFilter: true });
-    cy.verifyPageTitle('Edit Team');
-  });
-
-  it('can delete a team from the teams list row item', function () {
-    cy.createAwxTeam(this.globalOrganization as Organization).then((testTeam) => {
-      cy.navigateTo('awx', 'teams');
-      cy.filterTableByMultiSelect('name', [testTeam.name]);
-      cy.clickTableRowAction('name', testTeam.name, 'delete-team', {
-        disableFilter: true,
-        inKebab: true,
-      });
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', awxAPI`/teams/${testTeam.id.toString()}/`).as('deleted');
-      cy.clickButton(/^Delete team/);
-      cy.wait('@deleted')
-        .its('response')
-        .then((response) => {
-          expect(response?.statusCode).to.eql(204);
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clearAllFilters();
-        });
-    });
-  });
-
-  // FLAKY_06_19_2024
-  it.skip('can delete a team from the teams list toolbar', function () {
-    cy.createAwxTeam(this.globalOrganization as Organization).then((testTeam) => {
-      cy.navigateTo('awx', 'teams');
-      cy.filterTableByMultiSelect('name', [testTeam.name]);
-      cy.selectTableRowByCheckbox('name', testTeam.name, { disableFilter: true });
-      cy.clickToolbarKebabAction('delete-selected-teams');
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', awxAPI`/teams/${testTeam.id.toString()}/`).as('deleted');
-      cy.clickButton(/^Delete team/);
-      cy.wait('@deleted')
-        .its('response')
-        .then((response) => {
-          expect(response?.statusCode).to.eql(204);
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clearAllFilters();
-        });
-    });
   });
 });


### PR DESCRIPTION
This PR is:

- Adding two additional `describe` blocks in order to separate tests that are not using resources created during `beforeEach`
- Replacing unnecessary `filterTableByMultiSelect` with `filterTableBySingleSelect`
- Removing test `can render the team details page` because it's a component tests instead of an integration test
- Removing test `can edit a team from the details page` because it's a component tests instead of an integration test
- Removing unnecessary `function()`
- Adding new test for bulk deletion
