### PR TITLE
 Refactor link creation in jobUtils

### DIFF
--- a/frontend/awx/common/JobColumns.tsx
+++ b/frontend/awx/common/JobColumns.tsx
@@ -213,8 +213,9 @@ export function useJobScheduleColumn<T extends UnifiedJob>(
     () => ({
       header: t('Schedule'),
       cell: (job: UnifiedJob) => {
+        const scheduleUrl = getScheduleUrl(job);
         return (
-          <Link to={job.summary_fields?.schedule && getScheduleUrl(job) ? getScheduleUrl(job) : ''}>
+          <Link to={job.summary_fields?.schedule && scheduleUrl ? scheduleUrl : ''}>
             {job.summary_fields?.schedule?.name}
           </Link>
         );

--- a/frontend/awx/common/JobColumns.tsx
+++ b/frontend/awx/common/JobColumns.tsx
@@ -18,7 +18,7 @@ import { useOptions } from '../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../interfaces/OptionsResponse';
 import { UnifiedJob } from '../interfaces/UnifiedJob';
 import { AwxRoute } from '../main/AwxRoutes';
-import { getLaunchedByDetails, getScheduleUrl, isJobRunning } from '../views/jobs/jobUtils';
+import { useGetLaunchedByDetails, useGetScheduleUrl, isJobRunning } from '../views/jobs/jobUtils';
 import { awxAPI } from './api/awx-utils';
 
 export function useJobIdColumn<T extends UnifiedJob>() {
@@ -208,15 +208,17 @@ export function useJobScheduleColumn<T extends UnifiedJob>(
   defaultSort?: 'asc' | 'desc'
 ) {
   const { t } = useTranslation();
-
+  const getScheduleUrl = useGetScheduleUrl();
   const column = useMemo<ITableColumn<T>>(
     () => ({
       header: t('Schedule'),
-      cell: (job: UnifiedJob) => (
-        <Link to={job.summary_fields?.schedule ? getScheduleUrl(job) ?? '' : ''}>
-          {job.summary_fields?.schedule?.name}
-        </Link>
-      ),
+      cell: (job: UnifiedJob) => {
+        return (
+          <Link to={job.summary_fields?.schedule && getScheduleUrl(job) ? getScheduleUrl(job) : ''}>
+            {job.summary_fields?.schedule?.name}
+          </Link>
+        );
+      },
       value: (job: UnifiedJob) => job.summary_fields?.schedule?.name,
       table: tableOption ?? ColumnTableOption.expanded,
       card: cardOption ?? ColumnCardOption.hidden,
@@ -225,7 +227,16 @@ export function useJobScheduleColumn<T extends UnifiedJob>(
       modal: modalOption ?? ColumnModalOption.hidden,
       dashboard: dashboardOption ?? ColumnDashboardOption.hidden,
     }),
-    [cardOption, dashboardOption, defaultSort, listOption, modalOption, t, tableOption]
+    [
+      cardOption,
+      dashboardOption,
+      defaultSort,
+      listOption,
+      modalOption,
+      t,
+      tableOption,
+      getScheduleUrl,
+    ]
   );
 
   return column;
@@ -333,6 +344,7 @@ export function useJobLaunchedByColumn<T extends UnifiedJob>(
   defaultSort?: 'asc' | 'desc'
 ) {
   const { t } = useTranslation();
+  const getLaunchedByDetails = useGetLaunchedByDetails();
 
   const column = useMemo<ITableColumn<T>>(
     () => ({
@@ -352,7 +364,16 @@ export function useJobLaunchedByColumn<T extends UnifiedJob>(
       modal: modalOption ?? ColumnModalOption.hidden,
       dashboard: dashboardOption ?? ColumnDashboardOption.hidden,
     }),
-    [cardOption, dashboardOption, defaultSort, listOption, modalOption, t, tableOption]
+    [
+      cardOption,
+      dashboardOption,
+      defaultSort,
+      listOption,
+      modalOption,
+      t,
+      tableOption,
+      getLaunchedByDetails,
+    ]
   );
 
   return column;
@@ -367,6 +388,7 @@ export function useJobScehduleColumn<T extends UnifiedJob>(
   defaultSort?: 'asc' | 'desc'
 ) {
   const { t } = useTranslation();
+  const getScheduleUrl = useGetScheduleUrl();
 
   const column = useMemo<ITableColumn<T>>(
     () => ({
@@ -389,7 +411,16 @@ export function useJobScehduleColumn<T extends UnifiedJob>(
       modal: modalOption ?? ColumnModalOption.hidden,
       dashboard: dashboardOption ?? ColumnDashboardOption.hidden,
     }),
-    [cardOption, dashboardOption, defaultSort, listOption, modalOption, t, tableOption]
+    [
+      cardOption,
+      dashboardOption,
+      defaultSort,
+      listOption,
+      modalOption,
+      t,
+      tableOption,
+      getScheduleUrl,
+    ]
   );
 
   return column;

--- a/frontend/awx/interfaces/UnifiedJob.ts
+++ b/frontend/awx/interfaces/UnifiedJob.ts
@@ -93,6 +93,17 @@ export interface UnifiedJob
     schedule?: string;
     system_job_template?: string;
   };
+  launch_type?:
+    | 'manual'
+    | 'relaunch'
+    | 'callback'
+    | 'scheduled'
+    | 'dependency'
+    | 'workflow'
+    | 'webhook'
+    | 'sync'
+    | 'scm'
+    | undefined;
   summary_fields: JobSummaryFields;
   launched_by: {
     id: number;

--- a/frontend/awx/views/jobs/JobDetails.tsx
+++ b/frontend/awx/views/jobs/JobDetails.tsx
@@ -16,6 +16,7 @@ import { AwxRoute } from '../../main/AwxRoutes';
 import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
 import { Job } from '../../interfaces/Job';
 import { useVerbosityString } from '../../common/useVerbosityString';
+import { UnifiedJob } from '../../interfaces/UnifiedJob';
 
 export function JobDetails() {
   const { t } = useTranslation();
@@ -29,7 +30,7 @@ export function JobDetails() {
 
   return (
     <PageDetails>
-      <PageDetailsFromColumns columns={columns} item={job} />
+      <PageDetailsFromColumns columns={columns} item={job as UnifiedJob} />
       <PageDetail isEmpty={!job.playbook} label={t('Playbook')}>
         {job.playbook}
       </PageDetail>

--- a/frontend/awx/views/jobs/JobExpanded.tsx
+++ b/frontend/awx/views/jobs/JobExpanded.tsx
@@ -10,12 +10,13 @@ import { awxAPI } from '../../common/api/awx-utils';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { AwxRoute } from '../../main/AwxRoutes';
-import { getLaunchedByDetails, getScheduleUrl, isJobRunning } from './jobUtils';
+import { useGetLaunchedByDetails, useGetScheduleUrl, isJobRunning } from './jobUtils';
 
 export function JobExpanded(job: UnifiedJob) {
+  const getLaunchedByDetails = useGetLaunchedByDetails();
   const { value: launchedByValue, link: launchedByLink } = useMemo(
-    () => getLaunchedByDetails(job) ?? {},
-    [job]
+    () => (getLaunchedByDetails(job) ? getLaunchedByDetails(job) : {}),
+    [job, getLaunchedByDetails]
   );
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -31,9 +32,10 @@ export function JobExpanded(job: UnifiedJob) {
         : [],
     [data]
   );
+  const getScheduleUrl = useGetScheduleUrl();
   const scheduleUrl = useMemo(
-    () => (job.summary_fields?.schedule ? getScheduleUrl(job) ?? '' : ''),
-    [job]
+    () => (job.summary_fields?.schedule ? (getScheduleUrl(job) ? getScheduleUrl(job) : '') : ''),
+    [job, getScheduleUrl]
   );
   const inventoryUrlPaths: { [key: string]: string } = {
     '': 'inventory',

--- a/frontend/awx/views/jobs/JobExpanded.tsx
+++ b/frontend/awx/views/jobs/JobExpanded.tsx
@@ -14,10 +14,10 @@ import { useGetLaunchedByDetails, useGetScheduleUrl, isJobRunning } from './jobU
 
 export function JobExpanded(job: UnifiedJob) {
   const getLaunchedByDetails = useGetLaunchedByDetails();
-  const { value: launchedByValue, link: launchedByLink } = useMemo(
-    () => (getLaunchedByDetails(job) ? getLaunchedByDetails(job) : {}),
-    [job, getLaunchedByDetails]
-  );
+  const { value: launchedByValue, link: launchedByLink } = useMemo(() => {
+    const launchedByDetails = getLaunchedByDetails(job);
+    return launchedByDetails ? launchedByDetails : {};
+  }, [job, getLaunchedByDetails]);
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventory_sources/`);
@@ -33,10 +33,10 @@ export function JobExpanded(job: UnifiedJob) {
     [data]
   );
   const getScheduleUrl = useGetScheduleUrl();
-  const scheduleUrl = useMemo(
-    () => (job.summary_fields?.schedule ? (getScheduleUrl(job) ? getScheduleUrl(job) : '') : ''),
-    [job, getScheduleUrl]
-  );
+  const scheduleUrl = useMemo(() => {
+    const scheduleUrl = getScheduleUrl(job);
+    return job.summary_fields?.schedule ? (scheduleUrl ? scheduleUrl : '') : '';
+  }, [job, getScheduleUrl]);
   const inventoryUrlPaths: { [key: string]: string } = {
     '': 'inventory',
     smart: 'smart_inventory',

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -18,12 +18,13 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { ActionsResponse, OptionsResponse } from '../../../interfaces/OptionsResponse';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
 import { AwxRoute } from '../../../main/AwxRoutes';
-import { getLaunchedByDetails, getScheduleUrl } from '../jobUtils';
+import { useGetLaunchedByDetails, useGetScheduleUrl } from '../jobUtils';
 import { useGetJobOutputUrl } from '../useGetJobOutputUrl';
 
 export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?: boolean }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
+  const getScheduleUrl = useGetScheduleUrl();
 
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventory_sources/`);
   const inventorySourceChoices = useMemo(
@@ -39,6 +40,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
   );
 
   const getJobOutputUrl = useGetJobOutputUrl();
+  const getLaunchedByDetails = useGetLaunchedByDetails();
 
   const tableColumns = useMemo<ITableColumn<UnifiedJob>[]>(
     () => [
@@ -147,11 +149,13 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
       },
       {
         header: t('Schedule'),
-        cell: (job: UnifiedJob) => (
-          <Link to={job.summary_fields?.schedule ? getScheduleUrl(job) ?? '' : ''}>
-            {job.summary_fields?.schedule?.name}
-          </Link>
-        ),
+        cell: (job: UnifiedJob) => {
+          return (
+            <Link to={job.summary_fields?.schedule ? getScheduleUrl(job) ?? '' : ''}>
+              {job.summary_fields?.schedule?.name}
+            </Link>
+          );
+        },
         value: (job: UnifiedJob) => job.summary_fields?.schedule?.name,
         table: ColumnTableOption.expanded,
         card: 'hidden',
@@ -380,7 +384,15 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
         dashboard: 'hidden',
       },
     ],
-    [getJobOutputUrl, getPageUrl, inventorySourceChoices, options?.disableLinks, t]
+    [
+      getJobOutputUrl,
+      getPageUrl,
+      inventorySourceChoices,
+      options?.disableLinks,
+      t,
+      getLaunchedByDetails,
+      getScheduleUrl,
+    ]
   );
   return tableColumns;
 }

--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -12,7 +12,7 @@ import {
   WorkflowJobRelaunch,
 } from '../../../interfaces/RelaunchConfiguration';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
-import { getRelaunchEndpoint } from '../jobUtils';
+import { relaunchEndpoint } from '../jobUtils';
 import { useGetJobOutputUrl } from '../useGetJobOutputUrl';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
@@ -25,8 +25,6 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
   const pageNavigate = usePageNavigate();
 
   return async (job: UnifiedJob) => {
-    const relaunchEndpoint = getRelaunchEndpoint(job);
-
     if (!relaunchEndpoint) {
       return Promise.reject(new Error('Unable to retrieve launch configuration'));
     }
@@ -34,24 +32,26 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
       let relaunchConfig;
       switch (job.type) {
         case 'ad_hoc_command': {
-          relaunchConfig =
-            await requestGet<AwxItemsResponse<AdHocCommandRelaunch>>(relaunchEndpoint);
+          relaunchConfig = await requestGet<AwxItemsResponse<AdHocCommandRelaunch>>(
+            relaunchEndpoint(job)
+          );
           break;
         }
         case 'workflow_job': {
-          relaunchConfig =
-            await requestGet<AwxItemsResponse<WorkflowJobRelaunch>>(relaunchEndpoint);
+          relaunchConfig = await requestGet<AwxItemsResponse<WorkflowJobRelaunch>>(
+            relaunchEndpoint(job)
+          );
           break;
         }
         case 'job': {
-          relaunchConfig = await requestGet<JobRelaunch>(relaunchEndpoint);
+          relaunchConfig = await requestGet<JobRelaunch>(relaunchEndpoint(job));
           break;
         }
         case 'inventory_update':
-          relaunchConfig = await requestGet<InventorySourceUpdate>(relaunchEndpoint);
+          relaunchConfig = await requestGet<InventorySourceUpdate>(relaunchEndpoint(job));
           break;
         case 'project_update':
-          relaunchConfig = await requestGet<ProjectUpdateView>(relaunchEndpoint);
+          relaunchConfig = await requestGet<ProjectUpdateView>(relaunchEndpoint(job));
           break;
       }
 
@@ -69,24 +69,24 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
         let relaunchJob;
         switch (job.type) {
           case 'ad_hoc_command': {
-            relaunchJob = await postRequest(relaunchEndpoint, {} as AdHocCommandRelaunch);
+            relaunchJob = await postRequest(relaunchEndpoint(job), {} as AdHocCommandRelaunch);
             break;
           }
           case 'workflow_job': {
-            relaunchJob = await postRequest(relaunchEndpoint, {} as WorkflowJobRelaunch);
+            relaunchJob = await postRequest(relaunchEndpoint(job), {} as WorkflowJobRelaunch);
             break;
           }
           case 'job': {
-            relaunchJob = await postRequest(relaunchEndpoint, {
+            relaunchJob = await postRequest(relaunchEndpoint(job), {
               ...jobRelaunchParams,
             } as JobRelaunch);
             break;
           }
           case 'inventory_update':
-            relaunchJob = await postRequest(relaunchEndpoint, {} as InventorySourceUpdate);
+            relaunchJob = await postRequest(relaunchEndpoint(job), {} as InventorySourceUpdate);
             break;
           case 'project_update':
-            relaunchJob = await postRequest(relaunchEndpoint, {} as ProjectUpdateView);
+            relaunchJob = await postRequest(relaunchEndpoint(job), {} as ProjectUpdateView);
             break;
         }
         navigate(getJobOutputUrl(relaunchJob as UnifiedJob));

--- a/frontend/awx/views/jobs/jobUtils.cy.tsx
+++ b/frontend/awx/views/jobs/jobUtils.cy.tsx
@@ -1,6 +1,6 @@
 import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
-import { getJobsAPIUrl, getRelaunchEndpoint } from './jobUtils';
+import { getJobsAPIUrl, relaunchEndpoint } from './jobUtils';
 
 describe('jobUtils', () => {
   it('Returns correct endpoint based on job type', () => {
@@ -10,7 +10,7 @@ describe('jobUtils', () => {
 
   it('Returns correct relaunch endpoint based on job type', () => {
     cy.fixture('jobs.json').then((response: AwxItemsResponse<UnifiedJob>) => {
-      const endpoint = getRelaunchEndpoint(response.results[0]);
+      const endpoint = relaunchEndpoint(response.results[0]);
       expect(endpoint).to.equal('/api/v2/workflow_jobs/491/relaunch/');
     });
   });

--- a/frontend/awx/views/jobs/jobUtils.tsx
+++ b/frontend/awx/views/jobs/jobUtils.tsx
@@ -1,7 +1,7 @@
 import { awxAPI } from '../../common/api/awx-utils';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
 import { AwxRoute } from '../../main/AwxRoutes';
-import { useGetPageUrl } from '../../../../framework';
+import { useGetPageUrl } from '../../../../framework/PageNavigation/useGetPageUrl';
 import { useMemo } from 'react';
 
 /** Returns the jobs API endpoint based on the job type */


### PR DESCRIPTION
Instead of hardcoded strings use Routes and params. This causes problems on downstream.

Before/After:
All links in Jobs related pages works the same.

Related to https://issues.redhat.com/browse/AAP-24541