### PR TITLE
[AAP-27781] Fix EDA credential types test

### DIFF
--- a/cypress/e2e/eda/Credentials/credential-type-crud.cy.ts
+++ b/cypress/e2e/eda/Credentials/credential-type-crud.cy.ts
@@ -47,6 +47,7 @@ describe('EDA Credentials Type - Create, Edit, Delete', () => {
     cy.createEdaCredentialType().then((edaCredentialType) => {
       cy.navigateTo('eda', 'credential-types');
       cy.get('h1').should('contain', 'Credential Types');
+      cy.filterTableByText(edaCredentialType.name, 'MultiText');
       cy.clickTableRow(edaCredentialType.name, false);
       cy.clickButton(/^Edit credential type$/);
       cy.verifyPageTitle(`Edit ${edaCredentialType.name}`);
@@ -63,6 +64,7 @@ describe('EDA Credentials Type - Create, Edit, Delete', () => {
     cy.createEdaCredentialType().then((edaCredentialType) => {
       cy.navigateTo('eda', 'credential-types');
       cy.get('h1').should('contain', 'Credential Types');
+      cy.filterTableByText(edaCredentialType.name, 'MultiText');
       cy.clickTableRow(edaCredentialType.name, false);
       cy.verifyPageTitle(edaCredentialType.name);
       cy.intercept('DELETE', edaAPI`/credential-types/${edaCredentialType.id.toString()}/`).as(
@@ -89,6 +91,7 @@ describe('EDA Credentials Type - Create, Edit, Delete', () => {
       }).then((cred) => {
         cy.navigateTo('eda', 'credential-types');
         cy.get('h1').should('contain', 'Credential Types');
+        cy.filterTableByText(credtype.name, 'MultiText');
         cy.clickTableRow(credtype.name, false);
         cy.verifyPageTitle(credtype.name);
         cy.intercept('DELETE', edaAPI`/credential-types/${credtype.id.toString()}/`).as('deleted');
@@ -125,6 +128,7 @@ describe('EDA Credentials Type - Create, Edit, Delete', () => {
       }).then((cred) => {
         cy.navigateTo('eda', 'credential-types');
         cy.get('h1').should('contain', 'Credential Types');
+        cy.filterTableByText(credtype.name, 'MultiText');
         cy.clickTableRow(credtype.name, false);
         cy.verifyPageTitle(credtype.name);
         cy.intercept('PATCH', edaAPI`/credential-types/${credtype.id.toString()}/`).as('edit');
@@ -150,30 +154,20 @@ describe('EDA Credentials Type - Create, Edit, Delete', () => {
   });
 
   it('can bulk delete credential types', () => {
-    cy.createEdaCredentialType().then((credtype1) => {
-      cy.createEdaCredentialType().then((credtype2) => {
-        cy.navigateTo('eda', 'credential-types');
-        cy.get('h1').should('contain', 'Credential Types');
-        cy.selectTableRow(credtype1.name, false);
-        cy.selectTableRow(credtype2.name, false);
-        cy.clickToolbarKebabAction('delete-credential-types');
-        cy.intercept('DELETE', edaAPI`/credential-types/${credtype1.id.toString()}/`).as(
-          'credtype1'
-        );
-        cy.intercept('DELETE', edaAPI`/credential-types/${credtype2.id.toString()}/`).as(
-          'credtype2'
-        );
-        cy.clickModalConfirmCheckbox();
-        cy.clickModalButton('Delete credential types');
-        cy.wait('@credtype1').then((credtype1) => {
-          expect(credtype1?.response?.statusCode).to.eql(204);
-        });
-        cy.wait('@credtype2').then((credtype2) => {
-          expect(credtype2?.response?.statusCode).to.eql(204);
-        });
-        cy.assertModalSuccess();
-        cy.clickButton(/^Close$/);
+    cy.createEdaCredentialType().then((credtype) => {
+      cy.navigateTo('eda', 'credential-types');
+      cy.get('h1').should('contain', 'Credential Types');
+      cy.filterTableByText(credtype.name, 'MultiText');
+      cy.selectTableRow(credtype.name, false);
+      cy.clickToolbarKebabAction('delete-credential-types');
+      cy.intercept('DELETE', edaAPI`/credential-types/${credtype.id.toString()}/`).as('credtype');
+      cy.clickModalConfirmCheckbox();
+      cy.clickModalButton('Delete credential type');
+      cy.wait('@credtype').then((credtyperesponse) => {
+        expect(credtyperesponse?.response?.statusCode).to.eql(204);
       });
+      cy.assertModalSuccess();
+      cy.clickButton(/^Close$/);
     });
   });
 });

--- a/frontend/eda/access/credential-types/CredentialTypes.tsx
+++ b/frontend/eda/access/credential-types/CredentialTypes.tsx
@@ -12,6 +12,7 @@ import { edaAPI } from '../../common/eda-utils';
 import { useEdaView } from '../../common/useEventDrivenView';
 import { useOptions } from '../../../common/crud/useOptions';
 import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
+import { useCredentialTypeCredentialsFilters } from './hooks/useCredentialTypeCredentialsFilters';
 
 export function CredentialTypes() {
   const { t } = useTranslation();
@@ -19,9 +20,11 @@ export function CredentialTypes() {
   const pageNavigate = usePageNavigate();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(edaAPI`/credential-types/`);
   const canCreateCredentialTypes = Boolean(data && data.actions && data.actions['POST']);
+  const toolbarFilters = useCredentialTypeCredentialsFilters();
 
   const view = useEdaView<EdaCredentialType>({
     url: edaAPI`/credential-types/`,
+    toolbarFilters,
     tableColumns,
   });
 
@@ -43,6 +46,7 @@ export function CredentialTypes() {
         id="Eda-credential-types"
         toolbarActions={toolbarActions}
         tableColumns={tableColumns}
+        toolbarFilters={toolbarFilters}
         rowActions={rowActions}
         errorStateTitle={t('Error loading credential types')}
         emptyStateTitle={


### PR DESCRIPTION
Steps to reproduce failures:
- create credential names so there's at least 10 of them
- run tests
Before:
```
  1) EDA Credentials Type - Create, Edit, Delete
       can edit a credential type:
     AssertionError: Timed out retrying after 30000ms: Expected to find content: 'E2E Credential TypeSUTh' within the selector: 'tr' but never did.
      at Context.eval (webpack://@ansible/ansible-ui/./cypress/support/awx-commands.ts:350:0)

  2) EDA Credentials Type - Create, Edit, Delete
       can delete a credential type:
     AssertionError: Timed out retrying after 30000ms: Expected to find content: 'E2E Credential TypeOJVQ' within the selector: 'tr' but never did.
      at Context.eval (webpack://@ansible/ansible-ui/./cypress/support/awx-commands.ts:350:0)

  3) EDA Credentials Type - Create, Edit, Delete
       cannot delete a credential type if already in use:
     AssertionError: Timed out retrying after 30000ms: Expected to find content: 'E2E Credential TypePxmd' within the selector: 'tr' but never did.
      at Context.eval (webpack://@ansible/ansible-ui/./cypress/support/awx-commands.ts:350:0)

  4) EDA Credentials Type - Create, Edit, Delete
       cannot edit a credential type if already in use:
     AssertionError: Timed out retrying after 30000ms: Expected to find content: 'E2E Credential TypeeEBE' within the selector: 'tr' but never did.
      at Context.eval (webpack://@ansible/ansible-ui/./cypress/support/awx-commands.ts:350:0)

  5) EDA Credentials Type - Create, Edit, Delete
       can bulk delete credential types:
     AssertionError: Timed out retrying after 30000ms: Expected to find content: 'E2E Credential TypeewAU' within the selector: 'tr' but never did.
      at Context.eval (webpack://@ansible/ansible-ui/./cypress/support/awx-commands.ts:350:0)
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✖  credential-type-crud.cy.ts               09:33       11        6        5        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✖  1 of 1 failed (100%)                     09:33       11        6        5        -        -  

After:

       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  credential-type-crud.cy.ts               01:41       11       11        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:41       11       11        -        -        -  


- Add filter to Credential Types page
- Every test filters for the Credential Type before trying to click/select it
- Bulk delete only one item as there's no guarantee that two items can be correctly filtered

Fixes https://issues.redhat.com/browse/AAP-27781

