### PR TITLE
Fix placeholder text for multiple fields in prompt on launch

### DIFF
--- a/frontend/awx/access/credentials/components/PageFormCredentialSelect.tsx
+++ b/frontend/awx/access/credentials/components/PageFormCredentialSelect.tsx
@@ -40,7 +40,7 @@ export function PageFormCredentialSelect<
       name={props.name}
       id={props.id ? props.id : 'credential'}
       label={props.label ? props.label : t('Credential')}
-      placeholder={props.placeholder ? props.placeholder : t('Add credentials')}
+      placeholder={props.placeholder ? props.placeholder : t('Select credentials')}
       queryPlaceholder={t('Loading credentials...')}
       queryErrorText={t('Error loading credentials')}
       isRequired={props.isRequired}

--- a/frontend/awx/administration/execution-environments/components/PageFormSelectExecutionEnvironment.tsx
+++ b/frontend/awx/administration/execution-environments/components/PageFormSelectExecutionEnvironment.tsx
@@ -95,7 +95,7 @@ export function PageFormExecutionEnvironmentSelect<
       label={props.label ?? t('Execution environment')}
       name={name}
       id="execution-environment-select"
-      placeholder={placeholder ?? t('Create execution environment')}
+      placeholder={placeholder ?? t('Select execution environment')}
       labelHelpTitle={t('Execution environment')}
       labelHelp={t('The container image to be used for execution.')}
       selectTitle={t('Select an execution environment')}

--- a/frontend/awx/administration/instance-groups/components/PageFormInstanceGroupSelect.tsx
+++ b/frontend/awx/administration/instance-groups/components/PageFormInstanceGroupSelect.tsx
@@ -29,7 +29,7 @@ export function PageFormInstanceGroupSelect<
       queryErrorText={t('Error loading instance groups')}
       url={awxAPI`/instance_groups/`}
       id="instance-group-select"
-      placeholder={t('Add instance groups')}
+      placeholder={t('Select instance groups')}
       labelHelp={props.labelHelp}
       label={t('Instance Groups')}
       isRequired={props.isRequired}

--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -148,7 +148,7 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
           <PageFormCheckbox label={t('Prompt on launch')} name="ask_credential_on_launch" />
         }
         label={t('Credentials')}
-        placeholder={t('Add credentials')}
+        placeholder={t('Select credentials')}
         labelHelpTitle={t('Credentials')}
         labelHelp={t(
           'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch", the selected credential(s) become the defaults that can be updated at run time.'

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -274,7 +274,7 @@ export function LaunchWizard({
         <PageFormCredentialSelect<TemplateLaunch>
           name="credentials"
           label={t('Credentials')}
-          placeholder={t('Add credentials')}
+          placeholder={t('Select credentials')}
           labelHelpTitle={t('Credentials')}
           labelHelp={t(
             'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch", the selected credential(s) become the defaults that can be updated at run time.'

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
@@ -94,7 +94,7 @@ export function NodePromptsStep() {
         <PageFormCredentialSelect<WizardFormValues>
           name="prompt.credentials"
           label={t('Credentials')}
-          placeholder={t('Add credentials')}
+          placeholder={t('Select credentials')}
           labelHelpTitle={t('Credentials')}
           labelHelp={t(
             'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch", the selected credential(s) become the defaults that can be updated at run time.'


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-26760

Changes placeholder text to be clearer. While fixing these, it was noted that there were other places using the selection components with the ```Add``` placeholder instead of ```Select```. These areas have also been edited to have a placeholder containing ```Select```.

Before:
<img width="851" alt="Screenshot 2024-07-09 at 3 05 45 PM" src="https://github.com/ansible/ansible-ui/assets/14355897/6718af82-93ec-4cfd-bdca-964d060c1446">

After: 
<img width="851" alt="Screenshot 2024-07-09 at 3 05 10 PM" src="https://github.com/ansible/ansible-ui/assets/14355897/b33d79db-76ef-45ed-9559-6c879375479a">


