### PR TITLE
unskip inventorySource test

### DIFF
--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -9,7 +9,7 @@ import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../../../frontend/awx/interfaces/Schedule';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
-describe.skip('Inventory Sources', () => {
+describe('Inventory Sources', () => {
   const scheduleName = 'e2e-' + randomString(4);
 
   let project: Project;


### PR DESCRIPTION
Issue: AAP-26418

Looks like the failures in https://cloud.cypress.io/projects/iq7cj4/runs/1111/overview/98307e6d-76ed-4eb9-bb94-68772849ad33?roarHideRunsWithDiffGroupsAndTags=1 
were login session related, I haven't seem them since.

Unskipping.

