### PR TITLE
Fix extra vars not showing when on review step of job launch

### DIFF
--- a/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
@@ -97,7 +97,7 @@ export function TemplateLaunchReviewStep(props: { template: JobTemplate }) {
     execution_environment
   );
 
-  let extraVarDetails = extra_vars || '{}';
+  let extraVarDetails = template.extra_vars || '{}';
   if (survey) {
     extraVarDetails = processSurvey(extra_vars, survey, surveyConfig ?? null);
   }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/AAP-27061

Changes extra vars field in TemplateLaunchReviewStep to show the extra vars that were missing.

Before:
![Screenshot 2024-07-17 at 1 13 55 PM](https://github.com/user-attachments/assets/d3d62ab3-9bf8-43c8-b776-30035a8eda30)

After:
![Screenshot 2024-07-17 at 1 13 43 PM](https://github.com/user-attachments/assets/227e85bb-f50e-485c-bb16-7148412ff16e)
