### PR TITLE
test cypress with firefox

### DIFF
--- a/.github/workflows/awx-e2e.yml
+++ b/.github/workflows/awx-e2e.yml
@@ -74,6 +74,10 @@ jobs:
       matrix:
         containers: [1,2,3,4]
     steps:
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: latest    
       - name: Download container image
         if: ${{ !inputs.SKIP_JOB }}
         uses: actions/download-artifact@v4
@@ -119,6 +123,7 @@ jobs:
           # auto-cancel-after-failures: 1
           config-file: cypress.awx.config.ts
           tag: ${{ inputs.TAGS }}
+          browser: firefox
         env:
           AWX_SERVER: ${{ inputs.AWX_SERVER }}
           AWX_USERNAME: e2e

--- a/.github/workflows/awx-e2e.yml
+++ b/.github/workflows/awx-e2e.yml
@@ -74,10 +74,6 @@ jobs:
       matrix:
         containers: [1,2,3,4]
     steps:
-      - name: Setup firefox
-        uses: browser-actions/setup-firefox@v1
-        with:
-          firefox-version: latest    
       - name: Download container image
         if: ${{ !inputs.SKIP_JOB }}
         uses: actions/download-artifact@v4

--- a/framework/README.md
+++ b/framework/README.md
@@ -2,4 +2,4 @@
 
 A framework for building applications using [PatternFly](https://www.patternfly.org), developed by the Ansible UI developers.
 
-[Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework)
+[Documentation](https://github.com/ansible/ansible-ui/wiki/Ansible-UI-Framework).


### PR DESCRIPTION
The slowdown in the tests might be because chrome does not cache resources such as javascript when using an insecure certificate. Each test reloads the page and the loading of the javascript takes several seconds. That times 250 tests could mean minutes of extra testing time per PR. Firefox will cache the resources even with an insecure certificate. Testing that out to see the difference.