### PR TITLE
[AAP-27450] Adds validation to prevent duplicate credential types 

### DIFF
--- a/frontend/awx/access/credentials/components/PageFormCredentialSelect.tsx
+++ b/frontend/awx/access/credentials/components/PageFormCredentialSelect.tsx
@@ -8,6 +8,7 @@ import { useCredentialsColumns } from '../hooks/useCredentialsColumns';
 import { useCredentialsFilters } from '../hooks/useCredentialsFilters';
 import { QueryParams } from '../../../common/useAwxView';
 import { PageFormMultiSelectAwxResource } from '../../../common/PageFormMultiSelectAwxResource';
+import { useCredentialsValidate } from '../hooks/useCredentialsValidate';
 
 export function PageFormCredentialSelect<
   TFieldValues extends FieldValues = FieldValues,
@@ -34,6 +35,7 @@ export function PageFormCredentialSelect<
 
   const credentialColumns = useCredentialsColumns({ disableLinks: true });
   const credentialFilters = useCredentialsFilters();
+  const validateCredentials = useCredentialsValidate();
 
   return props.isMultiple ? (
     <PageFormMultiSelectAwxResource<Credential>
@@ -54,6 +56,10 @@ export function PageFormCredentialSelect<
       compareOptionValues={(currentCredential: Credential, selectCredential: Credential) =>
         currentCredential.id === selectCredential.id
       }
+      validate={validateCredentials}
+      formatLabel={(credential: Credential) => {
+        return `${credential.name} | ${credential.summary_fields.credential_type.name}`;
+      }}
     />
   ) : (
     <PageFormSingleSelectAwxResource<Credential, TFieldValues, TFieldName>

--- a/frontend/awx/access/credentials/hooks/useCredentialsValidate.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialsValidate.tsx
@@ -1,0 +1,55 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PromptFormValues } from '../../../resources/templates/WorkflowVisualizer/types';
+import { Credential } from '../../../interfaces/Credential';
+import { requestGet } from '../../../../common/crud/Data';
+import { awxAPI } from '../../../common/api/awx-utils';
+
+export function useCredentialsValidate() {
+  const { t } = useTranslation();
+  return useCallback(
+    async (selectedCredentials: PromptFormValues['credentials']) => {
+      const originalCredentials: number[] = [];
+      const newCredentials: Credential[] = [];
+      selectedCredentials?.forEach((credential) =>
+        !('summary_fields' in credential)
+          ? originalCredentials.push(credential.id)
+          : newCredentials.push(credential)
+      );
+      const fullDefaultCredentials: Credential[] = await Promise.all(
+        originalCredentials.map((defCred) =>
+          requestGet<Credential>(awxAPI`/credentials/${defCred.toString()}/`)
+        )
+      );
+      const allCredentials = [...(fullDefaultCredentials || []), ...newCredentials];
+      const vaultIds = allCredentials
+        .filter((credential) => credential.kind === 'vault' && credential.inputs.vault_id)
+        .map((vaultCred) => vaultCred.inputs.vault_id.toString());
+      const otherCredentialTypes = allCredentials
+        .filter((credential) => credential.kind !== 'vault')
+        .map((nonVaultCred) => nonVaultCred.summary_fields.credential_type.name);
+
+      const hasDuplicateVaultIds: boolean =
+        vaultIds.filter(
+          (vaultId, _index, array) => array.indexOf(vaultId) !== array.lastIndexOf(vaultId)
+        ).length > 0;
+      const duplicateCredentialTypes: string[] = [
+        ...new Set(
+          otherCredentialTypes.filter(
+            (cred, _index, array) => array.indexOf(cred) !== array.lastIndexOf(cred)
+          )
+        ),
+      ];
+
+      if (duplicateCredentialTypes.length > 0) {
+        return t(
+          `Cannot assign multiple credentials of the same type. Duplicated credential types are: ${duplicateCredentialTypes.join(', ')}`
+        );
+      }
+      if (hasDuplicateVaultIds) {
+        return t(`Cannot assign multiple vault credentials of the same vault id.`);
+      }
+    },
+    [t]
+  );
+}

--- a/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
+++ b/frontend/awx/common/PageFormMultiSelectAwxResource.tsx
@@ -32,7 +32,10 @@ export function PageFormMultiSelectAwxResource<
   labelHelp?: string;
   queryParams?: QueryParams;
   compareOptionValues?: (a: Value, b: Value) => boolean;
+  validate?: (items: Value[]) => Promise<string | undefined>;
+  formatLabel?: (item: Resource) => string;
 }) {
+  const { formatLabel = undefined } = props;
   const id = useID(props);
 
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<PathValue<FormData, Name>>>(
@@ -66,9 +69,9 @@ export function PageFormMultiSelectAwxResource<
           remaining: response.count - response.results.length,
           options:
             response.results?.map((resource) => ({
-              label: resource.name,
               value: resource as PathValue<FormData, Name>,
               description: resource.description,
+              label: formatLabel ? formatLabel(resource) : resource.name,
             })) ?? [],
           next: response.results[response.results.length - 1]?.name,
         };
@@ -80,7 +83,7 @@ export function PageFormMultiSelectAwxResource<
         };
       }
     },
-    [props.url, props.queryParams]
+    [props.url, props.queryParams, formatLabel]
   );
 
   const [_, setDialog] = usePageDialog();
@@ -146,6 +149,7 @@ export function PageFormMultiSelectAwxResource<
       queryLabel={queryLabel}
       additionalControls={props.additionalControls}
       compareOptionValues={props.compareOptionValues}
+      validate={props.validate}
     />
   );
 }


### PR DESCRIPTION
Across awx there are a few places where a user can select mutiple credentials.  In each of those cases there are limits.  
Limits
1) Cannot select more than 1 credential per credential type
except for Vault credentials
2) Cannot select more than 1 vault credential with the same vault ID.  Vault ID is an optional field.