### PR TITLE
Empty state icons props fix

### DIFF
--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -125,8 +125,8 @@ export type PageTableProps<T extends object> = {
 
   emptyStateTitle: string;
   emptyStateDescription?: string | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  emptyStateIcon?: React.ComponentType<any>;
+  emptyStateIcon?: React.ComponentClass;
+  emptyStateNoDataIcon?: React.ComponentClass;
   emptyStateActions?: IPageAction<T>[];
   emptyStateButtonIcon?: React.ReactNode;
   emptyStateButtonText?: string | null;
@@ -277,6 +277,7 @@ export function PageTable<T extends object>(props: PageTableProps<T>) {
       <EmptyStateNoData
         title={props.emptyStateTitle}
         description={props.emptyStateDescription}
+        icon={props.emptyStateNoDataIcon}
         button={
           (props.emptyStateButtonClick && (
             <Button
@@ -574,7 +575,7 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
           <EmptyState isFullHeight>
             <EmptyStateHeader
               titleText={<>{translations.noResultsFound}</>}
-              icon={<EmptyStateIcon icon={SearchIcon} />}
+              icon={<EmptyStateIcon icon={props.emptyStateIcon ?? SearchIcon} />}
               headingLevel="h2"
             />
             <EmptyStateBody>{translations.noResultsMatchCriteria}</EmptyStateBody>

--- a/framework/components/EmptyStateNoData.tsx
+++ b/framework/components/EmptyStateNoData.tsx
@@ -1,5 +1,5 @@
 import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, ComponentClass } from 'react';
 import { EmptyStateCustom } from './EmptyStateCustom';
 
 export function EmptyStateNoData(props: {
@@ -7,11 +7,12 @@ export function EmptyStateNoData(props: {
   title: string;
   description: ReactNode;
   variant?: 'xs' | 'sm' | 'lg' | 'xl' | 'full' | undefined;
+  icon?: ComponentClass;
 }) {
-  const { button, description, title, variant } = props;
+  const { button, description, title, variant, icon: Icon } = props;
   return (
     <EmptyStateCustom
-      icon={button ? PlusCircleIcon : CubesIcon}
+      icon={Icon ?? (button ? PlusCircleIcon : CubesIcon)}
       title={title}
       description={description}
       button={button}


### PR DESCRIPTION
this fixes `emptyStateIcon` and adds `emptyStateNoDataIcon` to allow set custom icons for empty states.