### PR TITLE
AAP-27359 Fix default LabelsCell wrapping

### DIFF
--- a/framework/PageCells/LabelsCell.tsx
+++ b/framework/PageCells/LabelsCell.tsx
@@ -7,21 +7,21 @@ type LabelsWithLinksProps = {
   labels?: never;
   labelsWithLinks: LabelWithLink[];
   numLabels?: number;
-  wrapLabels?: boolean;
+  noWrap?: boolean;
 };
 
 type LabelsProps = {
   labels: string[];
   labelsWithLinks?: never;
   numLabels?: number;
-  wrapLabels?: boolean;
+  noWrap?: boolean;
 };
 
 export function LabelsCell(props: LabelsProps | LabelsWithLinksProps) {
   return (
     <LabelGroup
       numLabels={props.numLabels ?? 999}
-      style={props.wrapLabels ? undefined : { flexWrap: 'nowrap' }}
+      style={props.noWrap ? { flexWrap: 'nowrap' } : undefined}
     >
       {props.labels
         ? props.labels.map((label) => <Label key={label}>{label}</Label>)


### PR DESCRIPTION
The default should be wrapping and a flag for nowrap should be available.
I have a follow on PR for downstream so that hub roles use nowrap.

Fixes https://issues.redhat.com/browse/AAP-27359?filter=-1
