### PR TITLE
[AAP-26470] Add an optional disabled property to the EdaActiveUserProvider

### DIFF
--- a/frontend/eda/common/useEdaActiveUser.tsx
+++ b/frontend/eda/common/useEdaActiveUser.tsx
@@ -16,7 +16,15 @@ export function useEdaActiveUser() {
   return useContext(EdaActiveUserContext);
 }
 
-export function EdaActiveUserProvider(props: { children: ReactNode }) {
+export function EdaActiveUserProvider(props: { children: ReactNode; disabled?: boolean }) {
+  return props?.disabled ? (
+    <EdaActiveUserContext.Provider value={{}}>{props.children}</EdaActiveUserContext.Provider>
+  ) : (
+    <EdaActiveUserProviderInternal>{props?.children}</EdaActiveUserProviderInternal>
+  );
+}
+
+export function EdaActiveUserProviderInternal(props: { children: ReactNode }) {
   const response = useSWR<EdaUser>(edaAPI`/users/me/`, requestGet, {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,


### PR DESCRIPTION
To be used in the aap-ui platform code to disable the EdaActiveUserProvider when there is no eda service.