### PR TITLE
Fix and refactor inventoryGroup tests for upstream and downstream

### DIFF
--- a/cypress.awx.config.ts
+++ b/cypress.awx.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress';
 import setValue from 'set-value';
 import { baseConfig } from './cypress.base.config';
 
-baseConfig.e2e!.specPattern = 'cypress/e2e/awx/resources/inventoryGroup.cy.ts';
+baseConfig.e2e!.specPattern = 'cypress/e2e/awx/**/*.cy.ts';
 baseConfig.e2e!.baseUrl = 'https://localhost:4101';
 baseConfig.component!.specPattern = 'frontend/awx/**/*.cy.{js,jsx,ts,tsx}';
 setValue(baseConfig, 'component.devServer.webpackConfig.devServer.port', 4201);

--- a/cypress.awx.config.ts
+++ b/cypress.awx.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress';
 import setValue from 'set-value';
 import { baseConfig } from './cypress.base.config';
 
-baseConfig.e2e!.specPattern = 'cypress/e2e/awx/**/*.cy.ts';
+baseConfig.e2e!.specPattern = 'cypress/e2e/awx/resources/inventoryGroup.cy.ts';
 baseConfig.e2e!.baseUrl = 'https://localhost:4101';
 baseConfig.component!.specPattern = 'frontend/awx/**/*.cy.{js,jsx,ts,tsx}';
 setValue(baseConfig, 'component.devServer.webpackConfig.devServer.port', 4201);

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -459,7 +459,6 @@ describe('Inventory Groups', () => {
     });
 
     it("can run an ad-hoc command against a group's host", () => {
-      //unskip this test when below issue is resolved
       cy.filterTableBySingleSelect('name', thisInventory.name);
       cy.clickTableRowLink('name', thisInventory.name, { disableFilter: true });
       cy.verifyPageTitle(thisInventory.name);


### PR DESCRIPTION
Refactored inventoryGroup run command test to use shared function, because run command is executed in multiple places through the application.

Fix test in can run an ad-hoc command against a group's related group list view, added filter for particular item, previous code assumes the item is displayed on the page without filter.
