### PR TITLE
schedules flaky tests

### DIFF
--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -204,7 +204,8 @@ describe('Schedules - Create and Delete', () => {
       cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
     });
 
-    it('can create a simple schedule of resource type Workflow job template, then delete the schedule', () => {
+    //FLAKY_DATE 07/03/24
+    it.skip('can create a simple schedule of resource type Workflow job template, then delete the schedule', () => {
       cy.navigateTo('awx', 'schedules');
       cy.verifyPageTitle('Schedules');
       const scheduleName = 'E2E Simple Schedule WFJT' + randomString(4);


### PR DESCRIPTION
This PR is:

- Removing the usage of `Global Project`
- Dividing tests into more `describe` blocks. 
- [AAP-26621](https://issues.redhat.com/browse/AAP-26621) Skipping `can create a simple schedule of resource type Workflow job template, then delete the schedule` because depends on how many workflow templates are at the moment of running the test