### PR TITLE
Unify Groups from buttons

### DIFF
--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -54,7 +54,7 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="description"]').type('This is a description');
         cy.dataEditorTypeByDataCy('variables', 'test: true');
         cy.intercept('POST', awxAPI`/groups/`).as('created');
-        cy.clickButton(/^Save/);
+        cy.clickButton(/^Save group/);
         cy.wait('@created')
           .its('response.statusCode')
           .then((statusCode) => {
@@ -229,7 +229,7 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="description"]').type('This is a description');
         cy.dataEditorTypeByDataCy('variables', 'test: true');
         cy.intercept('POST', awxAPI`/groups/`).as('createGroup');
-        cy.clickButton(/^Save/);
+        cy.clickButton(/^Save group/);
         cy.wait('@createGroup')
           .its('response.statusCode')
           .then((statusCode) => {

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -54,7 +54,7 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="description"]').type('This is a description');
         cy.dataEditorTypeByDataCy('variables', 'test: true');
         cy.intercept('POST', awxAPI`/groups/`).as('created');
-        cy.clickButton(/^Save group/);
+        cy.clickButton(/^Create group/);
         cy.wait('@created')
           .its('response.statusCode')
           .then((statusCode) => {
@@ -229,7 +229,7 @@ describe('Inventory Groups', () => {
         cy.get('[data-cy="description"]').type('This is a description');
         cy.dataEditorTypeByDataCy('variables', 'test: true');
         cy.intercept('POST', awxAPI`/groups/`).as('createGroup');
-        cy.clickButton(/^Save group/);
+        cy.clickButton(/^Create group/);
         cy.wait('@createGroup')
           .its('response.statusCode')
           .then((statusCode) => {

--- a/frontend/awx/resources/groups/GroupCreate.tsx
+++ b/frontend/awx/resources/groups/GroupCreate.tsx
@@ -61,7 +61,7 @@ export function GroupCreate() {
   const onCancel = () => navigate(-1);
   return (
     <AwxPageForm<InventoryGroupCreate>
-      submitText={t('Save')}
+      submitText={t('Create group')}
       onSubmit={onSubmit}
       cancelText={t('Cancel')}
       onCancel={onCancel}

--- a/frontend/awx/resources/groups/GroupEdit.tsx
+++ b/frontend/awx/resources/groups/GroupEdit.tsx
@@ -56,7 +56,7 @@ export function GroupEdit() {
 
   return (
     <AwxPageForm<InventoryGroupCreate>
-      submitText={t('Save')}
+      submitText={t('Save group')}
       onSubmit={onSubmit}
       cancelText={t('Cancel')}
       onCancel={onCancel}


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-24926

I renamed buttons in groups add/edit to match the correct naming style of the application.

However are the buttons in the empty state implemented wrongly? I see that pattern in the new UI, so this should also follow the new UI style.