### PR TITLE
[AAP-25666] Wizard error handling fix

### DIFF
--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -85,6 +85,7 @@ function StepErrors() {
 
 function RequestErrorAlert(props: { error?: unknown }) {
   const { t } = useTranslation();
+  const error = props.error as Error & { json?: Record<string, string> };
   if (!props.error) return null;
   if (!(props.error instanceof Error)) {
     if (typeof props.error === 'string') {
@@ -92,10 +93,9 @@ function RequestErrorAlert(props: { error?: unknown }) {
     }
     return <Alert variant="danger" title={t('An error occurred.')} />;
   }
-  if ('message' in props.error) {
+  if ('message' in props.error && !error.json) {
     return <Alert variant="danger" title={props.error.message} />;
   }
-  const error = props.error as Error & { json?: Record<string, string> };
   if (error.json) {
     return (
       <Alert variant="danger" title={error.message} isInline>

--- a/framework/PageWizard/PageWizardProvider.tsx
+++ b/framework/PageWizard/PageWizardProvider.tsx
@@ -1,14 +1,15 @@
+import { t } from 'i18next';
 import {
-  createContext,
   ReactNode,
-  useState,
-  useEffect,
-  useContext,
-  useMemo,
+  createContext,
   useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
 } from 'react';
 import { useURLSearchParams } from '../components/useURLSearchParams';
-import type { PageWizardStep, PageWizardState, PageWizardParentStep } from './types';
+import type { PageWizardParentStep, PageWizardState, PageWizardStep } from './types';
 
 export const PageWizardContext = createContext<PageWizardState>({} as PageWizardState);
 export function usePageWizard() {
@@ -71,7 +72,12 @@ export function PageWizardProvider<T extends object>(props: {
       const isLastStep =
         activeStep?.id === visibleStepsFlattened[visibleStepsFlattened.length - 1]?.id;
       if (isLastStep) {
-        return onSubmit(wizardData as T);
+        try {
+          await onSubmit(wizardData as T);
+        } catch (e) {
+          setSubmitError(e instanceof Error ? e : new Error(t('An error occurred.')));
+        }
+        return;
       }
 
       const activeStepIndex = visibleStepsFlattened.findIndex((step) => step.id === activeStep?.id);
@@ -87,7 +93,7 @@ export function PageWizardProvider<T extends object>(props: {
       setActiveStep(nextStep);
       return Promise.resolve();
     },
-    [activeStep, steps, onSubmit, setSearchParams, wizardData]
+    [activeStep, steps, onSubmit, setSearchParams, wizardData, setSubmitError]
   );
 
   const onBack = useCallback(() => {


### PR DESCRIPTION
This PR adds error handling when a bad manifest is uploaded in the subscriptions wizard. The user will now be shown an error banner upon clicking "finish" which will bubble up the error if there is one.

Jira issue: https://issues.redhat.com/browse/AAP-25666

![Screenshot 2024-07-11 at 4 14 33 PM](https://github.com/user-attachments/assets/eb4ff85e-1739-4738-9dbe-09873ba599d5)