### PR TITLE
[AAP-27455] Update docs helper function to link to either Upstream or Downstream Docs

### DIFF
--- a/frontend/awx/access/credential-types/CredentialTypes.tsx
+++ b/frontend/awx/access/credential-types/CredentialTypes.tsx
@@ -49,7 +49,7 @@ export function CredentialTypes() {
         titleHelp={t(
           'Define custom credential types to support authentication with other systems during automation.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/credential_types.html`}
+        titleDocLink={getDocsBaseUrl(config, 'credentialTypes')}
         headerActions={<ActivityStreamIcon type={'credential_type'} />}
       />
       <PageTable<CredentialType>

--- a/frontend/awx/access/credentials/Credentials.tsx
+++ b/frontend/awx/access/credentials/Credentials.tsx
@@ -22,7 +22,7 @@ export function Credentials() {
           `Credentials are utilized by {{product}} for authentication when launching jobs against machines, synchronizing with inventory sources, and importing project content from a version control system. You can grant users and teams the ability to use these credentials, without actually exposing the credential to the user. If you have a user move to a different team or leave the organization, you don’t have to re-key all of your systems just because that credential was available in {{product}}.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/credentials.html`}
+        titleDocLink={getDocsBaseUrl(config, 'credentials')}
         description={t(
           `Credentials are utilized by {{product}} for authentication when launching jobs against machines, synchronizing with inventory sources, and importing project content from a version control system.`,
           { product }

--- a/frontend/awx/access/organizations/Organizations.tsx
+++ b/frontend/awx/access/organizations/Organizations.tsx
@@ -161,7 +161,7 @@ export function Organizations() {
           `An Organization is a logical collection of Users, Teams, Projects, and Inventories, and is the highest level in the {{product}} object hierarchy.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/organizations.html`}
+        titleDocLink={getDocsBaseUrl(config, 'organizations')}
         description={t(
           `An Organization is a logical collection of Users, Teams, Projects, and Inventories, and is the highest level in the {{product}} object hierarchy.`,
           { product }

--- a/frontend/awx/access/teams/Teams.tsx
+++ b/frontend/awx/access/teams/Teams.tsx
@@ -45,7 +45,7 @@ export function Teams() {
             'For instance, permissions may be granted to a whole Team rather than each user on the Team.'
           ),
         ]}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/teams.html`}
+        titleDocLink={getDocsBaseUrl(config, 'teams')}
         description={t(
           'A Team is a subdivision of an organization with associated users, projects, credentials, and permissions.'
         )}

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -210,7 +210,7 @@ export function Users() {
           `A user is someone who has access to {{product}} with associated permissions and credentials.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/users.html`}
+        titleDocLink={getDocsBaseUrl(config, 'users')}
         description={t(
           `A user is someone who has access to {{product}} with associated permissions and credentials.`,
           { product }

--- a/frontend/awx/administration/activity-stream/ActivityStream.tsx
+++ b/frontend/awx/administration/activity-stream/ActivityStream.tsx
@@ -32,7 +32,7 @@ export function ActivityStreams() {
           `An activity stream shows all changes for a particular object. For each change, the activity stream shows the time of the event, the user that initiated the event, and the action.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/main_menu.html#activity-stream`}
+        titleDocLink={getDocsBaseUrl(config, 'activityStream')}
         description={t(
           `An activity stream shows all changes for a particular object. For each change, the activity stream shows the time of the event, the user that initiated the event, and the action.`,
           { product }

--- a/frontend/awx/administration/applications/Applications.tsx
+++ b/frontend/awx/administration/applications/Applications.tsx
@@ -18,7 +18,7 @@ export function Applications() {
         )}
         titleHelpTitle={t('Applications')}
         titleHelp={t('Create and configure token-based authentication for external applications.')}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/applications_auth.html`}
+        titleDocLink={`${getDocsBaseUrl(config, 'applications')}/userguide/applications_auth.html`}
         headerActions={<ActivityStreamIcon type={'o_auth2_application'} />}
       />
       <ApplicationsTable />

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironments.tsx
@@ -20,7 +20,7 @@ export function ExecutionEnvironments() {
         titleHelp={t(
           'Execution environments are container images that make it possible to incorporate system-level dependencies and collection-based content. Each execution environment allows you to have a customized image to run jobs, and each of them contain only what you need when running the job, nothing more.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/execution_environments.html`}
+        titleDocLink={getDocsBaseUrl(config, 'executionEnvironments')}
         headerActions={<ActivityStreamIcon type={'execution_environment'} />}
       />
       <ExecutionEnvironmentsList hideOrgColumn={false} />

--- a/frontend/awx/administration/management-jobs/ManagementJobsList.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobsList.tsx
@@ -33,7 +33,7 @@ export function ManagementJobs() {
         titleHelp={t(
           'Management Jobs assist in the cleaning of old data including system tracking information, tokens, job histories, and activity streams.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/management_jobs.html`}
+        titleDocLink={getDocsBaseUrl(config, 'managementJobs')}
       />
       <PageTable<SystemJobTemplate>
         id="awx-management-jobs"

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -63,7 +63,7 @@ export function Notifiers() {
         description={t('Configure custom notifications to be sent based on predefined events.')}
         titleHelpTitle={t('Notifiers')}
         titleHelp={t('Configure custom notifications to be sent based on predefined events.')}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/notifications.html`}
+        titleDocLink={getDocsBaseUrl(config, 'notifiers')}
         headerActions={<ActivityStreamIcon type={'notification_template'} />}
       />
       <PageTable

--- a/frontend/awx/administration/topology/Topology.tsx
+++ b/frontend/awx/administration/topology/Topology.tsx
@@ -30,7 +30,7 @@ export function Topology() {
         titleHelp={t(
           'View node type, node health, and specific details about each node in your mesh topology.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/administration/topology_viewer.html`}
+        titleDocLink={getDocsBaseUrl(config, 'topology')}
       />
       {isUnauthorized ? (
         <EmptyStateUnauthorized title={t('You do not have permission to perform this action.')} />

--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovals.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovals.tsx
@@ -59,7 +59,7 @@ export function WorkflowApprovals() {
           `A workflow approval represents a pause in a workflow where approval is needed before the workflow continues executing.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/workflows.html`}
+        titleDocLink={getDocsBaseUrl(config, 'workflows')}
         description={t(
           `A workflow approval represents a pause in a workflow where approval is needed before the workflow continues executing.`,
           { product }

--- a/frontend/awx/common/ExecutionEnvironmentDetail.tsx
+++ b/frontend/awx/common/ExecutionEnvironmentDetail.tsx
@@ -40,7 +40,7 @@ function ExecutionEnvironmentDetail(props: {
   } = props;
   const { t } = useTranslation();
   const config = useAwxConfig();
-  const docsLink = `${getDocsBaseUrl(config)}/html/upgrade-migration-guide/upgrade_to_ees.html`;
+  const docsLink = getDocsBaseUrl(config, 'eeMigration');
   const label = isDefaultEnvironment
     ? t('Default execution environment')
     : t('Execution environment');

--- a/frontend/awx/common/MultipleChoiceField.tsx
+++ b/frontend/awx/common/MultipleChoiceField.tsx
@@ -46,7 +46,7 @@ export function MultipleChoiceField(props: IProps) {
 
   const { type } = props;
 
-  const docsURL = `${getDocsBaseUrl(config)}/html/userguide/job_templates.html#surveys`;
+  const docsURL = getDocsBaseUrl(config, 'jobTemplateSurveys');
 
   const emptyChoiceMsg = t('Choice option cannot be empty.');
   const duplicateChoiceMsg = t('Choice option already exists.');

--- a/frontend/awx/common/useAwxConfig.tsx
+++ b/frontend/awx/common/useAwxConfig.tsx
@@ -18,27 +18,44 @@ export function useAwxConfigState() {
   return useContext(AwxConfigContext);
 }
 
-export function AwxConfigProvider(props: { children: ReactNode; disabled?: boolean }) {
+export function AwxConfigProvider(props: {
+  children: ReactNode;
+  disabled?: boolean;
+  platformVersion?: string;
+}) {
   return props?.disabled ? (
     <AwxConfigContext.Provider
-      value={{ awxConfig: undefined, awxConfigError: undefined, refreshAwxConfig: undefined }}
+      value={{
+        awxConfig: undefined,
+        awxConfigError: undefined,
+        refreshAwxConfig: undefined,
+      }}
     >
       {props.children}
     </AwxConfigContext.Provider>
   ) : (
-    <AwxConfigProviderInternal>{props?.children}</AwxConfigProviderInternal>
+    <AwxConfigProviderInternal platformVersion={props.platformVersion}>
+      {props?.children}
+    </AwxConfigProviderInternal>
   );
 }
 
-export function AwxConfigProviderInternal(props: { children?: ReactNode }) {
+export function AwxConfigProviderInternal(props: {
+  children?: ReactNode;
+  platformVersion?: string;
+}) {
+  const { platformVersion } = props;
   const response = useSWR<Config>(awxAPI`/config/`, requestGet);
   const value = useMemo(
     () => ({
-      awxConfig: response.data,
+      awxConfig: {
+        ...(response.data as Config),
+        platformVersion,
+      },
       awxConfigError: response.error as Error,
       refreshAwxConfig: () => response.mutate(undefined),
     }),
-    [response]
+    [response, platformVersion]
   );
   return <AwxConfigContext.Provider value={value}>{props.children}</AwxConfigContext.Provider>;
 }

--- a/frontend/awx/common/util/getDocsBaseUrl.ts
+++ b/frontend/awx/common/util/getDocsBaseUrl.ts
@@ -1,6 +1,6 @@
 import { Config } from '../../interfaces/Config';
 
-export interface docPathDictionary {
+export interface DocPathDictionary {
   credentialTypes: string;
   credentials: string;
   organizations: string;
@@ -30,7 +30,7 @@ export interface docPathDictionary {
 
 export function getDocsBaseUrl(
   config: Config | null | undefined,
-  doc: keyof docPathDictionary
+  doc: keyof DocPathDictionary
 ): string {
   const version = config?.platformVersion || '2.5';
   const licenseType = config?.license_info?.license_type;
@@ -41,7 +41,7 @@ export function getDocsBaseUrl(
   }
 }
 
-const upstreamPaths: docPathDictionary = {
+const upstreamPaths: DocPathDictionary = {
   credentialTypes: 'userguide/credential_types.html',
   credentials: 'userguide/credentials.html',
   organizations: 'userguide/organizations.html',
@@ -70,7 +70,7 @@ const upstreamPaths: docPathDictionary = {
   schedules: 'userguide/scheduling.html',
 };
 
-const downstreamPaths: docPathDictionary = {
+const downstreamPaths: DocPathDictionary = {
   credentialTypes: 'automation_controller_user_guide/assembly-controller-custom-credentials',
   credentials: 'automation_controller_user_guide/controller-credentials',
   organizations: 'automation_controller_user_guide/assembly-controller-organizations',

--- a/frontend/awx/common/util/getDocsBaseUrl.ts
+++ b/frontend/awx/common/util/getDocsBaseUrl.ts
@@ -32,7 +32,7 @@ export function getDocsBaseUrl(
   config: Config | null | undefined,
   doc: keyof docPathDictionary
 ): string {
-  const version = '2.4';
+  const version = config?.platformVersion || '2.5';
   const licenseType = config?.license_info?.license_type;
   if (licenseType && licenseType !== 'open') {
     return `https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/${version}/html/${downstreamPaths[doc]}`;

--- a/frontend/awx/common/util/getDocsBaseUrl.ts
+++ b/frontend/awx/common/util/getDocsBaseUrl.ts
@@ -63,7 +63,6 @@ const upstreamPaths: DocPathDictionary = {
   managePlaybooksSC: 'userguide/projects.html#manage-playbooks-using-source-control',
   projects: 'userguide/projects.html',
   templates: 'userguide/job_templates.html',
-  // workflowTemplates: 'userguide/automation_controller_user_guide/controller-workflow-job-templates',
   workflowVisualizer: 'userguide/workflow_templates.html#ug-wf-editor',
   workflowVisBuild: 'userguide/workflow_templates.html#converge-node',
   jobs: 'userguide/jobs.html',
@@ -88,7 +87,7 @@ const downstreamPaths: DocPathDictionary = {
   jobTemplateSurveys:
     'automation_controller_user_guide/controller-job-templates#controller-surveys-in-job-templates',
   index: 'automation_controller_user_guide/index',
-  hosts: 'automation_controller_user_guide/controller-hosts',
+  hosts: 'automation_controller_user_guide/assembly-controller-hosts',
   inventories: 'automation_controller_user_guide/controller-inventories',
   constructedInventories:
     'automation_controller_user_guide/controller-inventories#ref-controller-constructed-inventories',
@@ -96,7 +95,6 @@ const downstreamPaths: DocPathDictionary = {
     'automation_controller_user_guide/controller-projects#ref-projects-manage-playbooks-with-source-control',
   projects: 'automation_controller_user_guide/controller-projects',
   templates: 'automation_controller_user_guide/controller-job-templates',
-  // workflowTemplates: 'automation_controller_user_guide/controller-workflow-job-templates',
   workflowVisualizer:
     'automation_controller_user_guide/controller-workflow-job-templates#controller-workflow-visualizer',
   workflowVisBuild:

--- a/frontend/awx/common/util/getDocsBaseUrl.ts
+++ b/frontend/awx/common/util/getDocsBaseUrl.ts
@@ -1,10 +1,106 @@
 import { Config } from '../../interfaces/Config';
 
-export function getDocsBaseUrl(config: Config | null | undefined) {
-  let version = 'latest';
+export interface docPathDictionary {
+  credentialTypes: string;
+  credentials: string;
+  organizations: string;
+  teams: string;
+  users: string;
+  activityStream: string;
+  applications: string;
+  executionEnvironments: string;
+  managementJobs: string;
+  notifiers: string;
+  topology: string;
+  workflows: string;
+  eeMigration: string;
+  jobTemplateSurveys: string;
+  index: string;
+  hosts: string;
+  inventories: string;
+  constructedInventories: string;
+  managePlaybooksSC: string;
+  projects: string;
+  templates: string;
+  workflowVisualizer: string;
+  workflowVisBuild: string;
+  jobs: string;
+  schedules: string;
+}
+
+export function getDocsBaseUrl(
+  config: Config | null | undefined,
+  doc: keyof docPathDictionary
+): string {
+  const version = '2.4';
   const licenseType = config?.license_info?.license_type;
   if (licenseType && licenseType !== 'open') {
-    version = config?.version ? config.version.split('-')[0] : 'latest';
+    return `https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/${version}/html/${downstreamPaths[doc]}`;
+  } else {
+    return `https://ansible.readthedocs.io/projects/awx/en/latest/${upstreamPaths[doc]}`;
   }
-  return `https://docs.ansible.com/automation-controller/${version}`;
 }
+
+const upstreamPaths: docPathDictionary = {
+  credentialTypes: 'userguide/credential_types.html',
+  credentials: 'userguide/credentials.html',
+  organizations: 'userguide/organizations.html',
+  teams: 'userguide/teams.html',
+  users: 'userguide/users.html',
+  activityStream: 'userguide/main_menu.html#activity-stream',
+  applications: 'userguide/applications_auth.html',
+  executionEnvironments: 'userguide/execution_environments.html',
+  managementJobs: 'userguide/management_jobs.html',
+  notifiers: 'userguide/notifications.html',
+  topology: 'userguide/topology_viewer.html',
+  workflows: 'userguide/workflows.html',
+  eeMigration: 'upgrade-migration-guide/upgrade_to_ees.html',
+  jobTemplateSurveys: 'userguide/job_templates.html#surveys',
+  index: 'userguide/index.html',
+  hosts: 'userguide/hosts.html',
+  inventories: 'userguide/inventories.html',
+  constructedInventories: 'userguide/inventories.html#constructed-inventories',
+  managePlaybooksSC: 'userguide/projects.html#manage-playbooks-using-source-control',
+  projects: 'userguide/projects.html',
+  templates: 'userguide/job_templates.html',
+  // workflowTemplates: 'userguide/automation_controller_user_guide/controller-workflow-job-templates',
+  workflowVisualizer: 'userguide/workflow_templates.html#ug-wf-editor',
+  workflowVisBuild: 'userguide/workflow_templates.html#converge-node',
+  jobs: 'userguide/jobs.html',
+  schedules: 'userguide/scheduling.html',
+};
+
+const downstreamPaths: docPathDictionary = {
+  credentialTypes: 'automation_controller_user_guide/assembly-controller-custom-credentials',
+  credentials: 'automation_controller_user_guide/controller-credentials',
+  organizations: 'automation_controller_user_guide/assembly-controller-organizations',
+  teams: 'automation_controller_user_guide/assembly-controller-teams',
+  users: 'automation_controller_user_guide/assembly-controller-users',
+  activityStream: 'automation_controller_user_guide/assembly-controller-activity-stream',
+  applications: 'automation_controller_user_guide/assembly-controller-applications',
+  executionEnvironments:
+    'automation_controller_user_guide/assembly-controller-execution-environments',
+  managementJobs: 'automation_controller_user_guide/assembly-controller-management-jobs',
+  notifiers: 'automation_controller_user_guide/assembly-controller-notifications',
+  topology: 'automation_controller_user_guide/assembly-controller-topology-viewer',
+  workflows: 'automation_controller_user_guide/assembly-controller-workflows',
+  eeMigration: 'red_hat_ansible_automation_platform_upgrade_and_migration_guide/upgrading-to-ees',
+  jobTemplateSurveys:
+    'automation_controller_user_guide/controller-job-templates#controller-surveys-in-job-templates',
+  index: 'automation_controller_user_guide/index',
+  hosts: 'automation_controller_user_guide/controller-hosts',
+  inventories: 'automation_controller_user_guide/controller-inventories',
+  constructedInventories:
+    'automation_controller_user_guide/controller-inventories#ref-controller-constructed-inventories',
+  managePlaybooksSC:
+    'automation_controller_user_guide/controller-projects#ref-projects-manage-playbooks-with-source-control',
+  projects: 'automation_controller_user_guide/controller-projects',
+  templates: 'automation_controller_user_guide/controller-job-templates',
+  // workflowTemplates: 'automation_controller_user_guide/controller-workflow-job-templates',
+  workflowVisualizer:
+    'automation_controller_user_guide/controller-workflow-job-templates#controller-workflow-visualizer',
+  workflowVisBuild:
+    'automation_controller_user_guide/controller-workflow-job-templates#controller-build-workflow',
+  jobs: 'automation_controller_user_guide/controller-jobs',
+  schedules: 'automation_controller_user_guide/controller-schedules',
+};

--- a/frontend/awx/interfaces/Config.ts
+++ b/frontend/awx/interfaces/Config.ts
@@ -2,6 +2,7 @@ export interface Config {
   time_zone: string;
   license_info: ILicenseInfo;
   version: string;
+  platformVersion?: string;
   eula: string;
   analytics_status: string;
   analytics_collectors: {

--- a/frontend/awx/main/AwxMasthead.tsx
+++ b/frontend/awx/main/AwxMasthead.tsx
@@ -50,7 +50,7 @@ export function AwxMasthead() {
               id="documentation"
               icon={<ExternalLinkAltIcon />}
               component="a"
-              href={`${getDocsBaseUrl(config)}/html/userguide/index.html`}
+              href={getDocsBaseUrl(config, 'index')}
               target="_blank"
               data-cy="masthead-documentation"
             >

--- a/frontend/awx/resources/hosts/Hosts.tsx
+++ b/frontend/awx/resources/hosts/Hosts.tsx
@@ -49,7 +49,7 @@ export function Hosts() {
             'Ansible works against multiple managed nodes or “hosts” in your infrastructure at the same time, using a list or group of lists known as inventory. Once your inventory is defined, you use patterns to select the hosts or groups you want Ansible to run against.'
           ),
         ]}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/hosts.html`}
+        titleDocLink={getDocsBaseUrl(config, 'hosts')}
         headerActions={<ActivityStreamIcon type={'host'} />}
       />
       <PageTable<AwxHost>

--- a/frontend/awx/resources/inventories/Inventories.tsx
+++ b/frontend/awx/resources/inventories/Inventories.tsx
@@ -100,7 +100,7 @@ export function Inventories() {
         titleHelp={t(
           'An inventory defines the hosts and groups of hosts upon which commands, modules, and tasks in a playbook operate.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/inventories.html`}
+        titleDocLink={getDocsBaseUrl(config, 'inventories')}
         description={t(
           'An inventory defines the hosts and groups of hosts upon which commands, modules, and tasks in a playbook operate.'
         )}

--- a/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
+++ b/frontend/awx/resources/inventories/components/ConstructedInventoryHint.tsx
@@ -32,7 +32,7 @@ export function ConstructedInventoryHint() {
       title={t`How to use constructed inventory plugin`}
       actionLinks={
         <AlertActionLink
-          href={`${getDocsBaseUrl(config)}/html/userguide/inventories.html#constructed-inventories`}
+          href={getDocsBaseUrl(config, 'constructedInventories')}
           component="a"
           target="_blank"
           rel="noopener noreferrer"

--- a/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectDetails.tsx
@@ -108,9 +108,7 @@ export function ProjectDetails(props: { projectId?: string; disableScroll?: bool
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href={`${getDocsBaseUrl(
-          config
-        )}/html/userguide/projects.html#manage-playbooks-using-source-control`}
+        href={getDocsBaseUrl(config, 'managePlaybooksSC')}
       >
         {t`Documentation.`}
       </a>

--- a/frontend/awx/resources/projects/ProjectSubForms/GitSubForm.tsx
+++ b/frontend/awx/resources/projects/ProjectSubForms/GitSubForm.tsx
@@ -61,9 +61,7 @@ export function GitSubForm() {
         <a
           target="_blank"
           rel="noopener noreferrer"
-          href={`${getDocsBaseUrl(
-            config
-          )}/html/userguide/projects.html#manage-playbooks-using-source-control`}
+          href={getDocsBaseUrl(config, 'managePlaybooksSC')}
         >
           {t`Documentation.`}
         </a>

--- a/frontend/awx/resources/projects/Projects.tsx
+++ b/frontend/awx/resources/projects/Projects.tsx
@@ -72,7 +72,7 @@ export function Projects() {
           `A Project is a logical collection of Ansible playbooks, represented in {{product}}. You can manage playbooks and playbook directories by either placing them manually under the Project Base Path on your {{product}} server, or by placing your playbooks into a source code management (SCM) system supported by {{product}}, including Git, Subversion, Mercurial, and Red Hat Insights.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/projects.html`}
+        titleDocLink={getDocsBaseUrl(config, 'projects')}
         description={t(
           `A Project is a logical collection of Ansible playbooks, represented in {{product}}.`,
           { product }

--- a/frontend/awx/resources/templates/Templates.tsx
+++ b/frontend/awx/resources/templates/Templates.tsx
@@ -21,7 +21,7 @@ export function Templates() {
         titleHelp={t(
           'A job template is a definition and set of parameters for running an Ansible job. Job templates are useful to execute the same job many times. Job templates also encourage the reuse of Ansible playbook content and collaboration between teams.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/job_templates.html`}
+        titleDocLink={getDocsBaseUrl(config, 'templates')}
         description={t(
           'A job template is a definition and set of parameters for running an Ansible job.'
         )}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/WorkflowVisualizer.cy.tsx
@@ -162,7 +162,7 @@ describe('WorkflowVisualizer', () => {
       .get('[data-cy="workflow-documentation"]')
       .contains('Documentation')
       .should('have.attr', 'href')
-      .should('include', 'html/userguide/workflow_templates.html#ug-wf-editor');
+      .should('include', 'userguide/workflow_templates.html#ug-wf-editor');
     cy.get('.toggle-kebab').click();
     cy.get('.toggle-kebab')
       .click()

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowVisualizerToolbar.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/WorkflowVisualizerToolbar.tsx
@@ -251,7 +251,7 @@ export const WorkflowVisualizerToolbar = observer(() => {
             <DropdownItem
               icon={<ExternalLinkAltIcon />}
               data-cy="workflow-documentation"
-              to={`${getDocsBaseUrl(config)}/html/userguide/workflow_templates.html#ug-wf-editor`}
+              to={getDocsBaseUrl(config, 'workflowVisualizer')}
               target="_blank"
             >
               {t('Documentation')}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
@@ -404,11 +404,7 @@ function ConvergenceInput() {
       labelHelp={
         <>
           {t('Preconditions for running this node when there are multiple parents')}{' '}
-          <a
-            href={`${getDocsBaseUrl(config)}/html/userguide/workflow_templates.html#converge-node`}
-          >
-            {t('documentation.')}
-          </a>
+          <a href={getDocsBaseUrl(config, 'workflowVisBuild')}>{t('documentation.')}</a>
         </>
       }
       options={[

--- a/frontend/awx/views/jobs/Jobs.tsx
+++ b/frontend/awx/views/jobs/Jobs.tsx
@@ -65,7 +65,7 @@ export function Jobs() {
           `A job is an instance of {{product}} launching an Ansible playbook against an inventory of hosts.`,
           { product }
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/jobs.html`}
+        titleDocLink={getDocsBaseUrl(config, 'jobs')}
         description={t(
           `A job is an instance of {{product}} launching an Ansible playbook against an inventory of hosts.`,
           { product }

--- a/frontend/awx/views/schedules/Schedules.tsx
+++ b/frontend/awx/views/schedules/Schedules.tsx
@@ -18,7 +18,7 @@ export function Schedules(props: { sublistEndpoint?: string }) {
         titleHelp={t(
           'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
         )}
-        titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/scheduling.html`}
+        titleDocLink={getDocsBaseUrl(config, 'schedules')}
         description={t(
           'Schedules are used to launch jobs on a regular basis. They can be used to launch jobs against machines, synchronize with inventory sources, and import project content from a version control system.'
         )}

--- a/frontend/awx/views/schedules/components/RulesList.tsx
+++ b/frontend/awx/views/schedules/components/RulesList.tsx
@@ -109,7 +109,7 @@ export function RulesList(props: {
           title={isExceptions ? t('Schedule Exceptions') : t('Schedule Rules')}
           titleHelpTitle={isExceptions ? t('Schedule Exceptions') : t('Schedule Rules')}
           titleHelp={t('Create as many schedule rules as you need.')}
-          titleDocLink={`${getDocsBaseUrl(config)}/html/userguide/scheduling.html`}
+          titleDocLink={getDocsBaseUrl(config, 'schedules')}
           description={description}
           headerActions={
             <>

--- a/frontend/common/ExecutionEnvironmentPageDetail.tsx
+++ b/frontend/common/ExecutionEnvironmentPageDetail.tsx
@@ -32,7 +32,7 @@ export function ExecutionEnvironmentDetail(props: {
 }) {
   const config = useAwxConfig();
   const { t } = useTranslation();
-  const docsLink = `${getDocsBaseUrl(config)}/html/upgrade-migration-guide/upgrade_to_ees.html`;
+  const docsLink = getDocsBaseUrl(config, 'eeMigration');
   const label = props.isDefaultEnvironment
     ? t('Default Execution Environment')
     : t('Execution Environment');


### PR DESCRIPTION
This PR is for AAP-27455. It aims to ensure both upstream and downstream builds have the appropriate doc links throughout the UI. The changes here were tested upstream and seem to be working fine. This is still a draft as this solution still needs to be tested downstream. In addition, the problem with figuring out the version of docs we want to link for downstream still needs to be solved. Currently I am just linking to the 2.4 docs but ideally we would want to be able to figure out what version of the docs we want through checking the version of AAP in a deployment and doing some mapping to discern the correct docs version. Another solution would be to try and default to latest at all times. Currently this is hard because there is no way to provide a `latest` version in the product docs path like we can for upstream docs. We would need to talk to the docs team to support a `latest` path to do this.