### PR TITLE
[AAP-25659] Show error if resources are missing in Schedule wizard

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -94,7 +94,7 @@ describe.skip('Schedules - Create and Delete', () => {
     });
   });
 
-  describe.skip('Schedules - Create schedule of resource type Project', () => {
+  describe('Schedules - Create schedule of resource type Project', () => {
     let organization: Organization;
     let project: Project;
 

--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -74,9 +74,27 @@ describe.skip('Schedules - Create and Delete', () => {
       cy.clickModalButton('Delete schedule');
       cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
     });
+
+    it("can't create a schedule with missing resources", () => {
+      const scheduleName = 'E2E Schedule With Missing Resources' + randomString(4);
+      cy.deleteAwxInventory(inventory);
+      cy.navigateTo('awx', 'schedules');
+      cy.verifyPageTitle('Schedules');
+      cy.getByDataCy('create-schedule').click();
+      cy.verifyPageTitle('Create Schedule');
+      cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
+      cy.selectDropdownOptionByResourceName('job-template-select', jobTemplate.name);
+      cy.getByDataCy('name').type(`${scheduleName}`);
+      cy.clickButton('Next');
+      cy.clickButton('Save rule');
+      cy.clickButton('Next');
+      cy.clickButton('Next');
+      cy.clickButton('Finish');
+      cy.contains('Job Template inventory is missing or undefined.');
+    });
   });
 
-  describe('Schedules - Create schedule of resource type Project', () => {
+  describe.skip('Schedules - Create schedule of resource type Project', () => {
     let organization: Organization;
     let project: Project;
 
@@ -601,6 +619,7 @@ describe('Schedules - Edit', () => {
   let schedule: Schedule;
   let project: Project;
   let organization: Organization;
+  let jobTemplate: JobTemplate;
 
   beforeEach(() => {
     const name = 'E2E Edit Schedule ' + randomString(4);
@@ -626,6 +645,7 @@ describe('Schedules - Edit', () => {
     cy.deleteAWXSchedule(schedule, { failOnStatusCode: false });
     cy.deleteAwxProject(project, { failOnStatusCode: false });
     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
   });
 
   it('can edit a simple schedule from details page', () => {
@@ -883,5 +903,48 @@ describe('Schedules - Edit', () => {
       cy.getByDataCy('toggle-switch').click();
     });
     cy.get('input[aria-label="Click to disable schedule"]').should('exist');
+  });
+
+  it("can't edit a schedule with missing resources", () => {
+    const name = 'E2E Edit Schedule With Missing Resources' + randomString(4);
+
+    cy.createAwxInventory(organization).then((inv) => {
+      cy.createAwxJobTemplate({
+        name: 'E2E Job Template ' + randomString(4),
+        organization: organization.id,
+        project: project.id,
+        inventory: inv.id,
+      }).then((jt) => {
+        jobTemplate = jt;
+        cy.createAWXSchedule({
+          name,
+          unified_job_template: jt.id,
+          rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
+        }).then((sched: Schedule) => {
+          schedule = sched;
+          cy.deleteAwxInventory(inv);
+
+          cy.navigateTo('awx', 'templates');
+          cy.verifyPageTitle('Templates');
+          cy.filterTableByMultiSelect('name', [jt.name]);
+          cy.get('[data-cy="name-column-cell"]').within(() => {
+            cy.get('a').click();
+          });
+          cy.verifyPageTitle(jt.name);
+          cy.clickTab('Schedules', true);
+          cy.get('[data-cy="create-schedule"]').should('have.attr', 'aria-disabled', 'true');
+          cy.get('[data-cy="name-column-cell"]').within(() => {
+            cy.get('a').click();
+          });
+          cy.clickLink('Edit schedule');
+          cy.verifyPageTitle('Edit Schedule');
+          cy.clickButton('Next');
+          cy.clickButton('Next');
+          cy.clickButton('Next');
+          cy.clickButton('Finish');
+          cy.contains('Job Template inventory is missing or undefined.');
+        });
+      });
+    });
   });
 });

--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -15,7 +15,7 @@ describe.skip('Schedules - Create and Delete', () => {
     let project: Project;
     let inventory: Inventory;
 
-    before(() => {
+    beforeEach(() => {
       cy.createAwxOrganization().then((o) => {
         organization = o;
         cy.createAwxProject(organization).then((proj) => {
@@ -35,7 +35,7 @@ describe.skip('Schedules - Create and Delete', () => {
       });
     });
 
-    after(() => {
+    afterEach(() => {
       cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
       cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
       cy.deleteAwxProject(project, { failOnStatusCode: false });
@@ -645,7 +645,7 @@ describe('Schedules - Edit', () => {
     cy.deleteAWXSchedule(schedule, { failOnStatusCode: false });
     cy.deleteAwxProject(project, { failOnStatusCode: false });
     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+    jobTemplate?.id && cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
   });
 
   it('can edit a simple schedule from details page', () => {

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -91,6 +91,7 @@ export function TemplatePage() {
         }}
         tabs={tabs}
         params={{ id: template?.id }}
+        componentParams={{ template }}
       />
     </PageLayout>
   );

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -94,6 +94,7 @@ export function WorkflowJobTemplatePage() {
         }}
         tabs={tabs}
         params={{ id: template.id }}
+        componentParams={{ template }}
       />
     </PageLayout>
   );

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -1,6 +1,6 @@
-import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { CubesIcon, ExclamationTriangleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { PageTable } from '../../../../framework';
 import { usePersistentFilters } from '../../../common/PersistentFilters';
 import { useOptions } from '../../../common/crud/useOptions';
@@ -13,6 +13,8 @@ import { useSchedulesActions } from './hooks/useSchedulesActions';
 import { useSchedulesColumns } from './hooks/useSchedulesColumns';
 import { useSchedulesFilter } from './hooks/useSchedulesFilter';
 import { useScheduleToolbarActions } from './hooks/useSchedulesToolbarActions';
+import { missingResources } from '../../resources/templates/hooks/useTemplateColumns';
+import { JobTemplate } from '../../interfaces/JobTemplate';
 
 export function SchedulesList(props: { sublistEndpoint?: string; url?: string }) {
   const { t } = useTranslation();
@@ -20,6 +22,11 @@ export function SchedulesList(props: { sublistEndpoint?: string; url?: string })
   const location = useLocation();
   const params = useParams<{ inventory_type?: string; id?: string; source_id?: string }>();
   const resourceId = params.source_id ?? params.id;
+
+  const compParams = useOutletContext<{ template: JobTemplate }>();
+  const isMissingResource: boolean = compParams?.template
+    ? missingResources(compParams?.template)
+    : false;
 
   const apiEndPoint: string | undefined = props.sublistEndpoint
     ? `${props.sublistEndpoint}/${resourceId}/schedules/`
@@ -43,7 +50,11 @@ export function SchedulesList(props: { sublistEndpoint?: string; url?: string })
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(apiEndPoint ?? awxAPI`/schedules/`);
   const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
   const createUrl = useGetSchedulCreateUrl(apiEndPoint);
-  const toolbarActions = useScheduleToolbarActions(view.unselectItemsAndRefresh, apiEndPoint);
+  const toolbarActions = useScheduleToolbarActions(
+    view.unselectItemsAndRefresh,
+    apiEndPoint,
+    isMissingResource
+  );
   const rowActions = useSchedulesActions({
     onScheduleDeleteCompleted: view.unselectItemsAndRefresh,
     onScheduleToggleCompleted: view.updateItem,
@@ -59,20 +70,30 @@ export function SchedulesList(props: { sublistEndpoint?: string; url?: string })
       errorStateTitle={t('Error loading schedules')}
       emptyStateTitle={
         canCreateSchedule
-          ? t('No schedules yet')
+          ? isMissingResource
+            ? t('Resources are missing from this template.')
+            : t('No schedules yet')
           : t('You do not have permission to create a schedule')
       }
       emptyStateDescription={
         canCreateSchedule
-          ? t('Please create a schedule by using the button below.')
+          ? isMissingResource
+            ? undefined
+            : t('Please create a schedule by using the button below.')
           : t(
               'Please contact your organization administrator if there is an issue with your access.'
             )
       }
-      emptyStateIcon={canCreateSchedule ? undefined : CubesIcon}
+      emptyStateIcon={
+        canCreateSchedule ? (isMissingResource ? ExclamationTriangleIcon : undefined) : CubesIcon
+      }
       emptyStateButtonIcon={<PlusCircleIcon />}
-      emptyStateButtonText={canCreateSchedule ? t('Create schedule') : undefined}
-      emptyStateButtonClick={canCreateSchedule ? () => navigate(createUrl) : undefined}
+      emptyStateButtonText={
+        canCreateSchedule && !isMissingResource ? t('Create schedule') : undefined
+      }
+      emptyStateButtonClick={
+        canCreateSchedule && !isMissingResource ? () => navigate(createUrl) : undefined
+      }
       {...view}
     />
   );

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -84,7 +84,7 @@ export function SchedulesList(props: { sublistEndpoint?: string; url?: string })
               'Please contact your organization administrator if there is an issue with your access.'
             )
       }
-      emptyStateIcon={
+      emptyStateNoDataIcon={
         canCreateSchedule ? (isMissingResource ? ExclamationTriangleIcon : undefined) : CubesIcon
       }
       emptyStateButtonIcon={<PlusCircleIcon />}

--- a/frontend/awx/views/schedules/hooks/useSchedulesToolbarActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useSchedulesToolbarActions.tsx
@@ -13,7 +13,8 @@ import { cannotDeleteResources } from '../../../../common/utils/RBAChelpers';
 
 export function useScheduleToolbarActions(
   onComplete: (schedules: Schedule[]) => void,
-  sublistEndPoint = awxAPI`/schedules/`
+  sublistEndPoint = awxAPI`/schedules/`,
+  isMissingResource?: boolean
 ) {
   const createUrl = useGetSchedulCreateUrl(sublistEndPoint);
 
@@ -33,7 +34,9 @@ export function useScheduleToolbarActions(
         icon: PlusCircleIcon,
         label: t('Create schedule'),
         isDisabled: canCreateSchedule
-          ? undefined
+          ? isMissingResource
+            ? t('Resources are missing from this template.')
+            : undefined
           : t(
               'You do not have permission to create a schedule. Please contact your organization administrator if there is an issue with your access.'
             ),
@@ -52,7 +55,7 @@ export function useScheduleToolbarActions(
         isDanger: true,
       },
     ],
-    [canCreateSchedule, createUrl, deleteSchedules, t]
+    [canCreateSchedule, createUrl, deleteSchedules, t, isMissingResource]
   );
 
   return ScheduleToolbarActions;

--- a/frontend/awx/views/schedules/wizard/ScheduleAddWizard.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleAddWizard.tsx
@@ -139,7 +139,6 @@ export function ScheduleAddWizard() {
         }
 
         const ruleset = getRuleSet(wizardData.rules, wizardData.exceptions ?? []);
-
         const { utc, local } = await postRequest<{ utc: string[]; local: string[] }>(
           awxAPI`/schedules/preview/`,
           {
@@ -153,6 +152,22 @@ export function ScheduleAddWizard() {
                 'This schedule will never run.  If you have defined exceptions it is likely that the exceptions cancel out all the rules defined in the rules step.'
               ),
             ],
+          };
+
+          throw new RequestError('', '', 400, '', errors);
+        }
+
+        const { resource } = wizardData;
+        if (
+          (resource?.type === 'job_template' &&
+            (!resource?.summary_fields?.inventory ||
+              !resource?.summary_fields?.project ||
+              !resource?.summary_fields?.organization)) ||
+          (resource?.type === 'workflow_job_template' &&
+            (!resource?.summary_fields?.inventory || !resource?.summary_fields?.organization))
+        ) {
+          const errors = {
+            __all__: [t('Resources are missing from this template.')],
           };
 
           throw new RequestError('', '', 400, '', errors);

--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.tsx
@@ -59,13 +59,24 @@ export function ScheduleEditWizard() {
       ...rest,
     };
 
-    const {
-      schedule,
-    }: {
-      schedule: Schedule;
-    } = await processSchedules(data);
-    const pageUrl = getScheduleUrl('details', schedule) as schedulePageUrl;
-    return pageNavigate(pageUrl.pageId, { params: pageUrl.params });
+    try {
+      const {
+        schedule,
+      }: {
+        schedule: Schedule;
+      } = await processSchedules(data);
+      const pageUrl = getScheduleUrl('details', schedule) as schedulePageUrl;
+      return pageNavigate(pageUrl.pageId, { params: pageUrl.params });
+    } catch (error) {
+      const { fieldErrors } = awxErrorAdapter(error);
+      const missingResource = fieldErrors.find((err) => err?.name === 'resources_needed_to_start');
+      if (missingResource) {
+        const errors = {
+          __all__: [missingResource.message],
+        };
+        throw new RequestError('', '', 400, '', errors);
+      }
+    }
   };
 
   const onCancel = () => navigate(-1);


### PR DESCRIPTION
Issue: [AAP-25659](https://issues.redhat.com/browse/AAP-25659)


![Screenshot from 2024-06-26 14-53-39](https://github.com/ansible/ansible-ui/assets/19647757/d4f18216-2b66-4883-833a-0f3622a16806)

### Don't let create schedule if resources are missing
**empty state:**
![Screenshot from 2024-06-26 14-53-17](https://github.com/ansible/ansible-ui/assets/19647757/6d225b4d-0927-4c65-98f9-b8c1da4362f2)
~~(custom icon requires https://github.com/ansible/ansible-ui/pull/2585)~~

**disabled button:**
![Screenshot from 2024-06-24 16-44-53](https://github.com/ansible/ansible-ui/assets/19647757/24e5bce7-d4ae-49ea-a941-e25fafe23ec1)



