### PR TITLE
Order by ID instead of time for AWX ActivityStream 

### DIFF
--- a/frontend/awx/administration/activity-stream/hooks/useActivityStreamColumns.tsx
+++ b/frontend/awx/administration/activity-stream/hooks/useActivityStreamColumns.tsx
@@ -17,7 +17,7 @@ export function useActivityStreamColumns(options?: {
         header: t('Time'),
         cell: (activity_stream: ActivityStream) =>
           activity_stream.timestamp && <DateTimeCell value={activity_stream.timestamp} />,
-        sort: 'timestamp',
+        sort: 'id', // Timestamp for activity stream is not indexed result in slow query, id is effectively the same and more performant.
         list: 'secondary',
         defaultSortDirection: 'desc',
         modal: ColumnModalOption.hidden,


### PR DESCRIPTION
Timestamp for activity stream is not indexed result in slow query with large data set. Switching to ID (which effectively will is order by created time) to improve performance