### PR TITLE
[AAP-25216] Use the GET choice for the Select resource type options

### DIFF
--- a/cypress/fixtures/edaRoleDefinitionsOptions.json
+++ b/cypress/fixtures/edaRoleDefinitionsOptions.json
@@ -4,7 +4,7 @@
   "renders": ["application/json", "text/html"],
   "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
   "actions": {
-    "POST": {
+    "GET": {
       "id": {
         "type": "integer",
         "required": false,

--- a/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
+++ b/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
@@ -13,14 +13,14 @@ export function EdaSelectResourceTypeStep() {
   const { t } = useTranslation();
   const { wizardData, setWizardData, setStepData } = usePageWizard();
   const { data, isLoading } = useOptions<{
-    actions: { POST: { content_type: { choices: ContentTypeOption[] } } };
+    actions: { GET: { content_type: { choices: ContentTypeOption[] } } };
   }>(edaAPI`/role_definitions/`);
 
   if (isLoading || !data) {
     return <LoadingPage />;
   }
 
-  const options: ContentTypeOption[] = data?.actions?.POST?.content_type?.choices || [];
+  const options: ContentTypeOption[] = data?.actions?.GET?.content_type?.choices || [];
 
   return (
     <PageFormSelect


### PR DESCRIPTION

The UI uses the "choices" field under the POST action in OPTIONS for the /role_definitions endpoint in EDA to construct the resource type dropdown options. The POST action is not available to all users. The UI should use  the "choices" field under the GET action instead. These were not available in EDA until this PR: https://github.com/ansible/eda-server/pull/941 was merged.

This PR changes the  "choices" field from under the  POST to under the GET action.

Before:
![Screenshot from 2024-06-24 15-31-11](https://github.com/ansible/ansible-ui/assets/12769982/37464289-efaf-49f9-8c52-d932a294a1d1)

After:
![Screenshot from 2024-06-24 15-31-44](https://github.com/ansible/ansible-ui/assets/12769982/37c53165-f7e5-4cbd-8f91-e6f163787bef)
