### PR TITLE
Fix for clearing filter on roles page

### DIFF
--- a/framework/PageToolbar/PageToolbarFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilter.tsx
@@ -349,7 +349,7 @@ function ToolbarFilterComponent(props: {
           value={filterValues && filterValues?.length > 0 ? filterValues[0] : ''}
           onSelect={(item) => setFilterValues(() => [item!])}
           options={filter.options}
-          isRequired={filter.isRequired}
+          isRequired={filter.isRequired || !filter.isPinned}
           disableSortOptions={filter.disableSortOptions}
         />
       );


### PR DESCRIPTION
[AAP-24853](https://issues.redhat.com/browse/AAP-24853)

There was a bug in the single select PageToolbarFilter, where the "X" button does not work for non-pinned filters. As suggested by @jamestalton, the "X" button should not show up in the filter dropdown and the filter can instead be cleared using the "x" button in the chip group or the `Clear all filters` button.

![image](https://github.com/user-attachments/assets/84aa095e-6bdb-4de8-b21d-e89af643988b)

