### PR TITLE
[AAP-26562] Add an optional disabled property to the AWX and HUB context, active user and config AwxActiveUserProvider, AwxCo…

### DIFF
--- a/frontend/awx/common/useAwxActiveUser.tsx
+++ b/frontend/awx/common/useAwxActiveUser.tsx
@@ -17,7 +17,14 @@ export function useAwxActiveUser() {
   return useContext(AwxActiveUserContext);
 }
 
-export function AwxActiveUserProvider(props: { children: ReactNode }) {
+export function AwxActiveUserProvider(props: { children: ReactNode; disabled?: boolean }) {
+  return props?.disabled ? (
+    <AwxActiveUserContext.Provider value={{}}>{props.children}</AwxActiveUserContext.Provider>
+  ) : (
+    <AwxActiveUserProviderInternal>{props?.children}</AwxActiveUserProviderInternal>
+  );
+}
+export function AwxActiveUserProviderInternal(props: { children: ReactNode }) {
   const response = useSWR<AwxItemsResponse<AwxUser>>(awxAPI`/me/`, requestGet, {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,

--- a/frontend/awx/common/useAwxConfig.tsx
+++ b/frontend/awx/common/useAwxConfig.tsx
@@ -18,7 +18,19 @@ export function useAwxConfigState() {
   return useContext(AwxConfigContext);
 }
 
-export function AwxConfigProvider(props: { children?: ReactNode }) {
+export function AwxConfigProvider(props: { children: ReactNode; disabled?: boolean }) {
+  return props?.disabled ? (
+    <AwxConfigContext.Provider
+      value={{ awxConfig: undefined, awxConfigError: undefined, refreshAwxConfig: undefined }}
+    >
+      {props.children}
+    </AwxConfigContext.Provider>
+  ) : (
+    <AwxConfigProviderInternal>{props?.children}</AwxConfigProviderInternal>
+  );
+}
+
+export function AwxConfigProviderInternal(props: { children?: ReactNode }) {
   const response = useSWR<Config>(awxAPI`/config/`, requestGet);
   const value = useMemo(
     () => ({

--- a/frontend/hub/common/useHubActiveUser.tsx
+++ b/frontend/hub/common/useHubActiveUser.tsx
@@ -16,7 +16,15 @@ export function useHubActiveUser() {
   return useContext(HubActiveUserContext);
 }
 
-export function HubActiveUserProvider(props: { children: ReactNode }) {
+export function HubActiveUserProvider(props: { children: ReactNode; disabled?: boolean }) {
+  return props?.disabled ? (
+    <HubActiveUserContext.Provider value={{}}>{props.children}</HubActiveUserContext.Provider>
+  ) : (
+    <HubActiveUserProviderInternal>{props?.children}</HubActiveUserProviderInternal>
+  );
+}
+
+export function HubActiveUserProviderInternal(props: { children: ReactNode }) {
   const response = useSWR<HubUser>(hubAPI`/_ui/v1/me/`, requestGet, {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,

--- a/frontend/hub/common/useHubContext.tsx
+++ b/frontend/hub/common/useHubContext.tsx
@@ -24,7 +24,23 @@ export function useHubContext() {
   return useContext(HubContext);
 }
 
-export function HubContextProvider(props: { children: ReactNode }) {
+export function HubContextProvider(props: { children: ReactNode; disabled?: boolean }) {
+  return props?.disabled ? (
+    <HubContext.Provider
+      value={{
+        featureFlags: {},
+        settings: {},
+        user: undefined,
+        hasPermission: () => false,
+      }}
+    >
+      {props.children}
+    </HubContext.Provider>
+  ) : (
+    <HubContextProviderInternal>{props?.children}</HubContextProviderInternal>
+  );
+}
+export function HubContextProviderInternal(props: { children: ReactNode }) {
   const hubFeatureFlagResponse = useSWR<HubFeatureFlags>(
     hubAPI`/_ui/v1/feature-flags/`,
     requestGet


### PR DESCRIPTION
The same issue in AAP-26470 would occur if there would be no AWX or HUB services.
Add an optional disabled property to the AwxActiveUserProvider, AwxConfigProvider, HubActiveUserProvider, HubContextProvider, to be used in the platform when there is no AWX or HUB service, respectively.