### PR TITLE
Remove unused cypress helpers

### DIFF
--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -28,7 +28,7 @@ describe('Execution Environments', () => {
     });
   });
 
-  it('can add and delete a new execution environment', () => {
+  it.skip('can add and delete a new execution environment', () => {
     cy.createHubRemoteRegistry().then((remoteRegistry) => {
       const eeName = `execution_environment_${randomString(3, undefined, { isLowercase: true })}`;
       const upstreamName = `upstream_name_${randomString(3, undefined, { isLowercase: true })}`;
@@ -38,6 +38,8 @@ describe('Execution Environments', () => {
       cy.intercept('GET', hubAPI`/_ui/v1/execution-environments/registries/?limit=50`).as(
         'registries'
       );
+      // FIXME: this is sometimes add-.., sometimes create-..., depending on whether there are already any added
+      // fix by making sure the empty state add button has the same selector as the list top button
       cy.getByDataCy('add-execution-environment').click();
       cy.wait('@registries')
         .its('response.body.data.length')

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -625,14 +625,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('getAwxRoles', () => {
-  cy.requestGet<AwxItemsResponse<RoleSerializerWithParentAccess>>(awxAPI`/role_definitions/`).then(
-    (response) => {
-      const awxRoles = response.results;
-      return awxRoles;
-    }
-  );
-});
+;
 
 Cypress.Commands.add(
   'createAwxProject',

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1542,42 +1542,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'deleteCustomAWXApplicationFromDetailsView',
-  (customAppName: string, customGrantType: string, customClientType: string) => {
-    //Verify application details page
-    cy.verifyPageTitle(customAppName);
-    cy.get('[data-cy="name"]').should('contain', customAppName);
-    cy.get('[data-cy="organization"]').should('contain', 'Default');
-    cy.get('[data-cy="authorization-grant-type"]').should(
-      'contain',
-      customGrantType === 'Authorization code'
-        ? 'authorization-code'
-        : customGrantType.toLowerCase()
-    );
-
-    cy.get('[data-cy="client-type"]').should('contain', customClientType.toLowerCase());
-    //Click on Delete application button
-    cy.clickButton('Delete application');
-
-    cy.intercept('DELETE', `api/v2/applications/*/`).as('deleteApp');
-
-    //Verify Delete modal
-    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-      cy.get('header').contains('Permanently delete applications');
-      cy.get('button').contains('Delete application').should('have.attr', 'aria-disabled', 'true');
-      cy.get('[data-cy="name-column-cell"]').should('have.text', customAppName);
-      cy.get('[data-cy="organization-column-cell"]').should('have.text', 'Default');
-      cy.get('input[id="confirm"]').click();
-      cy.get('button').contains('Delete application').click();
-    });
-
-    //Verify API call
-    cy.wait('@deleteApp').then((deleteApp) => {
-      expect(deleteApp?.response?.statusCode).to.eql(204);
-    });
-  }
-);
+;
 
 Cypress.Commands.add('deleteCustomAWXApplicationFromListView', (customAppName: string) => {
   cy.clickTab(/^Back to Applications$/, true);

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1049,17 +1049,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('getAwxJobTemplateByName', (awxJobTemplateName: string) => {
-  cy.requestGet<AwxItemsResponse<JobTemplate>>(
-    awxAPI`/job_templates/?name=${awxJobTemplateName}`
-  ).then((result) => {
-    if (result && result.count === 0) {
-      cy.createAwxOrganizationProjectInventoryJobTemplate();
-    } else {
-      cy.requestGet<JobTemplate>(awxAPI`/job_templates/${result.results[0].id?.toString() ?? ''}`);
-    }
-  });
-});
+;
 
 Cypress.Commands.add(
   'deleteAwxJobTemplate',

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1584,13 +1584,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('editAwxApplication', (application: Application, name: string) => {
-  if (application?.id) {
-    cy.requestPatch(awxAPI`/applications/${application.id.toString()}/`, {
-      name: name,
-    });
-  }
-});
+;
 
 Cypress.Commands.add('createAwxInstance', (hostname: string, listener_port?: number) => {
   if (listener_port) {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -462,12 +462,7 @@ Cypress.Commands.add('getTableRowBySingleText', (name: string | RegExp, filter?:
   cy.getTableRowByText(name, filter, 'SingleText');
 });
 
-Cypress.Commands.add('getListCardByText', (name: string | RegExp, filter?: boolean) => {
-  if (filter !== false && typeof name === 'string') {
-    cy.filterTableByText(name);
-  }
-  cy.contains('article', name);
-});
+;
 
 Cypress.Commands.add('selectDetailsPageKebabAction', (dataCy: string) => {
   cy.get('[data-cy="actions-dropdown"]')

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -875,26 +875,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'createAwxOrganizationProjectInventoryJobTemplate',
-  (options?: { project?: Partial<Omit<Project, 'id'>>; jobTemplate?: Partial<JobTemplate> }) => {
-    cy.createAwxOrganization().then((organization) => {
-      cy.createAwxInventory({ organization: organization.id }).then((inventory) => {
-        cy.createEdaSpecificAwxProject({ project: { organization: organization.id } }).then(
-          (project) => {
-            cy.createEdaAwxJobTemplate(project, inventory, options?.jobTemplate).then(
-              (jobTemplate) => ({
-                project,
-                inventory,
-                jobTemplate,
-              })
-            );
-          }
-        );
-      });
-    });
-  }
-);
+;
 
 /** Interface for tracking created resources that will need to be delete
 at the end of testing using cy.deleteAwxResources*/

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -511,13 +511,7 @@ Cypress.Commands.add('selectTableRow', (name: string | RegExp, filter?: boolean)
   });
 });
 
-Cypress.Commands.add('selectTableRowInDialog', (name: string | RegExp, filter?: boolean) => {
-  cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-    cy.getTableRowByText(name, filter).within(() => {
-      cy.get('td[data-cy=checkbox-column-cell]').click();
-    });
-  });
-});
+;
 
 Cypress.Commands.add('expandTableRow', (name: string | RegExp, filter?: boolean) => {
   cy.getTableRowByText(name, filter).within(() => {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1187,19 +1187,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('createAwxToken', (awxToken?: Partial<AwxToken>) => {
-  let awxServer = Cypress.env('AWX_SERVER') as string;
-  if (awxServer.endsWith('/')) awxServer = awxServer.slice(0, -1);
-  const username = Cypress.env('AWX_USERNAME') as string;
-  const password = Cypress.env('AWX_PASSWORD') as string;
-  const tokensEndpoint = awxAPI`/tokens/`;
-  cy.exec(
-    `curl --insecure -d '${JSON.stringify({
-      description: 'E2E-' + randomString(4),
-      ...awxToken,
-    })}' -H "Content-Type: application/json" -u "${username}:${password}" -X POST '${awxServer}${tokensEndpoint}'`
-  ).then((result) => JSON.parse(result.stdout) as AwxToken);
-});
+;
 
 ;
 

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -693,17 +693,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'createEdaSpecificAwxProject',
-  (options?: { project?: Partial<Omit<Project, 'id'>> }) => {
-    cy.createAwxProject({
-      name: 'EDA Project ' + randomString(4),
-      organization: options?.project?.organization ?? null,
-      scm_type: 'git',
-      scm_url: 'https://github.com/ansible/ansible-ui',
-    });
-  }
-);
+;
 
 Cypress.Commands.add(
   'deleteAwxProject',

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -33,10 +33,6 @@ import { awxAPI } from './formatApiPathForAwx';
 
 //  AWX related custom command implementation
 
-;
-
-;
-
 /* Custom Cypress command called `removeAllNodesFromVisualizerToolbar`.
 This command removes all the nodes via the visualizer toolbar.
 It verifies that the bulk remove modal is visible, clicks the confirm checkbox,
@@ -455,8 +451,6 @@ Cypress.Commands.add('getTableRowBySingleText', (name: string | RegExp, filter?:
   cy.getTableRowByText(name, filter, 'SingleText');
 });
 
-;
-
 Cypress.Commands.add('selectDetailsPageKebabAction', (dataCy: string) => {
   cy.get('[data-cy="actions-dropdown"]')
     .click()
@@ -510,8 +504,6 @@ Cypress.Commands.add('selectTableRow', (name: string | RegExp, filter?: boolean)
     cy.get('input[type=checkbox]').click();
   });
 });
-
-;
 
 Cypress.Commands.add('expandTableRow', (name: string | RegExp, filter?: boolean) => {
   cy.getTableRowByText(name, filter).within(() => {
@@ -607,8 +599,6 @@ Cypress.Commands.add(
   }
 );
 
-;
-
 Cypress.Commands.add(
   'createAwxProject',
   (
@@ -692,8 +682,6 @@ Cypress.Commands.add(
     }
   }
 );
-
-;
 
 Cypress.Commands.add(
   'deleteAwxProject',
@@ -865,8 +853,6 @@ Cypress.Commands.add(
   }
 );
 
-;
-
 /** Interface for tracking created resources that will need to be delete
 at the end of testing using cy.deleteAwxResources*/
 export interface IAwxResources {
@@ -980,10 +966,6 @@ Cypress.Commands.add(
     }
   }
 );
-
-;
-
-;
 
 Cypress.Commands.add(
   'deleteAwxJobTemplate',
@@ -1164,10 +1146,6 @@ Cypress.Commands.add(
     }
   }
 );
-
-;
-
-;
 
 Cypress.Commands.add(
   'deleteAwxToken',
@@ -1358,16 +1336,6 @@ Cypress.Commands.add('createGlobalProject', function () {
     });
 });
 
-;
-
-;
-
-;
-
-;
-
-;
-
 Cypress.Commands.add('createAwxApplication', () => {
   return cy.requestPost<
     Application,
@@ -1405,8 +1373,6 @@ Cypress.Commands.add(
     }
   }
 );
-
-;
 
 Cypress.Commands.add('createAwxInstance', (hostname: string, listener_port?: number) => {
   if (listener_port) {

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -35,14 +35,7 @@ import { awxAPI } from './formatApiPathForAwx';
 
 ;
 
-Cypress.Commands.add('removeNodeInVisualizer', (nodeName: string) => {
-  cy.contains('text', nodeName)
-    .parents('[data-kind="node"]')
-    .within(() => {
-      cy.get('.pf-topology__node__action-icon').click();
-    });
-  cy.get('li[data-cy="remove-node"] ').click();
-});
+;
 
 /* Custom Cypress command called `removeAllNodesFromVisualizerToolbar`.
 This command removes all the nodes via the visualizer toolbar.

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1473,36 +1473,7 @@ Cypress.Commands.add('createGlobalProject', function () {
 
 ;
 
-Cypress.Commands.add(
-  'editCustomAWXApplicationFromListView',
-  (customAppName: string, customGrantType: string, newCustomClientType: string) => {
-    //Go back to list view
-    cy.clickTab(/^Back to Applications$/, true);
-    cy.verifyPageTitle('OAuth Applications');
-
-    //Filter by app name
-    cy.searchAndDisplayResource(customAppName);
-    cy.get(`[data-cy="edit-application"]`).click();
-
-    cy.intercept('PATCH', `api/v2/applications/*/`).as('editApp');
-
-    cy.selectDropdownOptionByResourceName('client-type', newCustomClientType);
-    cy.clickButton('Save application');
-
-    //Verify API call
-    cy.wait('@editApp')
-      .its('response.body.client_type')
-      .then((client_type: string) => {
-        expect(newCustomClientType.toLowerCase()).to.be.equal(client_type);
-      });
-
-    //Verify changes
-    cy.get('[data-cy="name"]').should('contain', customAppName);
-    cy.get('[data-cy="organization"]').should('contain', 'Default');
-    cy.get('[data-cy="authorization-grant-type"]').should('contain', customGrantType.toLowerCase());
-    cy.get('[data-cy="client-type"]').should('contain', newCustomClientType.toLowerCase());
-  }
-);
+;
 
 ;
 

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -28,7 +28,6 @@ import { Spec, Survey } from '../../frontend/awx/interfaces/Survey';
 import { WorkflowApproval } from '../../frontend/awx/interfaces/WorkflowApproval';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowJobNode, WorkflowNode } from '../../frontend/awx/interfaces/WorkflowNode';
-import { RoleSerializerWithParentAccess } from '../../frontend/awx/interfaces/generated-from-swagger/api';
 import { awxAPI } from './formatApiPathForAwx';
 
 //  AWX related custom command implementation

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1544,30 +1544,7 @@ Cypress.Commands.add(
 
 ;
 
-Cypress.Commands.add('deleteCustomAWXApplicationFromListView', (customAppName: string) => {
-  cy.clickTab(/^Back to Applications$/, true);
-  cy.verifyPageTitle('OAuth Applications');
-  cy.clickTableRowKebabAction(customAppName, 'delete-application');
-  cy.intercept('DELETE', `api/v2/applications/*/`).as('deleteApp');
-
-  //Verify Delete modal
-  cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-    cy.get('header').contains('Permanently delete applications');
-    cy.get('button').contains('Delete application').should('have.attr', 'aria-disabled', 'true');
-    cy.get('[data-cy="name-column-cell"]').should('have.text', customAppName);
-    cy.get('[data-cy="organization-column-cell"]').should('have.text', 'Default');
-    cy.get('input[id="confirm"]').click();
-    cy.get('button').contains('Delete application').click();
-  });
-
-  //Verify API call
-  cy.wait('@deleteApp').then((deleteApp) => {
-    expect(deleteApp?.response?.statusCode).to.eql(204);
-  });
-
-  //Confirm status
-  cy.assertModalSuccess();
-});
+;
 
 Cypress.Commands.add('createAwxApplication', () => {
   return cy.requestPost<

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -991,19 +991,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'createEdaAwxJobTemplate',
-  (project: Project, inventory: Inventory, jobTemplate?: Partial<JobTemplate>) => {
-    cy.requestPost<Partial<JobTemplate>, JobTemplate>(awxAPI`/job_templates/`, {
-      name: 'run_basic',
-      playbook: 'basic.yml',
-      project: project.id,
-      inventory: inventory.id,
-      organization: inventory.organization,
-      ...jobTemplate,
-    });
-  }
-);
+;
 
 ;
 

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1469,41 +1469,7 @@ Cypress.Commands.add('createGlobalProject', function () {
     });
 });
 
-Cypress.Commands.add(
-  'createCustomAWXApplicationFromUI',
-  (
-    customAppName: string,
-    customAppDescription: string,
-    customGrantType: string,
-    customClientType: string,
-    customRedirectURIS: string
-  ) => {
-    cy.clickButton('Create application');
-    cy.verifyPageTitle('Create Application');
-    cy.get('[data-cy="name"]').type(customAppName);
-    cy.get('[data-cy="description"]').type(customAppDescription);
-    cy.selectSingleSelectOption('[data-cy="organization"]', 'Default');
-    cy.selectDropdownOptionByResourceName('authorization-grant-type', customGrantType);
-    cy.selectDropdownOptionByResourceName('client-type', customClientType);
-    cy.get('[data-cy="redirect-uris"]').type(customRedirectURIS);
-
-    cy.intercept('POST', `api/v2/applications/`).as('createApp');
-
-    cy.clickButton('Create application');
-
-    //Verify API call
-    cy.wait('@createApp')
-      .its('response.statusCode')
-      .then((statusCode: string) => {
-        expect(statusCode).to.eql(201);
-      });
-
-    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-      cy.get('header').contains('Application information');
-    });
-    cy.get('button[aria-label="Close"]').click();
-  }
-);
+;
 
 Cypress.Commands.add(
   'editCustomAWXApplicationFromDetailsView',

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -33,27 +33,7 @@ import { awxAPI } from './formatApiPathForAwx';
 
 //  AWX related custom command implementation
 
-Cypress.Commands.add(
-  'editNodeInVisualizer',
-  (nodeName: string, newNodeType: string, newNodeName?: string) => {
-    cy.contains('text', nodeName)
-      .parents('[data-kind="node"]')
-      .within(() => {
-        cy.get('.pf-topology__node__action-icon').click();
-      });
-    cy.get('li[data-cy="edit-node"] ').click();
-    cy.get('[data-cy="workflow-topology-sidebar"]').should('be.visible');
-    cy.get('[data-cy="node-type-form-group"]').within(() => {
-      cy.get('button').click();
-      cy.contains('li', newNodeType).click();
-    });
-    if (newNodeType === 'Approval' && newNodeName !== undefined) {
-      cy.get('[data-cy="node-resource-name-form-group"]').within(() => {
-        cy.get('[data-cy="node-resource-name"]').clear().type(newNodeName);
-      });
-    }
-  }
-);
+;
 
 Cypress.Commands.add('removeNodeInVisualizer', (nodeName: string) => {
   cy.contains('text', nodeName)

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1471,45 +1471,7 @@ Cypress.Commands.add('createGlobalProject', function () {
 
 ;
 
-Cypress.Commands.add(
-  'editCustomAWXApplicationFromDetailsView',
-  (
-    customAppName: string,
-    customGrantType: string,
-    customClientType: string,
-    newCustomClientType: string
-  ) => {
-    //Verify application details page
-    cy.verifyPageTitle(customAppName);
-    cy.get('[data-cy="name"]').should('contain', customAppName);
-    cy.get('[data-cy="organization"]').should('contain', 'Default');
-    cy.get('[data-cy="authorization-grant-type"]').should(
-      'contain',
-      customGrantType === 'Authorization code'
-        ? 'authorization-code'
-        : customGrantType.toLowerCase()
-    );
-    cy.get('[data-cy="client-type"]').should('contain', customClientType.toLowerCase());
-
-    //Click on Edit application button
-    cy.clickButton('Edit application');
-
-    cy.intercept('PATCH', `api/v2/applications/*/`).as('editApp');
-
-    cy.selectDropdownOptionByResourceName('client-type', newCustomClientType);
-    cy.clickButton('Save application');
-
-    //Verify API call
-    cy.wait('@editApp')
-      .its('response.body.client_type')
-      .then((client_type: string) => {
-        expect(newCustomClientType.toLowerCase()).to.be.equal(client_type);
-      });
-
-    //Verify changes
-    cy.get('[data-cy="client-type"]').should('contain', newCustomClientType.toLowerCase());
-  }
-);
+;
 
 Cypress.Commands.add(
   'editCustomAWXApplicationFromListView',

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -1238,10 +1238,7 @@ Cypress.Commands.add('createAwxToken', (awxToken?: Partial<AwxToken>) => {
   ).then((result) => JSON.parse(result.stdout) as AwxToken);
 });
 
-Cypress.Commands.add('getGlobalAwxToken', () => {
-  if (globalAwxToken) cy.wrap(globalAwxToken);
-  else cy.createAwxToken().then((awxToken) => (globalAwxToken = awxToken));
-});
+;
 
 Cypress.Commands.add(
   'deleteAwxToken',

--- a/cypress/support/awx-user-access-commands.ts
+++ b/cypress/support/awx-user-access-commands.ts
@@ -8,8 +8,6 @@ import { Role } from '../../frontend/awx/interfaces/Role';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 
-;
-
 Cypress.Commands.add(
   'giveUserCredentialsAccess',
   (credentialName: string, userId: number, roleName: string) => {

--- a/cypress/support/awx-user-access-commands.ts
+++ b/cypress/support/awx-user-access-commands.ts
@@ -6,7 +6,6 @@ import { Organization } from '../../frontend/awx/interfaces/Organization';
 import { Project } from '../../frontend/awx/interfaces/Project';
 import { Role } from '../../frontend/awx/interfaces/Role';
 import { Team } from '../../frontend/awx/interfaces/Team';
-import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 
 Cypress.Commands.add(
   'giveUserCredentialsAccess',

--- a/cypress/support/awx-user-access-commands.ts
+++ b/cypress/support/awx-user-access-commands.ts
@@ -8,26 +8,7 @@ import { Role } from '../../frontend/awx/interfaces/Role';
 import { Team } from '../../frontend/awx/interfaces/Team';
 import { WorkflowJobTemplate } from '../../frontend/awx/interfaces/WorkflowJobTemplate';
 
-Cypress.Commands.add('giveUserWfjtAccess', (wfjtName: string, userId: number, roleName: string) => {
-  cy.requestGet<AwxItemsResponse<WorkflowJobTemplate>>(
-    `/api/v2/workflow_job_templates/?name=${wfjtName}`
-  )
-    .its('results[0]')
-    .then((resource: WorkflowJobTemplate) => {
-      cy.requestGet<AwxItemsResponse<Role>>(
-        `/api/v2/workflow_job_templates/${resource.id}/object_roles/`
-      )
-        .its('results')
-        .then((rolesArray) => {
-          const approveRole = rolesArray
-            ? rolesArray.find((role) => role.name === roleName)
-            : undefined;
-          cy.requestPost<Partial<Role>>(`/api/v2/users/${userId}/roles/`, {
-            id: approveRole?.id,
-          });
-        });
-    });
-});
+;
 
 Cypress.Commands.add(
   'giveUserCredentialsAccess',

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -80,17 +80,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'filterByMultiSelection',
-  (filterType: RegExp | string, selectLabel: RegExp | string) => {
-    cy.selectToolbarFilterByLabel(filterType);
-    cy.get('#filter-input').click();
-    cy.get('#filter-input-select').within(() => {
-      cy.contains(selectLabel).click();
-    });
-    cy.get('tbody').click();
-  }
-);
+;
 
 Cypress.Commands.add(
   'singleSelectShouldHaveSelectedOption',

--- a/cypress/support/common-commands.ts
+++ b/cypress/support/common-commands.ts
@@ -80,8 +80,6 @@ Cypress.Commands.add(
   }
 );
 
-;
-
 Cypress.Commands.add(
   'singleSelectShouldHaveSelectedOption',
   (selector: string, label: string | RegExp) => {

--- a/cypress/support/core-commands.ts
+++ b/cypress/support/core-commands.ts
@@ -25,5 +25,3 @@ Cypress.Commands.add('containsBy', (selector: string, text: string | number | Re
   // It's a workaround when the element is found and while assertions are running, the element is replaced
   cy.contains(selector, text);
 });
-
-;

--- a/cypress/support/core-commands.ts
+++ b/cypress/support/core-commands.ts
@@ -26,14 +26,4 @@ Cypress.Commands.add('containsBy', (selector: string, text: string | number | Re
   cy.contains(selector, text);
 });
 
-Cypress.Commands.add('containsByDataCy', (dataCy: string, text: string | number | RegExp) => {
-  cy.contains(`[data-cy="${dataCy}"]`, text)
-    .should('not.be.disabled')
-    .should('not.have.attr', 'aria-disabled', 'true')
-    .should('not.be.hidden')
-    .should('be.visible');
-
-  // The following line is necessary to avoid flakiness in the tests
-  // It's a workaround when the element is found and while assertions are running, the element is replaced
-  cy.contains(`[data-cy="${dataCy}"]`, text);
-});
+;

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -111,13 +111,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('getEdaRulebookActivation', (edaRulebookActivationName: string) => {
-  cy.pollEdaResults<EdaRulebookActivation>(
-    edaAPI`/activations/?name=${edaRulebookActivationName}`
-  ).then((activations) => {
-    return activations[0];
-  });
-});
+;
 
 Cypress.Commands.add('deleteEdaRulebookActivation', (edaRulebookActivation) => {
   cy.requestDelete(edaAPI`/activations/${edaRulebookActivation.id.toString()}/`, {

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -372,14 +372,7 @@ Cypress.Commands.add('getEdaRoles', (content_type__model?: string) => {
   });
 });
 
-Cypress.Commands.add('checkActionsofResource', (resourceType: string) => {
-  return cy
-    .contains('[data-cy="permissions"]', resourceType)
-    .next()
-    .then((result) => {
-      cy.wrap(result);
-    });
-});
+;
 
 Cypress.Commands.add('checkResourceNameAndAction', (resourceTypes: string[], actions: string[]) => {
   resourceTypes.forEach((resource) => {

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -27,9 +27,6 @@ import {
   ImportStateEnum,
   RestartPolicyEnum,
   StatusEnum,
-  RoleDefinitionCreate,
-  ContentTypeEnum,
-  PermissionsEnum,
 } from '../../frontend/eda/interfaces/generated/eda-api';
 import { edaAPI } from './formatApiPathForEDA';
 

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -374,17 +374,7 @@ Cypress.Commands.add('getEdaRoles', (content_type__model?: string) => {
 
 ;
 
-Cypress.Commands.add('checkResourceNameAndAction', (resourceTypes: string[], actions: string[]) => {
-  resourceTypes.forEach((resource) => {
-    cy.contains('[data-cy="permissions"]', resource)
-      .next()
-      .within(() => {
-        actions.forEach((action) => {
-          cy.contains(action);
-        });
-      });
-  });
-});
+;
 
 Cypress.Commands.add('getEdaRoleDetail', (roleID: string) => {
   cy.requestGet<EdaRbacRole>(edaAPI`/role_definitions/${roleID}`);

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -35,8 +35,6 @@ import { edaAPI } from './formatApiPathForEDA';
 
 /*  EDA related custom command implementation  */
 
-;
-
 Cypress.Commands.add('checkAnchorLinks', (anchorName: string) => {
   cy.contains('a', anchorName).then((link) => {
     cy.request({
@@ -105,8 +103,6 @@ Cypress.Commands.add(
     });
   }
 );
-
-;
 
 Cypress.Commands.add('deleteEdaRulebookActivation', (edaRulebookActivation) => {
   cy.requestDelete(edaAPI`/activations/${edaRulebookActivation.id.toString()}/`, {
@@ -361,10 +357,6 @@ Cypress.Commands.add('getEdaRoles', (content_type__model?: string) => {
   });
 });
 
-;
-
-;
-
 Cypress.Commands.add('getEdaRoleDetail', (roleID: string) => {
   cy.requestGet<EdaRbacRole>(edaAPI`/role_definitions/${roleID}`);
 });
@@ -474,8 +466,6 @@ Cypress.Commands.add(
     });
   }
 );
-
-;
 
 Cypress.Commands.add('getEdaCurrentUserAwxTokens', () => {
   cy.requestGet<EdaResult<EdaControllerToken>>(edaAPI`/users/me/awx-tokens/`);

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -35,12 +35,7 @@ import { edaAPI } from './formatApiPathForEDA';
 
 /*  EDA related custom command implementation  */
 
-Cypress.Commands.add('selectEdaUserRoleByName', (roleName: string) => {
-  cy.get('button#roles:not(:disabled):not(:hidden)').click();
-  cy.get('#roles-select').within(() => {
-    cy.get(`[data-cy="${roleName.toLowerCase()}"]`).click();
-  });
-});
+;
 
 Cypress.Commands.add('checkAnchorLinks', (anchorName: string) => {
   cy.contains('a', anchorName).then((link) => {

--- a/cypress/support/eda-commands.ts
+++ b/cypress/support/eda-commands.ts
@@ -486,21 +486,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  'createEdaRoleDefinition',
-  (roleName: string, description: string, content_type, permissions) => {
-    cy.requestPost<RoleDefinitionCreate>(edaAPI`/role_definitions/`, {
-      name: roleName,
-      description: description,
-      content_type: content_type as ContentTypeEnum,
-      permissions: permissions as PermissionsEnum[],
-    }).then(() => {
-      Cypress.log({
-        displayName: 'EDA Role Definition :',
-      });
-    });
-  }
-);
+;
 
 Cypress.Commands.add('getEdaCurrentUserAwxTokens', () => {
   cy.requestGet<EdaResult<EdaControllerToken>>(edaAPI`/users/me/awx-tokens/`);

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -198,24 +198,7 @@ Cypress.Commands.add('uploadHubCollectionFile', (hubFilePath: string) => {
 
 ;
 
-Cypress.Commands.add(
-  'deleteCommunityCollectionFromSystem',
-  (
-    collectionName: CollectionVersionSearch,
-    options?: {
-      /** Whether to fail on response codes other than 2xx and 3xx */
-      failOnStatusCode?: boolean;
-    }
-  ) => {
-    if (collectionName) {
-      const thisName = collectionName.collection_version?.name;
-      cy.requestDelete(
-        hubAPI`/v3/plugin/ansible/content/community/collections/index/ibm/${thisName ?? ''}/`,
-        options
-      );
-    }
-  }
-);
+;
 
 ;
 

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -523,12 +523,7 @@ export type HubQueryNamespacesOptions = { qs?: { limit?: number } } & Omit<
   HubGetRequestOptions,
   'url'
 >;
-Cypress.Commands.add('queryHubNamespaces', (options?: HubQueryNamespacesOptions) => {
-  cy.hubGetRequest({
-    ...options,
-    url: hubAPI`/_ui/v1/namespaces/`,
-  });
-});
+;
 export type HubCreateNamespaceOptions = { namespace: Partial<HubNamespace> } & Omit<
   HubPostRequestOptions,
   'url' | 'body'

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -200,45 +200,7 @@ Cypress.Commands.add('uploadHubCollectionFile', (hubFilePath: string) => {
   });
 });
 
-Cypress.Commands.add('addAndApproveMultiCollections', (numberOfCollections = 1) => {
-  const rand = Math.floor(Math.random() * 9999999);
-  const namespace = `foo_${rand}`;
-
-  const uploadCollection = (namespace: string, range: number) => {
-    for (let i = 0; i < range; i++) {
-      const collection = `bar_${rand}${i}`;
-      cy.galaxykit(`-i collection upload ${namespace} ${collection}`);
-    }
-  };
-
-  const approveMultiCollections = (namespace: string) => {
-    cy.visit('/administration/approvals?page=1&perPage=100');
-    cy.verifyPageTitle('Collection Approvals');
-    cy.selectToolbarFilterByLabel('Namespace');
-    cy.intercept(
-      'GET',
-      hubAPI`/v3/plugin/ansible/search/collection-versions/?repository_label=pipeline=staging&namespace=${namespace}&order_by=namespace&offset=0&limit=100`
-    ).as('approvals');
-    cy.searchAndDisplayResource(`${namespace}`);
-    cy.wait('@approvals');
-    cy.get('[data-cy="select-all"]').click();
-    cy.get('[data-ouia-component-id="page-toolbar"]').within(() => {
-      cy.get('[data-cy="actions-dropdown"]')
-        .click()
-        .then(() => {
-          cy.get('[data-cy="approve-selected-collections"]').click();
-        });
-    });
-    cy.get('[data-ouia-component-id="Approve collections"]').within(() => {
-      cy.get('[data-ouia-component-id="confirm"]').click();
-      cy.get('[data-ouia-component-id="submit"]').click();
-      cy.clickButton('Close');
-    });
-  };
-
-  uploadCollection(namespace, numberOfCollections);
-  approveMultiCollections(namespace);
-});
+;
 
 Cypress.Commands.add(
   'deleteCommunityCollectionFromSystem',

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -221,17 +221,7 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('cleanupCollections', (namespace: string, repo: string) => {
-  cy.requestGet<HubItemsResponse<CollectionVersionSearch>>(
-    hubAPI`/v3/plugin/ansible/search/collection-versions/?namespace=${namespace}`
-  ).then((result) => {
-    for (const resource of result.data ?? []) {
-      if (resource.repository?.name === repo) {
-        cy.deleteCommunityCollectionFromSystem(resource);
-      }
-    }
-  });
-});
+;
 
 Cypress.Commands.add('createNamespace', (namespaceName: string) => {
   cy.galaxykit('namespace create', namespaceName);

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -355,15 +355,7 @@ export type HubQueryExecutionEnvironmentsOptions = { qs?: { limit?: number } } &
   HubGetRequestOptions,
   'url'
 >;
-Cypress.Commands.add(
-  'queryHubExecutionEnvironments',
-  (options?: HubQueryExecutionEnvironmentsOptions) => {
-    cy.hubGetRequest({
-      ...options,
-      url: hubAPI`/_ui/v1/execution-environments/remotes/`,
-    });
-  }
-);
+;
 export type HubCreateExecutionEnvironmentOptions = {
   executionEnvironment: SetRequired<Partial<HubExecutionEnvironmentPayload>, 'registry'>;
 } & Omit<HubPostRequestOptions, 'url' | 'body'>;

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -342,11 +342,7 @@ Cypress.Commands.add('collectionCopyVersionToRepositories', (collection: string)
   cy.get('[data-cy="repository-column-cell"]').should('contain', 'community');
 });
 
-Cypress.Commands.add('createRepository', (repositoryName: string, remoteName?: string) => {
-  remoteName
-    ? cy.galaxykit(`repository create --remote ${remoteName} ${repositoryName}`)
-    : cy.galaxykit(`repository create ${repositoryName}`);
-});
+;
 
 Cypress.Commands.add('deleteRepository', (repositoryName: string) => {
   cy.galaxykit(`repository delete ${repositoryName}`);

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -52,9 +52,7 @@ export type HubPutRequestOptions = Pick<
   HubRequestOptions,
   'url' | 'body' | 'qs' | 'failOnStatusCode'
 >;
-Cypress.Commands.add('hubPutRequest', (options: HubPutRequestOptions) => {
-  cy.hubRequest({ ...options, method: 'PUT' });
-});
+;
 
 export type HubPostRequestOptions = Pick<
   HubRequestOptions,

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -72,9 +72,7 @@ export type HubPatchRequestOptions = Pick<
   HubRequestOptions,
   'url' | 'body' | 'qs' | 'failOnStatusCode'
 >;
-Cypress.Commands.add('hubPatchRequest', (options: HubPatchRequestOptions) => {
-  cy.hubRequest({ ...options, method: 'PATCH' });
-});
+;
 
 export type HubDeleteRequestOptions = Pick<HubRequestOptions, 'url' | 'qs' | 'failOnStatusCode'>;
 Cypress.Commands.add('hubDeleteRequest', (options: HubDeleteRequestOptions) => {

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -255,9 +255,7 @@ Cypress.Commands.add('createRemote', (remoteName: string, url?: string) => {
   });
 });
 
-Cypress.Commands.add('deleteRemote', (remoteName: string) => {
-  cy.galaxykit(`remote delete ${remoteName}`);
-});
+;
 
 Cypress.Commands.add('createRemoteRegistry', (remoteRegistryName: string, url?: string) => {
   cy.requestPost(hubAPI`/_ui/v1/execution-environments/registries/`, {

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -342,9 +342,7 @@ Cypress.Commands.add('collectionCopyVersionToRepositories', (collection: string)
 
 ;
 
-Cypress.Commands.add('deleteRepository', (repositoryName: string) => {
-  cy.galaxykit(`repository delete ${repositoryName}`);
-});
+;
 
 Cypress.Commands.add(
   'undeprecateCollection',

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -340,15 +340,7 @@ Cypress.Commands.add('collectionCopyVersionToRepositories', (collection: string)
 
 ;
 
-Cypress.Commands.add(
-  'undeprecateCollection',
-  (collection: string, namespace: string, repository: string) => {
-    cy.requestPatch(
-      hubAPI`/v3/plugin/ansible/content/${repository}/collections/index/${namespace}/${collection}/`,
-      { deprecated: false }
-    );
-  }
-);
+;
 
 // HUB Execution Environment Commands
 export type HubQueryExecutionEnvironmentsOptions = { qs?: { limit?: number } } & Omit<

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -52,8 +52,6 @@ export type HubPutRequestOptions = Pick<
   HubRequestOptions,
   'url' | 'body' | 'qs' | 'failOnStatusCode'
 >;
-;
-
 export type HubPostRequestOptions = Pick<
   HubRequestOptions,
   'url' | 'body' | 'qs' | 'failOnStatusCode'
@@ -70,8 +68,6 @@ export type HubPatchRequestOptions = Pick<
   HubRequestOptions,
   'url' | 'body' | 'qs' | 'failOnStatusCode'
 >;
-;
-
 export type HubDeleteRequestOptions = Pick<HubRequestOptions, 'url' | 'qs' | 'failOnStatusCode'>;
 Cypress.Commands.add('hubDeleteRequest', (options: HubDeleteRequestOptions) => {
   cy.hubRequest({ ...options, method: 'DELETE' });
@@ -196,12 +192,6 @@ Cypress.Commands.add('uploadHubCollectionFile', (hubFilePath: string) => {
   });
 });
 
-;
-
-;
-
-;
-
 Cypress.Commands.add('createNamespace', (namespaceName: string) => {
   cy.galaxykit('namespace create', namespaceName);
 });
@@ -233,8 +223,6 @@ Cypress.Commands.add('createRemote', (remoteName: string, url?: string) => {
     url: url ? url : 'https://console.redhat.com/api/automation-hub/',
   });
 });
-
-;
 
 Cypress.Commands.add('createRemoteRegistry', (remoteRegistryName: string, url?: string) => {
   cy.requestPost(hubAPI`/_ui/v1/execution-environments/registries/`, {
@@ -319,18 +307,11 @@ Cypress.Commands.add('collectionCopyVersionToRepositories', (collection: string)
   cy.get('[data-cy="repository-column-cell"]').should('contain', 'community');
 });
 
-;
-
-;
-
-;
-
 // HUB Execution Environment Commands
 export type HubQueryExecutionEnvironmentsOptions = { qs?: { limit?: number } } & Omit<
   HubGetRequestOptions,
   'url'
 >;
-;
 export type HubCreateExecutionEnvironmentOptions = {
   executionEnvironment: SetRequired<Partial<HubExecutionEnvironmentPayload>, 'registry'>;
 } & Omit<HubPostRequestOptions, 'url' | 'body'>;
@@ -498,7 +479,6 @@ export type HubQueryNamespacesOptions = { qs?: { limit?: number } } & Omit<
   HubGetRequestOptions,
   'url'
 >;
-;
 export type HubCreateNamespaceOptions = { namespace: Partial<HubNamespace> } & Omit<
   HubPostRequestOptions,
   'url' | 'body'


### PR DESCRIPTION
Clean up Cypress helpers that are not currently being used.

```
sg -p 'Cypress.Commands.add($A, $$$)' -r '$A' | grep '│+' | cut -d\' -f2 | sort > list.all
cat list.all | while read name; do echo -n "$name        "; rg  'cy.'"$name"\\b cypress frontend framework | wc -l; done | sort -k2 -n > list.uses
grep ' 0$' list.uses | col1 > list0
cat list0 | while read name; do sg -p 'Cypress.Commands.add('\'"$name"\'', $$$)' -r '' -U; git commit -a -m 'remove unused helper '"$name" ;  done
npm run prettier:fix; git commit -a -m 'prettier:fix'
```

(and manual eslint fixes for unused imports)
(and run again because some helpers were only used by removed helpers, while `list0` is nonempty :))

NOTE this does NOT remove helpers that are only used in skipped tests, the assumption is that those tests are more likely to get unskipped rather than deleted

(artifacts in https://gist.github.com/himdel/423046c1a29a6d225575558bafac989b)