### PR TITLE
[AAP-25805] Add support for OpenShift Virtualization inventory source.

### DIFF
--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.tsx
@@ -131,7 +131,7 @@ export function InventorySourceDetails(props: {
   const getSourceVarsHelpText = (source: string) => {
     let sourceType = '';
     if (source && source !== 'scm') {
-      const type: string[] = ansibleDocUrls[source].split(/[/,.]/);
+      const type: string[] = ansibleDocUrls[source]?.split(/[/,.]/) ?? [];
       sourceType = type[type.length - 2];
     }
 

--- a/frontend/awx/resources/sources/InventorySourceSubForm.tsx
+++ b/frontend/awx/resources/sources/InventorySourceSubForm.tsx
@@ -7,6 +7,7 @@ import { PageFormTextInput } from '../../../../framework/PageForm/Inputs/PageFor
 import { PageFormHidden } from '../../../../framework/PageForm/Utils/PageFormHidden';
 import { PageFormSection } from '../../../../framework/PageForm/Utils/PageFormSection';
 import { PageFormCredentialSelect } from '../../access/credentials/components/PageFormCredentialSelect';
+import { QueryParams } from '../../common/useAwxView';
 import { InventorySourceForm } from '../../interfaces/InventorySource';
 import { PageFormProjectSelect } from '../projects/components/PageFormProjectSelect';
 import { PageFormInventoryFileSelect } from './component/PageFormInventoryFileSelect';
@@ -30,7 +31,29 @@ export function InventorySourceSubForm() {
     'controller',
     'insights',
     'terraform',
+    'openshift_virtualization',
   ];
+
+  const handleQueryParams = (source: string): QueryParams => {
+    switch (source) {
+      case 'scm':
+        return {
+          credential_type__kind__in: 'cloud,kubernetes',
+        };
+      case 'ec2':
+        return {
+          credential_type__namespace: 'aws',
+        };
+      case 'openshift_virtualization':
+        return {
+          credential_type__namespace: 'kubernetes_bearer_token',
+        };
+      default:
+        return {
+          credential_type__namespace: source,
+        };
+    }
+  };
 
   return (
     <>
@@ -46,19 +69,7 @@ export function InventorySourceSubForm() {
               'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch", the selected credential(s) become the defaults that can be updated at run time.'
             )}
             isRequired={sourceTypes.slice(1).includes(source)}
-            queryParams={
-              source === 'scm'
-                ? {
-                    credential_type__kind__in: 'cloud,kubernetes',
-                  }
-                : source === 'ec2'
-                  ? {
-                      credential_type__namespace: 'aws',
-                    }
-                  : {
-                      credential_type__namespace: source,
-                    }
-            }
+            queryParams={handleQueryParams(source)}
           />
           <PageFormHidden watch="source" hidden={(type: string) => type !== 'scm'}>
             <PageFormProjectSelect<InventorySourceForm> name="source_project" isRequired />


### PR DESCRIPTION
Updates the Inventory Sources subform and details page to support OpenShift Virtualization inventory sources and fixes the Credential select dropdown to correctly query the related credential.

<img width="976" alt="Screenshot 2024-06-24 at 2 21 41 PM" src="https://github.com/ansible/ansible-ui/assets/2293210/8020c19c-4579-49c3-82bf-9a19e80e2835">
<img width="976" alt="Screenshot 2024-06-24 at 2 21 46 PM" src="https://github.com/ansible/ansible-ui/assets/2293210/b8972edc-36cd-46ca-a509-45643d4eb4ae">
