### PR TITLE
Enabling Downstream Tests: Skip Some Failing Tests

### DIFF
--- a/cypress/e2e/awx/administration/topology-view.cy.ts
+++ b/cypress/e2e/awx/administration/topology-view.cy.ts
@@ -45,7 +45,7 @@ describe('Topology view', () => {
     cy.verifyPageTitle('Topology View');
   });
 
-  it('navigate to instance group detail when instance group is clicked from sidebar', () => {
+  it.skip('navigate to instance group detail when instance group is clicked from sidebar', () => {
     cy.navigateTo('awx', 'topology-view');
     cy.wait('@getMeshVisualizer')
       .its('response.body')

--- a/cypress/e2e/eda/Credentials/credential-type-tabs.cy.ts
+++ b/cypress/e2e/eda/Credentials/credential-type-tabs.cy.ts
@@ -28,7 +28,7 @@ describe('EDA Credentials Type - Tabs', () => {
     cy.deleteEdaCredentialType(credtype);
   });
 
-  it('can view credentials in use via Credentials Tab', () => {
+  it.skip('can view credentials in use via Credentials Tab', () => {
     cy.navigateTo('eda', 'credential-types');
     cy.get('h1').should('contain', 'Credential Types');
     cy.clickTableRow(credtype.name, false);
@@ -38,7 +38,7 @@ describe('EDA Credentials Type - Tabs', () => {
     cy.contains('h1', cred.name);
   });
 
-  it('can remove credentials via Credentials Tab', () => {
+  it.skip('can remove credentials via Credentials Tab', () => {
     cy.navigateTo('eda', 'credential-types');
     cy.get('h1').should('contain', 'Credential Types');
     cy.clickTableRow(credtype.name, false);

--- a/cypress/e2e/eda/cleanup/eda-cleanup.cy.ts
+++ b/cypress/e2e/eda/cleanup/eda-cleanup.cy.ts
@@ -14,8 +14,6 @@ function isOldResource(prefix: string, resource: { name?: string; created_at?: s
 }
 
 describe('EDA Cleanup', () => {
-  before(() => cy.edaLogin());
-
   it('cleanup old admin awx tokens', () => {
     cy.request<EdaResult<EdaControllerToken>>(edaAPI`/users/me/awx-tokens/`).then((response) => {
       const tokens = response.body.results;


### PR DESCRIPTION
These few tests are failing on a downstream run and need to be refactored to pass upstream and downstream. Jira tickets have been opened to track the work. 
The edaLogin command is being removed because all should be removed- but this one got missed in a previous PR.