### PR TITLE
Fix inventory type filter

### DIFF
--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -170,6 +170,7 @@ export function useInventoryTypeToolbarFilter() {
         { label: t('Constructed inventory'), value: 'constructed' },
       ],
       placeholder: t('Select types'),
+      disableSortOptions: true,
     }),
     [t]
   );

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -160,10 +160,10 @@ export function useInventoryTypeToolbarFilter() {
   const { t } = useTranslation();
   return useMemo<IToolbarFilter>(
     () => ({
-      key: 'kind',
+      key: 'inventory-type',
       label: t('Inventory type'),
       type: ToolbarFilterType.MultiSelect,
-      query: 'or__kind',
+      query: 'kind',
       options: [
         { label: t('Inventory'), value: '' },
         { label: t('Smart inventory'), value: 'smart' },

--- a/frontend/awx/resources/inventories/hooks/useInventoriesFilters.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesFilters.tsx
@@ -1,18 +1,25 @@
 import {
   useCreatedByToolbarFilter,
+  useInventoryTypeToolbarFilter,
   useModifiedByToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
 import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 
 export function useInventoriesFilters() {
+  const inventoryTypeToolbarFilter = useInventoryTypeToolbarFilter();
   const createdByToolbarFilter = useCreatedByToolbarFilter();
   const modifiedByToolbarFilter = useModifiedByToolbarFilter();
 
   const toolbarFilters = useDynamicToolbarFilters({
     optionsPath: 'inventories',
-    preSortedKeys: ['name', 'id', 'created-by', 'modified-by'],
+    preSortedKeys: ['name', 'id', 'created-by', 'modified-by', 'inventory-type'],
     preFilledValueKeys: { name: { apiPath: 'inventories' }, id: { apiPath: 'inventories' } },
-    additionalFilters: [createdByToolbarFilter, modifiedByToolbarFilter],
+    additionalFilters: [
+      createdByToolbarFilter,
+      modifiedByToolbarFilter,
+      inventoryTypeToolbarFilter,
+    ],
+    removeFilters: ['kind'],
   });
   return toolbarFilters;
 }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-25463

Replaces ```Kind``` filter with ```Inventory Type``` filter in the Inventory list page. ```Inventory Type``` filters by the same value, but contains the correct labels for filter.

Before:
<img width="737" alt="Screenshot 2024-07-09 at 4 18 28 PM" src="https://github.com/ansible/ansible-ui/assets/14355897/f375b00f-e666-4893-b38e-0f721f00454f">


After:
<img width="505" alt="Screenshot 2024-07-09 at 4 18 04 PM" src="https://github.com/ansible/ansible-ui/assets/14355897/e5668caf-46cb-4a1b-80db-f26137a33f34">