### PR TITLE
Display social auth login error message

### DIFF
--- a/frontend/common/AnsibleLogin.cy.tsx
+++ b/frontend/common/AnsibleLogin.cy.tsx
@@ -1,0 +1,14 @@
+import { AnsibleLogin } from './AnsibleLogin';
+
+describe('AnsibleLogin', () => {
+  it('should render error message when auth_field url param present', () => {
+    cy.mount(<AnsibleLogin loginApiUrl="/login" brandImgAlt="" onSuccess={() => {}} />, {
+      path: '/',
+      initialEntries: ['?auth_failed'],
+    });
+
+    cy.get('.pf-m-error').then((el) => {
+      expect(el).to.contain('Unable to complete social auth login');
+    });
+  });
+});

--- a/frontend/common/AnsibleLogin.tsx
+++ b/frontend/common/AnsibleLogin.tsx
@@ -10,7 +10,7 @@ import {
   LoginMainHeader,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { ReactNode, useCallback, useState } from 'react';
+import { ReactNode, useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { ErrorBoundary } from '../../framework/components/ErrorBoundary';
@@ -109,6 +109,13 @@ export function AnsibleLogin(props: {
       }
     }
   }, [loginApiUrl, password, props, t, username]);
+
+  const hasAuthFailedFlag = window.location.search.includes('auth_failed');
+  useEffect(() => {
+    if (hasAuthFailedFlag) {
+      setHelperText(<ErrorSpanStyled>{t('Unable to complete social auth login')}</ErrorSpanStyled>);
+    }
+  }, [hasAuthFailedFlag, t]);
 
   // Need to use component version of PatternFly's LoginPage
   // because we need to be able to use a component for the brand image

--- a/frontend/common/AnsibleLogin.tsx
+++ b/frontend/common/AnsibleLogin.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { ReactNode, useCallback, useState, useEffect } from 'react';
+import { useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { ErrorBoundary } from '../../framework/components/ErrorBoundary';
@@ -52,6 +53,7 @@ export function AnsibleLogin(props: {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [helperText, setHelperText] = useState<ReactNode>('');
+  const location = useLocation();
 
   const { loginApiUrl } = props;
   const onSubmit = useCallback(async () => {
@@ -110,7 +112,7 @@ export function AnsibleLogin(props: {
     }
   }, [loginApiUrl, password, props, t, username]);
 
-  const hasAuthFailedFlag = window.location.search.includes('auth_failed');
+  const hasAuthFailedFlag = location.search.includes('auth_failed');
   useEffect(() => {
     if (hasAuthFailedFlag) {
       setHelperText(<ErrorSpanStyled>{t('Unable to complete social auth login')}</ErrorSpanStyled>);


### PR DESCRIPTION
When social auth fails, the user is redirected to `/?auth_failed` (https://github.com/ansible/django-ansible-base/pull/467)

This updates the login to look for that URL query param and display an error message to the user informing them of the authentication failure

![Screenshot 2024-07-23 at 10 29 40 AM](https://github.com/user-attachments/assets/51dc8551-69cb-48b5-9c04-ccb16c0b3035)
