### PR TITLE
Fix missing params on Credetial Types back button

### DIFF
--- a/frontend/awx/access/credential-types/CredentialTypePage/CredentialTypePage.tsx
+++ b/frontend/awx/access/credential-types/CredentialTypePage/CredentialTypePage.tsx
@@ -55,7 +55,7 @@ export function CredentialTypePage() {
         backTab={{
           label: t('Back to Credential Types'),
           page: AwxRoute.CredentialTypes,
-          persistentFilterKey: 'credential-types',
+          persistentFilterKey: 'credential_types',
         }}
         tabs={[
           { label: t('Details'), page: AwxRoute.CredentialTypeDetails },


### PR DESCRIPTION
There was a typo and no persistent params were returned.

Fixes https://issues.redhat.com/browse/AAP-27018

Steps to reproduce:
- Go to AWX -> Access management -> Credential Types
- click on any credential type
- click on back button `Back to Credential Types`

Before:
```
console.js:273 TypeError: Cannot read properties of undefined (reading 'documentElement')
    at u (getDocumentElement.js:8:76)
    at v (getParentNode.js:18:9)
    at _ (getScrollParent.js:17:28)
    at _ (getScrollParent.js:17:12)
    at b (listScrollParents.js:18:26)
    at Object.setOptions (index.js:57:27)
    at index.js:167:18
    at usePopper.js:77:54
    at ri (react-dom.production.min.js:243:332)
    at ki (react-dom.production.min.js:260:147)
overrideMethod @ console.js:273
fu @ react-dom.production.min.js:188
```

After:
Back button redirects to correct page