### PR TITLE
Remove unreachable job statuses from workflow output status bar

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/StatusBar.cy.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.cy.tsx
@@ -46,32 +46,13 @@ describe('HostStatusBar and WorkflowNodesStatusBar (StatusBar)', () => {
     cy.mount(
       <WorkflowNodesStatusBar nodes={jobWorkflowNodes.results as unknown as WorkflowNode[]} />
     );
-    cy.contains('Success 13%');
-    cy.contains('Canceled 13%');
-    cy.contains('Error 25%');
-    cy.contains('Unreachable 50%');
+    cy.contains('Success 25%');
+    cy.contains('Canceled 25%');
+    cy.contains('Error 50%');
 
     cy.mount(<WorkflowNodesStatusBar nodes={workflowNodes.results as unknown as WorkflowNode[]} />);
 
-    cy.contains('Failed 17%');
-    cy.contains('Unreachable 17%');
-    cy.contains('Success 67%');
-  });
-  it('WorkflowNodesStatusBar should NOT fail on unexpected value', () => {
-    const wfNode = workflowNodes.results[0];
-    const updatedWFNode = {
-      ...wfNode,
-      summary_fields: {
-        ...wfNode.summary_fields,
-        job: {
-          ...wfNode.summary_fields.job,
-          status: 'unexpected_status',
-        },
-      },
-    };
-
-    cy.mount(<WorkflowNodesStatusBar nodes={[updatedWFNode] as unknown as WorkflowNode[]} />);
-
-    cy.contains('Unreachable 100%');
+    cy.contains('Failed 20%');
+    cy.contains('Success 80%');
   });
 });

--- a/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
@@ -55,14 +55,12 @@ interface StatusProps {
   label: string;
 }
 
-type HostStatusCountType = 'ok' | 'skipped' | 'changed' | 'failures' | 'dark';
-type WorkflowStatusCountType = JobStatus | 'dark';
-
 type CommonStatusType = Record<'dark', StatusProps>;
+type HostStatusCountType = 'ok' | 'skipped' | 'changed' | 'failures' | 'dark';
 type HostStatusType = Record<HostStatusCountType, StatusProps>;
-type WorkflowStatusType = Record<WorkflowStatusCountType, StatusProps>;
 
-type WFNodesStatusProps = Partial<Record<WorkflowStatusCountType, number>>;
+type WorkflowStatusType = Record<JobStatus, StatusProps>;
+type WFNodesStatusProps = Partial<Record<JobStatus, number>>;
 
 export function WorkflowNodesStatusBar(props: { nodes: WorkflowNode[] }) {
   const { t } = useTranslation();
@@ -100,16 +98,16 @@ export function WorkflowNodesStatusBar(props: { nodes: WorkflowNode[] }) {
       color: pfDanger,
       label: t`Failed`,
     },
-    dark: {
-      color: pfUnreachable,
-      label: t`Unreachable`,
-    },
   };
 
   const segments: WFNodesStatusProps = {};
 
   props.nodes.map((node) => {
-    const nodeStatus = (node?.summary_fields?.job?.status ?? 'dark') as WorkflowStatusCountType;
+    if (!node?.summary_fields?.job?.status) {
+      return;
+    }
+
+    const nodeStatus = node.summary_fields.job.status as JobStatus;
 
     const nodeVal = segments[nodeStatus];
     segments[nodeStatus] = nodeStatus in segments && nodeVal ? nodeVal + 1 : 1;


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-26858

Remove the "unreachable" status for nodes that have not been run and only display the statuses of completed jobs in the workflow output status bar 

_Example: 1 success, 1 never run_
![Screenshot 2024-07-16 at 2 22 14 PM](https://github.com/user-attachments/assets/7a111b5d-e267-4c6d-8feb-755da112327f)


_Example: 3 success, 1 fail, 1 cancel, 1 never run_
![Screenshot 2024-07-16 at 2 15 17 PM](https://github.com/user-attachments/assets/8d6d88dc-b4a6-47e7-99ea-0b870bc78194)
