### PR TITLE
Update cypress awx org, team, and user create commands to use partial objects

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -45,9 +45,9 @@ describe('Organizations: Edit and Delete', function () {
 
   beforeEach(function () {
     const orgName = randomE2Ename();
-    cy.createAwxOrganization(orgName).then((testOrganization) => {
+    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
       organization = testOrganization;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });
@@ -165,9 +165,9 @@ describe('Organizations: Users Tab', function () {
 
   beforeEach(function () {
     const orgName = randomE2Ename();
-    cy.createAwxOrganization(orgName).then((testOrganization) => {
+    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
       organization = testOrganization;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });
@@ -193,9 +193,9 @@ describe('Organizations: Teams Tab', function () {
 
   beforeEach(function () {
     const orgName = randomE2Ename();
-    cy.createAwxOrganization(orgName).then((testOrganization) => {
+    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
       organization = testOrganization;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });
@@ -217,9 +217,9 @@ describe('Organizations: Execution Environments Tab', function () {
 
   beforeEach(function () {
     const orgName = randomE2Ename();
-    cy.createAwxOrganization(orgName).then((testOrganization) => {
+    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
       organization = testOrganization;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });
@@ -240,9 +240,9 @@ describe('Organizations: Notifications Tab', function () {
 
   beforeEach(function () {
     const orgName = randomE2Ename();
-    cy.createAwxOrganization(orgName).then((testOrganization) => {
+    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
       organization = testOrganization;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -53,7 +53,7 @@ describe('Teams: Edit and Delete', () => {
   beforeEach(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxTeam(organization).then((createdTeam) => {
+      cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
         team = createdTeam;
       });
     });
@@ -152,9 +152,9 @@ describe('Teams: Add and Remove users', () => {
   beforeEach(() => {
     cy.createAwxOrganization().then((o) => {
       organization = o;
-      cy.createAwxUser(organization).then((user) => {
+      cy.createAwxUser({ organization: organization.id }).then((user) => {
         user1 = user;
-        cy.createAwxTeam(organization).then((createdTeam) => {
+        cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
           team = createdTeam;
           cy.giveUserTeamAccess(team.name, user1.id, 'Read');
         });
@@ -273,7 +273,7 @@ describe('Teams: Bulk delete', () => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
       for (let i = 0; i < 5; i++) {
-        cy.createAwxTeam(organization).then((createdTeam) => {
+        cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
           team = createdTeam;
           arrayOfElementText.push(team.name);
         });

--- a/cypress/e2e/awx/access/tokens.cy.ts
+++ b/cypress/e2e/awx/access/tokens.cy.ts
@@ -10,7 +10,7 @@ describe('User Tokens Actions', () => {
   beforeEach(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -12,7 +12,7 @@ describe('Users List Actions', () => {
   beforeEach(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });
@@ -89,7 +89,7 @@ describe('Users Delete Actions', () => {
   beforeEach(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });

--- a/cypress/e2e/awx/administration/activity-stream.cy.ts
+++ b/cypress/e2e/awx/administration/activity-stream.cy.ts
@@ -9,9 +9,11 @@ describe('activity-stream', () => {
   let activeUser: AwxUser;
 
   before(function () {
-    cy.createAwxTeam(this.globalAwxOrganization as Organization).then((createdTeam) => {
-      team = createdTeam;
-    });
+    cy.createAwxTeam({ organization: (this.globalAwxOrganization as Organization).id }).then(
+      (createdTeam) => {
+        team = createdTeam;
+      }
+    );
     cy.requestGet<AwxItemsResponse<AwxUser>>(awxAPI`/me/`)
       .its('results')
       .then((results) => {

--- a/cypress/e2e/awx/administration/instanceGroups.cy.ts
+++ b/cypress/e2e/awx/administration/instanceGroups.cy.ts
@@ -335,7 +335,7 @@ instanceGroupTypes.forEach((igType) => {
     beforeEach(function () {
       cy.createAwxOrganization().then((o) => {
         organization = o;
-        cy.createAwxTeam(organization).then((createdTeam) => {
+        cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
           team = createdTeam;
           cy.createAwxInstanceGroup(
             igType === 'Container'
@@ -454,7 +454,7 @@ instanceGroupTypes.forEach((igType) => {
     beforeEach(function () {
       cy.createAwxOrganization().then((o) => {
         organization = o;
-        cy.createAwxUser(organization).then((u) => {
+        cy.createAwxUser({ organization: organization.id }).then((u) => {
           user = u;
           cy.createAwxInstanceGroup(
             igType === 'Container'

--- a/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
@@ -7,7 +7,7 @@ describe('Notifications: List View', () => {
   let organization: Organization;
 
   before(() => {
-    cy.createAwxOrganization(randomE2Ename()).then((org) => {
+    cy.createAwxOrganization().then((org) => {
       organization = org;
     });
   });

--- a/cypress/e2e/awx/administration/notifiers/notifiersSharedFunctions.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersSharedFunctions.ts
@@ -1,8 +1,8 @@
-import { randomE2Ename } from '../../../../support/utils';
 import { getDefaultMessages } from '../../../../../frontend/awx/administration/notifiers/notifierFormMessagesHelpers';
 import { AwxItemsResponse } from '../../../../../frontend/awx/common/AwxItemsResponse';
 import { awxAPI } from '../../../../../frontend/awx/common/api/awx-utils';
 import { Notification } from '../../../../../frontend/awx/interfaces/generated-from-swagger/api';
+import { randomE2Ename } from '../../../../support/utils';
 
 export function testNotification(
   type: string,
@@ -10,7 +10,7 @@ export function testNotification(
 ) {
   const notificationName = randomE2Ename();
   const orgName = randomE2Ename();
-  cy.createAwxOrganization(orgName).then(() => {
+  cy.createAwxOrganization({ name: orgName }).then(() => {
     cy.navigateTo('awx', 'notification-templates');
     cy.get(`[data-cy="add-notifier"]`).click();
     cy.verifyPageTitle('Add notifier');

--- a/cypress/e2e/awx/administration/notifiers/notifiersTabs.cy.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersTabs.cy.ts
@@ -1,7 +1,7 @@
 import { awxAPI } from '../../../../../frontend/awx/common/api/awx-utils';
-import { randomE2Ename } from '../../../../support/utils';
-import { testNotification, testDelete } from './notifiersSharedFunctions';
 import { Organization } from '../../../../../frontend/awx/interfaces/Organization';
+import { randomE2Ename } from '../../../../support/utils';
+import { testDelete, testNotification } from './notifiersSharedFunctions';
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 
@@ -11,7 +11,7 @@ describe('Notifications', () => {
 
   before(() => {
     cy.login();
-    cy.createAwxOrganization(randomE2Ename()).then((org) => {
+    cy.createAwxOrganization().then((org) => {
       organization = org;
     });
   });
@@ -95,7 +95,7 @@ describe('Notifications', () => {
     const orgName = randomE2Ename();
 
     before(() => {
-      cy.createAwxOrganization(orgName).then(() => {});
+      cy.createAwxOrganization({ name: orgName }).then(() => {});
     });
 
     it('can navigate to the Organizations -> Notifications list and then to the details page of the Notification', () => {

--- a/cypress/e2e/awx/administration/topology-view.cy.ts
+++ b/cypress/e2e/awx/administration/topology-view.cy.ts
@@ -5,7 +5,6 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Settings } from '../../../../frontend/awx/interfaces/Settings';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
-import { randomE2Ename } from '../../../support/utils';
 
 describe('Topology view', () => {
   let user: AwxUser;
@@ -14,7 +13,7 @@ describe('Topology view', () => {
   before(() => {
     cy.login();
 
-    cy.createAwxOrganization(randomE2Ename()).then((org) => {
+    cy.createAwxOrganization().then((org) => {
       organization = org;
     });
   });
@@ -65,7 +64,7 @@ describe('Topology view', () => {
   });
 
   it('does not show Topology View in sidebar for non admins', function () {
-    cy.createAwxUser(organization).then((awxUser) => {
+    cy.createAwxUser({ organization: organization.id }).then((awxUser) => {
       user = awxUser;
 
       cy.awxLoginTestUser(user.username, 'pw');

--- a/cypress/e2e/awx/administration/wfApprovalsList.cy.ts
+++ b/cypress/e2e/awx/administration/wfApprovalsList.cy.ts
@@ -34,16 +34,16 @@ describe.skip('Workflow Approvals Tests', () => {
       ).then((proj) => {
         project = proj;
 
-        cy.createAwxUser(organization).then((u) => {
+        cy.createAwxUser({ organization: organization.id }).then((u) => {
           user = u;
         });
-        cy.createAwxUser(organization).then((u) => {
+        cy.createAwxUser({ organization: organization.id }).then((u) => {
           userWFApprove = u;
         });
-        cy.createAwxUser(organization).then((u) => {
+        cy.createAwxUser({ organization: organization.id }).then((u) => {
           userWFDeny = u;
         });
-        cy.createAwxUser(organization).then((u) => {
+        cy.createAwxUser({ organization: organization.id }).then((u) => {
           userWFCancel = u;
         });
         cy.createAwxInventory({ organization: organization.id })

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -16,7 +16,7 @@ describe('Credentials', () => {
   before(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });
@@ -569,7 +569,7 @@ describe('Credentials Tabbed View - Team and User Access', () => {
     cy.awxLogin();
     cy.createAwxOrganization().then((awxOrg) => {
       awxOrganization = awxOrg;
-      cy.createAwxUser(awxOrganization).then((awxUser) => {
+      cy.createAwxUser({ organization: awxOrganization.id }).then((awxUser) => {
         createdAwxUser = awxUser;
         cy.createAWXCredential({
           kind: 'machine',
@@ -579,7 +579,7 @@ describe('Credentials Tabbed View - Team and User Access', () => {
           machineCredential = cred;
         });
       });
-      cy.createAwxTeam(awxOrganization).then((createdAwxTeam) => {
+      cy.createAwxTeam({ organization: awxOrganization.id }).then((createdAwxTeam) => {
         awxTeam = createdAwxTeam;
       });
     });

--- a/cypress/e2e/awx/resources/executionEnvironments.cy.ts
+++ b/cypress/e2e/awx/resources/executionEnvironments.cy.ts
@@ -26,11 +26,9 @@ describe('Execution Environments: Create', () => {
       }).then((cred) => {
         credential = cred;
       });
-      if (Cypress.currentTest.title.includes('access to a user')) {
-        cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-          user = testUser;
-        });
-      }
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+        user = testUser;
+      });
     });
     execEnvName = 'E2E Execution Environment Create' + randomString(4);
     image = 'quay.io/ansible/awx-ee:latest';

--- a/cypress/e2e/awx/resources/executionEnvironments.cy.ts
+++ b/cypress/e2e/awx/resources/executionEnvironments.cy.ts
@@ -27,7 +27,7 @@ describe('Execution Environments: Create', () => {
         credential = cred;
       });
       if (Cypress.currentTest.title.includes('access to a user')) {
-        cy.createAwxUser(organization).then((testUser) => {
+        cy.createAwxUser({ organization: organization.id }).then((testUser) => {
           user = testUser;
         });
       }
@@ -422,10 +422,10 @@ describe('Execution Environments: User/Team access', () => {
   before(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
-      cy.createAwxTeam(organization).then((testTeam) => {
+      cy.createAwxTeam({ organization: organization.id }).then((testTeam) => {
         team = testTeam;
       });
       cy.createAwxExecutionEnvironment({

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -21,7 +21,7 @@ describe('Inventories Tests', () => {
       if (kind === '') {
         beforeEach(() => {
           const orgName = 'E2E Organization Inv tests' + randomString(4);
-          cy.createAwxOrganization(orgName).then((org) => {
+          cy.createAwxOrganization({ name: orgName }).then((org) => {
             organization = org;
             cy.createAwxLabel({ organization: organization.id }).then((lbl) => {
               label = lbl;
@@ -34,7 +34,7 @@ describe('Inventories Tests', () => {
             cy.createAwxInstanceGroup().then((ig) => {
               instanceGroup = ig;
             });
-            cy.createAwxUser(organization).then((testUser) => {
+            cy.createAwxUser({ organization: organization.id }).then((testUser) => {
               user = testUser;
               cy.giveUserInventoryAccess(inventory.name, user.id, 'Read');
             });

--- a/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
+++ b/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
@@ -16,7 +16,7 @@ describe('Constructed Inventories CRUD Tests', () => {
 
   before(() => {
     const orgName = 'E2E Org Constructed Inventory tests ' + randomString(4);
-    cy.createAwxOrganization(orgName).then((org) => {
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
       organization = org;
       cy.createAwxInstanceGroup().then((ig) => {
         instanceGroup = ig;

--- a/cypress/e2e/awx/resources/inventoryHost/inventoryHost.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryHost/inventoryHost.cy.ts
@@ -20,7 +20,7 @@
 //     cy.createAwxInventory({ organization: organization.id }).then((inv) => {
 //       inventory = inv;
 //     });
-//     cy.createAwxUser(organization).then((testUser) => {
+//     cy.createAwxUser({ organization: organization.id }).then((testUser) => {
 //       user = testUser;
 //     });
 //   });

--- a/cypress/e2e/awx/resources/inventoryHost/inventoryHostRegular.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryHost/inventoryHostRegular.cy.ts
@@ -1,18 +1,18 @@
+import { randomString } from '../../../../../framework/utils/random-string';
 import { awxAPI } from '../../../../../frontend/awx/common/api/awx-utils';
 import { Inventory } from '../../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../../frontend/awx/interfaces/Organization';
+import { Project } from '../../../../../frontend/awx/interfaces/Project';
 import { AwxUser } from '../../../../../frontend/awx/interfaces/User';
 import { runCommand } from './runCommandFunction';
-import { randomString } from '../../../../../framework/utils/random-string';
-import { Project } from '../../../../../frontend/awx/interfaces/Project';
 
 import {
+  checkFactsInHost,
   checkHostGroup,
   createAndEditAndDeleteHost,
-  testHostBulkDelete,
-  checkFactsInHost,
   createHost,
   createHostAndCancelJob,
+  testHostBulkDelete,
 } from '../../../../support/hostsfunctions';
 
 describe('Inventory Host Tab Tests for regular inventory', () => {
@@ -30,7 +30,7 @@ describe('Inventory Host Tab Tests for regular inventory', () => {
       cy.createAwxProject({ organization: organization.id }).then((proj) => {
         project = proj;
       });
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });

--- a/cypress/e2e/awx/resources/inventoryHost/inventoryHostSmart.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryHost/inventoryHostSmart.cy.ts
@@ -3,8 +3,8 @@ import { awxAPI } from '../../../../../frontend/awx/common/api/awx-utils';
 import { Inventory } from '../../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../../frontend/awx/interfaces/Organization';
 import { AwxUser } from '../../../../../frontend/awx/interfaces/User';
-import { runCommand } from './runCommandFunction';
 import { checkHiddenButton, checkHiddenTab } from '../../../../support/hostsfunctions';
+import { runCommand } from './runCommandFunction';
 
 describe('Inventory Host Tab Tests for smart inventory', () => {
   let organization: Organization;
@@ -19,7 +19,7 @@ describe('Inventory Host Tab Tests for smart inventory', () => {
         inventory = inv;
       });
 
-      cy.createAwxUser(organization).then((testUser) => {
+      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
       });
     });

--- a/cypress/e2e/awx/resources/jobTemplateSurveys.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplateSurveys.cy.ts
@@ -3,7 +3,6 @@ import { JobTemplate } from '../../../../frontend/awx/interfaces/JobTemplate';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { ReusableTemplateSurveyTestSuite } from './sharedTemplateSurvey';
-import { randomE2Ename } from '../../../support/utils';
 
 describe('Job Templates Surveys', function () {
   let inventory: Inventory;
@@ -27,7 +26,7 @@ describe('Job Templates Surveys', function () {
     };
 
     before(function () {
-      cy.createAwxOrganization(randomE2Ename()).then((org) => {
+      cy.createAwxOrganization().then((org) => {
         organization = org;
         cy.createAwxProject({ organization: organization.id }).then((proj) => {
           project = proj;
@@ -75,7 +74,7 @@ describe('Job Templates Surveys', function () {
 
   describe('JT Surveys: Launch JT with Survey Enabled', function () {
     before(() => {
-      cy.createAwxOrganization(randomE2Ename()).then((org) => {
+      cy.createAwxOrganization().then((org) => {
         organization = org;
         cy.createAwxProject({ organization: organization.id }).then((proj) => {
           project = proj;

--- a/cypress/e2e/awx/resources/projects.cy.ts
+++ b/cypress/e2e/awx/resources/projects.cy.ts
@@ -70,7 +70,7 @@ describe('Projects', () => {
     beforeEach(() => {
       cy.createAwxOrganization().then((org) => {
         organization = org;
-        cy.createAwxUser(organization).then((testUser) => {
+        cy.createAwxUser({ organization: organization.id }).then((testUser) => {
           user = testUser;
           cy.createAwxProject({ organization: organization.id }).then((proj) => {
             project = proj;
@@ -211,7 +211,7 @@ describe('Projects', () => {
       cy.createAwxOrganization().then((org) => {
         organization = org;
 
-        cy.createAwxUser(organization).then((testUser) => {
+        cy.createAwxUser({ organization: organization.id }).then((testUser) => {
           user = testUser;
           cy.createAwxProject({ organization: organization.id }).then((proj) => {
             project = proj;

--- a/cypress/e2e/awx/resources/workflowJobTemplateSurveys.cy.ts
+++ b/cypress/e2e/awx/resources/workflowJobTemplateSurveys.cy.ts
@@ -2,7 +2,6 @@ import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { WorkflowJobTemplate } from '../../../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { ReusableTemplateSurveyTestSuite } from './sharedTemplateSurvey';
-import { randomE2Ename } from '../../../support/utils';
 
 describe('Workflow Job Templates Surveys', function () {
   let inventory: Inventory;
@@ -25,7 +24,7 @@ describe('Workflow Job Templates Surveys', function () {
     };
 
     before(function () {
-      cy.createAwxOrganization(randomE2Ename()).then((org) => {
+      cy.createAwxOrganization().then((org) => {
         organization = org;
       });
     });
@@ -70,7 +69,7 @@ describe('Workflow Job Templates Surveys', function () {
 
   describe('WFJT Surveys: Launch WFJT with Survey Enabled', function () {
     before(() => {
-      cy.createAwxOrganization(randomE2Ename()).then((org) => {
+      cy.createAwxOrganization().then((org) => {
         organization = org;
       });
     });

--- a/cypress/support/awx-access-commands.ts
+++ b/cypress/support/awx-access-commands.ts
@@ -9,74 +9,65 @@ import { awxAPI } from './formatApiPathForAwx';
 
 // Base create and delete commands for AWX organizations, teams, and users
 
-Cypress.Commands.add('createAwxOrganization', (orgName?: string, failOnStatusCode?: boolean) => {
+Cypress.Commands.add('createAwxOrganization', (awxOrganization?: Partial<Organization>) => {
+  if (!awxOrganization) {
+    awxOrganization = {};
+  }
+
+  if (!awxOrganization.name) {
+    awxOrganization.name = 'E2E Organization ' + randomString(4);
+  }
+
   cy.requestPost<Pick<Organization, 'name'>, Organization>(
     awxAPI`/organizations/`,
-    { name: orgName ? orgName : 'E2E Organization ' + randomString(4) },
-    failOnStatusCode
+    awxOrganization
   );
 });
 
 Cypress.Commands.add(
   'deleteAwxOrganization',
-  (
-    organization: Organization,
-    options?: {
-      /** Whether to fail on response codes other than 2xx and 3xx */
-      failOnStatusCode?: boolean;
-    }
-  ) => {
-    if (!organization?.id) return;
-    cy.requestDelete(awxAPI`/organizations/${organization?.id.toString()}/`, options);
+  (awxOrganization: Organization, options?: { failOnStatusCode?: boolean }) => {
+    cy.requestDelete(awxAPI`/organizations/${awxOrganization?.id.toString()}/`, options);
   }
 );
 
-Cypress.Commands.add('createAwxTeam', (organization: Organization) => {
-  cy.requestPost<Pick<Team, 'name' | 'organization'>, Team>(awxAPI`/teams/`, {
-    name: 'E2E Team ' + randomString(4),
-    organization: organization.id,
-  });
+Cypress.Commands.add('createAwxTeam', (awxTeam?: Partial<Team>) => {
+  if (!awxTeam) {
+    awxTeam = {};
+  }
+  if (!awxTeam.name) {
+    awxTeam.name = 'E2E Team ' + randomString(4);
+  }
+
+  cy.requestPost<Pick<Team, 'name' | 'organization'>, Team>(awxAPI`/teams/`, awxTeam);
 });
 
-Cypress.Commands.add(
-  'deleteAwxTeam',
-  (
-    team: Team,
-    options?: {
-      /** Whether to fail on response codes other than 2xx and 3xx */
-      failOnStatusCode?: boolean;
-    }
-  ) => {
-    if (team.id) {
-      cy.requestDelete(awxAPI`/teams/${team.id.toString()}/`, options);
-    }
-  }
-);
+Cypress.Commands.add('deleteAwxTeam', (team: Team, options?: { failOnStatusCode?: boolean }) => {
+  cy.requestDelete(awxAPI`/teams/${team.id.toString()}/`, options);
+});
 
-Cypress.Commands.add('createAwxUser', (organization: Organization) => {
-  cy.requestPost<Omit<AwxUser, 'id' | 'auth' | 'summary_fields'>, AwxUser>(
-    awxAPI`/organizations/${organization.id.toString()}/users/`,
-    {
+Cypress.Commands.add('createAwxUser', (awxUser?: Partial<AwxUser>) => {
+  const newUser: Partial<AwxUser> = {
+    ...{
       username: 'e2e-user-' + randomString(4),
       is_superuser: false,
       is_system_auditor: false,
       password: 'pw',
       user_type: 'normal',
-    }
-  ).then((user) => user);
+    },
+    ...awxUser,
+  };
+
+  if (newUser.organization !== undefined) {
+    cy.requestPost<AwxUser>(
+      awxAPI`/organizations/${newUser.organization.toString()}/users/`,
+      newUser
+    );
+  } else {
+    cy.requestPost<AwxUser>(awxAPI`/users/`, newUser);
+  }
 });
 
-Cypress.Commands.add(
-  'deleteAwxUser',
-  (
-    user: AwxUser,
-    options?: {
-      /** Whether to fail on response codes other than 2xx and 3xx */
-      failOnStatusCode?: boolean;
-    }
-  ) => {
-    if (user?.id) {
-      cy.requestDelete(awxAPI`/users/${user.id.toString()}/`, options);
-    }
-  }
-);
+Cypress.Commands.add('deleteAwxUser', (user: AwxUser, options?: { failOnStatusCode?: boolean }) => {
+  cy.requestDelete(awxAPI`/users/${user.id.toString()}/`, options);
+});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -664,7 +664,7 @@ declare global {
       // AWX Commands
       // ==============================================================================================================
 
-      createAwxOrganization(orgName?: string, failOnStatusCode?: boolean): Chainable<Organization>;
+      createAwxOrganization(awxOrganization?: Partial<Organization>): Chainable<Organization>;
       editAwxApplication(application: Application, name: string): Chainable<Application>;
 
       /**
@@ -855,8 +855,15 @@ declare global {
       giveUserTeamAccess(teamName: string, userId: number, roleName: string): Chainable<Role>;
 
       getAwxJobTemplateByName(awxJobTemplateName: string): Chainable<JobTemplate>;
-      createAwxTeam(organization: Organization): Chainable<Team>;
-      createAwxUser(organization: Organization): Chainable<AwxUser>;
+
+      /**
+       * @Example
+       * ```tsx
+       * cy.createAwxUser({ organization: organization.id, is_superuser:true });
+       * ```
+       */
+      createAwxTeam(awxTeam?: Partial<Team>): Chainable<Team>;
+      createAwxUser(awxUser?: Partial<AwxUser>): Chainable<AwxUser>;
       getAwxRoles(): Chainable<RoleSerializerWithParentAccess>;
       createAwxInstanceGroup(
         instanceGroup?: Partial<Omit<InstanceGroup, 'id'>>


### PR DESCRIPTION
This makes those commands much more useful as a tester can pass an more fields for those objects

Example:

instead of 
```tsx
cy.createAwxUser(organization)
```

we have
```tsx
cy.createAwxUser({ name: "John", orgianization: organization.id, is_superuser: true})
```
