### PR TITLE
unskip inventory checks in activity stream page

### DIFF
--- a/cypress/e2e/awx/administration/activity-stream.cy.ts
+++ b/cypress/e2e/awx/administration/activity-stream.cy.ts
@@ -35,7 +35,7 @@ describe('activity-stream', () => {
     );
   }
 
-  it.skip('event column displays correct info', function () {
+  it('event column displays correct info', function () {
     cy.navigateTo('awx', 'activity-stream');
     cy.verifyPageTitle('Activity Stream');
     cy.getTableRow('event', ` created inventory ${inventory.name}`, { disableFilter: true }).within(
@@ -48,7 +48,7 @@ describe('activity-stream', () => {
     );
   });
 
-  it.skip('event details modal displays correct info', function () {
+  it('event details modal displays correct info', function () {
     cy.navigateTo('awx', 'activity-stream');
     cy.verifyPageTitle('Activity Stream');
     openEventDetails(inventory.name);


### PR DESCRIPTION
This pr unskips the following tests in `cypress/e2e/awx/administration/activity-stream.cy.ts`. Both tests have a description and have been run multiple times in the cypress UI tool with success.


`  it.skip('event column displays correct info', function () {`
`  it.skip('event details modal displays correct info', function () {`