### PR TITLE
[AAP-26667] Fix resource name in Schedule Review step

### DIFF
--- a/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
@@ -12,8 +12,8 @@ import { RulesList } from '../components/RulesList';
 const ResourceLink: { [key: string]: string } = {
   inventory_update: AwxRoute.InventorySourceDetail,
   job: AwxRoute.JobTemplateDetails,
-  project_update: AwxRoute.ProjectDetails,
-  system_job: AwxRoute.ManagementJobSchedules,
+  project: AwxRoute.ProjectDetails,
+  management_job_template: AwxRoute.ManagementJobSchedules,
   workflow_approval: AwxRoute.WorkflowApprovalDetails,
   workflow_job: AwxRoute.WorkflowJobTemplateDetails,
 };
@@ -83,7 +83,7 @@ export function ScheduleReviewStep() {
         <PageDetails numberOfColumns={'two'} disablePadding>
           <PageDetail label={t('Resource type')}>{resourceTypeDetail}</PageDetail>
           <PageDetail label={t('Resource')}>
-            <Link to={resourceDetailsLink}>{name}</Link>
+            <Link to={resourceDetailsLink}>{resource?.name}</Link>
           </PageDetail>
           <PageDetail label={t('Name')}>{name}</PageDetail>
           <PageDetail label={t('Description')}>{description}</PageDetail>


### PR DESCRIPTION
Issue: [AAP-26667](https://issues.redhat.com/browse/AAP-26667)

before:
![Screenshot from 2024-07-08 17-01-26](https://github.com/ansible/ansible-ui/assets/19647757/6d932307-f882-48a6-8d1f-83a64e80f4f5)


after:
![Screenshot from 2024-07-08 17-01-02](https://github.com/ansible/ansible-ui/assets/19647757/8419de1f-2387-441f-b2d1-6abf8a9ca52f)

- also fixes links for `project` and `management_job_template`

