### PR TITLE
Login - fix spacing when using a custom brand logo

### DIFF
--- a/frontend/common/AnsibleLogin.tsx
+++ b/frontend/common/AnsibleLogin.tsx
@@ -123,7 +123,7 @@ export function AnsibleLogin(props: {
               typeof props.brandImg === 'string' ? (
                 <Brand src={props.brandImg} alt={props.brandImgAlt} />
               ) : (
-                props.brandImg
+                <BrandStyled>{props.brandImg}</BrandStyled>
               )
             }
           />
@@ -196,4 +196,8 @@ const ErrorSpanStyled = styled.span`
 
 const ErrorExclamationCircleIconStyled = styled(ExclamationCircleIcon)`
   color: var(--pf-v5-global--danger-color--100);
+`;
+
+const BrandStyled = styled.div`
+  margin-bottom: 16px;
 `;


### PR DESCRIPTION
When a customer provides a custom logo we cant use the `Brand` component because it takes in a src url to load the image. We instead create a ReactNode that contains the customer logo, but since the LoginPage was is not using the `Brand` component in that case, we need to add spacing.

![Screenshot 2024-07-08 at 1 22 24 PM](https://github.com/ansible/ansible-ui/assets/6277895/d28ef53f-86ca-47aa-b798-95181da3e195)
