### PR TITLE
Hub - unify on "Create execution environment", fix test failing because of it

### DIFF
--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -28,7 +28,7 @@ describe('Execution Environments', () => {
     });
   });
 
-  it.skip('can add and delete a new execution environment', () => {
+  it('can add and delete a new execution environment', () => {
     cy.createHubRemoteRegistry().then((remoteRegistry) => {
       const eeName = `execution_environment_${randomString(3, undefined, { isLowercase: true })}`;
       const upstreamName = `upstream_name_${randomString(3, undefined, { isLowercase: true })}`;
@@ -38,9 +38,7 @@ describe('Execution Environments', () => {
       cy.intercept('GET', hubAPI`/_ui/v1/execution-environments/registries/?limit=50`).as(
         'registries'
       );
-      // FIXME: this is sometimes add-.., sometimes create-..., depending on whether there are already any added
-      // fix by making sure the empty state add button has the same selector as the list top button
-      cy.getByDataCy('add-execution-environment').click();
+      cy.getByDataCy('create-execution-environment').click();
       cy.wait('@registries')
         .its('response.body.data.length')
         .then((count) => {

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
@@ -37,7 +37,7 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
         variant: ButtonVariant.primary,
         isPinned: true,
         icon: PlusCircleIcon,
-        label: t('Add execution environment'),
+        label: t('Create execution environment'),
         onClick: () => {
           pageNavigate(HubRoute.CreateExecutionEnvironment);
         },


### PR DESCRIPTION
The `can add and delete a new execution environment` test in `cypress/e2e/hub/execution-environments.cy.ts` fails sporadically, because when there are no EEs, the button has `data-cy=create-execution-environment`, while when there are EEs, the button has `data-cy=add-execution-environment`. These labels are generated from the button text, which is also inconsistent.

Fixing the button text to say "Create execution environment" on both the empty state screen and the list screen.

(the only place remaining that says "Add execution environment" is now `useAwxRoleMetadata`, which seems related to awx role names)