### PR TITLE
Update link to old UI

### DIFF
--- a/frontend/awx/overview/AwxOverview.tsx
+++ b/frontend/awx/overview/AwxOverview.tsx
@@ -48,7 +48,7 @@ export function AwxOverview() {
             <InfoCircleIcon />{' '}
             <Trans>
               You are currently viewing a tech preview of the new {{ product }} user interface. To
-              return to the original interface, click <a href="/">here</a>.
+              return to the original interface, click <a href="/ui_legacy/">here</a>.
             </Trans>
           </p>
         </Banner>


### PR DESCRIPTION
pairs with https://github.com/ansible/awx/pull/15347

ansible-ui will be served by default, and older UI will be served at

`/ui_legacy/`