### PR TITLE
Add page ID as on option for created and modified columns

### DIFF
--- a/frontend/common/columns.tsx
+++ b/frontend/common/columns.tsx
@@ -195,6 +195,7 @@ export function useCreatedColumn(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
   sort?: string;
+  userDetailsPageId?: string;
 }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
@@ -228,10 +229,13 @@ export function useCreatedColumn(options?: {
             onClick={
               options?.disableLinks || !('summary_fields' in item)
                 ? undefined
-                : () =>
-                    pageNavigate(AwxRoute.UserDetails, {
-                      params: { id: item.summary_fields?.created_by?.id },
-                    })
+                : () => {
+                    pageNavigate(options?.userDetailsPageId || AwxRoute.UserDetails, {
+                      params: {
+                        id: item.summary_fields?.created_by?.id,
+                      },
+                    });
+                  }
             }
           />
         );
@@ -245,7 +249,14 @@ export function useCreatedColumn(options?: {
       dashboard: 'hidden',
       priority: ColumnPriority.last,
     }),
-    [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
+    [
+      t,
+      options?.disableSort,
+      options?.sort,
+      options?.disableLinks,
+      options?.userDetailsPageId,
+      pageNavigate,
+    ]
   );
   return column;
 }
@@ -254,6 +265,7 @@ export function useModifiedColumn(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
   sort?: string;
+  userDetailsPageId?: string;
 }) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
@@ -280,8 +292,10 @@ export function useModifiedColumn(options?: {
               options?.disableLinks || !('summary_fields' in item)
                 ? undefined
                 : () =>
-                    pageNavigate(AwxRoute.UserDetails, {
-                      params: { id: item.summary_fields?.modified_by?.id },
+                    pageNavigate(options?.userDetailsPageId || AwxRoute.UserDetails, {
+                      params: {
+                        id: item.summary_fields?.modified_by?.id,
+                      },
                     })
             }
           />
@@ -296,7 +310,14 @@ export function useModifiedColumn(options?: {
       dashboard: 'hidden',
       priority: ColumnPriority.last,
     }),
-    [t, options?.disableSort, options?.sort, options?.disableLinks, pageNavigate]
+    [
+      t,
+      options?.disableSort,
+      options?.sort,
+      options?.disableLinks,
+      options?.userDetailsPageId,
+      pageNavigate,
+    ]
   );
   return column;
 }


### PR DESCRIPTION
[AAP-27329](https://issues.redhat.com/browse/AAP-27329)

Option to specify user details page ID for routing to the correct user details page from the `created` and `modified` columns.