### PR TITLE
Add a dropdown to job header to choose job type on relaunch

### DIFF
--- a/frontend/awx/interfaces/RelaunchConfiguration.ts
+++ b/frontend/awx/interfaces/RelaunchConfiguration.ts
@@ -17,6 +17,7 @@ export interface JobRelaunch {
   hosts?: 'all' | 'failed' | null;
   /** Credential passwords */
   credential_passwords?: string;
+  job_type?: 'run' | 'check' | null;
 }
 
 export interface InventorySourceUpdate {

--- a/frontend/awx/views/jobs/JobHeader.cy.tsx
+++ b/frontend/awx/views/jobs/JobHeader.cy.tsx
@@ -14,7 +14,10 @@ describe('Job Page', () => {
   });
   it('Relaunch and cancel buttons are visible on a running job', () => {
     cy.mount(<JobHeader />, { path: ':job_type/:id', initialEntries: ['/workflow/1'] });
-    cy.get('[data-cy="relaunch-job"]').should('contain', 'Relaunch job');
+    cy.get('[data-cy="relaunch-job-with"]').should('exist');
+    cy.get('[data-cy="relaunch-job-with"]').click();
+    cy.get('[data-cy="job-type-run"]').should('exist');
+    cy.get('[data-cy="job-type-check"]').should('exist');
     cy.get('[data-cy="cancel-job"]').should('contain', 'Cancel job');
   });
   it('Delete button is disabled on a running job', () => {

--- a/frontend/awx/views/jobs/hooks/useRelaunchOptions.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchOptions.tsx
@@ -11,6 +11,8 @@ export function useRelaunchOptions(): IPageAction<UnifiedJob>[] {
   const relaunchJob = useRelaunchJob();
   const relaunchAllHosts = useRelaunchJob({ hosts: 'all' });
   const relaunchFailedHosts = useRelaunchJob({ hosts: 'failed' });
+  const relaunchRunJobType = useRelaunchJob({ job_type: 'run' });
+  const relaunchCheckJobType = useRelaunchJob({ job_type: 'check' });
   return useMemo(
     () => [
       {
@@ -22,8 +24,30 @@ export function useRelaunchOptions(): IPageAction<UnifiedJob>[] {
         label: t(`Relaunch job`),
         isHidden: (job: UnifiedJob) =>
           !(job.type !== 'system_job' && job.summary_fields?.user_capabilities?.start) ||
-          (job.status === 'failed' && job.type === 'job'),
+          job.type === 'job',
         onClick: (job: UnifiedJob) => void relaunchJob(job),
+      },
+      {
+        type: PageActionType.Dropdown,
+        selection: PageActionSelection.Single,
+        isPinned: true,
+        icon: RocketIcon,
+        label: t(`Relaunch job with`),
+        isHidden: (job: UnifiedJob) => job.type !== 'job' || job.status === 'failed',
+        actions: [
+          {
+            type: PageActionType.Button,
+            selection: PageActionSelection.Single,
+            label: t(`Job type run`),
+            onClick: (job: UnifiedJob) => void relaunchRunJobType(job),
+          },
+          {
+            type: PageActionType.Button,
+            selection: PageActionSelection.Single,
+            label: t(`Job type check`),
+            onClick: (job: UnifiedJob) => void relaunchCheckJobType(job),
+          },
+        ],
       },
       {
         type: PageActionType.Dropdown,
@@ -50,6 +74,13 @@ export function useRelaunchOptions(): IPageAction<UnifiedJob>[] {
         ],
       },
     ],
-    [t, relaunchAllHosts, relaunchFailedHosts, relaunchJob]
+    [
+      t,
+      relaunchRunJobType,
+      relaunchCheckJobType,
+      relaunchAllHosts,
+      relaunchFailedHosts,
+      relaunchJob,
+    ]
   );
 }


### PR DESCRIPTION
This PR adds a feature for users to change the Job Type (run type) on relaunching the job, but this should not be merged until 
the API changes land on AWX ([AWX PR](https://github.com/ansible/awx/pull/15249))