### PR TITLE
Milan controller fix schedules wizard add rule

### DIFF
--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -408,7 +408,7 @@ export function RuleForm(props: {
           {t('Discard')}
         </Button>
       </ActionGroup>
-      {error && <AwxError error={{ message: error }} />}
+      {error && <AwxError error={{ name: '', message: error }} />}
     </PageFormSection>
   );
 }

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -1,6 +1,6 @@
 import { ActionGroup, Button, Chip, ChipGroup } from '@patternfly/react-core';
 import { DateTime } from 'luxon';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { RRule, datetime } from 'rrule';
@@ -24,6 +24,7 @@ import { useGet24HourTime } from '../hooks/useGet24HourTime';
 import { PageFormSection } from '../../../../../framework/PageForm/Utils/PageFormSection';
 import { PageFormSelect, PageFormTextInput } from '../../../../../framework';
 import { PageFormMultiSelect } from '../../../../../framework/PageForm/Inputs/PageFormMultiSelect';
+import { AwxError } from '../../../common/AwxError';
 export function pad(num: number) {
   if (typeof num === 'string') {
     return num;
@@ -35,6 +36,7 @@ export function RuleForm(props: {
   isOpen: boolean | number;
   setIsOpen: (isOpen: boolean) => void;
 }) {
+  const [error, setError] = useState<string>('');
   const { t } = useTranslation();
   const get24Hour = useGet24HourTime();
   const {
@@ -78,6 +80,14 @@ export function RuleForm(props: {
   }, [getValues, reset, props.isOpen, timezone, ruleId]);
   const handleAddItem = () => {
     const values = getValues() as RuleFields;
+
+    if (values.until && values.count) {
+      setError(t(`You can't use both 'Until' and 'Count' fields at the same time`));
+      return;
+    }
+
+    setError('');
+
     delete values.id;
     const { rules = [], exceptions = [], until = null, ...rest } = values;
     const start = DateTime.fromISO(`${date}`).set(get24Hour(time));
@@ -393,6 +403,7 @@ export function RuleForm(props: {
           {t('Discard')}
         </Button>
       </ActionGroup>
+      {error && <AwxError error={{ message: error }} />}
     </PageFormSection>
   );
 }

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -25,6 +25,7 @@ import { PageFormSection } from '../../../../../framework/PageForm/Utils/PageFor
 import { PageFormSelect, PageFormTextInput } from '../../../../../framework';
 import { PageFormMultiSelect } from '../../../../../framework/PageForm/Inputs/PageFormMultiSelect';
 import { AwxError } from '../../../common/AwxError';
+
 export function pad(num: number) {
   if (typeof num === 'string') {
     return num;
@@ -52,6 +53,7 @@ export function RuleForm(props: {
     timezone = 'America/New_York',
     startDateTime: { date, time },
   } = wizardData as ScheduleFormWizard;
+
   const isRulesStep = activeStep && activeStep.id === 'rules';
   const weekdayOptions = useGetWeekdayOptions();
   const frequencyOptions = useGetFrequencyOptions();
@@ -78,11 +80,14 @@ export function RuleForm(props: {
       );
     }
   }, [getValues, reset, props.isOpen, timezone, ruleId]);
+
   const handleAddItem = () => {
     const values = getValues() as RuleFields;
 
-    if (values.until && values.count) {
+    if ((values.until?.date || values.until?.time) && values.count) {
       setError(t(`You can't use both 'Until' and 'Count' fields at the same time`));
+      setValue('until', { date: undefined, time: undefined });
+      setValue('count', undefined);
       return;
     }
 


### PR DESCRIPTION
Adding fix for catching error when both Until and Count is added as part of the rule in schedules.

https://issues.redhat.com/browse/AAP-27555
5) Saving rule occasionaly fails in some combinations - for example count and until.