### PR TITLE
teams > fixing flaky create basic team test

### DIFF
--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -26,17 +26,17 @@ describe('Teams: Create', () => {
   it('can create a basic team, assert details page and then delete team', () => {
     const teamName = 'E2E Team ' + randomString(4);
     cy.intercept('POST', awxAPI`/teams/`).as('newTeam');
-    cy.containsBy('a', /^Create team$/).click();
+    cy.getByDataCy('create-team').click();
     cy.getByDataCy('name').type(teamName);
     cy.singleSelectByDataCy('organization', organization.name);
     cy.getByDataCy('Submit').click();
     cy.wait('@newTeam')
       .its('response.body')
       .then((thisTeam: Team) => {
+        cy.verifyPageTitle(thisTeam.name);
         cy.url().then((currentUrl) => {
           expect(currentUrl.includes(`/access/teams/${thisTeam.id.toString()}/details`)).to.be.true;
         });
-        cy.verifyPageTitle(thisTeam.name);
         cy.hasDetail('Name', thisTeam.name);
         cy.hasDetail('Organization', organization.name);
         cy.intercept('DELETE', awxAPI`/teams/${thisTeam.id.toString()}/`).as('deleted');


### PR DESCRIPTION
In some cases, empty state is shown for teams so this PR is changing to use `data-cy` for Create team button.
![image](https://github.com/ansible/ansible-ui/assets/88343229/325e9a65-dc4d-4700-940c-06fbd38c9c11)
