### PR TITLE
remove notifications test already completed

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -253,6 +253,4 @@ describe('Organizations: Notifications Tab', function () {
     cy.deleteAwxUser(user, { failOnStatusCode: false });
     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
   });
-
-  it.skip('can create a Notification with a specific Org and toggle the Notification on and off on the Notifications tab of the Org', () => {});
 });


### PR DESCRIPTION
Small prs for the win,

Here I confirmed with @akus062381 that the following test has already been written and that the skipped/empty test here can be removed.

`it.skip('can create a Notification with a specific Org and toggle the Notification on and off on the Notifications tab of the Org', () => {});`

