### PR TITLE
HubMasthead - link to full experience approvals

### DIFF
--- a/frontend/hub/main/HubMasthead.tsx
+++ b/frontend/hub/main/HubMasthead.tsx
@@ -18,7 +18,6 @@ import { hubAPI } from '../common/api/formatPath';
 import { useHubActiveUser } from '../common/useHubActiveUser';
 import { useHubContext } from '../common/useHubContext';
 import { HubItemsResponse } from '../common/useHubView';
-import { HubRoute } from './HubRoutes';
 
 export function HubMasthead() {
   const { t } = useTranslation();
@@ -111,7 +110,10 @@ export function useHubNotifications() {
             variant: 'info',
 
             // TODO to should goto the specific approval page instead of the approvals page
-            to: getPageUrl(HubRoute.Approvals, { query: { status: 'pipeline=staging' } }),
+            // to: getPageUrl(HubRoute.Approvals, { query: { status: 'pipeline=staging' } }),
+
+            // go to full experience approvals
+            to: '/ui/approval-dashboard/',
           })) ?? [],
       };
       return { ...groups };


### PR DESCRIPTION
From new ui approval notifications, link to full experience approvals instead of new ui approvals.

![20240719115114](https://github.com/user-attachments/assets/2d292eb4-532e-4056-ab46-6c82524e44a3)
![20240719115121](https://github.com/user-attachments/assets/02e4f06a-e29f-4100-be29-2868056eeeb3)

Issue: AAP-27342
