### PR TITLE
fix ActivityStream button at details page

### DIFF
--- a/frontend/awx/access/common/useViewActivityStream.tsx
+++ b/frontend/awx/access/common/useViewActivityStream.tsx
@@ -1,6 +1,7 @@
 import { HistoryIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import {
   IPageAction,
   PageActionSelection,
@@ -11,6 +12,15 @@ import { AwxRoute } from '../../main/AwxRoutes';
 export function useViewActivityStream<T extends object>(queryType: string) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
+
+  const query = { query: { type: queryType } };
+
+  // Filtering by resource id, like host__id=2, instance__id=5, etc.
+  const params = useParams<{ id: string }>();
+  if (/^\d+$/.test(params.id)) {
+    query['query'][`${queryType}__id`] = params.id;
+  }
+
   return useMemo<IPageAction<T>[]>(() => {
     return [
       {
@@ -18,9 +28,9 @@ export function useViewActivityStream<T extends object>(queryType: string) {
         selection: PageActionSelection.Single,
         icon: HistoryIcon,
         label: t('View activity stream'),
-        onClick: () => pageNavigate(AwxRoute.ActivityStream, { query: { type: queryType } }),
+        onClick: () => pageNavigate(AwxRoute.ActivityStream, query),
       },
       { type: PageActionType.Seperator },
     ];
-  }, [pageNavigate, queryType, t]);
+  }, [pageNavigate, query, t]);
 }

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -107,6 +107,13 @@ export function useAwxView<T extends { id: number }>(options: {
                 .split('+')
                 .join(',')}&or__object2__in=${values[0].split('+').join(',')}`;
             }
+            // add Activity Stream id filtering, like host__id=2
+            for (const keyId in filterState) {
+              if (/.+__id/.test(keyId)) {
+                const valId: string = filterState[keyId];
+                queryString += `&${keyId}=${valId}`;
+              }
+            }
           } else if (toolbarFilter.query === 'search') {
             queryString += values.map((value) => `${toolbarFilter.query}=${value}`).join('&');
           } else {

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -25,12 +25,14 @@ import { useTemplateActions } from '../hooks/useTemplateActions';
 
 export function TemplatePage() {
   const { t } = useTranslation();
-  const activityStream = useViewActivityStream(
-    'job_template+workflow_job_template+workflow_job_template_node'
-  );
+  const params = useParams<{ id: string }>();
+  let activityStreamType: string = 'job_template+workflow_job_template+workflow_job_template_node';
+  if (/^\d+$/.test(params.id)) {
+    activityStreamType = 'job_template';
+  }
+  const activityStream = useViewActivityStream(activityStreamType);
 
   const { activeAwxUser } = useAwxActiveUser();
-  const params = useParams<{ id: string }>();
   const {
     error: templateError,
     data: template,

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -25,10 +25,12 @@ import { useTemplateActions } from '../hooks/useTemplateActions';
 
 export function WorkflowJobTemplatePage() {
   const { t } = useTranslation();
-  const activityStream = useViewActivityStream(
-    'job_template+workflow_job_template+workflow_job_template_node'
-  );
   const params = useParams<{ id: string }>();
+  let activityStreamType: string = 'job_template+workflow_job_template+workflow_job_template_node';
+  if (/^\d+$/.test(params.id)) {
+    activityStreamType = 'workflow_job_template';
+  }
+  const activityStream = useViewActivityStream(activityStreamType);
   const { activeAwxUser } = useAwxActiveUser();
   const {
     error: templateError,


### PR DESCRIPTION
The current PR has  the same fixes as [this PR from the old user interface](https://github.com/ansible/awx/pull/15286).

In short: at any "details" page (like, `/access/organizations/1/details`, `/infrastructure/hosts/1/details`, etc.) - if you click at the three dots at the top-right corner and choose `View Activity Stream`, it shows a generic activity stream for the category (`organizations`, `hosts`, etc.). 

With the current PR, an `__id` parameter is added to the end of the Activity Stream query string, so the Activity Stream is filtered by `host__id`, `orgranization__id`, etc. - to the specific item.

Testing Done: tested locally