### PR TITLE
Display defined_in_file setting form fields as read-only

### DIFF
--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -16,6 +16,7 @@ import { PageFormFileUpload } from '../../../../framework/PageForm/Inputs/PageFo
 
 export interface AwxSettingsOptionsResponse {
   actions: {
+    GET: Record<string, AwxSettingsOptionsAction>;
     PUT: Record<string, AwxSettingsOptionsAction>;
   };
 }
@@ -38,6 +39,7 @@ interface IOptionActionBase {
   required?: boolean;
   help_text?: string;
   hidden?: boolean;
+  defined_in_file?: boolean;
 }
 
 interface IOptionStringAction extends IOptionActionBase {
@@ -196,6 +198,7 @@ export function AwxSettingsForm(props: {
 
 export function OptionActionsFormInput(props: { name: string; option: AwxSettingsOptionsAction }) {
   const option = props.option;
+  const isReadOnly = props.option.defined_in_file;
 
   if (props.name.endsWith('SECRET') || props.name.endsWith('PASSWORD')) {
     return (
@@ -286,8 +289,9 @@ export function OptionActionsFormInput(props: { name: string; option: AwxSetting
             isRequired={option.required}
             isArray
             defaultValue={option.default}
-            enableUndo
-            enableReset
+            enableUndo={!isReadOnly}
+            enableReset={!isReadOnly}
+            isReadOnly={isReadOnly}
           />
         </PageFormSection>
       );


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-25721

Settings marked as 'defined_in_file' are read-only in the API and won't be included in the OPTIONS PUT response,
because they are defined in a deployment file and cannot be modified. These settings do appear in the GET response.

We compare the GET and PUT responses to identify these read-only settings and display them as 
disabled fields in the UI.

![Screenshot 2024-07-10 at 10 11 32 AM](https://github.com/ansible/ansible-ui/assets/15881645/7a0db8bb-f1ff-4bc8-aadd-f486aa3bdf53)
