### PR TITLE
Reduces org calls

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -3,147 +3,140 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 import { randomE2Ename } from '../../../support/utils';
-
-describe('Organizations: Create', () => {
-  it('can create a basic organization, assert info on the details page, and delete it', () => {
-    const organizationName = randomE2Ename();
-    const orgDescription = 'orgDescription' + randomString(4);
-    cy.navigateTo('awx', 'organizations');
-    cy.verifyPageTitle('Organizations');
-    cy.clickLink(/^Create organization$/);
-    cy.getByDataCy('name').type(organizationName);
-    cy.getByDataCy('description').type(orgDescription);
-    cy.intercept('POST', awxAPI`/organizations/`).as('newOrg');
-    cy.clickButton(/^Create organization$/);
-    cy.wait('@newOrg')
-      .its('response.body')
-      .then((response: Organization) => {
-        cy.intercept('GET', awxAPI`/organizations/${response.id.toString()}/`).as('createdOrg');
-        cy.wait('@createdOrg');
-        cy.getByDataCy('Details').should('be.visible');
-        cy.verifyPageTitle(response.name);
-        cy.getByDataCy('id').should('contain', response.id);
-        cy.getByDataCy('name').should('contain', response.name);
-        cy.getByDataCy('description').should('contain', response?.description);
-        cy.clickPageAction('delete-organization');
-        cy.get('#confirm').click();
-        cy.intercept('DELETE', awxAPI`/organizations/${response.id.toString()}/`).as('delete');
-        cy.clickButton(/^Delete organization/);
-        cy.wait('@delete')
-          .its('response.statusCode')
-          .then((statusCode) => {
-            expect(statusCode).to.eql(204);
-            cy.verifyPageTitle('Organizations');
-          });
-      });
-  });
-});
-
-describe('Organizations: Edit and Delete', function () {
+describe('Wrapper, deletes organization', () => {
   let organization: Organization;
-  let user: AwxUser;
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  describe('Organizations: Create', () => {
+    it('can create a basic organization, assert info on the details page, and delete it', () => {
+      const organizationName = randomE2Ename();
+      const orgDescription = 'orgDescription' + randomString(4);
+      cy.navigateTo('awx', 'organizations');
+      cy.verifyPageTitle('Organizations');
+      cy.clickLink(/^Create organization$/);
+      cy.getByDataCy('name').type(organizationName);
+      cy.getByDataCy('description').type(orgDescription);
+      cy.intercept('POST', awxAPI`/organizations/`).as('newOrg');
+      cy.clickButton(/^Create organization$/);
+      cy.wait('@newOrg')
+        .its('response.body')
+        .then((response: Organization) => {
+          organization = response;
+          cy.intercept('GET', awxAPI`/organizations/${response.id.toString()}/`).as('createdOrg');
+          cy.wait('@createdOrg');
+          cy.getByDataCy('Details').should('be.visible');
+          cy.verifyPageTitle(response.name);
+          cy.getByDataCy('id').should('contain', response.id);
+          cy.getByDataCy('name').should('contain', response.name);
+          cy.getByDataCy('description').should('contain', response?.description);
+          cy.clickPageAction('delete-organization');
+          cy.get('#confirm').click();
+          cy.intercept('DELETE', awxAPI`/organizations/${response.id.toString()}/`).as('delete');
+          cy.clickButton(/^Delete organization/);
+          cy.wait('@delete')
+            .its('response.statusCode')
+            .then((statusCode) => {
+              expect(statusCode).to.eql(204);
+              cy.verifyPageTitle('Organizations');
+            });
+        });
+    });
+  });
 
-  beforeEach(function () {
-    const orgName = randomE2Ename();
-    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
-      organization = testOrganization;
+  describe('Organizations: Edit and Delete', function () {
+    // let organization: Organization;
+    let user: AwxUser;
+    // before(() => {
+    //   const orgName = randomE2Ename();
+    //   cy.createAwxOrganization({ name: orgName }).then((org) => {
+    //     organization = org;
+    //   });
+    // });
+    // after(() => {
+    //   cy.deleteAwxOrganization(organization);
+    // });
+    beforeEach(function () {
+      // cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+      //   organization = testOrganization;
       cy.createAwxUser({ organization: organization.id }).then((testUser) => {
         user = testUser;
         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
       });
+      // });
     });
-  });
 
-  afterEach(function () {
-    cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+    afterEach(function () {
+      cy.deleteAwxUser(user, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    });
 
-  it('can edit an organization from the list view', function () {
-    const stringRandom = randomString(4);
-    cy.navigateTo('awx', 'organizations');
-    cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.getByDataCy('actions-column-cell').within(() => {
+    it('can edit an organization from the list view', function () {
+      const stringRandom = randomString(4);
+      cy.navigateTo('awx', 'organizations');
+      cy.filterTableByMultiSelect('name', [organization.name]);
+      cy.getByDataCy('actions-column-cell').within(() => {
+        cy.getByDataCy('edit-organization').click();
+      });
+      cy.verifyPageTitle('Edit Organization');
+      cy.getByDataCy('name')
+        .clear()
+        .type('now-edited ' + `${stringRandom}`);
+      cy.clickButton(/^Save organization$/);
+      cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
       cy.getByDataCy('edit-organization').click();
+      cy.getByDataCy('name').clear().type(`${organization.name}`);
+      cy.clickButton(/^Save organization$/);
+      cy.verifyPageTitle(`${organization.name}`);
     });
-    cy.verifyPageTitle('Edit Organization');
-    cy.getByDataCy('name')
-      .clear()
-      .type('now-edited ' + `${stringRandom}`);
-    cy.clickButton(/^Save organization$/);
-    cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
-    cy.getByDataCy('edit-organization').click();
-    cy.getByDataCy('name').clear().type(`${organization.name}`);
-    cy.clickButton(/^Save organization$/);
-    cy.verifyPageTitle(`${organization.name}`);
-  });
 
-  it('can edit an organization from the details page', function () {
-    const stringRandom = randomString(4);
+    it('can edit an organization from the details page', function () {
+      const stringRandom = randomString(4);
 
-    cy.navigateTo('awx', 'organizations');
-    cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.get('[data-cy="name-column-cell"]').within(() => {
-      cy.get('a').click();
-    });
-    cy.verifyPageTitle(`${organization.name}`);
-    cy.containsBy('button', /^Edit organization/).click();
-    cy.verifyPageTitle('Edit Organization');
-    cy.getByDataCy('name')
-      .clear()
-      .type('now-edited ' + `${stringRandom}`);
-    cy.containsBy('button', /^Save organization/).click();
-    cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
-    cy.getByDataCy('edit-organization').click();
-    cy.getByDataCy('name').clear().type(`${organization.name}`);
-    cy.containsBy('button', /^Save organization/).click();
-    cy.verifyPageTitle(`${organization.name}`);
-  });
-
-  it('can delete an organization from the details page', function () {
-    cy.navigateTo('awx', 'organizations');
-    cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.get('[data-cy="name-column-cell"]').within(() => {
-      cy.get('a').click();
-    });
-    cy.verifyPageTitle(organization.name);
-    cy.clickPageAction('delete-organization');
-    cy.get('#confirm').click();
-    cy.intercept('DELETE', awxAPI`/organizations/${organization.id.toString()}`).as('delete');
-    cy.clickButton(/^Delete organization/);
-    cy.wait('@delete')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-        cy.verifyPageTitle('Organizations');
+      cy.navigateTo('awx', 'organizations');
+      cy.filterTableByMultiSelect('name', [organization.name]);
+      cy.get('[data-cy="name-column-cell"]').within(() => {
+        cy.get('a').click();
       });
-  });
-
-  it('can delete an organization from the organizations list row item', function () {
-    cy.navigateTo('awx', 'organizations');
-    cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.getByDataCy('actions-column-cell').within(() => {
-      cy.clickKebabAction('actions-dropdown', 'delete-organization');
+      cy.verifyPageTitle(`${organization.name}`);
+      cy.containsBy('button', /^Edit organization/).click();
+      cy.verifyPageTitle('Edit Organization');
+      cy.getByDataCy('name')
+        .clear()
+        .type('now-edited ' + `${stringRandom}`);
+      cy.containsBy('button', /^Save organization/).click();
+      cy.verifyPageTitle('now-edited ' + `${stringRandom}`);
+      cy.getByDataCy('edit-organization').click();
+      cy.getByDataCy('name').clear().type(`${organization.name}`);
+      cy.containsBy('button', /^Save organization/).click();
+      cy.verifyPageTitle(`${organization.name}`);
     });
-    cy.get('#confirm').click();
-    cy.intercept('DELETE', awxAPI`/organizations/${organization.id.toString()}`).as('delete');
-    cy.clickButton(/^Delete organization/);
-    cy.wait('@delete')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
-        cy.verifyPageTitle('Organizations');
-      });
-  });
 
-  it('can delete an organization from the organizations list toolbar', function () {
-    cy.navigateTo('awx', 'organizations');
-    cy.filterTableByMultiSelect('name', [organization.name]);
-    cy.selectTableRow(organization.name, false);
-    cy.clickToolbarKebabAction('delete-organizations');
-    cy.getModal().within(() => {
+    it('can delete an organization from the details page', function () {
+      cy.navigateTo('awx', 'organizations');
+      cy.filterTableByMultiSelect('name', [organization.name]);
+      cy.get('[data-cy="name-column-cell"]').within(() => {
+        cy.get('a').click();
+      });
+      cy.verifyPageTitle(organization.name);
+      cy.clickPageAction('delete-organization');
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/organizations/${organization.id.toString()}`).as('delete');
+      cy.clickButton(/^Delete organization/);
+      cy.wait('@delete')
+        .its('response')
+        .then((response) => {
+          expect(response?.statusCode).to.eql(204);
+          cy.verifyPageTitle('Organizations');
+        });
+    });
+
+    it('can delete an organization from the organizations list row item', function () {
+      cy.navigateTo('awx', 'organizations');
+      cy.filterTableByMultiSelect('name', [organization.name]);
+      cy.getByDataCy('actions-column-cell').within(() => {
+        cy.clickKebabAction('actions-dropdown', 'delete-organization');
+      });
       cy.get('#confirm').click();
       cy.intercept('DELETE', awxAPI`/organizations/${organization.id.toString()}`).as('delete');
       cy.clickButton(/^Delete organization/);
@@ -153,97 +146,131 @@ describe('Organizations: Edit and Delete', function () {
           expect(response?.statusCode).to.eql(204);
           cy.contains(/^Success$/);
           cy.clickButton(/^Close$/);
+          cy.verifyPageTitle('Organizations');
         });
     });
-    cy.verifyPageTitle('Organizations');
-  });
-});
 
-describe('Organizations: Users Tab', function () {
-  let organization: Organization;
-  let user: AwxUser;
-
-  beforeEach(function () {
-    const orgName = randomE2Ename();
-    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
-      organization = testOrganization;
-      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-        user = testUser;
-        cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
+    it('can delete an organization from the organizations list toolbar', function () {
+      cy.navigateTo('awx', 'organizations');
+      cy.filterTableByMultiSelect('name', [organization.name]);
+      cy.selectTableRow(organization.name, false);
+      cy.clickToolbarKebabAction('delete-organizations');
+      cy.getModal().within(() => {
+        cy.get('#confirm').click();
+        cy.intercept('DELETE', awxAPI`/organizations/${organization.id.toString()}`).as('delete');
+        cy.clickButton(/^Delete organization/);
+        cy.wait('@delete')
+          .its('response')
+          .then((response) => {
+            expect(response?.statusCode).to.eql(204);
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+          });
       });
+      cy.verifyPageTitle('Organizations');
     });
   });
 
-  afterEach(function () {
-    cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+  // describe('Organizations: Users Tab', function () {
+  //   let organization: Organization;
+  //   let user: AwxUser;
+  //   before(() => {
+  //     const orgName = randomE2Ename();
+  //     cy.createAwxOrganization({ name: orgName }).then((org) => {
+  //       organization = org;
+  //     });
+  //   });
+  //   after(() => {
+  //     cy.deleteAwxOrganization(organization);
+  //   });
+  //   beforeEach(function () {
+  //     // cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+  //     //   organization = testOrganization;
+  //     cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+  //       user = testUser;
+  //       cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
+  //     });
+  //     // });
+  //   });
 
-  it.skip('can add a brand new normal user to the Org', () => {});
-  it.skip('can add a brand new auditor user to the Org', () => {});
-  it.skip('can bulk remove users from the users tab of an Org', () => {});
-});
+  //   afterEach(function () {
+  //     cy.deleteAwxUser(user, { failOnStatusCode: false });
+  //     // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  //   });
 
-describe('Organizations: Teams Tab', function () {
-  let organization: Organization;
-  let user: AwxUser;
+  //   it.skip('can add a brand new normal user to the Org', () => {});
+  //   it.skip('can add a brand new auditor user to the Org', () => {});
+  //   it.skip('can bulk remove users from the users tab of an Org', () => {});
+  // });
 
-  beforeEach(function () {
-    const orgName = randomE2Ename();
-    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
-      organization = testOrganization;
-      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-        user = testUser;
-        cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
-      });
-    });
-  });
+  // describe('Organizations: Teams Tab', function () {
+  //   let organization: Organization;
+  //   let user: AwxUser;
+  //   before(() => {
+  //     const orgName = randomE2Ename();
+  //     cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+  //       organization = testOrganization;
+  //     });
+  //   });
+  //   after(() => {
+  //     cy.deleteAwxOrganization(organization);
+  //   });
+  //   beforeEach(function () {
+  //     // cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+  //     // organization = testOrganization;
+  //     cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+  //       user = testUser;
+  //       cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
+  //     });
+  //     // });
+  //   });
 
-  afterEach(function () {
-    cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
-  it.skip('can edit a team from the teams tab inside of an Org', () => {});
-});
+  //   afterEach(function () {
+  //     cy.deleteAwxUser(user, { failOnStatusCode: false });
+  //     // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  //   });
+  //   it.skip('can edit a team from the teams tab inside of an Org', () => {});
+  // });
 
-describe('Organizations: Execution Environments Tab', function () {
-  let organization: Organization;
-  let user: AwxUser;
+  // describe('Organizations: Execution Environments Tab', function () {
+  //   let organization: Organization;
+  //   let user: AwxUser;
 
-  beforeEach(function () {
-    const orgName = randomE2Ename();
-    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
-      organization = testOrganization;
-      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-        user = testUser;
-        cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
-      });
-    });
-  });
+  //   beforeEach(function () {
+  //     const orgName = randomE2Ename();
+  //     cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+  //       organization = testOrganization;
+  //       cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+  //         user = testUser;
+  //         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
+  //       });
+  //     });
+  //   });
 
-  afterEach(function () {
-    cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
-});
+  //   afterEach(function () {
+  //     cy.deleteAwxUser(user, { failOnStatusCode: false });
+  //     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  //   });
+  // });
 
-describe('Organizations: Notifications Tab', function () {
-  let organization: Organization;
-  let user: AwxUser;
+  // describe('Organizations: Notifications Tab', function () {
+  //   let organization: Organization;
+  //   let user: AwxUser;
 
-  beforeEach(function () {
-    const orgName = randomE2Ename();
-    cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
-      organization = testOrganization;
-      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-        user = testUser;
-        cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
-      });
-    });
-  });
+  //   beforeEach(function () {
+  //     const orgName = randomE2Ename();
+  //     cy.createAwxOrganization({ name: orgName }).then((testOrganization) => {
+  //       organization = testOrganization;
+  //       cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+  //         user = testUser;
+  //         cy.giveUserOrganizationAccess(organization.name, user.id, 'Read');
+  //       });
+  //     });
+  //   });
 
-  afterEach(function () {
-    cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+  //   afterEach(function () {
+  //     cy.deleteAwxUser(user, { failOnStatusCode: false });
+  //     cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+  //   });
+  // });
 });

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -3,155 +3,167 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Team } from '../../../../frontend/awx/interfaces/Team';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
-
-describe('Teams: Create', () => {
+import { randomE2Ename } from '../../../support/utils';
+describe('Wrapper, creates organization and deletes organization', () => {
   let organization: Organization;
 
-  beforeEach(() => {
-    cy.createAwxOrganization().then((org) => {
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
       organization = org;
     });
-    cy.navigateTo('awx', 'teams');
-    cy.verifyPageTitle('Teams');
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
   });
 
-  afterEach(() => {
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+  describe('Teams: Create', () => {
+    // beforeEach(() => {
+    //   cy.createAwxOrganization().then((org) => {
+    //     organization = org;
+    //   });
+    //   cy.navigateTo('awx', 'teams');
+    //   cy.verifyPageTitle('Teams');
+    // });
 
-  it('can create a basic team, assert details page and then delete team', () => {
-    const teamName = 'E2E Team ' + randomString(4);
-    cy.intercept('POST', awxAPI`/teams/`).as('newTeam');
-    cy.getByDataCy('create-team').click();
-    cy.getByDataCy('name').type(teamName);
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.getByDataCy('Submit').click();
-    cy.wait('@newTeam')
-      .its('response.body')
-      .then((thisTeam: Team) => {
-        cy.verifyPageTitle(thisTeam.name);
-        cy.url().then((currentUrl) => {
-          expect(currentUrl.includes(`/access/teams/${thisTeam.id.toString()}/details`)).to.be.true;
-        });
-        cy.hasDetail('Name', thisTeam.name);
-        cy.hasDetail('Organization', organization.name);
-        cy.intercept('DELETE', awxAPI`/teams/${thisTeam.id.toString()}/`).as('deleted');
-        cy.selectDetailsPageKebabAction('delete-team');
-        cy.wait('@deleted')
-          .its('response')
-          .then((response) => {
-            expect(response?.statusCode).to.eql(204);
+    // afterEach(() => {
+    //   cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    // });
+
+    it('can create a basic team, assert details page and then delete team', () => {
+      const teamName = 'E2E Team ' + randomString(4);
+      cy.intercept('POST', awxAPI`/teams/`).as('newTeam');
+      cy.getByDataCy('create-team').click();
+      cy.getByDataCy('name').type(teamName);
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.getByDataCy('Submit').click();
+      cy.wait('@newTeam')
+        .its('response.body')
+        .then((thisTeam: Team) => {
+          cy.verifyPageTitle(thisTeam.name);
+          cy.url().then((currentUrl) => {
+            expect(currentUrl.includes(`/access/teams/${thisTeam.id.toString()}/details`)).to.be
+              .true;
           });
-      });
+          cy.hasDetail('Name', thisTeam.name);
+          cy.hasDetail('Organization', organization.name);
+          cy.intercept('DELETE', awxAPI`/teams/${thisTeam.id.toString()}/`).as('deleted');
+          cy.selectDetailsPageKebabAction('delete-team');
+          cy.wait('@deleted')
+            .its('response')
+            .then((response) => {
+              expect(response?.statusCode).to.eql(204);
+            });
+        });
+    });
   });
-});
 
-describe('Teams: Edit and Delete', () => {
-  let team: Team;
-  let organization: Organization;
+  describe('Teams: Edit and Delete', () => {
+    let team: Team;
+    // let organization: Organization;
 
-  beforeEach(() => {
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
+    beforeEach(() => {
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
       cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
         team = createdTeam;
       });
+      // });
+
+      cy.navigateTo('awx', 'teams');
+      cy.verifyPageTitle('Teams');
     });
 
-    cy.navigateTo('awx', 'teams');
-    cy.verifyPageTitle('Teams');
-  });
-
-  afterEach(() => {
-    cy.deleteAwxTeam(team, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
-
-  it('can edit a team from the details page', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.hasDetail('Name', team.name);
-    cy.hasDetail('Organization', organization.name);
-    cy.clickButton(/^Edit team$/);
-    cy.verifyPageTitle('Edit Team');
-    cy.get('[data-cy="name"]')
-      .clear()
-      .type(team.name + '-edited');
-
-    cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
-    cy.clickButton(/^Save team$/);
-    cy.wait('@editTeam')
-      .its('response.statusCode')
-      .then((statusCode) => {
-        expect(statusCode).to.eql(200);
-      });
-    cy.verifyPageTitle(`${team.name}-edited`);
-  });
-
-  it('can navigate to the edit form from the team list row item', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowAction('name', team.name, 'edit-team', { disableFilter: true });
-    cy.verifyPageTitle('Edit Team');
-    cy.get('[data-cy="name"]')
-      .clear()
-      .type(team.name + '-edited');
-
-    cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
-    cy.clickButton(/^Save team$/);
-    cy.wait('@editTeam')
-      .its('response.statusCode')
-      .then((statusCode) => {
-        expect(statusCode).to.eql(200);
-      });
-    cy.clearAllFilters();
-    cy.filterTableBySingleSelect('name', `${team.name}-edited`);
-  });
-
-  it('can delete a team from the details page', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickPageAction('delete-team');
-    cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete team/);
-    cy.wait('@deleted')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-        cy.verifyPageTitle('Teams');
-      });
-  });
-
-  it('can delete a team from the teams list row item', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowAction('name', team.name, 'delete-team', {
-      disableFilter: true,
-      inKebab: true,
+    afterEach(() => {
+      cy.deleteAwxTeam(team, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
     });
-    cy.get('#confirm').click();
-    cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
-    cy.clickButton(/^Delete team/);
-    cy.wait('@deleted')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
-        cy.clearAllFilters();
+
+    it('can edit a team from the details page', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowLink('name', team.name, { disableFilter: true });
+      cy.verifyPageTitle(team.name);
+      cy.hasDetail('Name', team.name);
+      cy.hasDetail('Organization', organization.name);
+      cy.clickButton(/^Edit team$/);
+      cy.verifyPageTitle('Edit Team');
+      cy.get('[data-cy="name"]')
+        .clear()
+        .type(team.name + '-edited');
+
+      cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
+      cy.clickButton(/^Save team$/);
+      cy.wait('@editTeam')
+        .its('response.statusCode')
+        .then((statusCode) => {
+          expect(statusCode).to.eql(200);
+        });
+      cy.verifyPageTitle(`${team.name}-edited`);
+    });
+
+    it('can navigate to the edit form from the team list row item', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowAction('name', team.name, 'edit-team', { disableFilter: true });
+      cy.verifyPageTitle('Edit Team');
+      cy.get('[data-cy="name"]')
+        .clear()
+        .type(team.name + '-edited');
+
+      cy.intercept('PATCH', awxAPI`/teams/*/`).as('editTeam');
+      cy.clickButton(/^Save team$/);
+      cy.wait('@editTeam')
+        .its('response.statusCode')
+        .then((statusCode) => {
+          expect(statusCode).to.eql(200);
+        });
+      cy.clearAllFilters();
+      cy.filterTableBySingleSelect('name', `${team.name}-edited`);
+    });
+
+    it('can delete a team from the details page', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowLink('name', team.name, { disableFilter: true });
+      cy.verifyPageTitle(team.name);
+      cy.clickPageAction('delete-team');
+      cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete team/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((response) => {
+          expect(response?.statusCode).to.eql(204);
+          cy.verifyPageTitle('Teams');
+        });
+    });
+
+    it('can delete a team from the teams list row item', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowAction('name', team.name, 'delete-team', {
+        disableFilter: true,
+        inKebab: true,
       });
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/teams/${team.id.toString()}/`).as('deleted');
+      cy.clickButton(/^Delete team/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((response) => {
+          expect(response?.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+          cy.clearAllFilters();
+        });
+    });
   });
-});
 
-describe('Teams: Add and Remove users', () => {
-  let team: Team;
-  let user1: AwxUser;
-  let organization: Organization;
+  describe('Teams: Add and Remove users', () => {
+    let team: Team;
+    let user1: AwxUser;
+    // let organization: Organization;
 
-  beforeEach(() => {
-    cy.createAwxOrganization().then((o) => {
-      organization = o;
+    beforeEach(() => {
+      // cy.createAwxOrganization().then((o) => {
+      //   organization = o;
       cy.createAwxUser({ organization: organization.id }).then((user) => {
         user1 = user;
         cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
@@ -159,151 +171,152 @@ describe('Teams: Add and Remove users', () => {
           cy.giveUserTeamAccess(team.name, user1.id, 'Read');
         });
       });
-    });
-    cy.navigateTo('awx', 'teams');
-    cy.verifyPageTitle('Teams');
-  });
-
-  afterEach(() => {
-    cy.deleteAwxUser(user1, { failOnStatusCode: false });
-    cy.deleteAwxTeam(team, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
-
-  it('can remove users from the team via the teams list row item', () => {
-    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
+      // });
+      cy.navigateTo('awx', 'teams');
+      cy.verifyPageTitle('Teams');
     });
 
-    // Remove users
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowAction('name', team.name, 'remove-users', {
-      inKebab: true,
-      disableFilter: true,
+    afterEach(() => {
+      cy.deleteAwxUser(user1, { failOnStatusCode: false });
+      cy.deleteAwxTeam(team, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
     });
 
-    // Select users
-    cy.getModal().within(() => {
-      cy.selectTableRowByCheckbox('username', user1.username);
-      cy.get('#submit').click();
+    it('can remove users from the team via the teams list row item', () => {
+      cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+        id: team.summary_fields.object_roles.member_role.id,
+      });
+
+      // Remove users
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowAction('name', team.name, 'remove-users', {
+        inKebab: true,
+        disableFilter: true,
+      });
+
+      // Select users
+      cy.getModal().within(() => {
+        cy.selectTableRowByCheckbox('username', user1.username);
+        cy.get('#submit').click();
+      });
+
+      // Confirm and remove users
+      cy.getModal().within(() => {
+        cy.get('#confirm').click();
+        cy.get('#submit').click();
+        cy.contains(/^Success$/).should('be.visible');
+        cy.containsBy('button', /^Close$/).click();
+      });
+
+      // Verify modal is closed
+      cy.getModal().should('not.exist');
     });
 
-    // Confirm and remove users
-    cy.getModal().within(() => {
+    it('can add users to the team via the team access tab toolbar', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowLink('name', team.name, { disableFilter: true });
+      cy.verifyPageTitle(team.name);
+      cy.clickTab(/^Users$/, true);
+      cy.get('[data-cy="add-users"]').click();
+      cy.getTableRow('username', `${user1.username}`).within(() => {
+        cy.get('input[type="checkbox"]').click({ force: true });
+      });
+      cy.clickButton(/^Next$/);
+      cy.getTableRow('name', 'Team Admin', {
+        disableFilter: true,
+        disableFilterSelection: true,
+      }).within(() => {
+        cy.get('input[type="checkbox"]').click({ force: true });
+      });
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Finish$/);
+      cy.clickModalButton('Close');
+      cy.getTableRow('username', user1.username, {
+        disableFilter: true,
+        disableFilterSelection: true,
+      }).should('be.visible');
+    });
+
+    it('can remove users from the team via the team access tab toolbar', () => {
+      cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
+        id: team.summary_fields.object_roles.member_role.id,
+      });
+
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowLink('name', team.name, { disableFilter: true });
+      cy.verifyPageTitle(team.name);
+      cy.clickTab(/^Users$/, true);
+      // Remove users
+      cy.getTableRow('username', `${user1.username}`).within(() => {
+        cy.get('input[type="checkbox"]').click({ force: true });
+      });
+      cy.clickToolbarKebabAction('remove-roles');
       cy.get('#confirm').click();
-      cy.get('#submit').click();
-      cy.contains(/^Success$/).should('be.visible');
-      cy.containsBy('button', /^Close$/).click();
+      cy.clickButton(/^Remove user/);
+      cy.contains(/^Success$/);
+      cy.clickButton(/^Close$/);
+      cy.get(`tr[data-cy=row-id-${user1.id}]`).should('not.exist');
     });
 
-    // Verify modal is closed
-    cy.getModal().should('not.exist');
-  });
-
-  it('can add users to the team via the team access tab toolbar', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickTab(/^Users$/, true);
-    cy.get('[data-cy="add-users"]').click();
-    cy.getTableRow('username', `${user1.username}`).within(() => {
-      cy.get('input[type="checkbox"]').click({ force: true });
-    });
-    cy.clickButton(/^Next$/);
-    cy.getTableRow('name', 'Team Admin', {
-      disableFilter: true,
-      disableFilterSelection: true,
-    }).within(() => {
-      cy.get('input[type="checkbox"]').click({ force: true });
-    });
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Finish$/);
-    cy.clickModalButton('Close');
-    cy.getTableRow('username', user1.username, {
-      disableFilter: true,
-      disableFilterSelection: true,
-    }).should('be.visible');
-  });
-
-  it('can remove users from the team via the team access tab toolbar', () => {
-    cy.requestPost<AwxUser>(awxAPI`/users/${user1.id.toString()}/roles/`, {
-      id: team.summary_fields.object_roles.member_role.id,
-    });
-
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickTab(/^Users$/, true);
-    // Remove users
-    cy.getTableRow('username', `${user1.username}`).within(() => {
-      cy.get('input[type="checkbox"]').click({ force: true });
-    });
-    cy.clickToolbarKebabAction('remove-roles');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Remove user/);
-    cy.contains(/^Success$/);
-    cy.clickButton(/^Close$/);
-    cy.get(`tr[data-cy=row-id-${user1.id}]`).should('not.exist');
-  });
-
-  it('can remove a role from a user via the team access tab row action', () => {
-    cy.filterTableBySingleSelect('name', team.name);
-    cy.clickTableRowLink('name', team.name, { disableFilter: true });
-    cy.verifyPageTitle(team.name);
-    cy.clickTab(/^Users$/, true);
-    cy.getTableRow('username', user1.username).within(() => {
-      cy.get(`button[data-cy="remove-role"]`).click();
-    });
-    cy.contains('Remove users');
-    cy.clickModalConfirmCheckbox();
-    cy.clickButton('Remove users');
-    cy.clickModalButton('Close');
-    cy.get('tbody').within(() => {
-      cy.get('tr').should('not.have.length');
+    it('can remove a role from a user via the team access tab row action', () => {
+      cy.filterTableBySingleSelect('name', team.name);
+      cy.clickTableRowLink('name', team.name, { disableFilter: true });
+      cy.verifyPageTitle(team.name);
+      cy.clickTab(/^Users$/, true);
+      cy.getTableRow('username', user1.username).within(() => {
+        cy.get(`button[data-cy="remove-role"]`).click();
+      });
+      cy.contains('Remove users');
+      cy.clickModalConfirmCheckbox();
+      cy.clickButton('Remove users');
+      cy.clickModalButton('Close');
+      cy.get('tbody').within(() => {
+        cy.get('tr').should('not.have.length');
+      });
     });
   });
-});
 
-describe('Teams: Bulk delete', () => {
-  let team: Team;
-  let organization: Organization;
-  const arrayOfElementText: string[] = [];
+  describe('Teams: Bulk delete', () => {
+    let team: Team;
+    // let organization: Organization;
+    const arrayOfElementText: string[] = [];
 
-  beforeEach(() => {
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
+    beforeEach(() => {
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
       for (let i = 0; i < 5; i++) {
         cy.createAwxTeam({ organization: organization.id }).then((createdTeam) => {
           team = createdTeam;
           arrayOfElementText.push(team.name);
         });
       }
+      // });
+
+      cy.navigateTo('awx', 'teams');
+      cy.verifyPageTitle('Teams');
     });
 
-    cy.navigateTo('awx', 'teams');
-    cy.verifyPageTitle('Teams');
-  });
+    afterEach(() => {
+      cy.deleteAwxTeam(team, { failOnStatusCode: false });
+    });
 
-  afterEach(() => {
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+    it('can bulk delete teams from the teams list toolbar', () => {
+      cy.filterTableByMultiSelect('name', arrayOfElementText);
+      cy.get('tbody tr').should('have.length', 5);
+      cy.getByDataCy('select-all').click();
+      cy.clickToolbarKebabAction('delete-selected-teams');
 
-  it('can bulk delete teams from the teams list toolbar', () => {
-    cy.filterTableByMultiSelect('name', arrayOfElementText);
-    cy.get('tbody tr').should('have.length', 5);
-    cy.getByDataCy('select-all').click();
-    cy.clickToolbarKebabAction('delete-selected-teams');
-
-    cy.get('#confirm').click();
-    cy.intercept('DELETE', awxAPI`/teams/*/`).as('deleted');
-    cy.clickButton(/^Delete team/);
-    cy.wait('@deleted')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
-        cy.clearAllFilters();
-      });
+      cy.get('#confirm').click();
+      cy.intercept('DELETE', awxAPI`/teams/*/`).as('deleted');
+      cy.clickButton(/^Delete team/);
+      cy.wait('@deleted')
+        .its('response')
+        .then((response) => {
+          expect(response?.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+          cy.clearAllFilters();
+        });
+    });
   });
 });

--- a/cypress/e2e/awx/access/users.cy.ts
+++ b/cypress/e2e/awx/access/users.cy.ts
@@ -4,23 +4,32 @@
 import { randomString } from '../../../../framework/utils/random-string';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
+import { randomE2Ename } from '../../../support/utils';
 
 describe('Users List Actions', () => {
   let organization: Organization;
   let user: AwxUser;
-
-  beforeEach(() => {
-    cy.createAwxOrganization().then((org) => {
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
       organization = org;
-      cy.createAwxUser({ organization: organization.id }).then((testUser) => {
-        user = testUser;
-      });
     });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  beforeEach(() => {
+    // cy.createAwxOrganization().then((org) => {
+    //   organization = org;
+    cy.createAwxUser({ organization: organization.id }).then((testUser) => {
+      user = testUser;
+    });
+    // });
   });
 
   afterEach(() => {
     cy.deleteAwxUser(user, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
   });
 
   it('renders the users list page', () => {

--- a/cypress/e2e/awx/administration/applications.cy.ts
+++ b/cypress/e2e/awx/administration/applications.cy.ts
@@ -4,220 +4,234 @@ import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 import { AwxToken } from '../../../../frontend/awx/interfaces/AwxToken';
 import { AwxUser } from '../../../../frontend/awx/interfaces/User';
-
-describe('AWX OAuth Applications CRUD actions List page', () => {
+import { randomE2Ename } from '../../../support/utils';
+describe('Wrapper, creates and deletes organization', () => {
   let awxOrganization: Organization;
-  beforeEach(() => {
-    cy.createAwxOrganization().then((organization) => {
-      awxOrganization = organization;
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
+      awxOrganization = org;
     });
-    cy.navigateTo('awx', 'applications');
+  });
+  after(() => {
+    cy.deleteAwxOrganization(awxOrganization);
   });
 
-  const authorizationGrantTypes = ['Authorization code', 'Password'];
-  const clientTypes = ['Confidential', 'Public'];
-  authorizationGrantTypes.forEach((grantType) => {
-    clientTypes.forEach((clientType) => {
-      it(`creates a new AWX OAuth application with grant type ${grantType} and client type ${clientType} and deletes from the details page`, () => {
-        const oauthApplicationName = `AWX OAuth Application ${randomString(2)}`;
-        const authGrantType = grantType.replace(/ /g, '-').toLowerCase();
-        const appClientType = clientType.toLowerCase();
-        cy.getByDataCy('create-application').click();
-        cy.getByDataCy('name').type(oauthApplicationName);
-        cy.getByDataCy('description').type(`${authGrantType} with ${appClientType} description`);
-        cy.singleSelectByDataCy('organization', `${awxOrganization.name}`);
-        cy.selectDropdownOptionByResourceName('authorization-grant-type', grantType);
-        cy.selectDropdownOptionByResourceName('client-type', clientType);
-        cy.getByDataCy('redirect-uris').type('https://redhat.com');
-        cy.getByDataCy('Submit').click();
-        cy.getModal().within(() => {
-          cy.contains('h1', 'Application information');
-          if (
-            (grantType === 'Authorization code' || grantType === 'Password') &&
-            clientType === 'Confidential'
-          ) {
-            cy.contains('dt', 'Client ID');
-            cy.contains('dt', 'Client Secret');
-          } else if (
-            (grantType === 'Authorization code' || grantType === 'Password') &&
-            clientType === 'Public'
-          ) {
-            cy.contains('dt', 'Client ID');
-          }
-          cy.contains('h1', 'Application information');
-          cy.contains('dd', oauthApplicationName);
-          cy.get('button[aria-label="Close"]').click();
+  describe('AWX OAuth Applications CRUD actions List page', () => {
+    // beforeEach(() => {
+    //   cy.createAwxOrganization().then((organization) => {
+    //     awxOrganization = organization;
+    //   });
+    //   cy.navigateTo('awx', 'applications');
+    // });
+
+    const authorizationGrantTypes = ['Authorization code', 'Password'];
+    const clientTypes = ['Confidential', 'Public'];
+    authorizationGrantTypes.forEach((grantType) => {
+      clientTypes.forEach((clientType) => {
+        it(`creates a new AWX OAuth application with grant type ${grantType} and client type ${clientType} and deletes from the details page`, () => {
+          const oauthApplicationName = `AWX OAuth Application ${randomString(2)}`;
+          const authGrantType = grantType.replace(/ /g, '-').toLowerCase();
+          const appClientType = clientType.toLowerCase();
+          cy.getByDataCy('create-application').click();
+          cy.getByDataCy('name').type(oauthApplicationName);
+          cy.getByDataCy('description').type(`${authGrantType} with ${appClientType} description`);
+          cy.singleSelectByDataCy('organization', `${awxOrganization.name}`);
+          cy.selectDropdownOptionByResourceName('authorization-grant-type', grantType);
+          cy.selectDropdownOptionByResourceName('client-type', clientType);
+          cy.getByDataCy('redirect-uris').type('https://redhat.com');
+          cy.getByDataCy('Submit').click();
+          cy.getModal().within(() => {
+            cy.contains('h1', 'Application information');
+            if (
+              (grantType === 'Authorization code' || grantType === 'Password') &&
+              clientType === 'Confidential'
+            ) {
+              cy.contains('dt', 'Client ID');
+              cy.contains('dt', 'Client Secret');
+            } else if (
+              (grantType === 'Authorization code' || grantType === 'Password') &&
+              clientType === 'Public'
+            ) {
+              cy.contains('dt', 'Client ID');
+            }
+            cy.contains('h1', 'Application information');
+            cy.contains('dd', oauthApplicationName);
+            cy.get('button[aria-label="Close"]').click();
+          });
+          cy.verifyPageTitle(oauthApplicationName);
+          cy.hasDetail('Name', oauthApplicationName);
+          cy.hasDetail('Description', `${authGrantType} with ${appClientType} description`);
+          //edit from list row and delete from details page
+          cy.navigateTo('awx', 'applications');
+          cy.verifyPageTitle('OAuth Applications');
+          cy.filterTableByMultiSelect('name', [oauthApplicationName]);
+          cy.clickTableRowPinnedAction(oauthApplicationName, 'edit-application', false);
+          cy.verifyPageTitle('Edit Application');
+          cy.getByDataCy('description')
+            .clear()
+            .type(`${authGrantType} with ${appClientType} edited`);
+          cy.getByDataCy('Submit').click();
+          cy.verifyPageTitle(oauthApplicationName);
+          cy.clickButton(/^Delete application/);
+          cy.getModal().within(() => {
+            cy.get('#confirm').click();
+            cy.clickButton(/^Delete application/);
+          });
         });
-        cy.verifyPageTitle(oauthApplicationName);
-        cy.hasDetail('Name', oauthApplicationName);
-        cy.hasDetail('Description', `${authGrantType} with ${appClientType} description`);
-        //edit from list row and delete from details page
-        cy.navigateTo('awx', 'applications');
-        cy.verifyPageTitle('OAuth Applications');
-        cy.filterTableByMultiSelect('name', [oauthApplicationName]);
-        cy.clickTableRowPinnedAction(oauthApplicationName, 'edit-application', false);
-        cy.verifyPageTitle('Edit Application');
-        cy.getByDataCy('description').clear().type(`${authGrantType} with ${appClientType} edited`);
-        cy.getByDataCy('Submit').click();
-        cy.verifyPageTitle(oauthApplicationName);
+      });
+    });
+  });
+
+  describe('AWX OAuth Applications CRUD actions Details page', () => {
+    // let awxOrganization: Organization;
+    // beforeEach(() => {
+    //   cy.createAwxOrganization().then((organization) => {
+    //     awxOrganization = organization;
+    //   });
+    //   cy.navigateTo('awx', 'applications');
+    // });
+
+    const authorizationGrantTypes = ['Authorization code', 'Password'];
+    const clientTypes = ['Confidential', 'Public'];
+    authorizationGrantTypes.forEach((grantType) => {
+      clientTypes.forEach((clientType) => {
+        it(`creates a new AWX OAuth application with grant type ${grantType} and client type ${clientType} and deletes from the list page`, () => {
+          const oauthApplicationName = `AWX OAuth Application ${randomString(2)}`;
+          const authGrantType = grantType.replace(/ /g, '-').toLowerCase();
+          const appClientType = clientType.toLowerCase();
+          cy.getByDataCy('create-application').click();
+          cy.getByDataCy('name').type(oauthApplicationName);
+          cy.getByDataCy('description').type(`${authGrantType} with ${appClientType} description`);
+          cy.singleSelectByDataCy('organization', `${awxOrganization.name}`);
+          cy.selectDropdownOptionByResourceName('authorization-grant-type', grantType);
+          cy.selectDropdownOptionByResourceName('client-type', clientType);
+          cy.getByDataCy('redirect-uris').type('https://redhat.com');
+          cy.getByDataCy('Submit').click();
+          cy.getModal().within(() => {
+            cy.contains('h1', 'Application information');
+            if (
+              (grantType === 'Authorization code' || grantType === 'Password') &&
+              clientType === 'Confidential'
+            ) {
+              cy.contains('dt', 'Client ID');
+              cy.contains('dt', 'Client Secret');
+            } else if (
+              (grantType === 'Authorization code' || grantType === 'Password') &&
+              clientType === 'Public'
+            ) {
+              cy.contains('dt', 'Client ID');
+            }
+            cy.contains('h1', 'Application information');
+            cy.contains('dd', oauthApplicationName);
+            cy.get('button[aria-label="Close"]').click();
+          });
+          cy.verifyPageTitle(oauthApplicationName);
+          cy.hasDetail('Name', oauthApplicationName);
+          cy.hasDetail('Description', `${authGrantType} with ${appClientType} description`);
+          //delete from list page
+          cy.navigateTo('awx', 'applications');
+          cy.verifyPageTitle('OAuth Applications');
+          cy.filterTableByMultiSelect('name', [oauthApplicationName]);
+          cy.clickTableRowAction('name', oauthApplicationName, 'delete-application', {
+            inKebab: true,
+            disableFilter: true,
+          });
+          cy.clickModalConfirmCheckbox();
+          cy.getModal().within(() => {
+            cy.clickButton(/^Delete application/);
+            cy.clickButton(/^Close/);
+          });
+          cy.clickButton(/^Clear all filters$/);
+        });
+      });
+    });
+  });
+
+  describe('AWX OAuth Applications CRUD actions and Bulk Deletion', () => {
+    let awxApplication1: Application;
+    let awxApplication2: Application;
+    beforeEach(() => {
+      cy.createAwxApplication('authorization-code', 'public').then((OAuthApplication1) => {
+        awxApplication1 = OAuthApplication1;
+      });
+      cy.createAwxApplication('authorization-code', 'confidential').then((OAuthApplication2) => {
+        awxApplication2 = OAuthApplication2;
+      });
+      cy.navigateTo('awx', 'applications');
+    });
+
+    it('creates auth code applications (confidential & public clients) and performs bulk deletion from the list toolbar', () => {
+      cy.verifyPageTitle('OAuth Applications');
+      cy.filterTableByMultiSelect('name', [`${awxApplication1.name}`, `${awxApplication2.name}`]);
+      cy.selectTableRow(`${awxApplication1.name}`, false);
+      cy.selectTableRow(`${awxApplication2.name}`, false);
+      cy.clickToolbarKebabAction('delete-selected-applications');
+      cy.clickModalConfirmCheckbox();
+      cy.intercept('DELETE', awxAPI`/applications/*/`).as('deleteOAuthApp1');
+      cy.intercept('DELETE', awxAPI`/applications/*/`).as('deleteOAuthApp2');
+      cy.getModal().within(() => {
         cy.clickButton(/^Delete application/);
-        cy.getModal().within(() => {
-          cy.get('#confirm').click();
-          cy.clickButton(/^Delete application/);
+        cy.wait(['@deleteOAuthApp1', '@deleteOAuthApp2']).then((deleteOAuthApp) => {
+          expect(deleteOAuthApp[0]?.response?.statusCode).to.eql(204);
+          expect(deleteOAuthApp[1]?.response?.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
         });
       });
+      cy.clickButton(/^Clear all filters$/);
     });
   });
-});
 
-describe('AWX OAuth Applications CRUD actions Details page', () => {
-  let awxOrganization: Organization;
-  beforeEach(() => {
-    cy.createAwxOrganization().then((organization) => {
-      awxOrganization = organization;
-    });
-    cy.navigateTo('awx', 'applications');
-  });
-
-  const authorizationGrantTypes = ['Authorization code', 'Password'];
-  const clientTypes = ['Confidential', 'Public'];
-  authorizationGrantTypes.forEach((grantType) => {
-    clientTypes.forEach((clientType) => {
-      it(`creates a new AWX OAuth application with grant type ${grantType} and client type ${clientType} and deletes from the list page`, () => {
-        const oauthApplicationName = `AWX OAuth Application ${randomString(2)}`;
-        const authGrantType = grantType.replace(/ /g, '-').toLowerCase();
-        const appClientType = clientType.toLowerCase();
-        cy.getByDataCy('create-application').click();
-        cy.getByDataCy('name').type(oauthApplicationName);
-        cy.getByDataCy('description').type(`${authGrantType} with ${appClientType} description`);
-        cy.singleSelectByDataCy('organization', `${awxOrganization.name}`);
-        cy.selectDropdownOptionByResourceName('authorization-grant-type', grantType);
-        cy.selectDropdownOptionByResourceName('client-type', clientType);
-        cy.getByDataCy('redirect-uris').type('https://redhat.com');
-        cy.getByDataCy('Submit').click();
-        cy.getModal().within(() => {
-          cy.contains('h1', 'Application information');
-          if (
-            (grantType === 'Authorization code' || grantType === 'Password') &&
-            clientType === 'Confidential'
-          ) {
-            cy.contains('dt', 'Client ID');
-            cy.contains('dt', 'Client Secret');
-          } else if (
-            (grantType === 'Authorization code' || grantType === 'Password') &&
-            clientType === 'Public'
-          ) {
-            cy.contains('dt', 'Client ID');
-          }
-          cy.contains('h1', 'Application information');
-          cy.contains('dd', oauthApplicationName);
-          cy.get('button[aria-label="Close"]').click();
-        });
-        cy.verifyPageTitle(oauthApplicationName);
-        cy.hasDetail('Name', oauthApplicationName);
-        cy.hasDetail('Description', `${authGrantType} with ${appClientType} description`);
-        //delete from list page
-        cy.navigateTo('awx', 'applications');
-        cy.verifyPageTitle('OAuth Applications');
-        cy.filterTableByMultiSelect('name', [oauthApplicationName]);
-        cy.clickTableRowAction('name', oauthApplicationName, 'delete-application', {
-          inKebab: true,
-          disableFilter: true,
-        });
-        cy.clickModalConfirmCheckbox();
-        cy.getModal().within(() => {
-          cy.clickButton(/^Delete application/);
-          cy.clickButton(/^Close/);
-        });
-        cy.clickButton(/^Clear all filters$/);
-      });
-    });
-  });
-});
-
-describe('AWX OAuth Applications CRUD actions and Bulk Deletion', () => {
-  let awxApplication1: Application;
-  let awxApplication2: Application;
-  beforeEach(() => {
-    cy.createAwxApplication('authorization-code', 'public').then((OAuthApplication1) => {
-      awxApplication1 = OAuthApplication1;
-    });
-    cy.createAwxApplication('authorization-code', 'confidential').then((OAuthApplication2) => {
-      awxApplication2 = OAuthApplication2;
-    });
-    cy.navigateTo('awx', 'applications');
-  });
-
-  it('creates auth code applications (confidential & public clients) and performs bulk deletion from the list toolbar', () => {
-    cy.verifyPageTitle('OAuth Applications');
-    cy.filterTableByMultiSelect('name', [`${awxApplication1.name}`, `${awxApplication2.name}`]);
-    cy.selectTableRow(`${awxApplication1.name}`, false);
-    cy.selectTableRow(`${awxApplication2.name}`, false);
-    cy.clickToolbarKebabAction('delete-selected-applications');
-    cy.clickModalConfirmCheckbox();
-    cy.intercept('DELETE', awxAPI`/applications/*/`).as('deleteOAuthApp1');
-    cy.intercept('DELETE', awxAPI`/applications/*/`).as('deleteOAuthApp2');
-    cy.getModal().within(() => {
-      cy.clickButton(/^Delete application/);
-      cy.wait(['@deleteOAuthApp1', '@deleteOAuthApp2']).then((deleteOAuthApp) => {
-        expect(deleteOAuthApp[0]?.response?.statusCode).to.eql(204);
-        expect(deleteOAuthApp[1]?.response?.statusCode).to.eql(204);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
-      });
-    });
-    cy.clickButton(/^Clear all filters$/);
-  });
-});
-
-describe('AWX OAuth Application Creation and AWX token association with it', () => {
-  let awxApplication: Application;
-  let awxOrganization: Organization;
-  beforeEach(() => {
-    cy.createAwxOrganization().then((organization) => {
-      awxOrganization = organization;
+  describe('AWX OAuth Application Creation and AWX token association with it', () => {
+    let awxApplication: Application;
+    // let awxOrganization: Organization;
+    beforeEach(() => {
+      // cy.createAwxOrganization().then((organization) => {
+      //   awxOrganization = organization;
       cy.createAwxApplication('authorization-code', 'public', awxOrganization).then(
         (awxOAuthApplication: Application) => {
           awxApplication = awxOAuthApplication;
         }
       );
+      // });
+      cy.navigateTo('awx', 'applications');
     });
-    cy.navigateTo('awx', 'applications');
-  });
 
-  it('admin user creates an oauth application and associates an awx token with it, verifies the association in the application token tab', () => {
-    cy.verifyPageTitle('OAuth Applications');
-    cy.clickTableRowLink('name', `${awxApplication.name}`, { disableFilter: true });
-    cy.verifyPageTitle(`${awxApplication.name}`);
-    cy.clickTab('Tokens', true);
-    // verifies initially the oauth application has no tokens associated with it
-    cy.contains('h4', 'There are currently no tokens associated with this application');
-    cy.contains('.pf-v5-c-empty-state__body', 'You can create a token from your user page.');
-    cy.getCurrentUser().then((currentAwxUser: AwxUser) => {
-      cy.createAwxToken({ application: awxApplication.id, scope: 'write' }).then(
-        (createdAwxToken: AwxToken) => {
-          cy.wrap(createdAwxToken)
-            .its('summary_fields.user.username')
-            .then((userAssociatedWithOAuthApp: string) => {
-              expect(userAssociatedWithOAuthApp).to.eql(currentAwxUser.username);
-            });
-        }
-      );
-      cy.verifyPageTitle(awxApplication.name);
-      // verifies the oauth application has tokens associated with it by searching
-      cy.selectTableRow(currentAwxUser.username);
-    });
-    cy.clickToolbarKebabAction('delete-selected-tokens');
-    cy.clickModalConfirmCheckbox();
-    cy.intercept('DELETE', awxAPI`/tokens/*/`).as('deleteAWXToken');
-    cy.getModal().within(() => {
-      cy.clickButton(/^Delete token/);
-      cy.wait('@deleteAWXToken').then((deleteAWXToken) => {
-        expect(deleteAWXToken?.response?.statusCode).to.eql(204);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
+    it('admin user creates an oauth application and associates an awx token with it, verifies the association in the application token tab', () => {
+      cy.verifyPageTitle('OAuth Applications');
+      cy.clickTableRowLink('name', `${awxApplication.name}`, { disableFilter: true });
+      cy.verifyPageTitle(`${awxApplication.name}`);
+      cy.clickTab('Tokens', true);
+      // verifies initially the oauth application has no tokens associated with it
+      cy.contains('h4', 'There are currently no tokens associated with this application');
+      cy.contains('.pf-v5-c-empty-state__body', 'You can create a token from your user page.');
+      cy.getCurrentUser().then((currentAwxUser: AwxUser) => {
+        cy.createAwxToken({ application: awxApplication.id, scope: 'write' }).then(
+          (createdAwxToken: AwxToken) => {
+            cy.wrap(createdAwxToken)
+              .its('summary_fields.user.username')
+              .then((userAssociatedWithOAuthApp: string) => {
+                expect(userAssociatedWithOAuthApp).to.eql(currentAwxUser.username);
+              });
+          }
+        );
+        cy.verifyPageTitle(awxApplication.name);
+        // verifies the oauth application has tokens associated with it by searching
+        cy.selectTableRow(currentAwxUser.username);
       });
+      cy.clickToolbarKebabAction('delete-selected-tokens');
+      cy.clickModalConfirmCheckbox();
+      cy.intercept('DELETE', awxAPI`/tokens/*/`).as('deleteAWXToken');
+      cy.getModal().within(() => {
+        cy.clickButton(/^Delete token/);
+        cy.wait('@deleteAWXToken').then((deleteAWXToken) => {
+          expect(deleteAWXToken?.response?.statusCode).to.eql(204);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+        });
+      });
+      cy.clickButton(/^Clear all filters$/);
     });
-    cy.clickButton(/^Clear all filters$/);
   });
 });

--- a/cypress/e2e/awx/administration/credentialTypes.cy.ts
+++ b/cypress/e2e/awx/administration/credentialTypes.cy.ts
@@ -16,30 +16,30 @@ describe('Credential Types', () => {
     const credentialName = 'E2E Custom Credential ' + randomString(4);
 
     beforeEach(function () {
-      cy.createAwxOrganization().then((org) => {
-        awxOrganization = org;
+      // cy.createAwxOrganization().then((org) => {
+      //   awxOrganization = org;
 
-        cy.createAwxCredentialType().then((credentialType: CredentialType) => {
-          credType1 = credentialType;
+      cy.createAwxCredentialType().then((credentialType: CredentialType) => {
+        credType1 = credentialType;
 
-          cy.createAWXCredential({
-            name: credentialName,
-            kind: 'gce',
-            organization: awxOrganization.id,
-            credential_type: credType1.id,
-          }).then((cred) => {
-            credential = cred;
-          });
-        });
-
-        cy.fixture('credTypes-input-config').then((credentialType: CredentialType) => {
-          inputCredType = JSON.stringify(credentialType);
-        });
-
-        cy.fixture('credTypes-injector-config').then((credentialType: CredentialType) => {
-          injectorCredType = JSON.stringify(credentialType);
+        cy.createAWXCredential({
+          name: credentialName,
+          kind: 'gce',
+          // organization: awxOrganization.id,
+          credential_type: credType1.id,
+        }).then((cred) => {
+          credential = cred;
         });
       });
+
+      cy.fixture('credTypes-input-config').then((credentialType: CredentialType) => {
+        inputCredType = JSON.stringify(credentialType);
+      });
+
+      cy.fixture('credTypes-injector-config').then((credentialType: CredentialType) => {
+        injectorCredType = JSON.stringify(credentialType);
+      });
+      // });
     });
 
     afterEach(() => {

--- a/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersListView.cy.ts
@@ -17,39 +17,39 @@ describe('Notifications: List View', () => {
   });
 
   it('can create, edit a new Email Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Email');
+    testNotification('Email', organization);
   });
 
   it('can create a new Grafana Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Grafana');
+    testNotification('Grafana', organization);
   });
 
   it('can create, edit a new IRC Notification in the AAP UI, assert the info in the list view, and delete the notification', () => {
-    testNotification('IRC');
+    testNotification('IRC', organization);
   });
 
   it('can create, edit a new Mattermost Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Mattermost');
+    testNotification('Mattermost', organization);
   });
 
   it('can create, edit a new Pagerduty Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Pagerduty');
+    testNotification('Pagerduty', organization);
   });
 
   it('can create, edit a new Rocket.Chat Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Rocket.Chat');
+    testNotification('Rocket.Chat', organization);
   });
 
   it('can create, edit a new Slack Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Slack');
+    testNotification('Slack', organization);
   });
 
   it('can create, edit a new Twilio Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Twilio');
+    testNotification('Twilio', organization);
   });
 
   it('can create, edit a new Webhook Notification, assert the info in the list view, and delete the notification', () => {
-    testNotification('Webhook');
+    testNotification('Webhook', organization);
   });
 
   /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */

--- a/cypress/e2e/awx/administration/notifiers/notifiersSharedFunctions.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersSharedFunctions.ts
@@ -3,59 +3,61 @@ import { AwxItemsResponse } from '../../../../../frontend/awx/common/AwxItemsRes
 import { awxAPI } from '../../../../support/formatApiPathForAwx';
 import { Notification } from '../../../../../frontend/awx/interfaces/generated-from-swagger/api';
 import { randomE2Ename } from '../../../../support/utils';
+import { Organization } from '../../../../../frontend/awx/interfaces/Organization';
 
 export function testNotification(
   type: string,
+  organization: Organization,
   options?: { details?: boolean; skipMessages?: boolean }
 ) {
   const notificationName = randomE2Ename();
-  const orgName = randomE2Ename();
-  cy.createAwxOrganization({ name: orgName }).then(() => {
-    cy.navigateTo('awx', 'notification-templates');
-    cy.get(`[data-cy="add-notifier"]`).click();
-    cy.verifyPageTitle('Add notifier');
+  // const orgName = randomE2Ename();
+  // cy.createAwxOrganization({ name: orgName }).then(() => {
+  cy.navigateTo('awx', 'notification-templates');
+  cy.get(`[data-cy="add-notifier"]`).click();
+  cy.verifyPageTitle('Add notifier');
 
-    fillBasicData(notificationName, type);
-    fillNotificationType(type);
-    selectOrganization(orgName);
-    verifyDefaultsMessages(type);
+  fillBasicData(notificationName, type);
+  fillNotificationType(type);
+  selectOrganization(organization.name);
+  verifyDefaultsMessages(type);
 
-    cy.get(`[data-cy="Submit"]`).click();
+  cy.get(`[data-cy="Submit"]`).click();
 
-    // test detail
-    testBasicData(notificationName, type, orgName);
-    testNotificationType(type);
+  // test detail
+  testBasicData(notificationName, type, organization.name);
+  testNotificationType(type);
 
-    // test edit
-    if (options?.details === true) {
-      cy.getByDataCy(`edit-notifier`).click();
-    } else {
-      // if not in detail, we go back to list and click edit there
-      cy.getByDataCy('back-to notifiers').click();
-      cy.filterTableByMultiSelect('name', [notificationName]);
-      cy.contains(notificationName);
-      cy.get(`[aria-label="Simple table"] [data-cy="actions-dropdown"]`).click();
-      cy.getByDataCy(`edit-notifier`).click();
-    }
+  // test edit
+  if (options?.details === true) {
+    cy.getByDataCy(`edit-notifier`).click();
+  } else {
+    // if not in detail, we go back to list and click edit there
+    cy.getByDataCy('back-to notifiers').click();
+    cy.filterTableByMultiSelect('name', [notificationName]);
+    cy.contains(notificationName);
+    cy.get(`[aria-label="Simple table"] [data-cy="actions-dropdown"]`).click();
+    cy.getByDataCy(`edit-notifier`).click();
+  }
 
-    const name2 = randomE2Ename();
-    editBasicData(name2);
-    editNotificationType(type);
+  const name2 = randomE2Ename();
+  editBasicData(name2);
+  editNotificationType(type);
 
-    if (!options?.skipMessages) {
-      editCustomMessages(type);
-    }
-    cy.get(`[data-cy="Submit"]`).click();
+  if (!options?.skipMessages) {
+    editCustomMessages(type);
+  }
+  cy.get(`[data-cy="Submit"]`).click();
 
-    testBasicDataEdited(name2, orgName);
-    testNotificationTypeEdited(type);
+  testBasicDataEdited(name2, organization.name);
+  testNotificationTypeEdited(type);
 
-    if (!options?.skipMessages) {
-      verifyEditedMessages(type);
-    }
+  if (!options?.skipMessages) {
+    verifyEditedMessages(type);
+  }
 
-    testDelete(name2, options);
-  });
+  testDelete(name2, options);
+  // });
 }
 
 export function testDelete(name: string, options?: { details?: boolean }) {

--- a/cypress/e2e/awx/administration/notifiers/notifiersTabs.cy.ts
+++ b/cypress/e2e/awx/administration/notifiers/notifiersTabs.cy.ts
@@ -27,7 +27,7 @@ describe('Notifications', () => {
 
     it('can edit a Notification on its details page and assert the edited info', () => {
       cy.navigateTo('awx', 'notification-templates');
-      testNotification('Email', { details: true, skipMessages: true });
+      testNotification('Email', awxOrganization, { details: true, skipMessages: true });
     });
 
     it('can test the Notification on its details page and assert that the test completed', () => {

--- a/cypress/e2e/awx/administration/wfApprovalsList.cy.ts
+++ b/cypress/e2e/awx/administration/wfApprovalsList.cy.ts
@@ -24,48 +24,56 @@ describe('Workflow Approvals Tests', () => {
   let jobTemplateNode: WorkflowNode;
   let approvalWFNode: WorkflowNode;
   let jobName = '';
-
-  beforeEach(function () {
-    cy.createAwxOrganization().then((org) => {
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
       organization = org;
-
-      cy.createAwxProject(
-        organization,
-        { name: randomE2Ename() },
-        'https://github.com/ansible/test-playbooks'
-      ).then((proj) => {
-        project = proj;
-
-        cy.createAwxUser({ organization: organization.id }).then((u) => {
-          user = u;
-        });
-        cy.createAwxUser({ organization: organization.id }).then((u) => {
-          userWFApprove = u;
-        });
-        cy.createAwxUser({ organization: organization.id }).then((u) => {
-          userWFDeny = u;
-        });
-        cy.createAwxUser({ organization: organization.id }).then((u) => {
-          userWFCancel = u;
-        });
-        cy.createAwxInventory(organization)
-          .then((i) => {
-            inventory = i;
-          })
-          .then(() => {
-            cy.createAwxJobTemplate(
-              {
-                organization: organization.id,
-                project: project.id,
-                inventory: inventory.id,
-              },
-              'hello world.yml'
-            ).then((jt) => {
-              jobTemplate = jt;
-            });
-          });
-      });
     });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  beforeEach(function () {
+    // cy.createAwxOrganization().then((org) => {
+    //   organization = org;
+
+    cy.createAwxProject(
+      organization,
+      { name: randomE2Ename() },
+      'https://github.com/ansible/test-playbooks'
+    ).then((proj) => {
+      project = proj;
+
+      cy.createAwxUser({ organization: organization.id }).then((u) => {
+        user = u;
+      });
+      cy.createAwxUser({ organization: organization.id }).then((u) => {
+        userWFApprove = u;
+      });
+      cy.createAwxUser({ organization: organization.id }).then((u) => {
+        userWFDeny = u;
+      });
+      cy.createAwxUser({ organization: organization.id }).then((u) => {
+        userWFCancel = u;
+      });
+      cy.createAwxInventory(organization)
+        .then((i) => {
+          inventory = i;
+        })
+        .then(() => {
+          cy.createAwxJobTemplate(
+            {
+              organization: organization.id,
+              project: project.id,
+              inventory: inventory.id,
+            },
+            'hello world.yml'
+          ).then((jt) => {
+            jobTemplate = jt;
+          });
+        });
+    });
+    // });
   });
 
   afterEach(() => {
@@ -361,7 +369,7 @@ describe('Workflow Approvals Tests', () => {
     });
   });
 
-  /* 
+  /*
   Used in the Workflow Approvals - Bulk Approve, Bulk Deny, Bulk Delete tests (below)
   **/
   function editWorkflowJobTemplate() {
@@ -384,7 +392,7 @@ describe('Workflow Approvals Tests', () => {
       });
   }
 
-  /* 
+  /*
   Used in the Workflow Approvals - Bulk Approve, Bulk Deny, Bulk Delete tests (below)
   **/
   function workflowApprovalBulkAction(selectorDataCy: 'approve' | 'deny') {
@@ -450,7 +458,7 @@ describe('Workflow Approvals Tests', () => {
       });
   }
 
-  /* 
+  /*
   Used in the Workflow Approvals - Bulk Approve, Bulk Deny, Bulk Delete tests (below)
   **/
   function deleteApprovalFromListToolbar() {

--- a/cypress/e2e/awx/resources/credentials.cy.ts
+++ b/cypress/e2e/awx/resources/credentials.cy.ts
@@ -10,488 +10,208 @@ import { awxAPI } from '../../../support/formatApiPathForAwx';
 import { tag } from '../../../support/tag';
 import { randomE2Ename } from '../../../support/utils';
 
-describe('Credentials', () => {
-  let awxOrganization: Organization;
-  let project: Project;
-
-  before(() => {
-    cy.createAwxOrganization().then((org) => {
-      awxOrganization = org;
-      cy.createAwxProject(awxOrganization).then((proj) => {
-        project = proj;
-      });
-    });
-  });
-
-  after(() => {
-    cy.deleteAwxProject(project, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
-  });
-
-  describe('Credentials: List View', () => {
-    let credential: Credential;
-    beforeEach(() => {
-      cy.createAWXCredential({
-        kind: 'machine',
-        organization: awxOrganization.id,
-        credential_type: 1,
-      }).then((cred) => {
-        credential = cred;
-      });
-    });
-    afterEach(() => {
-      cy.deleteAwxCredential(credential, { failOnStatusCode: false });
-    });
-
-    it('can edit machine credential from the list row action', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.get(`[data-cy="row-id-${credential.id}"]`).within(() => {
-        cy.getByDataCy('edit-credential').click();
-      });
-      cy.verifyPageTitle('Edit Credential');
-      cy.getByDataCy('name').clear().type(`${credential.name} - edited`);
-      cy.clickButton(/^Save credential$/);
-      cy.clearAllFilters();
-      cy.filterTableByMultiSelect('name', [`${credential.name} - edited`]);
-      cy.clickTableRowLink('name', `${credential.name} - edited`, { disableFilter: true });
-      cy.verifyPageTitle(`${credential.name} - edited`);
-      cy.clickButton(/^Edit credential$/);
-      cy.getByDataCy('name').clear().type(`${credential.name}`);
-      cy.clickButton(/^Save credential$/);
-      cy.verifyPageTitle(credential.name);
-      cy.deleteAwxCredential(credential);
-    });
-
-    it('can delete machine credential from the list row action', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.clickTableRowAction('name', credential.name, 'delete-credential', {
-        disableFilter: true,
-        inKebab: true,
-      });
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
-      cy.clickButton(/^Delete credential/);
-      cy.wait('@deleted')
-        .its('response')
-        .then((deleted) => {
-          expect(deleted?.statusCode).to.eql(204);
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clickButton(/^Clear all filters$/);
-          cy.verifyPageTitle('Credentials');
-        });
-    });
-
-    it('can delete machine credential from the list toolbar', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.selectTableRowByCheckbox('name', credential.name, { disableFilter: true });
-      cy.clickToolbarKebabAction('delete-credentials');
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
-      cy.clickButton(/^Delete credential/);
-      cy.wait('@deleted')
-        .its('response')
-        .then((deleted) => {
-          expect(deleted?.statusCode).to.eql(204);
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clickButton(/^Clear all filters$/);
-          cy.verifyPageTitle('Credentials');
-        });
-    });
-
-    it('copies a credential from the list row action', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.getByDataCy('actions-column-cell').within(() => {
-        cy.getByDataCy('copy-credential').click();
-      });
-      cy.getByDataCy('alert-toaster').contains('copied').should('be.visible');
-      cy.clickButton(/^Clear all filters/);
-      cy.deleteAwxCredential(credential, { failOnStatusCode: false });
-      cy.filterTableByMultiSelect('name', [`${credential.name} @`]);
-      cy.getByDataCy('checkbox-column-cell').within(() => {
-        cy.get('input').click();
-      });
-      cy.clickToolbarKebabAction('delete-credentials');
-      cy.getModal().within(() => {
-        cy.get('#confirm').click();
-        cy.clickButton(/^Delete credential/);
-        cy.contains(/^Success$/);
-        cy.clickButton(/^Close$/);
-      });
-    });
-  });
-
-  describe('Credentials: Details View', () => {
-    let credential: Credential;
-    beforeEach(() => {
-      cy.createAWXCredential({
-        name: 'E2E Credential ' + randomString(4),
-        kind: 'Centrify Vault Credential Provider Lookup',
-        organization: awxOrganization.id,
-        credential_type: 25,
-        inputs: { url: 'http://foo.com', client_id: 'foo', client_password: 'foo' },
-      }).then((cred) => {
-        credential = cred;
-      });
-    });
-
-    afterEach(() => {
-      cy.deleteAwxCredential(credential, { failOnStatusCode: false });
-    });
-    it('details page should render boolean field', () => {
-      const credentialName = 'E2E Credential ' + randomString(4);
-      cy.navigateTo('awx', 'credentials');
-      cy.clickButton(/^Create credential$/);
-      cy.getByDataCy('name').type(credentialName);
-      cy.singleSelectBy('[data-cy="credential_type"]', 'Container Registry');
-      cy.contains('Type Details').should('be.visible');
-      cy.getByDataCy('host').clear().type('https://host.com');
-      cy.getByDataCy('verify_ssl').check();
-      cy.clickButton(/^Create credential$/);
-      cy.verifyPageTitle(credentialName);
-      cy.getByDataCy('name').contains(credentialName);
-      cy.contains('Authentication URL').should('be.visible');
-      cy.getByDataCy('authentication-url').contains('https://host.com');
-      cy.contains('Verify SSL').should('be.visible');
-      cy.getByDataCy('verify-ssl').contains('Yes');
-      cy.clickPageAction('delete-credential');
-      cy.get('#confirm').click();
-      cy.clickButton(/^Delete credential/);
-      cy.verifyPageTitle('Credentials');
-    });
-
-    it('can edit machine credential from the details page', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.clickTableRowLink('name', credential.name, {
-        disableFilter: true,
-      });
-      cy.clickButton(/^Edit credential$/);
-      cy.verifyPageTitle('Edit Credential');
-      cy.getByDataCy('name')
-        .clear()
-        .type(credential.name + '-edited');
-      cy.intercept('PATCH', awxAPI`/credentials/${credential.id.toString()}/`).as('edited');
-      cy.clickButton(/^Save credential$/);
-      cy.wait('@edited')
-        .its('response.body')
-        .then((edited: Credential) => {
-          expect(edited.name).to.eql(credential.name + '-edited');
-          cy.getByDataCy('name').should('contain', edited.name);
-          cy.verifyPageTitle(edited.name);
-          cy.clickPageAction('delete-credential');
-          cy.get('#confirm').click();
-          cy.clickButton(/^Delete credential/);
-        });
-    });
-
-    it('can delete a machine credential from the details page', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.clickTableRowLink('name', credential.name, {
-        disableFilter: true,
-      });
-      cy.verifyPageTitle(credential.name);
-      cy.clickPageAction('delete-credential');
-      cy.get('#confirm').click();
-      cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
-      cy.clickButton(/^Delete credential/);
-      cy.wait('@deleted')
-        .its('response')
-        .then((deleted) => {
-          expect(deleted?.statusCode).to.eql(204);
-          cy.verifyPageTitle('Credentials');
-        });
-    });
-  });
-
-  describe('Credentials Create: External test modal', () => {
-    it('can display error toast message when running a test from the create credential form', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.clickButton(/^Create credential/);
-      cy.getByDataCy('name').type('foo');
-      cy.getByDataCy('credential_type').click();
-      cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
-      cy.getByDataCy('url').type('http://foo.com');
-      cy.getByDataCy('client-id').type('foo');
-      cy.getByDataCy('client-password').type('foo');
-      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
-      cy.contains('Test external credential').should('be.visible');
-      cy.getByDataCy('account-name').type('foo');
-      cy.getByDataCy('system-name').type('foo');
-      cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
-      cy.getByDataCy('alert-toaster')
-        .should('be.visible')
-        .and('contain', 'Something went wrong with the request to test this credential.')
-        .within(() => {
-          cy.get('button').click();
-        });
-      cy.clickModalButton('Cancel');
-      cy.clickButton(/^Cancel/);
-    });
-
-    it('can display success toast message when running a test from the create credential form', () => {
-      cy.intercept('POST', awxAPI`/credential_types/25/test`, {}).as('runTest');
-      cy.navigateTo('awx', 'credentials');
-      cy.clickButton(/^Create credential/);
-      cy.getByDataCy('name').type('foo');
-      cy.getByDataCy('credential_type').click();
-      cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
-      cy.getByDataCy('url').type('http://foo.com');
-      cy.getByDataCy('client-id').type('foo');
-      cy.getByDataCy('client-password').type('foo');
-      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
-      cy.contains('Test external credential').should('be.visible');
-      cy.getByDataCy('account-name').type('foo');
-      cy.getByDataCy('system-name').type('foo');
-      cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
-      cy.wait('@runTest');
-      cy.getByDataCy('alert-toaster')
-        .should('be.visible')
-        .and('contain', 'Test passed.')
-        .within(() => {
-          cy.get('button').click();
-        });
-      cy.clickModalButton('Cancel');
-      cy.clickButton(/^Cancel/);
-    });
-  });
-
-  describe('Credentials Edit: External test modal', () => {
-    let credential: Credential;
-    before(() => {
-      cy.createAWXCredential({
-        name: 'E2E Credential ' + randomString(4),
-        kind: 'Centrify Vault Credential Provider Lookup',
-        organization: awxOrganization.id,
-        credential_type: 25,
-        inputs: { url: 'http://foo.com', client_id: 'foo', client_password: 'foo' },
-      }).then((cred) => {
-        credential = cred;
-      });
-    });
-
-    after(() => {
-      cy.deleteAwxCredential(credential, { failOnStatusCode: false });
-    });
-
-    it('can display error toast message when running a test from the edit credential form', () => {
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.clickTableRowAction('name', credential.name, 'edit-credential', { disableFilter: true });
-      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
-      cy.contains('Test external credential').should('be.visible');
-      cy.getByDataCy('account-name').type('foo');
-      cy.getByDataCy('system-name').type('foo');
-      cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
-      cy.getByDataCy('alert-toaster')
-        .should('be.visible')
-        .and('contain', 'Something went wrong with the request to test this credential.')
-        .within(() => {
-          cy.get('button').click();
-        });
-      cy.clickModalButton('Cancel');
-      cy.clickButton(/^Cancel/);
-    });
-
-    it('can display success toast message when running a test from the edit credential form', () => {
-      cy.intercept('POST', awxAPI`/credentials/${credential.id.toString()}/test`, {}).as('runTest');
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [credential.name]);
-      cy.clickTableRowAction('name', credential.name, 'edit-credential', { disableFilter: true });
-      cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
-      cy.contains('Test external credential').should('be.visible');
-      cy.getByDataCy('account-name').type('foo');
-      cy.getByDataCy('system-name').type('foo');
-      cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
-      cy.wait('@runTest');
-      cy.getByDataCy('alert-toaster')
-        .should('be.visible')
-        .and('contain', 'Test passed.')
-        .within(() => {
-          cy.get('button').click();
-        });
-      cy.clickModalButton('Cancel');
-      cy.clickButton(/^Cancel/);
-    });
-  });
-
-  describe('Credentials Tabbed View - Job Templates', () => {
-    let machineCredential: Credential;
-    let awxOrganization: Organization;
-    let awxInventory: Inventory;
-
-    beforeEach(() => {
-      cy.createAwxOrganization().then((awxOrg) => {
-        awxOrganization = awxOrg;
-        cy.createAWXCredential({
-          kind: 'machine',
-          organization: awxOrganization.id,
-          credential_type: 1,
-        }).then((cred) => {
-          machineCredential = cred;
-        });
-
-        cy.createAwxInventory(awxOrganization).then((inv) => {
-          awxInventory = inv;
-        });
-      });
-    });
-
-    afterEach(() => {
-      cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
-      cy.deleteAwxInventory(awxInventory, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
-    });
-
-    it('can create a job template within the context of credential job template tab', () => {
-      const jobTemplateName = `E2E Job Template ${randomE2Ename()}`;
-      cy.intercept('POST', awxAPI`/job_templates`).as('createJT');
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [machineCredential.name]);
-      cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
-      cy.clickTab('Job Templates', true);
-      cy.getByDataCy('create-template').click();
-      cy.verifyPageTitle('Create job template');
-      cy.getByDataCy('name').type(jobTemplateName);
-      cy.selectDropdownOptionByResourceName('inventory', awxInventory.name);
-      cy.selectDropdownOptionByResourceName('project', project.name);
-      cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
-      cy.multiSelectByDataCy('credential', [machineCredential.name]);
-      cy.getByDataCy('Submit').click();
-    });
-  });
-});
-
-describe('Credentials: Credential Types Tests', () => {
+describe('Wrapper, creates and deletes organization', () => {
   let organization: Organization;
-  beforeEach(() => {
-    cy.createAwxOrganization().then((o) => (organization = o));
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
+      organization = org;
+    });
   });
-  afterEach(() => {
+  after(() => {
     cy.deleteAwxOrganization(organization);
   });
 
-  it('can create credential using custom credential type', () => {
-    cy.createAwxCredentialType().then((credType) => {
-      const credentialName = 'E2E Credential ' + randomString(4);
-      cy.navigateTo('awx', 'credentials');
-      cy.clickButton(/^Create credential$/);
-      cy.getByDataCy('name').type(credentialName);
-      cy.singleSelectBy('[data-cy="credential_type"]', credType.name, true);
-      cy.clickButton(/^Create credential$/);
-      cy.verifyPageTitle(credentialName);
-      cy.getByDataCy('name').contains(credentialName);
-      //delete created credential
-      cy.clickPageAction('delete-credential');
-      cy.get('#confirm').click();
-      cy.clickButton(/^Delete credential/);
-      cy.verifyPageTitle('Credentials');
-      cy.deleteAwxCredentialType(credType);
-    });
-  });
+  describe('Credentials', () => {
+    // let organization: Organization;
+    let project: Project;
 
-  it('cannot edit vault id for Vault credential type', () => {
-    const credentialName = 'E2E Credential ' + randomString(4);
-    cy.navigateTo('awx', 'credentials');
-    cy.clickButton(/^Create credential$/);
-    cy.getByDataCy('name').type(credentialName);
-    cy.singleSelectBy('[data-cy="credential_type"]', 'Vault', true);
-    cy.contains('Type Details').should('be.visible');
-    cy.getByDataCy('vault-password').type('password');
-    cy.getByDataCy('vault-id').type('id');
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.clickButton(/^Create credential$/);
-    cy.verifyPageTitle(credentialName);
-    cy.getByDataCy('name').contains(credentialName);
-    cy.contains('Vault Identifier').should('be.visible');
-    cy.getByDataCy('vault-identifier').contains('id');
-    cy.contains('Vault Password').should('be.visible');
-    cy.getByDataCy('vault-password').contains('Encrypted');
-    cy.getByDataCy('edit-credential').click();
-    cy.verifyPageTitle('Edit Credential');
-    cy.get('[data-cy="vault-password"]').then(($pwd) => {
-      cy.wrap($pwd).should('have.value', 'ENCRYPTED');
+    before(() => {
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
+      cy.createAwxProject(organization).then((proj) => {
+        project = proj;
+      });
+      // });
     });
-    cy.getByDataCy('ask_vault_password').check();
-    cy.clickButton(/^Save credential$/);
-    cy.getByDataCy('name').contains(credentialName);
-    cy.contains('Vault Identifier').should('be.visible');
-    cy.getByDataCy('vault-identifier').contains('id');
-    cy.contains('Vault Password').should('be.visible');
-    cy.getByDataCy('vault-password').contains('Prompt on launch');
-    //delete created credential
-    cy.clickPageAction('delete-credential');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.verifyPageTitle('Credentials');
-  });
 
-  it('can create, edit and delete a credential that renders a sub form', () => {
-    const credentialName = 'E2E Credential ' + randomString(4);
-    cy.navigateTo('awx', 'credentials');
-    cy.clickButton(/^Create credential$/);
-    cy.getByDataCy('name').type(credentialName);
-    cy.singleSelectByDataCy('credential_type', 'Amazon Web Services');
-    cy.contains('Type Details').should('be.visible');
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.getByDataCy('username').type('username');
-    cy.getByDataCy('password').type('password');
-    cy.getByDataCy('security-token').type('security-token');
-    cy.getByDataCy('description').type('description');
-    cy.intercept('POST', awxAPI`/credentials/`).as('newCred');
-    cy.clickButton(/^Create credential$/);
-    cy.wait('@newCred')
-      .its('response.body')
-      .then((newCred: Credential) => {
-        cy.getByDataCy('name').contains(credentialName);
-        cy.getByDataCy('label-credential-type').contains('Credential type');
-        cy.getByDataCy('credential-type').contains('Amazon Web Services');
-        cy.getByDataCy('label-access-key').contains('Access Key');
-        cy.getByDataCy('access-key').contains('username');
-        cy.getByDataCy('label-secret-key').contains('Secret Key');
-        cy.getByDataCy('secret-key').contains('Encrypted');
-        cy.getByDataCy('label-sts-token').contains('STS Token');
-        cy.getByDataCy('label-organization').contains('Organization');
-        cy.getByDataCy('organization').contains(organization.name);
-        cy.getByDataCy('label-description').contains('Description');
-        cy.getByDataCy('description').contains('description');
-        cy.getByDataCy('edit-credential').click();
+    after(() => {
+      cy.deleteAwxProject(project, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    });
+
+    describe('Credentials: List View', () => {
+      let credential: Credential;
+      beforeEach(() => {
+        cy.createAWXCredential({
+          kind: 'machine',
+          organization: organization.id,
+          credential_type: 1,
+        }).then((cred) => {
+          credential = cred;
+        });
+      });
+      afterEach(() => {
+        cy.deleteAwxCredential(credential, { failOnStatusCode: false });
+      });
+
+      it('can edit machine credential from the list row action', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.get(`[data-cy="row-id-${credential.id}"]`).within(() => {
+          cy.getByDataCy('edit-credential').click();
+        });
         cy.verifyPageTitle('Edit Credential');
-        const ModifiedCredentialName = credentialName + ' - edited';
-        cy.getByDataCy('name').type(ModifiedCredentialName);
-        cy.get('input[data-cy="username"]').then(($username) => {
-          cy.wrap($username).should('have.value', 'username');
-        });
-        cy.get('input[data-cy="password"]').then(($pwd) => {
-          cy.wrap($pwd).should('have.value', 'ENCRYPTED');
-        });
-        cy.get('input[data-cy="security-token"]').then(($token) => {
-          cy.wrap($token).should('have.value', 'ENCRYPTED');
-        });
-        const newDescription = 'new description';
-        cy.getByDataCy('description').clear().type(newDescription);
+        cy.getByDataCy('name').clear().type(`${credential.name} - edited`);
         cy.clickButton(/^Save credential$/);
-        cy.getByDataCy('name').contains(ModifiedCredentialName);
-        cy.getByDataCy('label-credential-type').contains('Credential type');
-        cy.getByDataCy('credential-type').contains('Amazon Web Services');
-        cy.getByDataCy('label-access-key').contains('Access Key');
-        cy.getByDataCy('access-key').contains('username');
-        cy.getByDataCy('label-secret-key').contains('Secret Key');
-        cy.getByDataCy('secret-key').contains('Encrypted');
-        cy.getByDataCy('label-sts-token').contains('STS Token');
-        cy.getByDataCy('sts-token').contains('Encrypted');
-        cy.getByDataCy('label-description').contains('Description');
-        cy.getByDataCy('description').contains(newDescription);
+        cy.clearAllFilters();
+        cy.filterTableByMultiSelect('name', [`${credential.name} - edited`]);
+        cy.clickTableRowLink('name', `${credential.name} - edited`, { disableFilter: true });
+        cy.verifyPageTitle(`${credential.name} - edited`);
+        cy.clickButton(/^Edit credential$/);
+        cy.getByDataCy('name').clear().type(`${credential.name}`);
+        cy.clickButton(/^Save credential$/);
+        cy.verifyPageTitle(credential.name);
+        cy.deleteAwxCredential(credential);
+      });
 
+      it('can delete machine credential from the list row action', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.clickTableRowAction('name', credential.name, 'delete-credential', {
+          disableFilter: true,
+          inKebab: true,
+        });
+        cy.get('#confirm').click();
+        cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
+        cy.clickButton(/^Delete credential/);
+        cy.wait('@deleted')
+          .its('response')
+          .then((deleted) => {
+            expect(deleted?.statusCode).to.eql(204);
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+            cy.clickButton(/^Clear all filters$/);
+            cy.verifyPageTitle('Credentials');
+          });
+      });
+
+      it('can delete machine credential from the list toolbar', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.selectTableRowByCheckbox('name', credential.name, { disableFilter: true });
+        cy.clickToolbarKebabAction('delete-credentials');
+        cy.get('#confirm').click();
+        cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
+        cy.clickButton(/^Delete credential/);
+        cy.wait('@deleted')
+          .its('response')
+          .then((deleted) => {
+            expect(deleted?.statusCode).to.eql(204);
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+            cy.clickButton(/^Clear all filters$/);
+            cy.verifyPageTitle('Credentials');
+          });
+      });
+
+      it('copies a credential from the list row action', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.getByDataCy('actions-column-cell').within(() => {
+          cy.getByDataCy('copy-credential').click();
+        });
+        cy.getByDataCy('alert-toaster').contains('copied').should('be.visible');
+        cy.clickButton(/^Clear all filters/);
+        cy.deleteAwxCredential(credential, { failOnStatusCode: false });
+        cy.filterTableByMultiSelect('name', [`${credential.name} @`]);
+        cy.getByDataCy('checkbox-column-cell').within(() => {
+          cy.get('input').click();
+        });
+        cy.clickToolbarKebabAction('delete-credentials');
+        cy.getModal().within(() => {
+          cy.get('#confirm').click();
+          cy.clickButton(/^Delete credential/);
+          cy.contains(/^Success$/);
+          cy.clickButton(/^Close$/);
+        });
+      });
+    });
+
+    describe('Credentials: Details View', () => {
+      let credential: Credential;
+      beforeEach(() => {
+        cy.createAWXCredential({
+          name: 'E2E Credential ' + randomString(4),
+          kind: 'Centrify Vault Credential Provider Lookup',
+          organization: organization.id,
+          credential_type: 25,
+          inputs: { url: 'http://foo.com', client_id: 'foo', client_password: 'foo' },
+        }).then((cred) => {
+          credential = cred;
+        });
+      });
+
+      afterEach(() => {
+        cy.deleteAwxCredential(credential, { failOnStatusCode: false });
+      });
+      it('details page should render boolean field', () => {
+        const credentialName = 'E2E Credential ' + randomString(4);
+        cy.navigateTo('awx', 'credentials');
+        cy.clickButton(/^Create credential$/);
+        cy.getByDataCy('name').type(credentialName);
+        cy.singleSelectBy('[data-cy="credential_type"]', 'Container Registry');
+        cy.contains('Type Details').should('be.visible');
+        cy.getByDataCy('host').clear().type('https://host.com');
+        cy.getByDataCy('verify_ssl').check();
+        cy.clickButton(/^Create credential$/);
+        cy.verifyPageTitle(credentialName);
+        cy.getByDataCy('name').contains(credentialName);
+        cy.contains('Authentication URL').should('be.visible');
+        cy.getByDataCy('authentication-url').contains('https://host.com');
+        cy.contains('Verify SSL').should('be.visible');
+        cy.getByDataCy('verify-ssl').contains('Yes');
         cy.clickPageAction('delete-credential');
         cy.get('#confirm').click();
-        cy.intercept('DELETE', awxAPI`/credentials/${newCred.id.toString()}/`).as('deleted');
+        cy.clickButton(/^Delete credential/);
+        cy.verifyPageTitle('Credentials');
+      });
+
+      it('can edit machine credential from the details page', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.clickTableRowLink('name', credential.name, {
+          disableFilter: true,
+        });
+        cy.clickButton(/^Edit credential$/);
+        cy.verifyPageTitle('Edit Credential');
+        cy.getByDataCy('name')
+          .clear()
+          .type(credential.name + '-edited');
+        cy.intercept('PATCH', awxAPI`/credentials/${credential.id.toString()}/`).as('edited');
+        cy.clickButton(/^Save credential$/);
+        cy.wait('@edited')
+          .its('response.body')
+          .then((edited: Credential) => {
+            expect(edited.name).to.eql(credential.name + '-edited');
+            cy.getByDataCy('name').should('contain', edited.name);
+            cy.verifyPageTitle(edited.name);
+            cy.clickPageAction('delete-credential');
+            cy.get('#confirm').click();
+            cy.clickButton(/^Delete credential/);
+          });
+      });
+
+      it('can delete a machine credential from the details page', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.clickTableRowLink('name', credential.name, {
+          disableFilter: true,
+        });
+        cy.verifyPageTitle(credential.name);
+        cy.clickPageAction('delete-credential');
+        cy.get('#confirm').click();
+        cy.intercept('DELETE', awxAPI`/credentials/${credential.id.toString()}/`).as('deleted');
         cy.clickButton(/^Delete credential/);
         cy.wait('@deleted')
           .its('response')
@@ -500,235 +220,529 @@ describe('Credentials: Credential Types Tests', () => {
             cy.verifyPageTitle('Credentials');
           });
       });
-  });
+    });
 
-  it('create/edit a credential using prompt on launch', () => {
-    const credentialName = 'E2E Credential ' + randomString(4);
-    cy.navigateTo('awx', 'credentials');
-    cy.clickButton(/^Create credential$/);
-    cy.getByDataCy('name').type(credentialName);
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.singleSelectBy('[data-cy="credential_type"]', 'Machine');
-    cy.contains('Type Details').should('be.visible');
-    cy.getByDataCy('ask_password').check();
-    cy.getByDataCy('ask_ssh_key_unlock').check();
-    cy.clickButton(/^Create credential$/);
-    cy.verifyPageTitle(credentialName);
-    cy.getByDataCy('name').contains(credentialName);
-    cy.contains('Private Key Passphrase').should('be.visible');
-    cy.getByDataCy('private-key-passphrase').contains('Prompt on launch');
-    cy.contains('Password').should('be.visible');
-    cy.getByDataCy('password').contains('Prompt on launch');
-    cy.getByDataCy('edit-credential').click();
-    cy.verifyPageTitle('Edit Credential');
-    cy.getByDataCy('ask_password').uncheck();
-    cy.getByDataCy('password').type('password');
-    cy.clickButton(/^Save credential$/);
-    cy.contains('Password').should('be.visible');
-    cy.getByDataCy('password').contains('Encrypted');
-    cy.contains('Private Key Passphrase').should('be.visible');
-    cy.getByDataCy('private-key-passphrase').contains('Prompt on launch');
-    cy.clickPageAction('delete-credential');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.verifyPageTitle('Credentials');
-  });
-
-  it('machine credential type should render privilege escalation', () => {
-    // This is a test for the custom component that renders the privilege
-    // escalation method using a custom component
-    const credentialName = 'E2E Credential ' + randomString(4);
-    cy.navigateTo('awx', 'credentials');
-    cy.clickButton(/^Create credential$/);
-    cy.getByDataCy('name').type(credentialName);
-    cy.singleSelectByDataCy('organization', organization.name);
-    cy.singleSelectBy('[data-cy="credential_type"]', 'Machine');
-    cy.contains('Type Details').should('be.visible');
-    // Use custom component to render the privilege escalation method is sudo
-    cy.contains('Privilege Escalation Method ').should('be.visible');
-    cy.get('button[aria-label="Options menu"]').click();
-    cy.getByDataCy('select-option-sudo').click();
-    cy.clickButton(/^Create credential$/);
-    cy.verifyPageTitle(credentialName);
-    cy.getByDataCy('name').contains(credentialName);
-    cy.contains('Privilege Escalation Method').should('be.visible');
-    cy.getByDataCy('privilege-escalation-method').contains('sudo');
-    cy.clickPageAction('delete-credential');
-    cy.get('#confirm').click();
-    cy.clickButton(/^Delete credential/);
-    cy.verifyPageTitle('Credentials');
-  });
-});
-
-tag(['upstream'], () => {
-  describe('Credentials Tabbed View - Team and User Access', () => {
-    let machineCredential: Credential;
-    let createdAwxUser: AwxUser;
-    let awxOrganization: Organization;
-    let awxTeam: Team;
-    beforeEach(() => {
-      cy.createAwxOrganization().then((awxOrg) => {
-        awxOrganization = awxOrg;
-        cy.createAwxUser({ organization: awxOrganization.id }).then((awxUser) => {
-          createdAwxUser = awxUser;
-          cy.createAWXCredential({
-            kind: 'machine',
-            organization: awxOrganization.id,
-            credential_type: 1,
-          }).then((cred) => {
-            machineCredential = cred;
+    describe('Credentials Create: External test modal', () => {
+      it('can display error toast message when running a test from the create credential form', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.clickButton(/^Create credential/);
+        cy.getByDataCy('name').type('foo');
+        cy.getByDataCy('credential_type').click();
+        cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
+        cy.getByDataCy('url').type('http://foo.com');
+        cy.getByDataCy('client-id').type('foo');
+        cy.getByDataCy('client-password').type('foo');
+        cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+        cy.contains('Test external credential').should('be.visible');
+        cy.getByDataCy('account-name').type('foo');
+        cy.getByDataCy('system-name').type('foo');
+        cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
+        cy.getByDataCy('alert-toaster')
+          .should('be.visible')
+          .and('contain', 'Something went wrong with the request to test this credential.')
+          .within(() => {
+            cy.get('button').click();
           });
-        });
-        cy.createAwxTeam({ organization: awxOrganization.id }).then((createdAwxTeam) => {
-          awxTeam = createdAwxTeam;
-        });
+        cy.clickModalButton('Cancel');
+        cy.clickButton(/^Cancel/);
+      });
+
+      it('can display success toast message when running a test from the create credential form', () => {
+        cy.intercept('POST', awxAPI`/credential_types/25/test`, {}).as('runTest');
+        cy.navigateTo('awx', 'credentials');
+        cy.clickButton(/^Create credential/);
+        cy.getByDataCy('name').type('foo');
+        cy.getByDataCy('credential_type').click();
+        cy.getByDataCy('centrify-vault-credential-provider-lookup').click();
+        cy.getByDataCy('url').type('http://foo.com');
+        cy.getByDataCy('client-id').type('foo');
+        cy.getByDataCy('client-password').type('foo');
+        cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+        cy.contains('Test external credential').should('be.visible');
+        cy.getByDataCy('account-name').type('foo');
+        cy.getByDataCy('system-name').type('foo');
+        cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
+        cy.wait('@runTest');
+        cy.getByDataCy('alert-toaster')
+          .should('be.visible')
+          .and('contain', 'Test passed.')
+          .within(() => {
+            cy.get('button').click();
+          });
+        cy.clickModalButton('Cancel');
+        cy.clickButton(/^Cancel/);
       });
     });
 
-    afterEach(() => {
-      cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
-      cy.deleteAwxUser(createdAwxUser, { failOnStatusCode: false });
-      cy.deleteAwxTeam(awxTeam, { failOnStatusCode: false });
+    describe('Credentials Edit: External test modal', () => {
+      let credential: Credential;
+      before(() => {
+        cy.createAWXCredential({
+          name: 'E2E Credential ' + randomString(4),
+          kind: 'Centrify Vault Credential Provider Lookup',
+          organization: organization.id,
+          credential_type: 25,
+          inputs: { url: 'http://foo.com', client_id: 'foo', client_password: 'foo' },
+        }).then((cred) => {
+          credential = cred;
+        });
+      });
+
+      after(() => {
+        cy.deleteAwxCredential(credential, { failOnStatusCode: false });
+      });
+
+      it('can display error toast message when running a test from the edit credential form', () => {
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.clickTableRowAction('name', credential.name, 'edit-credential', { disableFilter: true });
+        cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+        cy.contains('Test external credential').should('be.visible');
+        cy.getByDataCy('account-name').type('foo');
+        cy.getByDataCy('system-name').type('foo');
+        cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
+        cy.getByDataCy('alert-toaster')
+          .should('be.visible')
+          .and('contain', 'Something went wrong with the request to test this credential.')
+          .within(() => {
+            cy.get('button').click();
+          });
+        cy.clickModalButton('Cancel');
+        cy.clickButton(/^Cancel/);
+      });
+
+      it('can display success toast message when running a test from the edit credential form', () => {
+        cy.intercept('POST', awxAPI`/credentials/${credential.id.toString()}/test`, {}).as(
+          'runTest'
+        );
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [credential.name]);
+        cy.clickTableRowAction('name', credential.name, 'edit-credential', { disableFilter: true });
+        cy.get('button').contains('Test').should('have.attr', 'aria-disabled', 'false').click();
+        cy.contains('Test external credential').should('be.visible');
+        cy.getByDataCy('account-name').type('foo');
+        cy.getByDataCy('system-name').type('foo');
+        cy.get('button').contains('Run').should('have.attr', 'aria-disabled', 'false').click();
+        cy.wait('@runTest');
+        cy.getByDataCy('alert-toaster')
+          .should('be.visible')
+          .and('contain', 'Test passed.')
+          .within(() => {
+            cy.get('button').click();
+          });
+        cy.clickModalButton('Cancel');
+        cy.clickButton(/^Cancel/);
+      });
     });
 
-    function removeRoleFromListRow(roleName: string, assignmentType: string) {
-      cy.intercept('DELETE', awxAPI`/role_${assignmentType}_assignments/*`).as('deleteRole');
-      cy.clickTableRowPinnedAction(roleName, 'remove-role', false);
-      cy.getModal().within(() => {
+    describe('Credentials Tabbed View - Job Templates', () => {
+      let machineCredential: Credential;
+      // let organization: Organization;
+      let awxInventory: Inventory;
+
+      beforeEach(() => {
+        // cy.createAwxOrganization().then((awxOrg) => {
+        //   organization = awxOrg;
+        cy.createAWXCredential({
+          kind: 'machine',
+          organization: organization.id,
+          credential_type: 1,
+        }).then((cred) => {
+          machineCredential = cred;
+        });
+
+        cy.createAwxInventory(organization).then((inv) => {
+          awxInventory = inv;
+        });
+        // });
+      });
+
+      afterEach(() => {
+        cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
+        cy.deleteAwxInventory(awxInventory, { failOnStatusCode: false });
+        cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+      });
+
+      it('can create a job template within the context of credential job template tab', () => {
+        const jobTemplateName = `E2E Job Template ${randomE2Ename()}`;
+        cy.intercept('POST', awxAPI`/job_templates`).as('createJT');
+        cy.navigateTo('awx', 'credentials');
+        cy.filterTableByMultiSelect('name', [machineCredential.name]);
+        cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
+        cy.clickTab('Job Templates', true);
+        cy.getByDataCy('create-template').click();
+        cy.verifyPageTitle('Create job template');
+        cy.getByDataCy('name').type(jobTemplateName);
+        cy.selectDropdownOptionByResourceName('inventory', awxInventory.name);
+        cy.selectDropdownOptionByResourceName('project', project.name);
+        cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
+        cy.multiSelectByDataCy('credential', [machineCredential.name]);
+        cy.getByDataCy('Submit').click();
+      });
+    });
+  });
+
+  describe('Credentials: Credential Types Tests', () => {
+    // let organization: Organization;
+    // before(() => {
+    //   cy.createAwxOrganization().then((o) => (organization = o));
+    // });
+    // after(() => {
+    //   cy.deleteAwxOrganization(organization);
+    // });
+
+    it('can create credential using custom credential type', () => {
+      cy.createAwxCredentialType().then((credType) => {
+        const credentialName = 'E2E Credential ' + randomString(4);
+        cy.navigateTo('awx', 'credentials');
+        cy.clickButton(/^Create credential$/);
+        cy.getByDataCy('name').type(credentialName);
+        cy.singleSelectBy('[data-cy="credential_type"]', credType.name, true);
+        cy.clickButton(/^Create credential$/);
+        cy.verifyPageTitle(credentialName);
+        cy.getByDataCy('name').contains(credentialName);
+        //delete created credential
+        cy.clickPageAction('delete-credential');
         cy.get('#confirm').click();
-        cy.clickButton(/^Remove role/);
-        cy.wait('@deleteRole')
-          .its('response')
-          .then((deleted) => {
-            expect(deleted?.statusCode).to.eql(204);
-            cy.contains(/^Success$/).should('be.visible');
-            cy.containsBy('button', /^Close$/).click();
-          });
+        cy.clickButton(/^Delete credential/);
+        cy.verifyPageTitle('Credentials');
+        cy.deleteAwxCredentialType(credType);
       });
-    }
-    it('create a new credential, assign a team and apply role(s)', () => {
-      cy.intercept('POST', awxAPI`/role_team_assignments/`).as('teamRoleAssignment');
-      cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [machineCredential.name]);
-      cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
-      cy.clickTab('Team Access', true);
-
-      cy.getByDataCy('add-roles').click();
-      cy.verifyPageTitle('Add roles');
-      cy.getWizard().within(() => {
-        cy.contains('h1', 'Select team(s)').should('be.visible');
-        cy.filterTableByMultiSelect('name', [awxTeam.name]);
-        cy.selectTableRowByCheckbox('name', awxTeam.name, { disableFilter: true });
-        cy.clickButton(/^Next/);
-        cy.contains('h1', 'Select roles to apply').should('be.visible');
-        cy.filterTableByTextFilter('name', 'Credential Admin', {
-          disableFilterSelection: true,
-        });
-        cy.selectTableRowByCheckbox('name', 'Credential Admin', {
-          disableFilter: true,
-        });
-        cy.filterTableByTextFilter('name', 'Credential Use', {
-          disableFilterSelection: true,
-        });
-        cy.selectTableRowByCheckbox('name', 'Credential Use', {
-          disableFilter: true,
-        });
-        cy.clickButton(/^Next/);
-        cy.contains('h1', 'Review').should('be.visible');
-        cy.verifyReviewStepWizardDetails('teams', [awxTeam.name], '1');
-        cy.verifyReviewStepWizardDetails(
-          'awxRoles',
-          [
-            'Credential Admin',
-            'Has all permissions to a single credential',
-            'Credential Use',
-            'Has use permissions to a single credential',
-          ],
-          '2'
-        );
-        cy.clickButton(/^Finish/);
-        cy.wait('@teamRoleAssignment')
-          .its('response')
-          .then((response) => {
-            expect(response?.statusCode).to.eql(201);
-          });
-      });
-      cy.getModal().within(() => {
-        cy.clickButton(/^Close$/);
-      });
-      cy.getModal().should('not.exist');
-      cy.verifyPageTitle(machineCredential.name);
-      cy.selectTableRowByCheckbox('team-name', awxTeam.name, {
-        disableFilter: true,
-      });
-      removeRoleFromListRow('Credential Admin', 'team');
-      cy.selectTableRowByCheckbox('team-name', awxTeam.name, {
-        disableFilter: true,
-      });
-      removeRoleFromListRow('Credential Use', 'team');
     });
 
-    it('create a new credential, assign a user and apply role(s)', () => {
-      cy.intercept('POST', awxAPI`/role_user_assignments/`).as('userRoleAssignment');
+    it('cannot edit vault id for Vault credential type', () => {
+      const credentialName = 'E2E Credential ' + randomString(4);
       cy.navigateTo('awx', 'credentials');
-      cy.filterTableByMultiSelect('name', [machineCredential.name]);
-      cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
-      cy.clickTab('User Access', true);
+      cy.clickButton(/^Create credential$/);
+      cy.getByDataCy('name').type(credentialName);
+      cy.singleSelectBy('[data-cy="credential_type"]', 'Vault', true);
+      cy.contains('Type Details').should('be.visible');
+      cy.getByDataCy('vault-password').type('password');
+      cy.getByDataCy('vault-id').type('id');
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.clickButton(/^Create credential$/);
+      cy.verifyPageTitle(credentialName);
+      cy.getByDataCy('name').contains(credentialName);
+      cy.contains('Vault Identifier').should('be.visible');
+      cy.getByDataCy('vault-identifier').contains('id');
+      cy.contains('Vault Password').should('be.visible');
+      cy.getByDataCy('vault-password').contains('Encrypted');
+      cy.getByDataCy('edit-credential').click();
+      cy.verifyPageTitle('Edit Credential');
+      cy.get('[data-cy="vault-password"]').then(($pwd) => {
+        cy.wrap($pwd).should('have.value', 'ENCRYPTED');
+      });
+      cy.getByDataCy('ask_vault_password').check();
+      cy.clickButton(/^Save credential$/);
+      cy.getByDataCy('name').contains(credentialName);
+      cy.contains('Vault Identifier').should('be.visible');
+      cy.getByDataCy('vault-identifier').contains('id');
+      cy.contains('Vault Password').should('be.visible');
+      cy.getByDataCy('vault-password').contains('Prompt on launch');
+      //delete created credential
+      cy.clickPageAction('delete-credential');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete credential/);
+      cy.verifyPageTitle('Credentials');
+    });
 
-      cy.getByDataCy('add-roles').click();
-      cy.verifyPageTitle('Add roles');
-      cy.getWizard().within(() => {
-        cy.contains('h1', 'Select user(s)').should('be.visible');
-        cy.selectTableRowByCheckbox('username', createdAwxUser.username);
-
-        cy.clickButton(/^Next/);
-        cy.contains('h1', 'Select roles to apply').should('be.visible');
-        cy.filterTableByTextFilter('name', 'Credential Admin', {
-          disableFilterSelection: true,
-        });
-        cy.selectTableRowByCheckbox('name', 'Credential Admin', {
-          disableFilter: true,
-        });
-        cy.filterTableByTextFilter('name', 'Credential Use', {
-          disableFilterSelection: true,
-        });
-        cy.selectTableRowByCheckbox('name', 'Credential Use', {
-          disableFilter: true,
-        });
-        cy.clickButton(/^Next/);
-        cy.contains('h1', 'Review').should('be.visible');
-        cy.verifyReviewStepWizardDetails('users', [createdAwxUser.username], '1');
-        cy.verifyReviewStepWizardDetails(
-          'awxRoles',
-          [
-            'Credential Admin',
-            'Has all permissions to a single credential',
-            'Credential Use',
-            'Has use permissions to a single credential',
-          ],
-          '2'
-        );
-        cy.clickButton(/^Finish/);
-        cy.wait('@userRoleAssignment')
-          .its('response')
-          .then((response) => {
-            expect(response?.statusCode).to.eql(201);
+    it('can create, edit and delete a credential that renders a sub form', () => {
+      const credentialName = 'E2E Credential ' + randomString(4);
+      cy.navigateTo('awx', 'credentials');
+      cy.clickButton(/^Create credential$/);
+      cy.getByDataCy('name').type(credentialName);
+      cy.singleSelectByDataCy('credential_type', 'Amazon Web Services');
+      cy.contains('Type Details').should('be.visible');
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.getByDataCy('username').type('username');
+      cy.getByDataCy('password').type('password');
+      cy.getByDataCy('security-token').type('security-token');
+      cy.getByDataCy('description').type('description');
+      cy.intercept('POST', awxAPI`/credentials/`).as('newCred');
+      cy.clickButton(/^Create credential$/);
+      cy.wait('@newCred')
+        .its('response.body')
+        .then((newCred: Credential) => {
+          cy.getByDataCy('name').contains(credentialName);
+          cy.getByDataCy('label-credential-type').contains('Credential type');
+          cy.getByDataCy('credential-type').contains('Amazon Web Services');
+          cy.getByDataCy('label-access-key').contains('Access Key');
+          cy.getByDataCy('access-key').contains('username');
+          cy.getByDataCy('label-secret-key').contains('Secret Key');
+          cy.getByDataCy('secret-key').contains('Encrypted');
+          cy.getByDataCy('label-sts-token').contains('STS Token');
+          cy.getByDataCy('label-organization').contains('Organization');
+          cy.getByDataCy('organization').contains(organization.name);
+          cy.getByDataCy('label-description').contains('Description');
+          cy.getByDataCy('description').contains('description');
+          cy.getByDataCy('edit-credential').click();
+          cy.verifyPageTitle('Edit Credential');
+          const ModifiedCredentialName = credentialName + ' - edited';
+          cy.getByDataCy('name').type(ModifiedCredentialName);
+          cy.get('input[data-cy="username"]').then(($username) => {
+            cy.wrap($username).should('have.value', 'username');
           });
+          cy.get('input[data-cy="password"]').then(($pwd) => {
+            cy.wrap($pwd).should('have.value', 'ENCRYPTED');
+          });
+          cy.get('input[data-cy="security-token"]').then(($token) => {
+            cy.wrap($token).should('have.value', 'ENCRYPTED');
+          });
+          const newDescription = 'new description';
+          cy.getByDataCy('description').clear().type(newDescription);
+          cy.clickButton(/^Save credential$/);
+          cy.getByDataCy('name').contains(ModifiedCredentialName);
+          cy.getByDataCy('label-credential-type').contains('Credential type');
+          cy.getByDataCy('credential-type').contains('Amazon Web Services');
+          cy.getByDataCy('label-access-key').contains('Access Key');
+          cy.getByDataCy('access-key').contains('username');
+          cy.getByDataCy('label-secret-key').contains('Secret Key');
+          cy.getByDataCy('secret-key').contains('Encrypted');
+          cy.getByDataCy('label-sts-token').contains('STS Token');
+          cy.getByDataCy('sts-token').contains('Encrypted');
+          cy.getByDataCy('label-description').contains('Description');
+          cy.getByDataCy('description').contains(newDescription);
+
+          cy.clickPageAction('delete-credential');
+          cy.get('#confirm').click();
+          cy.intercept('DELETE', awxAPI`/credentials/${newCred.id.toString()}/`).as('deleted');
+          cy.clickButton(/^Delete credential/);
+          cy.wait('@deleted')
+            .its('response')
+            .then((deleted) => {
+              expect(deleted?.statusCode).to.eql(204);
+              cy.verifyPageTitle('Credentials');
+            });
+        });
+    });
+
+    it('create/edit a credential using prompt on launch', () => {
+      const credentialName = 'E2E Credential ' + randomString(4);
+      cy.navigateTo('awx', 'credentials');
+      cy.clickButton(/^Create credential$/);
+      cy.getByDataCy('name').type(credentialName);
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.singleSelectBy('[data-cy="credential_type"]', 'Machine');
+      cy.contains('Type Details').should('be.visible');
+      cy.getByDataCy('ask_password').check();
+      cy.getByDataCy('ask_ssh_key_unlock').check();
+      cy.clickButton(/^Create credential$/);
+      cy.verifyPageTitle(credentialName);
+      cy.getByDataCy('name').contains(credentialName);
+      cy.contains('Private Key Passphrase').should('be.visible');
+      cy.getByDataCy('private-key-passphrase').contains('Prompt on launch');
+      cy.contains('Password').should('be.visible');
+      cy.getByDataCy('password').contains('Prompt on launch');
+      cy.getByDataCy('edit-credential').click();
+      cy.verifyPageTitle('Edit Credential');
+      cy.getByDataCy('ask_password').uncheck();
+      cy.getByDataCy('password').type('password');
+      cy.clickButton(/^Save credential$/);
+      cy.contains('Password').should('be.visible');
+      cy.getByDataCy('password').contains('Encrypted');
+      cy.contains('Private Key Passphrase').should('be.visible');
+      cy.getByDataCy('private-key-passphrase').contains('Prompt on launch');
+      cy.clickPageAction('delete-credential');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete credential/);
+      cy.verifyPageTitle('Credentials');
+    });
+
+    it('machine credential type should render privilege escalation', () => {
+      // This is a test for the custom component that renders the privilege
+      // escalation method using a custom component
+      const credentialName = 'E2E Credential ' + randomString(4);
+      cy.navigateTo('awx', 'credentials');
+      cy.clickButton(/^Create credential$/);
+      cy.getByDataCy('name').type(credentialName);
+      cy.singleSelectByDataCy('organization', organization.name);
+      cy.singleSelectBy('[data-cy="credential_type"]', 'Machine');
+      cy.contains('Type Details').should('be.visible');
+      // Use custom component to render the privilege escalation method is sudo
+      cy.contains('Privilege Escalation Method ').should('be.visible');
+      cy.get('button[aria-label="Options menu"]').click();
+      cy.getByDataCy('select-option-sudo').click();
+      cy.clickButton(/^Create credential$/);
+      cy.verifyPageTitle(credentialName);
+      cy.getByDataCy('name').contains(credentialName);
+      cy.contains('Privilege Escalation Method').should('be.visible');
+      cy.getByDataCy('privilege-escalation-method').contains('sudo');
+      cy.clickPageAction('delete-credential');
+      cy.get('#confirm').click();
+      cy.clickButton(/^Delete credential/);
+      cy.verifyPageTitle('Credentials');
+    });
+    tag(['upstream'], () => {
+      describe('Credentials Tabbed View - Team and User Access', () => {
+        let machineCredential: Credential;
+        let createdAwxUser: AwxUser;
+        // let organization: Organization;
+        let awxTeam: Team;
+        beforeEach(() => {
+          // cy.createAwxOrganization().then((awxOrg) => {
+          //   organization = awxOrg;
+          cy.createAwxUser({ organization: organization.id }).then((awxUser) => {
+            createdAwxUser = awxUser;
+            cy.createAWXCredential({
+              kind: 'machine',
+              organization: organization.id,
+              credential_type: 1,
+            }).then((cred) => {
+              machineCredential = cred;
+            });
+          });
+          cy.createAwxTeam({ organization: organization.id }).then((createdAwxTeam) => {
+            awxTeam = createdAwxTeam;
+          });
+          // });
+        });
+
+        afterEach(() => {
+          cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
+          cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+          cy.deleteAwxUser(createdAwxUser, { failOnStatusCode: false });
+          cy.deleteAwxTeam(awxTeam, { failOnStatusCode: false });
+        });
+
+        function removeRoleFromListRow(roleName: string, assignmentType: string) {
+          cy.intercept('DELETE', awxAPI`/role_${assignmentType}_assignments/*`).as('deleteRole');
+          cy.clickTableRowPinnedAction(roleName, 'remove-role', false);
+          cy.getModal().within(() => {
+            cy.get('#confirm').click();
+            cy.clickButton(/^Remove role/);
+            cy.wait('@deleteRole')
+              .its('response')
+              .then((deleted) => {
+                expect(deleted?.statusCode).to.eql(204);
+                cy.contains(/^Success$/).should('be.visible');
+                cy.containsBy('button', /^Close$/).click();
+              });
+          });
+        }
+        it('create a new credential, assign a team and apply role(s)', () => {
+          cy.intercept('POST', awxAPI`/role_team_assignments/`).as('teamRoleAssignment');
+          cy.navigateTo('awx', 'credentials');
+          cy.filterTableByMultiSelect('name', [machineCredential.name]);
+          cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
+          cy.clickTab('Team Access', true);
+
+          cy.getByDataCy('add-roles').click();
+          cy.verifyPageTitle('Add roles');
+          cy.getWizard().within(() => {
+            cy.contains('h1', 'Select team(s)').should('be.visible');
+            cy.filterTableByMultiSelect('name', [awxTeam.name]);
+            cy.selectTableRowByCheckbox('name', awxTeam.name, { disableFilter: true });
+            cy.clickButton(/^Next/);
+            cy.contains('h1', 'Select roles to apply').should('be.visible');
+            cy.filterTableByTextFilter('name', 'Credential Admin', {
+              disableFilterSelection: true,
+            });
+            cy.selectTableRowByCheckbox('name', 'Credential Admin', {
+              disableFilter: true,
+            });
+            cy.filterTableByTextFilter('name', 'Credential Use', {
+              disableFilterSelection: true,
+            });
+            cy.selectTableRowByCheckbox('name', 'Credential Use', {
+              disableFilter: true,
+            });
+            cy.clickButton(/^Next/);
+            cy.contains('h1', 'Review').should('be.visible');
+            cy.verifyReviewStepWizardDetails('teams', [awxTeam.name], '1');
+            cy.verifyReviewStepWizardDetails(
+              'awxRoles',
+              [
+                'Credential Admin',
+                'Has all permissions to a single credential',
+                'Credential Use',
+                'Has use permissions to a single credential',
+              ],
+              '2'
+            );
+            cy.clickButton(/^Finish/);
+            cy.wait('@teamRoleAssignment')
+              .its('response')
+              .then((response) => {
+                expect(response?.statusCode).to.eql(201);
+              });
+          });
+          cy.getModal().within(() => {
+            cy.clickButton(/^Close$/);
+          });
+          cy.getModal().should('not.exist');
+          cy.verifyPageTitle(machineCredential.name);
+          cy.selectTableRowByCheckbox('team-name', awxTeam.name, {
+            disableFilter: true,
+          });
+          removeRoleFromListRow('Credential Admin', 'team');
+          cy.selectTableRowByCheckbox('team-name', awxTeam.name, {
+            disableFilter: true,
+          });
+          removeRoleFromListRow('Credential Use', 'team');
+        });
+
+        it('create a new credential, assign a user and apply role(s)', () => {
+          cy.intercept('POST', awxAPI`/role_user_assignments/`).as('userRoleAssignment');
+          cy.navigateTo('awx', 'credentials');
+          cy.filterTableByMultiSelect('name', [machineCredential.name]);
+          cy.clickTableRowLink('name', machineCredential.name, { disableFilter: true });
+          cy.clickTab('User Access', true);
+
+          cy.getByDataCy('add-roles').click();
+          cy.verifyPageTitle('Add roles');
+          cy.getWizard().within(() => {
+            cy.contains('h1', 'Select user(s)').should('be.visible');
+            cy.selectTableRowByCheckbox('username', createdAwxUser.username);
+
+            cy.clickButton(/^Next/);
+            cy.contains('h1', 'Select roles to apply').should('be.visible');
+            cy.filterTableByTextFilter('name', 'Credential Admin', {
+              disableFilterSelection: true,
+            });
+            cy.selectTableRowByCheckbox('name', 'Credential Admin', {
+              disableFilter: true,
+            });
+            cy.filterTableByTextFilter('name', 'Credential Use', {
+              disableFilterSelection: true,
+            });
+            cy.selectTableRowByCheckbox('name', 'Credential Use', {
+              disableFilter: true,
+            });
+            cy.clickButton(/^Next/);
+            cy.contains('h1', 'Review').should('be.visible');
+            cy.verifyReviewStepWizardDetails('users', [createdAwxUser.username], '1');
+            cy.verifyReviewStepWizardDetails(
+              'awxRoles',
+              [
+                'Credential Admin',
+                'Has all permissions to a single credential',
+                'Credential Use',
+                'Has use permissions to a single credential',
+              ],
+              '2'
+            );
+            cy.clickButton(/^Finish/);
+            cy.wait('@userRoleAssignment')
+              .its('response')
+              .then((response) => {
+                expect(response?.statusCode).to.eql(201);
+              });
+          });
+          cy.getModal().within(() => {
+            cy.clickButton(/^Close$/);
+          });
+          cy.getModal().should('not.exist');
+          cy.verifyPageTitle(machineCredential.name);
+          cy.selectTableRowByCheckbox('username', createdAwxUser.username, {
+            disableFilter: true,
+          });
+          removeRoleFromListRow('Credential Admin', 'user');
+          cy.selectTableRowByCheckbox('username', createdAwxUser.username, {
+            disableFilter: true,
+          });
+          removeRoleFromListRow('Credential Use', 'user');
+        });
       });
-      cy.getModal().within(() => {
-        cy.clickButton(/^Close$/);
-      });
-      cy.getModal().should('not.exist');
-      cy.verifyPageTitle(machineCredential.name);
-      cy.selectTableRowByCheckbox('username', createdAwxUser.username, {
-        disableFilter: true,
-      });
-      removeRoleFromListRow('Credential Admin', 'user');
-      cy.selectTableRowByCheckbox('username', createdAwxUser.username, {
-        disableFilter: true,
-      });
-      removeRoleFromListRow('Credential Use', 'user');
     });
   });
 });

--- a/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
+++ b/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
@@ -3,268 +3,279 @@ import { InstanceGroup } from '../../../../frontend/awx/interfaces/InstanceGroup
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
-
-describe('Constructed Inventories CRUD Tests', () => {
+describe('Wrapper, creates and deletes organization', () => {
   let organization: Organization;
-  let inventoriesList: Inventory[] = [];
-  let invNames: string[] = [];
-  let constructedInv: Inventory;
-  let instanceGroup: InstanceGroup;
-  const invToDelete: Inventory[] = [];
-  const constrInvToDelete: Inventory[] = [];
-  const invToCreate: number = 3;
-
-  before(() => {
-    cy.login();
-    const orgName = 'E2E Org Constructed Inventory tests ' + randomString(4);
-    cy.createAwxOrganization({ name: orgName }).then((org) => {
-      organization = org;
-      cy.createAwxInstanceGroup().then((ig) => {
-        instanceGroup = ig;
-      });
-    });
-  });
-
-  beforeEach(() => {
-    inventoriesList = [];
-    invNames = [];
-    for (let i = 0; i < invToCreate; i++) {
-      cy.createAwxInventory(organization).then((inv) => {
-        inventoriesList.push(inv);
-      });
-    }
-    cy.createAwxConstructedInventory(organization).then((constInv) => {
-      constructedInv = constInv;
-    });
-  });
-
-  afterEach(() => {
-    constrInvToDelete.push(constructedInv);
-    invToDelete.push(...inventoriesList);
-  });
-
-  after(() => {
-    cy.deleteAwxInstanceGroup(instanceGroup);
-    invToDelete.map((inventory) => cy.deleteAwxInventory(inventory, { failOnStatusCode: false }));
-    constrInvToDelete.map((constrInventory) => cy.deleteAwxConstructedInventory(constrInventory));
-    cy.deleteAwxOrganization(organization);
-  });
-
-  it('can create a constructed inventory using specific source_vars and limit and then delete that inventory', () => {
-    invNames = inventoriesList.map(({ name }) => String(name));
-    cy.intercept('POST', awxAPI`/constructed_inventories/`).as('createInv');
-    const constInvName = 'E2E Constructed Inventory ' + randomString(4);
-    // generates random values to be used during the test.
-    const cacheTimeoutValue = generateRandom(0, 15);
-    // which combination should be used to test verbosity from 1 to 5 - UI forces to use only 0-2
-    const verbosityValue = generateRandom(0, 2);
-
-    cy.navigateTo('awx', 'inventories');
-    cy.clickButton(/^Create inventory$/);
-    cy.clickButton(/^Create constructed inventory$/);
-    cy.getByDataCy('name').type(constInvName);
-    cy.getByDataCy('description').type(`Description of "${constInvName}" typed by Cypress`);
-    cy.intercept({
-      method: 'GET',
-      pathname: awxAPI`/organizations/`,
-      query: { name__icontains: organization.name },
-    }).as('filterOrg');
-    cy.singleSelectBy('[data-cy="organization"]', organization.name);
-    cy.wait('@filterOrg');
-    // this can be simplified if we include data-cy to the search button of instance groups
-    cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup.name]);
-
-    cy.intercept({
-      method: 'GET',
-      pathname: awxAPI`/instance_groups/`,
-      query: { name: instanceGroup.name },
-    }).as('filterInstanceG');
-    cy.intercept({
-      method: 'GET',
-      pathname: awxAPI`/inventories/`,
-      query: { name__icontains: invNames[invToCreate - 1] },
-    }).as('filterInputInventories');
-    cy.multiSelectBy('[data-cy="inventories"]', invNames);
-    cy.wait('@filterInputInventories');
-    cy.getByDataCy('update_cache_timeout').clear().type(String(cacheTimeoutValue));
-    cy.singleSelectByDataCy('verbosity', String(verbosityValue));
-    cy.getByDataCy('limit').type('5');
-    cy.dataEditorTypeByDataCy('source-vars', 'plugin: constructed');
-    cy.clickButton(/^Create inventory$/);
-    cy.wait('@createInv')
-      .its('response.statusCode')
-      .then((statusCode) => {
-        expect(statusCode).to.be.equal(201);
-        cy.verifyPageTitle(constInvName);
-      });
-    cy.clickKebabAction('actions-dropdown', 'delete-inventory');
-
-    cy.getModal().within(() => {
-      cy.get('header').contains('Permanently delete inventory');
-      cy.get('button').contains('Delete inventory').should('have.attr', 'aria-disabled', 'true');
-      cy.get('[data-cy="name-column-cell"]').should('have.text', constInvName);
-      cy.get('input[id="confirm"]').click();
-      cy.clickButton(/^Delete inventory/);
-    });
-
-    // Assert the inventory doesn't exist anymore
-    cy.intercept({
-      method: 'GET',
-      pathname: awxAPI`/inventories/`,
-      query: { name__icontains: constInvName },
-    }).as('filterInventory');
-    cy.filterTableBySingleSelect('name', constInvName, true);
-    cy.wait('@filterInventory');
-  });
-
-  it('can edit and run a sync on the edited constructed inventory', () => {
-    cy.intercept('PATCH', awxAPI`/constructed_inventories/*`).as('saveInv');
-    cy.intercept('POST', awxAPI`/inventory_sources/*/update`).as('syncInv');
-    cy.navigateTo('awx', 'inventories');
-    cy.intercept({
-      method: 'GET',
-      pathname: awxAPI`/inventories/`,
-      query: { name__icontains: constructedInv.name },
-    }).as('filterConstInventory');
-    cy.filterTableBySingleSelect('name', constructedInv.name);
-    cy.wait('@filterConstInventory');
-    cy.clickTableRowLink('name', constructedInv.name, { disableFilter: true });
-    cy.verifyPageTitle(constructedInv.name);
-
-    const description = 'Edit action: New description typed by cypress';
-    cy.getByDataCy('edit-inventory').click();
-    cy.getByDataCy('name').should('have.value', constructedInv.name);
-    cy.getByDataCy('description').should('have.value', '');
-    cy.getByDataCy('description').type(description);
-    cy.dataEditorTypeByDataCy('source-vars', 'plugin: constructed');
-    cy.clickButton(/^Save inventory$/);
-    cy.wait('@saveInv')
-      .its('response.statusCode')
-      .then((statusCode) => {
-        expect(statusCode).to.be.equal(200);
-        cy.verifyPageTitle(constructedInv.name);
-        cy.getByDataCy('description').contains(description);
-      });
-    cy.clickButton(/^Sync inventory$/);
-    cy.wait('@syncInv')
-      .then((response) => {
-        expect(response.response?.statusCode).to.be.equal(202);
-      })
-      .its('response.body.id')
-      .then((jobID: number) => {
-        cy.verifyPageTitle(constructedInv.name);
-        cy.getByDataCy('last-job-status').contains('Success');
-        cy.waitForJobToProcessEvents(jobID.toString(), 'inventory_updates');
-      });
-  });
-
-  it.skip('shows a failed sync on the constructed inventory if the user sets strict to true and enters bad variables', () => {
-    //Create a constructed inventory in the beforeEach hook
-    //Assert the original details of the inventory
-    //Assert the user navigating to the edit constructed inventory form
-    //Assert the change to the strict setting
-    //Add bad variables
-    //Assert the edited changes of the inventory
-    //Run a sync and assert failure of the job
-  });
-});
-
-describe('Constructed Inventories CRUD Tests - reorder input inventories', () => {
-  let organization: Organization;
-  let constructedInv: Inventory;
-  let instanceGroup: InstanceGroup;
-  const constrInvToDelete: Inventory[] = [];
-
   before(() => {
     const orgName = 'E2E Org Constructed Inventory tests ' + randomString(4);
     cy.createAwxOrganization({ name: orgName }).then((org) => {
       organization = org;
+    });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  describe('Constructed Inventories CRUD Tests', () => {
+    // let organizat .ion: Organization;
+    let inventoriesList: Inventory[] = [];
+    let invNames: string[] = [];
+    let constructedInv: Inventory;
+    let instanceGroup: InstanceGroup;
+    const invToDelete: Inventory[] = [];
+    const constrInvToDelete: Inventory[] = [];
+    const invToCreate: number = 3;
+
+    before(() => {
+      cy.login();
+      // const orgName = 'E2E Org Constructed Inventory tests ' + randomString(4);
+      // cy.createAwxOrganization({ name: orgName }).then((org) => {
+      //   organization = org;
       cy.createAwxInstanceGroup().then((ig) => {
         instanceGroup = ig;
       });
+      // });
+    });
+
+    beforeEach(() => {
+      inventoriesList = [];
+      invNames = [];
+      for (let i = 0; i < invToCreate; i++) {
+        cy.createAwxInventory(organization).then((inv) => {
+          inventoriesList.push(inv);
+        });
+      }
+      cy.createAwxConstructedInventory(organization).then((constInv) => {
+        constructedInv = constInv;
+      });
+    });
+
+    afterEach(() => {
+      constrInvToDelete.push(constructedInv);
+      invToDelete.push(...inventoriesList);
+    });
+
+    after(() => {
+      cy.deleteAwxInstanceGroup(instanceGroup);
+      invToDelete.map((inventory) => cy.deleteAwxInventory(inventory, { failOnStatusCode: false }));
+      constrInvToDelete.map((constrInventory) => cy.deleteAwxConstructedInventory(constrInventory));
+      // cy.deleteAwxOrganization(organization);
+    });
+
+    it('can create a constructed inventory using specific source_vars and limit and then delete that inventory', () => {
+      invNames = inventoriesList.map(({ name }) => String(name));
+      cy.intercept('POST', awxAPI`/constructed_inventories/`).as('createInv');
+      const constInvName = 'E2E Constructed Inventory ' + randomString(4);
+      // generates random values to be used during the test.
+      const cacheTimeoutValue = generateRandom(0, 15);
+      // which combination should be used to test verbosity from 1 to 5 - UI forces to use only 0-2
+      const verbosityValue = generateRandom(0, 2);
+
+      cy.navigateTo('awx', 'inventories');
+      cy.clickButton(/^Create inventory$/);
+      cy.clickButton(/^Create constructed inventory$/);
+      cy.getByDataCy('name').type(constInvName);
+      cy.getByDataCy('description').type(`Description of "${constInvName}" typed by Cypress`);
+      cy.intercept({
+        method: 'GET',
+        pathname: awxAPI`/organizations/`,
+        query: { name__icontains: organization.name },
+      }).as('filterOrg');
+      cy.singleSelectBy('[data-cy="organization"]', organization.name);
+      cy.wait('@filterOrg');
+      // this can be simplified if we include data-cy to the search button of instance groups
+      cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup.name]);
+
+      cy.intercept({
+        method: 'GET',
+        pathname: awxAPI`/instance_groups/`,
+        query: { name: instanceGroup.name },
+      }).as('filterInstanceG');
+      cy.intercept({
+        method: 'GET',
+        pathname: awxAPI`/inventories/`,
+        query: { name__icontains: invNames[invToCreate - 1] },
+      }).as('filterInputInventories');
+      cy.multiSelectBy('[data-cy="inventories"]', invNames);
+      cy.wait('@filterInputInventories');
+      cy.getByDataCy('update_cache_timeout').clear().type(String(cacheTimeoutValue));
+      cy.singleSelectByDataCy('verbosity', String(verbosityValue));
+      cy.getByDataCy('limit').type('5');
+      cy.dataEditorTypeByDataCy('source-vars', 'plugin: constructed');
+      cy.clickButton(/^Create inventory$/);
+      cy.wait('@createInv')
+        .its('response.statusCode')
+        .then((statusCode) => {
+          expect(statusCode).to.be.equal(201);
+          cy.verifyPageTitle(constInvName);
+        });
+      cy.clickKebabAction('actions-dropdown', 'delete-inventory');
+
+      cy.getModal().within(() => {
+        cy.get('header').contains('Permanently delete inventory');
+        cy.get('button').contains('Delete inventory').should('have.attr', 'aria-disabled', 'true');
+        cy.get('[data-cy="name-column-cell"]').should('have.text', constInvName);
+        cy.get('input[id="confirm"]').click();
+        cy.clickButton(/^Delete inventory/);
+      });
+
+      // Assert the inventory doesn't exist anymore
+      cy.intercept({
+        method: 'GET',
+        pathname: awxAPI`/inventories/`,
+        query: { name__icontains: constInvName },
+      }).as('filterInventory');
+      cy.filterTableBySingleSelect('name', constInvName, true);
+      cy.wait('@filterInventory');
+    });
+
+    it('can edit and run a sync on the edited constructed inventory', () => {
+      cy.intercept('PATCH', awxAPI`/constructed_inventories/*`).as('saveInv');
+      cy.intercept('POST', awxAPI`/inventory_sources/*/update`).as('syncInv');
+      cy.navigateTo('awx', 'inventories');
+      cy.intercept({
+        method: 'GET',
+        pathname: awxAPI`/inventories/`,
+        query: { name__icontains: constructedInv.name },
+      }).as('filterConstInventory');
+      cy.filterTableBySingleSelect('name', constructedInv.name);
+      cy.wait('@filterConstInventory');
+      cy.clickTableRowLink('name', constructedInv.name, { disableFilter: true });
+      cy.verifyPageTitle(constructedInv.name);
+
+      const description = 'Edit action: New description typed by cypress';
+      cy.getByDataCy('edit-inventory').click();
+      cy.getByDataCy('name').should('have.value', constructedInv.name);
+      cy.getByDataCy('description').should('have.value', '');
+      cy.getByDataCy('description').type(description);
+      cy.dataEditorTypeByDataCy('source-vars', 'plugin: constructed');
+      cy.clickButton(/^Save inventory$/);
+      cy.wait('@saveInv')
+        .its('response.statusCode')
+        .then((statusCode) => {
+          expect(statusCode).to.be.equal(200);
+          cy.verifyPageTitle(constructedInv.name);
+          cy.getByDataCy('description').contains(description);
+        });
+      cy.clickButton(/^Sync inventory$/);
+      cy.wait('@syncInv')
+        .then((response) => {
+          expect(response.response?.statusCode).to.be.equal(202);
+        })
+        .its('response.body.id')
+        .then((jobID: number) => {
+          cy.verifyPageTitle(constructedInv.name);
+          cy.getByDataCy('last-job-status').contains('Success');
+          cy.waitForJobToProcessEvents(jobID.toString(), 'inventory_updates');
+        });
+    });
+
+    it.skip('shows a failed sync on the constructed inventory if the user sets strict to true and enters bad variables', () => {
+      //Create a constructed inventory in the beforeEach hook
+      //Assert the original details of the inventory
+      //Assert the user navigating to the edit constructed inventory form
+      //Assert the change to the strict setting
+      //Add bad variables
+      //Assert the edited changes of the inventory
+      //Run a sync and assert failure of the job
     });
   });
 
-  beforeEach(() => {
-    cy.createAwxConstructedInventory(organization, { source_vars: true }).then((constInv) => {
-      constructedInv = constInv;
+  describe('Constructed Inventories CRUD Tests - reorder input inventories', () => {
+    let organization: Organization;
+    let constructedInv: Inventory;
+    let instanceGroup: InstanceGroup;
+    const constrInvToDelete: Inventory[] = [];
+
+    before(() => {
+      // const orgName = 'E2E Org Constructed Inventory tests ' + randomString(4);
+      // cy.createAwxOrganization({ name: orgName }).then((org) => {
+      //   organization = org;
+      cy.createAwxInstanceGroup().then((ig) => {
+        instanceGroup = ig;
+      });
+      // });
     });
-  });
 
-  afterEach(() => {
-    constrInvToDelete.push(constructedInv);
-  });
+    beforeEach(() => {
+      cy.createAwxConstructedInventory(organization, { source_vars: true }).then((constInv) => {
+        constructedInv = constInv;
+      });
+    });
 
-  after(() => {
-    cy.deleteAwxInstanceGroup(instanceGroup);
-    constrInvToDelete.map((constrInventory) => cy.deleteAwxConstructedInventory(constrInventory));
-    cy.deleteAwxOrganization(organization);
-  });
+    afterEach(() => {
+      constrInvToDelete.push(constructedInv);
+    });
 
-  it('can edit the input_inventories, verify the preservation of the order they were added in, and manually change the order', () => {
-    //Create a constructed inventory in the beforeEach hook
-    //Assert the original order of the input inventories
-    //Assert the UI change to the order of input inventories
-    cy.navigateTo('awx', 'inventories');
-    cy.filterTableByMultiSelect('name', [constructedInv.name]);
-    cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
-    cy.contains('a', constructedInv.name).click();
+    after(() => {
+      cy.deleteAwxInstanceGroup(instanceGroup);
+      constrInvToDelete.map((constrInventory) => cy.deleteAwxConstructedInventory(constrInventory));
+      // cy.deleteAwxOrganization(organization);
+    });
 
-    let expectedOrder: string[] = [];
+    it('can edit the input_inventories, verify the preservation of the order they were added in, and manually change the order', () => {
+      //Create a constructed inventory in the beforeEach hook
+      //Assert the original order of the input inventories
+      //Assert the UI change to the order of input inventories
+      cy.navigateTo('awx', 'inventories');
+      cy.filterTableByMultiSelect('name', [constructedInv.name]);
+      cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
+      cy.contains('a', constructedInv.name).click();
 
-    cy.getByDataCy('input-inventories');
+      let expectedOrder: string[] = [];
 
-    // get initial order
-    cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
-      .should(($lis) => {
-        expectedOrder = $lis.map((index, el) => Cypress.$(el).text()).get();
-      })
-      .then(() => {
-        cy.getByDataCy('edit-inventory').click();
+      cy.getByDataCy('input-inventories');
 
-        // remove one item
-        cy.contains(`[aria-label="Chip group category"] li`, expectedOrder[0]).within(() => {
-          cy.get('button').click();
-        });
+      // get initial order
+      cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
+        .should(($lis) => {
+          expectedOrder = $lis.map((index, el) => Cypress.$(el).text()).get();
+        })
+        .then(() => {
+          cy.getByDataCy('edit-inventory').click();
 
-        const deletedItem = expectedOrder[0];
-        expectedOrder = expectedOrder.slice(1);
-        expectedOrder.push(deletedItem);
-
-        // now add it also in GUI
-        cy.get(`[aria-label="Search input"]`).type(deletedItem);
-        cy.contains('label', deletedItem).within(() => {
-          cy.get('input').click();
-        });
-
-        cy.clickButton(/^Save inventory$/);
-        cy.getByDataCy('input-inventories');
-
-        cy.navigateTo('awx', 'inventories');
-        cy.filterTableByMultiSelect('name', [constructedInv.name]);
-        cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
-        cy.contains('a', constructedInv.name).click();
-        // verify order
-        cy.getByDataCy('input-inventories');
-
-        cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
-          .should(($lis) => {
-            const actualOrder = $lis.map((index, el) => Cypress.$(el).text()).get();
-            expect(actualOrder).to.deep.equal(expectedOrder);
+          // remove one item
+          cy.contains(`[aria-label="Chip group category"] li`, expectedOrder[0]).within(() => {
+            cy.get('button').click();
           });
-      });
+
+          const deletedItem = expectedOrder[0];
+          expectedOrder = expectedOrder.slice(1);
+          expectedOrder.push(deletedItem);
+
+          // now add it also in GUI
+          cy.get(`[aria-label="Search input"]`).type(deletedItem);
+          cy.contains('label', deletedItem).within(() => {
+            cy.get('input').click();
+          });
+
+          cy.clickButton(/^Save inventory$/);
+          cy.getByDataCy('input-inventories');
+
+          cy.navigateTo('awx', 'inventories');
+          cy.filterTableByMultiSelect('name', [constructedInv.name]);
+          cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
+          cy.contains('a', constructedInv.name).click();
+          // verify order
+          cy.getByDataCy('input-inventories');
+
+          cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
+            .should(($lis) => {
+              const actualOrder = $lis.map((index, el) => Cypress.$(el).text()).get();
+              expect(actualOrder).to.deep.equal(expectedOrder);
+            });
+        });
+    });
   });
+
+  function generateRandom(min = 0, max = 5) {
+    // find diff
+    const difference = max - min;
+    // generate random number
+    let rand = Math.random();
+    // multiply with difference
+    rand = Math.floor(rand * difference);
+    // add with min value
+    rand = rand + min;
+
+    return rand;
+  }
 });
-
-function generateRandom(min = 0, max = 5) {
-  // find diff
-  const difference = max - min;
-  // generate random number
-  let rand = Math.random();
-  // multiply with difference
-  rand = Math.floor(rand * difference);
-  // add with min value
-  rand = rand + min;
-
-  return rand;
-}

--- a/cypress/e2e/awx/resources/inventoryGroup.cy.ts
+++ b/cypress/e2e/awx/resources/inventoryGroup.cy.ts
@@ -16,21 +16,26 @@ describe('Inventory Groups', () => {
   function generateGroupName(): string {
     return `test-${testSignature}-inventory-group-${randomString(5, undefined, { isLowercase: true })}`;
   }
-
-  beforeEach(() => {
+  before(() => {
     cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAWXCredential({
-        kind: 'machine',
-        organization: organization.id,
-        credential_type: 1,
-      }).then((cred) => {
-        machineCredential = cred;
-      });
-      cy.createAwxExecutionEnvironment({ organization: organization.id }).then((ee) => {
-        executionEnvironment = ee;
-      });
     });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  beforeEach(() => {
+    cy.createAWXCredential({
+      kind: 'machine',
+      organization: organization.id,
+      credential_type: 1,
+    }).then((cred) => {
+      machineCredential = cred;
+    });
+    cy.createAwxExecutionEnvironment({ organization: organization.id }).then((ee) => {
+      executionEnvironment = ee;
+    });
+    // });
   });
 
   afterEach(() => {

--- a/cypress/e2e/awx/resources/inventorySource.cy.ts
+++ b/cypress/e2e/awx/resources/inventorySource.cy.ts
@@ -16,18 +16,25 @@ describe('Inventory Sources', () => {
   let inventory: Inventory;
   let inventorySource: InventorySource;
   let organization: Organization;
-
-  beforeEach(function () {
-    cy.createAwxOrganization().then(function (org) {
+  before(() => {
+    cy.createAwxOrganization().then((org) => {
       organization = org;
-      cy.createAwxInventory(organization).then((inv) => {
-        inventory = inv;
-        cy.createAwxProject(organization).then((proj) => {
-          project = proj;
-          cy.createAwxInventorySource(inv, project).then((invSrc) => {
-            inventorySource = invSrc;
-          });
+    });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  beforeEach(function () {
+    // cy.createAwxOrganization().then(function (org) {
+    //   organization = org;
+    cy.createAwxInventory(organization).then((inv) => {
+      inventory = inv;
+      cy.createAwxProject(organization).then((proj) => {
+        project = proj;
+        cy.createAwxInventorySource(inv, project).then((invSrc) => {
+          inventorySource = invSrc;
         });
+        // });
       });
     });
   });

--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -3,43 +3,52 @@ import { Credential } from '../../../../frontend/awx/interfaces/Credential';
 import { ExecutionEnvironment } from '../../../../frontend/awx/interfaces/ExecutionEnvironment';
 import { Inventory } from '../../../../frontend/awx/interfaces/Inventory';
 import { JobTemplate } from '../../../../frontend/awx/interfaces/JobTemplate';
-import { NotificationTemplate } from '../../../../frontend/awx/interfaces/NotificationTemplate';
 import { Organization } from '../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 import { randomE2Ename } from '../../../support/utils';
-
-describe.skip('Job Templates Tests', function () {
+describe.skip('Wrapper, creates and deletes organization', () => {
   let awxOrganization: Organization;
-  let project: Project;
+  before(() => {
+    const orgName = randomE2Ename();
+    cy.createAwxOrganization({ name: orgName }).then((org) => {
+      awxOrganization = org;
+    });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(awxOrganization);
+  });
+  describe('Job Templates Tests', function () {
+    // let awxOrganization: Organization;
+    let project: Project;
 
-  before(function () {
-    cy.createAwxOrganization().then((thisAwxOrg) => {
-      awxOrganization = thisAwxOrg;
+    before(function () {
+      // cy.createAwxOrganization().then((thisAwxOrg) => {
+      //   awxOrganization = thisAwxOrg;
       cy.createAwxProject(awxOrganization).then((proj) => {
         project = proj;
       });
+      // });
     });
-  });
 
-  after(function () {
-    cy.deleteAwxProject(project, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
-  });
+    after(function () {
+      cy.deleteAwxProject(project, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
+    });
 
-  describe('Job Templates Tests: Create', function () {
-    let inventory: Inventory;
-    let inventoryWithHost: Inventory;
-    let machineCredential: Credential;
-    let project: Project;
-    let organization: Organization;
-    let executionEnvironment: ExecutionEnvironment;
-    const executionEnvironmentName = 'Control Plane Execution Environment';
-    const instanceGroup = 'default';
+    describe('Job Templates Tests: Create', function () {
+      let inventory: Inventory;
+      let inventoryWithHost: Inventory;
+      let machineCredential: Credential;
+      let project: Project;
+      let organization: Organization;
+      let executionEnvironment: ExecutionEnvironment;
+      const executionEnvironmentName = 'Control Plane Execution Environment';
+      const instanceGroup = 'default';
 
-    beforeEach(function () {
-      cy.createAwxOrganization().then((org) => {
-        organization = org;
+      beforeEach(function () {
+        // // cy.createAwxOrganization().then((org) => {
+        //   organization = org;
         cy.createAwxInventory(organization).then((inv) => {
           inventory = inv;
 
@@ -50,797 +59,689 @@ describe.skip('Job Templates Tests', function () {
           }).then((cred) => {
             machineCredential = cred;
           });
+          // });
         });
       });
-    });
 
-    afterEach(function () {
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
-      executionEnvironment?.id &&
-        cy.deleteAwxExecutionEnvironment(executionEnvironment, { failOnStatusCode: false });
-      project?.id && cy.deleteAwxProject(project, { failOnStatusCode: false });
-      inventoryWithHost?.id &&
-        cy.deleteAwxInventory(inventoryWithHost, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization);
-    });
+      afterEach(function () {
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
+        executionEnvironment?.id &&
+          cy.deleteAwxExecutionEnvironment(executionEnvironment, { failOnStatusCode: false });
+        project?.id && cy.deleteAwxProject(project, { failOnStatusCode: false });
+        inventoryWithHost?.id &&
+          cy.deleteAwxInventory(inventoryWithHost, { failOnStatusCode: false });
+        // cy.deleteAwxOrganization(organization);
+      });
 
-    it('can create a job template with all fields without prompt on launch option', function () {
-      cy.intercept('POST', awxAPI`/job_templates`).as('createJT');
-      const jtName = 'E2E-JT ' + randomString(4);
-      cy.navigateTo('awx', 'templates');
-      cy.getBy('[data-cy="create-template"]').click();
-      cy.clickLink(/^Create job template$/);
-      cy.getBy('[data-cy="name"]').type(jtName);
-      cy.getBy('[data-cy="description"]').type('This is a JT description');
-      cy.selectDropdownOptionByResourceName('inventory', inventory.name);
-      cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-      cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
-      cy.getBy('[data-cy="Submit"]').click();
-      cy.wait('@createJT')
-        .its('response.body.id')
-        .then((id: string) => {
-          cy.log(id);
-          cy.verifyPageTitle(jtName);
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [jtName]);
-          cy.getTableRow('name', jtName, { disableFilter: true }).should('be.visible');
-          cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
-          cy.clickTableRowAction('name', jtName, 'launch-template', { disableFilter: true });
-          cy.wait('@postLaunch')
-            .its('response.body.id')
-            .then((jobId: string) => {
-              cy.waitForTemplateStatus(jobId);
+      it('can create a job template with all fields without prompt on launch option', function () {
+        cy.intercept('POST', awxAPI`/job_templates`).as('createJT');
+        const jtName = 'E2E-JT ' + randomString(4);
+        cy.navigateTo('awx', 'templates');
+        cy.getBy('[data-cy="create-template"]').click();
+        cy.clickLink(/^Create job template$/);
+        cy.getBy('[data-cy="name"]').type(jtName);
+        cy.getBy('[data-cy="description"]').type('This is a JT description');
+        cy.selectDropdownOptionByResourceName('inventory', inventory.name);
+        cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+        cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
+        cy.getBy('[data-cy="Submit"]').click();
+        cy.wait('@createJT')
+          .its('response.body.id')
+          .then((id: string) => {
+            cy.log(id);
+            cy.verifyPageTitle(jtName);
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jtName]);
+            cy.getTableRow('name', jtName, { disableFilter: true }).should('be.visible');
+            cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
+            cy.clickTableRowAction('name', jtName, 'launch-template', { disableFilter: true });
+            cy.wait('@postLaunch')
+              .its('response.body.id')
+              .then((jobId: string) => {
+                cy.waitForTemplateStatus(jobId);
+              });
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jtName]);
+            cy.clickTableRowAction('name', jtName, 'delete-template', {
+              inKebab: true,
+              disableFilter: true,
             });
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [jtName]);
-          cy.clickTableRowAction('name', jtName, 'delete-template', {
-            inKebab: true,
-            disableFilter: true,
-          });
-          cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
-          cy.clickModalConfirmCheckbox();
-          cy.getBy('[data-ouia-component-id="submit"]').click();
-          cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
-            expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
-          });
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clearAllFilters();
-        });
-    });
-
-    it('can create a job template using the prompt on launch wizard', function () {
-      cy.intercept('POST', awxAPI`/job_templates`).as('createPOLJT');
-      const jtName = 'E2E-POLJT ' + randomString(4);
-      cy.navigateTo('awx', 'templates');
-      cy.getBy('[data-cy="create-template"]').click();
-      cy.clickLink(/^Create job template$/);
-      cy.getBy('[data-cy="name"]').type(jtName);
-      cy.getBy('[data-cy="description"]').type('This is a JT with POL wizard description');
-      cy.selectPromptOnLaunch('inventory');
-      cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-      cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
-      cy.selectPromptOnLaunch('execution_environment');
-      cy.selectPromptOnLaunch('credential');
-      cy.selectPromptOnLaunch('instance_groups');
-      cy.getBy('[data-cy="Submit"]').click();
-      cy.wait('@createPOLJT')
-        .its('response.body.id')
-        .then((id: string) => {
-          cy.verifyPageTitle(jtName);
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [jtName]);
-          cy.getTableRow('name', jtName, { disableFilter: true }).should('be.visible');
-          cy.clickTableRowAction('name', jtName, 'launch-template', { disableFilter: true });
-          cy.selectDropdownOptionByResourceName('inventory', inventory.name);
-          cy.clickButton(/^Next/);
-          cy.multiSelectByDataCy('credential', [machineCredential.name]);
-          cy.clickButton(/^Next/);
-          cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
-            cy.get('button').eq(1).click();
-          });
-          cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-            cy.filterTableBySingleSelect('name', executionEnvironmentName);
-            cy.selectTableRowByCheckbox('name', executionEnvironmentName, { disableFilter: true });
-            cy.clickButton(/^Confirm/);
-          });
-          cy.clickButton(/^Next/);
-          cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup]);
-          cy.clickButton(/^Next/);
-          cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
-          cy.clickButton(/^Finish/);
-          cy.wait('@postLaunch')
-            .its('response.body.id')
-            .then((jobId: string) => {
-              cy.log(jobId);
-              cy.waitForTemplateStatus(jobId);
+            cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
+            cy.clickModalConfirmCheckbox();
+            cy.getBy('[data-ouia-component-id="submit"]').click();
+            cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
+              expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
             });
-          cy.navigateTo('awx', 'templates');
-          cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
-          cy.filterTableByMultiSelect('name', [jtName]);
-          cy.clickTableRowAction('name', jtName, 'delete-template', {
-            inKebab: true,
-            disableFilter: true,
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+            cy.clearAllFilters();
           });
-          cy.clickModalConfirmCheckbox();
-          cy.getBy('[data-ouia-component-id="submit"]').click();
-          cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
-            expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
-          });
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clearAllFilters();
-        });
-    });
+      });
 
-    it('can launch a job template from the details page launch button using the prompt on launch', function () {
-      cy.intercept('POST', awxAPI`/job_templates`).as('createPOLJT');
-      const jtName = 'E2E-POLJT ' + randomString(4);
-      cy.navigateTo('awx', 'templates');
-      cy.getBy('[data-cy="create-template"]').click();
-      cy.clickLink(/^Create job template$/);
-      cy.getBy('[data-cy="name"]').type(jtName);
-      cy.getBy('[data-cy="description"]').type('This is a JT with POL wizard description');
-      cy.selectPromptOnLaunch('inventory');
-      cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-      cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
-      cy.selectPromptOnLaunch('execution_environment');
-      cy.selectPromptOnLaunch('credential');
-      cy.selectPromptOnLaunch('instance_groups');
-      cy.getBy('[data-cy="Submit"]').click();
-      cy.wait('@createPOLJT')
-        .its('response.body.id')
-        .then((id: string) => {
-          cy.verifyPageTitle(jtName);
-          cy.clickButton(/^Launch template$/);
-          cy.selectDropdownOptionByResourceName('inventory', inventory.name);
-          cy.clickButton(/^Next/);
-          cy.selectItemFromLookupModal('credential-select', machineCredential.name);
-          cy.clickButton(/^Next/);
-          cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
-            cy.get('button').eq(1).click();
-          });
-          cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-            cy.filterTableBySingleSelect('name', executionEnvironmentName);
-            cy.get('[data-ouia-component-id="simple-table"] tbody').within(() => {
-              cy.get('[data-cy="checkbox-column-cell"] input').click();
+      it('can create a job template using the prompt on launch wizard', function () {
+        cy.intercept('POST', awxAPI`/job_templates`).as('createPOLJT');
+        const jtName = 'E2E-POLJT ' + randomString(4);
+        cy.navigateTo('awx', 'templates');
+        cy.getBy('[data-cy="create-template"]').click();
+        cy.clickLink(/^Create job template$/);
+        cy.getBy('[data-cy="name"]').type(jtName);
+        cy.getBy('[data-cy="description"]').type('This is a JT with POL wizard description');
+        cy.selectPromptOnLaunch('inventory');
+        cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+        cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
+        cy.selectPromptOnLaunch('execution_environment');
+        cy.selectPromptOnLaunch('credential');
+        cy.selectPromptOnLaunch('instance_groups');
+        cy.getBy('[data-cy="Submit"]').click();
+        cy.wait('@createPOLJT')
+          .its('response.body.id')
+          .then((id: string) => {
+            cy.verifyPageTitle(jtName);
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jtName]);
+            cy.getTableRow('name', jtName, { disableFilter: true }).should('be.visible');
+            cy.clickTableRowAction('name', jtName, 'launch-template', { disableFilter: true });
+            cy.selectDropdownOptionByResourceName('inventory', inventory.name);
+            cy.clickButton(/^Next/);
+            cy.multiSelectByDataCy('credential', [machineCredential.name]);
+            cy.clickButton(/^Next/);
+            cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
+              cy.get('button').eq(1).click();
             });
-            cy.clickButton(/^Confirm/);
-          });
-          cy.clickButton(/^Next/);
-          cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup]);
-          cy.clickButton(/^Next/);
-          cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
-          cy.clickButton(/^Finish/);
-          cy.wait('@postLaunch')
-            .its('response.body.id')
-            .then((jobId: string) => {
-              cy.waitForTemplateStatus(jobId);
+            cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+              cy.filterTableBySingleSelect('name', executionEnvironmentName);
+              cy.selectTableRowByCheckbox('name', executionEnvironmentName, {
+                disableFilter: true,
+              });
+              cy.clickButton(/^Confirm/);
             });
-          cy.navigateTo('awx', 'templates');
-          cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
-          cy.filterTableByMultiSelect('name', [jtName]);
-          cy.clickTableRowAction('name', jtName, 'delete-template', {
-            inKebab: true,
-            disableFilter: true,
+            cy.clickButton(/^Next/);
+            cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup]);
+            cy.clickButton(/^Next/);
+            cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
+            cy.clickButton(/^Finish/);
+            cy.wait('@postLaunch')
+              .its('response.body.id')
+              .then((jobId: string) => {
+                cy.log(jobId);
+                cy.waitForTemplateStatus(jobId);
+              });
+            cy.navigateTo('awx', 'templates');
+            cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
+            cy.filterTableByMultiSelect('name', [jtName]);
+            cy.clickTableRowAction('name', jtName, 'delete-template', {
+              inKebab: true,
+              disableFilter: true,
+            });
+            cy.clickModalConfirmCheckbox();
+            cy.getBy('[data-ouia-component-id="submit"]').click();
+            cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
+              expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
+            });
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+            cy.clearAllFilters();
           });
-          cy.clickModalConfirmCheckbox();
-          cy.getBy('[data-ouia-component-id="submit"]').click();
-          cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
-            expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
-          });
-          cy.contains(/^Success$/);
-          cy.clickButton(/^Close$/);
-          cy.clearAllFilters();
-        });
-    });
+      });
 
-    it('can create a job template, select concurrent jobs, launch the job template two times and verify that both jobs appear in the table', function () {
-      const jtName = 'E2E Concurrent JT ' + randomString(4);
-      cy.createAwxProject(
-        awxOrganization,
-        { name: randomE2Ename() },
-        'https://github.com/ansible/test-playbooks'
-      ).then((gitProject: Project) => {
-        cy.createInventoryHost(awxOrganization, '').then((inventoryHost) => {
-          const { inventory } = inventoryHost;
-          inventoryWithHost = inventory;
-          cy.navigateTo('awx', 'templates');
-          cy.getBy('[data-cy="create-template"]').click();
-          cy.clickLink(/^Create job template$/);
-          cy.getByDataCy('name').type(jtName);
-          cy.selectDropdownOptionByResourceName('inventory', inventory.name);
-          cy.selectDropdownOptionByResourceName('project', gitProject.name);
-          cy.selectDropdownOptionByResourceName('playbook', 'debug-loop.yml');
-          cy.getByDataCy('allow_simultaneous').click();
-          cy.clickButton('Create job template');
-          cy.intercept('POST', awxAPI`/job_templates/*/launch/`).as('launchTemplate');
-          cy.clickButton('Launch template');
-          cy.wait('@launchTemplate')
-            .its('response.body')
-            .then(({ id: jobId, name }: { id: number; name: string }) => {
-              cy.url().should('contain', `/jobs/playbook/${jobId}/output`);
-              cy.contains('Running');
-              cy.contains(jtName);
-              cy.intercept('POST', awxAPI`/jobs/${jobId.toString()}/relaunch/`).as('relaunchJob');
-              cy.getByDataCy('relaunch-job').click();
-              cy.wait('@relaunchJob')
-                .its('response.body')
-                .then(({ id: jobId2, name: name2 }: { id: number; name: string }) => {
-                  cy.url().should('contain', `/jobs/playbook/${jobId2}/output`);
-                  cy.contains('Running');
-                  cy.contains(jtName);
-                  cy.navigateTo('awx', 'jobs');
-                  cy.filterTableByMultiSelect('name', [name, name2]);
-                  cy.contains('Running').each(($element) => {
-                    cy.wrap($element).should('be.visible');
+      it('can launch a job template from the details page launch button using the prompt on launch', function () {
+        cy.intercept('POST', awxAPI`/job_templates`).as('createPOLJT');
+        const jtName = 'E2E-POLJT ' + randomString(4);
+        cy.navigateTo('awx', 'templates');
+        cy.getBy('[data-cy="create-template"]').click();
+        cy.clickLink(/^Create job template$/);
+        cy.getBy('[data-cy="name"]').type(jtName);
+        cy.getBy('[data-cy="description"]').type('This is a JT with POL wizard description');
+        cy.selectPromptOnLaunch('inventory');
+        cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+        cy.selectDropdownOptionByResourceName('playbook', 'hello_world.yml');
+        cy.selectPromptOnLaunch('execution_environment');
+        cy.selectPromptOnLaunch('credential');
+        cy.selectPromptOnLaunch('instance_groups');
+        cy.getBy('[data-cy="Submit"]').click();
+        cy.wait('@createPOLJT')
+          .its('response.body.id')
+          .then((id: string) => {
+            cy.verifyPageTitle(jtName);
+            cy.clickButton(/^Launch template$/);
+            cy.selectDropdownOptionByResourceName('inventory', inventory.name);
+            cy.clickButton(/^Next/);
+            cy.selectItemFromLookupModal('credential-select', machineCredential.name);
+            cy.clickButton(/^Next/);
+            cy.get(`[data-cy*="execution-environment-select-form-group"]`).within(() => {
+              cy.get('button').eq(1).click();
+            });
+            cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+              cy.filterTableBySingleSelect('name', executionEnvironmentName);
+              cy.get('[data-ouia-component-id="simple-table"] tbody').within(() => {
+                cy.get('[data-cy="checkbox-column-cell"] input').click();
+              });
+              cy.clickButton(/^Confirm/);
+            });
+            cy.clickButton(/^Next/);
+            cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup]);
+            cy.clickButton(/^Next/);
+            cy.intercept('POST', awxAPI`/job_templates/${id}/launch/`).as('postLaunch');
+            cy.clickButton(/^Finish/);
+            cy.wait('@postLaunch')
+              .its('response.body.id')
+              .then((jobId: string) => {
+                cy.waitForTemplateStatus(jobId);
+              });
+            cy.navigateTo('awx', 'templates');
+            cy.intercept('DELETE', awxAPI`/job_templates/${id}/`).as('deleteJobTemplate');
+            cy.filterTableByMultiSelect('name', [jtName]);
+            cy.clickTableRowAction('name', jtName, 'delete-template', {
+              inKebab: true,
+              disableFilter: true,
+            });
+            cy.clickModalConfirmCheckbox();
+            cy.getBy('[data-ouia-component-id="submit"]').click();
+            cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
+              expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
+            });
+            cy.contains(/^Success$/);
+            cy.clickButton(/^Close$/);
+            cy.clearAllFilters();
+          });
+      });
+
+      it('can create a job template, select concurrent jobs, launch the job template two times and verify that both jobs appear in the table', function () {
+        const jtName = 'E2E Concurrent JT ' + randomString(4);
+        cy.createAwxProject(
+          awxOrganization,
+          { name: randomE2Ename() },
+          'https://github.com/ansible/test-playbooks'
+        ).then((gitProject: Project) => {
+          cy.createInventoryHost(awxOrganization, '').then((inventoryHost) => {
+            const { inventory } = inventoryHost;
+            inventoryWithHost = inventory;
+            cy.navigateTo('awx', 'templates');
+            cy.getBy('[data-cy="create-template"]').click();
+            cy.clickLink(/^Create job template$/);
+            cy.getByDataCy('name').type(jtName);
+            cy.selectDropdownOptionByResourceName('inventory', inventory.name);
+            cy.selectDropdownOptionByResourceName('project', gitProject.name);
+            cy.selectDropdownOptionByResourceName('playbook', 'debug-loop.yml');
+            cy.getByDataCy('allow_simultaneous').click();
+            cy.clickButton('Create job template');
+            cy.intercept('POST', awxAPI`/job_templates/*/launch/`).as('launchTemplate');
+            cy.clickButton('Launch template');
+            cy.wait('@launchTemplate')
+              .its('response.body')
+              .then(({ id: jobId, name }: { id: number; name: string }) => {
+                cy.url().should('contain', `/jobs/playbook/${jobId}/output`);
+                cy.contains('Running');
+                cy.contains(jtName);
+                cy.intercept('POST', awxAPI`/jobs/${jobId.toString()}/relaunch/`).as('relaunchJob');
+                cy.getByDataCy('relaunch-job').click();
+                cy.wait('@relaunchJob')
+                  .its('response.body')
+                  .then(({ id: jobId2, name: name2 }: { id: number; name: string }) => {
+                    cy.url().should('contain', `/jobs/playbook/${jobId2}/output`);
+                    cy.contains('Running');
+                    cy.contains(jtName);
+                    cy.navigateTo('awx', 'jobs');
+                    cy.filterTableByMultiSelect('name', [name, name2]);
+                    cy.contains('Running').each(($element) => {
+                      cy.wrap($element).should('be.visible');
+                    });
                   });
-                });
-            });
-        });
-      });
-    });
-  });
-
-  describe('Job Templates Tests: Edit', function () {
-    let inventory: Inventory;
-    let inventory2: Inventory;
-    let machineCredential: Credential;
-    let githubCredential: Credential;
-    let jobTemplate: JobTemplate;
-
-    beforeEach(function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        inventory = inv;
-        cy.createAWXCredential({
-          kind: 'machine',
-          organization: awxOrganization.id,
-          credential_type: 1,
-        }).then((cred) => {
-          machineCredential = cred;
-          cy.createAwxJobTemplate({
-            organization: awxOrganization.id,
-            project: project.id,
-            inventory: inventory.id,
-          }).then((jt1) => {
-            jobTemplate = jt1;
-          });
-        });
-      });
-    });
-
-    afterEach(function () {
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      inventory2?.id && cy.deleteAwxInventory(inventory2, { failOnStatusCode: false });
-      cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
-      githubCredential?.id && cy.deleteAwxCredential(githubCredential, { failOnStatusCode: false });
-    });
-
-    it('can edit a job template using the kebab menu of the template list page', function () {
-      const newName = (jobTemplate.name ?? '') + ' edited';
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.getTableRow('name', jobTemplate.name, { disableFilter: true }).should('be.visible');
-      cy.selectTableRow(jobTemplate.name, false);
-      cy.getBy('[data-cy="edit-template"]').click();
-      cy.verifyPageTitle(`Edit ${jobTemplate.name}`);
-      cy.getBy('[data-cy="name"]').clear().type(newName);
-      cy.getBy('[data-cy="description"]').type('this is a new description after editing');
-      cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
-      cy.clickButton(/^Save job template$/);
-      cy.wait('@editJT')
-        .its('response.body.name')
-        .then((name: string) => {
-          expect(newName).to.be.equal(name);
-        });
-      cy.verifyPageTitle(newName);
-      cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
-        'deleteJobTemplate'
-      );
-      cy.selectDetailsPageKebabAction('delete-template');
-      cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
-        expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
-      });
-      cy.verifyPageTitle('Templates');
-    });
-
-    it('can assign a new inventory to a job template if the originally assigned inventory was deleted', function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        inventory2 = inv;
-        cy.navigateTo('awx', 'templates');
-        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-        cy.clickTableRowLink('name', jobTemplate.name, {
-          disableFilter: true,
-        });
-        cy.verifyPageTitle(jobTemplate.name);
-        cy.getByDataCy('inventory').contains(jobTemplate.summary_fields.inventory.name).click();
-        cy.clickKebabAction('actions-dropdown', 'delete-inventory');
-        cy.clickModalConfirmCheckbox();
-        cy.intercept('DELETE', awxAPI`/inventories/${inventory.id.toString()}/`).as(
-          'deleteInventory'
-        );
-        cy.clickModalButton('Delete inventory');
-        cy.wait('@deleteInventory');
-        cy.navigateTo('awx', 'templates');
-        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-        cy.clickTableRowLink('name', jobTemplate.name, {
-          disableFilter: true,
-        });
-        cy.verifyPageTitle(jobTemplate.name);
-        cy.getByDataCy('inventory').contains('Deleted');
-        cy.clickLink('Edit template');
-        cy.selectDropdownOptionByResourceName('inventory', inv.name);
-        cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('saveJT');
-        cy.clickButton('Save job template');
-        cy.wait('@saveJT');
-        cy.contains(inv.name).should('be.visible');
-      });
-    });
-
-    it('can edit a job template to enable provisioning callback and enable webhook, then edit again to disable those options', function () {
-      const jtURL = document.location.origin + awxAPI`/job_templates/${jobTemplate.id.toString()}`;
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
-      cy.get('[data-cy="enabled-options"]').should('not.exist');
-      cy.clickLink('Edit template');
-      cy.getByDataCy('isWebhookEnabled').should('not.be.checked');
-      cy.getByDataCy('isProvisioningCallbackEnabled').should('not.be.checked');
-      // Enable webhook
-      cy.getByDataCy('isWebhookEnabled').click();
-      cy.getByDataCy('isWebhookEnabled').should('be.checked');
-      cy.get('[data-cy="related-webhook-receiver"]').should('have.value', '');
-      cy.selectDropdownOptionByResourceName('webhook-service', 'GitLab');
-      cy.getByDataCy('related-webhook-receiver').should('have.attr', 'readonly');
-      cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/gitlab/`);
-      cy.selectDropdownOptionByResourceName('webhook-service', 'GitHub');
-      cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
-      cy.getByDataCy('related-webhook-receiver').should('have.attr', 'readonly');
-      cy.getByDataCy('webhook-key').should(
-        'have.value',
-        'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.'
-      );
-      cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
-      cy.clickButton('Save job template');
-      cy.wait('@editJT');
-      cy.getByDataCy('enabled-options').contains('Webhooks');
-      cy.clickLink('Edit template');
-      cy.getByDataCy('isWebhookEnabled').should('be.checked');
-      cy.getByDataCy('webhook-service-form-group').contains('GitHub');
-      cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
-      cy.getByDataCy('webhook-key').should(
-        'not.have.value',
-        'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.'
-      );
-      cy.getByDataCy('isWebhookEnabled').click();
-      cy.getByDataCy('isWebhookEnabled').should('not.be.checked');
-      cy.contains('Webhook details').should('not.exist');
-      cy.getByDataCy('isWebhookEnabled').click();
-      cy.getByDataCy('isWebhookEnabled').should('be.checked');
-      cy.getByDataCy('webhook-service-form-group').contains('GitHub');
-      cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
-      // Enable provisioning callback
-      cy.getByDataCy('isProvisioningCallbackEnabled').click();
-      cy.contains('Provisioning callback details');
-      cy.getByDataCy('host-config-key').type('foobar');
-      cy.clickButton('Save job template');
-      cy.getByDataCy('enabled-options').contains('Provisioning Callbacks');
-      cy.clickLink('Edit template');
-      cy.getByDataCy('isProvisioningCallbackEnabled').should('be.checked');
-      cy.get('[data-cy="host-config-key"]').should('have.value', 'foobar');
-      cy.get('[data-cy="related-callback"]').should('have.attr', 'disabled');
-      cy.get('[data-cy="related-callback"]').should('have.value', `${jtURL}/callback/`);
-      cy.getByDataCy('isProvisioningCallbackEnabled').click();
-      cy.getByDataCy('isProvisioningCallbackEnabled').should('not.be.checked');
-      cy.clickButton('Save job template');
-      cy.getByDataCy('enabled-options').contains('Provisioning Callbacks').should('not.exist');
-    });
-
-    it('can edit a job template to enable webhook, regenerate webhook key and set webhook credentials', function () {
-      cy.createAWXCredential({
-        kind: 'github_token',
-        organization: awxOrganization.id,
-        credential_type: 11,
-      }).then((ghCred) => {
-        githubCredential = ghCred;
-        let webhookKey: string;
-        cy.navigateTo('awx', 'templates');
-        cy.verifyPageTitle('Templates');
-        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-        cy.clickTableRowAction('name', jobTemplate.name, 'edit-template', {
-          inKebab: false,
-          disableFilter: true,
-        });
-        cy.getByDataCy('isWebhookEnabled').click();
-        cy.selectDropdownOptionByResourceName('webhook-service', 'GitHub');
-        cy.singleSelectByDataCy('webhook_credential', ghCred.name);
-        cy.clickButton('Save job template');
-        cy.contains('Webhook credential');
-        cy.getByDataCy('webhook-credential').contains(ghCred.name);
-        cy.intercept('GET', awxAPI`/job_templates/${jobTemplate.id.toString()}/webhook_key/`).as(
-          'getWebhookKey'
-        );
-        cy.clickLink('Edit template');
-        cy.wait('@getWebhookKey')
-          .its('response.body.webhook_key')
-          .then((webhook_key: string) => {
-            webhookKey = webhook_key;
-            cy.getByDataCy('webhook_credential').should('have.text', ghCred.name);
-            cy.getByDataCy('webhook-service-form-group').contains('GitHub');
-            cy.getByDataCy('webhook-key').should('have.value', webhookKey);
-            cy.intercept(
-              'POST',
-              awxAPI`/job_templates/${jobTemplate.id.toString()}/webhook_key/`
-            ).as('generateWebhookKey');
-            cy.getByDataCy('webhook-key-form-group').within(() => {
-              cy.get('button').click();
-            });
-            cy.wait('@generateWebhookKey')
-              .its('response.body.webhook_key')
-              .then((webhook_key: string) => {
-                webhookKey = webhook_key;
-                cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
-                  'saveJT'
-                );
-                cy.clickButton('Save job template');
-                cy.wait('@saveJT');
-                cy.getByDataCy('webhook-service').contains('GitHub');
-                cy.clickLink('Edit template');
-                cy.getByDataCy('webhook-key').should('have.value', webhookKey);
               });
           });
-      });
-    });
-
-    it('can edit a job template using the edit template button on details page', function () {
-      const newName = (jobTemplate.name ?? '') + ' edited';
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.clickLink(/^Edit template$/);
-      cy.verifyPageTitle(`Edit ${jobTemplate.name}`);
-      cy.getBy('[data-cy="name"]').clear().type(newName);
-      cy.getBy('[data-cy="description"]').type('this is a new description after editing');
-      cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
-      cy.clickButton(/^Save job template$/);
-      cy.wait('@editJT')
-        .its('response.body')
-        .then((response: JobTemplate) => {
-          expect(response.name).to.eql(newName);
-          cy.verifyPageTitle(response.name);
-          cy.getByDataCy('name').should('contain', response.name);
-        });
-    });
-  });
-
-  describe('Job Templates Tests: Copy', function () {
-    let inventory: Inventory;
-    let jobTemplate: JobTemplate;
-
-    beforeEach(function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        inventory = inv;
-        cy.createAwxJobTemplate({
-          organization: awxOrganization.id,
-          project: project.id,
-          inventory: inventory.id,
-        }).then((jt) => {
-          jobTemplate = jt;
         });
       });
     });
 
-    afterEach(function () {
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-    });
+    describe('Job Templates Tests: Edit', function () {
+      let inventory: Inventory;
+      let inventory2: Inventory;
+      let machineCredential: Credential;
+      let githubCredential: Credential;
+      let jobTemplate: JobTemplate;
 
-    it('can copy an existing job template from the list', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableBySingleSelect('name', jobTemplate.name);
-      cy.intercept('POST', awxAPI`/job_templates/${jobTemplate.id.toString()}/copy/`).as(
-        'copyTemplate'
-      );
-      cy.clickTableRowAction('name', jobTemplate.name, 'copy-template', {
-        inKebab: true,
-        disableFilter: true,
-      });
-      cy.wait('@copyTemplate')
-        .its('response.body.name')
-        .then((copiedName: string) => {
-          cy.clearAllFilters();
-          cy.filterTableBySingleSelect('name', copiedName);
+      beforeEach(function () {
+        cy.createAwxInventory(awxOrganization).then((inv) => {
+          inventory = inv;
+          cy.createAWXCredential({
+            kind: 'machine',
+            organization: awxOrganization.id,
+            credential_type: 1,
+          }).then((cred) => {
+            machineCredential = cred;
+            cy.createAwxJobTemplate({
+              organization: awxOrganization.id,
+              project: project.id,
+              inventory: inventory.id,
+            }).then((jt1) => {
+              jobTemplate = jt1;
+            });
+          });
         });
-    });
-
-    it('can copy an existing job template from the details page', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, {
-        disableFilter: true,
       });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.intercept('POST', awxAPI`/job_templates/${jobTemplate.id.toString()}/copy/`).as(
-        'copyTemplate'
-      );
-      cy.clickKebabAction('actions-dropdown', 'copy-template');
-      cy.getByDataCy('alert-toaster').contains(`${jobTemplate.name} copied.`);
-      cy.wait('@copyTemplate')
-        .its('response.body')
-        .then(({ name }: { name: string }) => {
+
+      afterEach(function () {
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        inventory2?.id && cy.deleteAwxInventory(inventory2, { failOnStatusCode: false });
+        cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
+        githubCredential?.id &&
+          cy.deleteAwxCredential(githubCredential, { failOnStatusCode: false });
+      });
+
+      it('can edit a job template using the kebab menu of the template list page', function () {
+        const newName = (jobTemplate.name ?? '') + ' edited';
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.getTableRow('name', jobTemplate.name, { disableFilter: true }).should('be.visible');
+        cy.selectTableRow(jobTemplate.name, false);
+        cy.getBy('[data-cy="edit-template"]').click();
+        cy.verifyPageTitle(`Edit ${jobTemplate.name}`);
+        cy.getBy('[data-cy="name"]').clear().type(newName);
+        cy.getBy('[data-cy="description"]').type('this is a new description after editing');
+        cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
+        cy.clickButton(/^Save job template$/);
+        cy.wait('@editJT')
+          .its('response.body.name')
+          .then((name: string) => {
+            expect(newName).to.be.equal(name);
+          });
+        cy.verifyPageTitle(newName);
+        cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
+          'deleteJobTemplate'
+        );
+        cy.selectDetailsPageKebabAction('delete-template');
+        cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
+          expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
+        });
+        cy.verifyPageTitle('Templates');
+      });
+
+      it('can assign a new inventory to a job template if the originally assigned inventory was deleted', function () {
+        cy.createAwxInventory(awxOrganization).then((inv) => {
+          inventory2 = inv;
           cy.navigateTo('awx', 'templates');
           cy.filterTableByMultiSelect('name', [jobTemplate.name]);
           cy.clickTableRowLink('name', jobTemplate.name, {
             disableFilter: true,
           });
-          cy.verifyPageTitle(name);
-        });
-    });
-  });
-
-  describe('Job Templates Tests: Delete', function () {
-    let inventory: Inventory;
-    let deletedInventory: Inventory;
-    let machineCredential: Credential;
-    let jobTemplate: JobTemplate;
-    let jobTemplate2: JobTemplate;
-    let jobTemplateWithDeletedInventory: JobTemplate;
-
-    beforeEach(function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        inventory = inv;
-        cy.createAWXCredential({
-          kind: 'machine',
-          organization: awxOrganization.id,
-          credential_type: 1,
-        }).then((cred) => {
-          machineCredential = cred;
-          cy.createAwxJobTemplate({
-            organization: awxOrganization.id,
-            project: project.id,
-            inventory: inventory.id,
-          }).then((jt1) => {
-            jobTemplate = jt1;
-          });
-          cy.createAwxJobTemplate({
-            organization: awxOrganization.id,
-            project: project.id,
-            inventory: inventory.id,
-          }).then((jt2) => {
-            jobTemplate2 = jt2;
-          });
-        });
-      });
-    });
-
-    afterEach(function () {
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxJobTemplate(jobTemplate2, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
-      jobTemplateWithDeletedInventory?.id &&
-        cy.deleteAwxJobTemplate(jobTemplateWithDeletedInventory, { failOnStatusCode: false });
-    });
-
-    it('can delete a job template from the list line item', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableBySingleSelect('name', jobTemplate.name);
-      cy.clickTableRowKebabAction(jobTemplate.name, 'delete-template');
-      cy.clickModalConfirmCheckbox();
-      cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('deleteJT');
-      cy.clickModalButton('Delete template');
-      cy.wait('@deleteJT')
-        .its('response')
-        .then((response) => {
-          expect(response?.statusCode).to.eql(204);
-        });
-      cy.getModal().within(() => {
-        cy.contains(jobTemplate.name);
-        cy.contains('Success');
-        cy.clickButton('Close');
-      });
-    });
-
-    it('can delete a job template from the details page', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.intercept('OPTIONS', awxAPI`/unified_job_templates/`).as('options');
-      cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
-        'deleteJobTemplate'
-      );
-      cy.selectDetailsPageKebabAction('delete-template');
-      cy.wait('@options');
-      cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
-        expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
-      });
-      cy.verifyPageTitle('Templates');
-    });
-
-    it('can delete a resource related to a JT and view warning on the JT', function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        deletedInventory = inv;
-        cy.createAwxJobTemplate({
-          organization: awxOrganization.id,
-          project: project.id,
-          inventory: deletedInventory.id,
-        }).then((jt) => {
-          jobTemplateWithDeletedInventory = jt;
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [jobTemplateWithDeletedInventory.name]);
-          cy.clickTableRowLink('name', jobTemplateWithDeletedInventory.name, {
-            disableFilter: true,
-          });
-          cy.verifyPageTitle(jobTemplateWithDeletedInventory.name);
-          cy.getByDataCy('inventory').contains(deletedInventory.name).click();
+          cy.verifyPageTitle(jobTemplate.name);
+          cy.getByDataCy('inventory').contains(jobTemplate.summary_fields.inventory.name).click();
           cy.clickKebabAction('actions-dropdown', 'delete-inventory');
           cy.clickModalConfirmCheckbox();
-          cy.intercept('DELETE', awxAPI`/inventories/${deletedInventory.id.toString()}/`).as(
+          cy.intercept('DELETE', awxAPI`/inventories/${inventory.id.toString()}/`).as(
             'deleteInventory'
           );
           cy.clickModalButton('Delete inventory');
-          cy.wait('@deleteInventory')
-            .its('response')
-            .then((response) => {
-              expect(response?.statusCode).to.eql(202);
-            });
+          cy.wait('@deleteInventory');
           cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [jobTemplateWithDeletedInventory.name]);
-          cy.clickTableRowLink('name', jobTemplateWithDeletedInventory.name, {
+          cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+          cy.clickTableRowLink('name', jobTemplate.name, {
             disableFilter: true,
           });
-          cy.verifyPageTitle(jobTemplateWithDeletedInventory.name);
+          cy.verifyPageTitle(jobTemplate.name);
           cy.getByDataCy('inventory').contains('Deleted');
+          cy.clickLink('Edit template');
+          cy.selectDropdownOptionByResourceName('inventory', inv.name);
+          cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('saveJT');
+          cy.clickButton('Save job template');
+          cy.wait('@saveJT');
+          cy.contains(inv.name).should('be.visible');
         });
       });
-    });
 
-    it('can bulk delete job templates from the list page', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name, jobTemplate2.name]);
-      cy.selectTableRow(jobTemplate.name, false);
-      cy.selectTableRow(jobTemplate2.name, false);
-      cy.clickToolbarKebabAction('delete-selected-templates');
-      cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
-        'deleteJobTemplate1'
-      );
-      cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate2.id.toString()}/`).as(
-        'deleteJobTemplate2'
-      );
-      cy.clickModalConfirmCheckbox();
-      cy.clickModalButton('Delete template');
-      cy.wait(['@deleteJobTemplate1', '@deleteJobTemplate2']).then((jtArray) => {
-        expect(jtArray[0]?.response?.statusCode).to.eql(204);
-        expect(jtArray[1]?.response?.statusCode).to.eql(204);
+      it('can edit a job template to enable provisioning callback and enable webhook, then edit again to disable those options', function () {
+        const jtURL =
+          document.location.origin + awxAPI`/job_templates/${jobTemplate.id.toString()}`;
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
+        cy.get('[data-cy="enabled-options"]').should('not.exist');
+        cy.clickLink('Edit template');
+        cy.getByDataCy('isWebhookEnabled').should('not.be.checked');
+        cy.getByDataCy('isProvisioningCallbackEnabled').should('not.be.checked');
+        // Enable webhook
+        cy.getByDataCy('isWebhookEnabled').click();
+        cy.getByDataCy('isWebhookEnabled').should('be.checked');
+        cy.get('[data-cy="related-webhook-receiver"]').should('have.value', '');
+        cy.selectDropdownOptionByResourceName('webhook-service', 'GitLab');
+        cy.getByDataCy('related-webhook-receiver').should('have.attr', 'readonly');
+        cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/gitlab/`);
+        cy.selectDropdownOptionByResourceName('webhook-service', 'GitHub');
+        cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
+        cy.getByDataCy('related-webhook-receiver').should('have.attr', 'readonly');
+        cy.getByDataCy('webhook-key').should(
+          'have.value',
+          'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.'
+        );
+        cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
+        cy.clickButton('Save job template');
+        cy.wait('@editJT');
+        cy.getByDataCy('enabled-options').contains('Webhooks');
+        cy.clickLink('Edit template');
+        cy.getByDataCy('isWebhookEnabled').should('be.checked');
+        cy.getByDataCy('webhook-service-form-group').contains('GitHub');
+        cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
+        cy.getByDataCy('webhook-key').should(
+          'not.have.value',
+          'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.'
+        );
+        cy.getByDataCy('isWebhookEnabled').click();
+        cy.getByDataCy('isWebhookEnabled').should('not.be.checked');
+        cy.contains('Webhook details').should('not.exist');
+        cy.getByDataCy('isWebhookEnabled').click();
+        cy.getByDataCy('isWebhookEnabled').should('be.checked');
+        cy.getByDataCy('webhook-service-form-group').contains('GitHub');
+        cy.getByDataCy('related-webhook-receiver').should('have.value', `${jtURL}/github/`);
+        // Enable provisioning callback
+        cy.getByDataCy('isProvisioningCallbackEnabled').click();
+        cy.contains('Provisioning callback details');
+        cy.getByDataCy('host-config-key').type('foobar');
+        cy.clickButton('Save job template');
+        cy.getByDataCy('enabled-options').contains('Provisioning Callbacks');
+        cy.clickLink('Edit template');
+        cy.getByDataCy('isProvisioningCallbackEnabled').should('be.checked');
+        cy.get('[data-cy="host-config-key"]').should('have.value', 'foobar');
+        cy.get('[data-cy="related-callback"]').should('have.attr', 'disabled');
+        cy.get('[data-cy="related-callback"]').should('have.value', `${jtURL}/callback/`);
+        cy.getByDataCy('isProvisioningCallbackEnabled').click();
+        cy.getByDataCy('isProvisioningCallbackEnabled').should('not.be.checked');
+        cy.clickButton('Save job template');
+        cy.getByDataCy('enabled-options').contains('Provisioning Callbacks').should('not.exist');
       });
-      cy.assertModalSuccess();
-      cy.clickButton(/^Close$/);
-      cy.clearAllFilters();
-    });
-  });
 
-  describe('Schedules Tab for Job Templates', () => {
-    //These tests live on the schedules.cy.ts spec file
-  });
-
-  describe('Surveys Tab for Job Templates', () => {
-    //These tests live on the jobTemplateSurvey.cy.ts spec file
-  });
-
-  describe('Notifications Tab for Job Templates', () => {
-    let inventory: Inventory;
-    let jobTemplate: JobTemplate;
-    let notification: NotificationTemplate;
-
-    function toggleNotificationType(type: 'start' | 'success' | 'failure') {
-      const switchType = type === 'start' ? 'Start' : type === 'success' ? 'Success' : 'Failure';
-      const apiSuffix = type === 'start' ? 'started' : type === 'success' ? 'success' : 'error';
-
-      cy.filterTableByTextFilter('name', notification.name);
-      cy.getByDataCy(`row-id-${notification.id}`).within(() => {
-        cy.getByDataCy('name-column-cell').contains(notification.name);
-        cy.getByDataCy('type-column-cell').contains('Email');
-        cy.getByDataCy('toggle-switch').contains('Start');
-        cy.getByDataCy('toggle-switch').contains('Success');
-        cy.getByDataCy('toggle-switch').contains('Failure');
-        cy.intercept(
-          'POST',
-          awxAPI`/job_templates/${jobTemplate.id.toString()}/notification_templates_${apiSuffix}/`
-        ).as('toggleStart');
-        cy.getByDataCy('toggle-switch').contains(switchType).click();
-        cy.wait('@toggleStart');
-        cy.getByDataCy('toggle-switch')
-          .contains(switchType)
-          .within(() => {
-            cy.get(`[aria-label="Click to disable ${type}"]`);
-          });
-        cy.intercept(
-          'POST',
-          awxAPI`/job_templates/${jobTemplate.id.toString()}/notification_templates_${apiSuffix}/`
-        ).as('toggleStart');
-        cy.getByDataCy('toggle-switch').contains(switchType).click();
-        cy.wait('@toggleStart');
-        cy.getByDataCy('toggle-switch')
-          .contains(switchType)
-          .within(() => {
-            cy.get(`[aria-label="Click to enable ${type}"]`);
-          });
-      });
-    }
-
-    beforeEach(function () {
-      cy.createAwxInventory(awxOrganization).then((inv) => {
-        inventory = inv;
-
-        cy.createAwxJobTemplate({
+      it('can edit a job template to enable webhook, regenerate webhook key and set webhook credentials', function () {
+        cy.createAWXCredential({
+          kind: 'github_token',
           organization: awxOrganization.id,
-          project: project.id,
-          inventory: inventory.id,
-        }).then((jt) => {
-          jobTemplate = jt;
+          credential_type: 11,
+        }).then((ghCred) => {
+          githubCredential = ghCred;
+          let webhookKey: string;
+          cy.navigateTo('awx', 'templates');
+          cy.verifyPageTitle('Templates');
+          cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+          cy.clickTableRowAction('name', jobTemplate.name, 'edit-template', {
+            inKebab: false,
+            disableFilter: true,
+          });
+          cy.getByDataCy('isWebhookEnabled').click();
+          cy.selectDropdownOptionByResourceName('webhook-service', 'GitHub');
+          cy.singleSelectByDataCy('webhook_credential', ghCred.name);
+          cy.clickButton('Save job template');
+          cy.contains('Webhook credential');
+          cy.getByDataCy('webhook-credential').contains(ghCred.name);
+          cy.intercept('GET', awxAPI`/job_templates/${jobTemplate.id.toString()}/webhook_key/`).as(
+            'getWebhookKey'
+          );
+          cy.clickLink('Edit template');
+          cy.wait('@getWebhookKey')
+            .its('response.body.webhook_key')
+            .then((webhook_key: string) => {
+              webhookKey = webhook_key;
+              cy.getByDataCy('webhook_credential').should('have.text', ghCred.name);
+              cy.getByDataCy('webhook-service-form-group').contains('GitHub');
+              cy.getByDataCy('webhook-key').should('have.value', webhookKey);
+              cy.intercept(
+                'POST',
+                awxAPI`/job_templates/${jobTemplate.id.toString()}/webhook_key/`
+              ).as('generateWebhookKey');
+              cy.getByDataCy('webhook-key-form-group').within(() => {
+                cy.get('button').click();
+              });
+              cy.wait('@generateWebhookKey')
+                .its('response.body.webhook_key')
+                .then((webhook_key: string) => {
+                  webhookKey = webhook_key;
+                  cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
+                    'saveJT'
+                  );
+                  cy.clickButton('Save job template');
+                  cy.wait('@saveJT');
+                  cy.getByDataCy('webhook-service').contains('GitHub');
+                  cy.clickLink('Edit template');
+                  cy.getByDataCy('webhook-key').should('have.value', webhookKey);
+                });
+            });
+        });
+      });
 
-          cy.createNotificationTemplate(randomE2Ename(), awxOrganization).then((n) => {
-            notification = n;
+      it('can edit a job template using the edit template button on details page', function () {
+        const newName = (jobTemplate.name ?? '') + ' edited';
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
+        cy.verifyPageTitle(jobTemplate.name);
+        cy.clickLink(/^Edit template$/);
+        cy.verifyPageTitle(`Edit ${jobTemplate.name}`);
+        cy.getBy('[data-cy="name"]').clear().type(newName);
+        cy.getBy('[data-cy="description"]').type('this is a new description after editing');
+        cy.intercept('PATCH', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('editJT');
+        cy.clickButton(/^Save job template$/);
+        cy.wait('@editJT')
+          .its('response.body')
+          .then((response: JobTemplate) => {
+            expect(response.name).to.eql(newName);
+            cy.verifyPageTitle(response.name);
+            cy.getByDataCy('name').should('contain', response.name);
+          });
+      });
+    });
+
+    describe('Job Templates Tests: Copy', function () {
+      let inventory: Inventory;
+      let jobTemplate: JobTemplate;
+
+      beforeEach(function () {
+        cy.createAwxInventory(awxOrganization).then((inv) => {
+          inventory = inv;
+          cy.createAwxJobTemplate({
+            organization: awxOrganization.id,
+            project: project.id,
+            inventory: inventory.id,
+          }).then((jt) => {
+            jobTemplate = jt;
           });
         });
       });
-    });
 
-    afterEach(function () {
-      cy.deleteNotificationTemplate(notification, { failOnStatusCode: false });
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-    });
-
-    it('can navigate to the Job Templates -> Notifications list and then to the details page of the Notification', () => {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, {
-        disableFilter: true,
+      afterEach(function () {
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
       });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.clickTab('Notifications', true);
-      cy.filterTableByTextFilter('name', notification.name);
-      cy.getByDataCy('name-column-cell').contains(notification.name).click();
-      cy.url().should('contain', `/administration/notifiers/${notification.id}/details`);
-      cy.getByDataCy('name').contains(notification.name);
+
+      it('can copy an existing job template from the list', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableBySingleSelect('name', jobTemplate.name);
+        cy.intercept('POST', awxAPI`/job_templates/${jobTemplate.id.toString()}/copy/`).as(
+          'copyTemplate'
+        );
+        cy.clickTableRowAction('name', jobTemplate.name, 'copy-template', {
+          inKebab: true,
+          disableFilter: true,
+        });
+        cy.wait('@copyTemplate')
+          .its('response.body.name')
+          .then((copiedName: string) => {
+            cy.clearAllFilters();
+            cy.filterTableBySingleSelect('name', copiedName);
+          });
+      });
+
+      it('can copy an existing job template from the details page', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.clickTableRowLink('name', jobTemplate.name, {
+          disableFilter: true,
+        });
+        cy.verifyPageTitle(jobTemplate.name);
+        cy.intercept('POST', awxAPI`/job_templates/${jobTemplate.id.toString()}/copy/`).as(
+          'copyTemplate'
+        );
+        cy.clickKebabAction('actions-dropdown', 'copy-template');
+        cy.getByDataCy('alert-toaster').contains(`${jobTemplate.name} copied.`);
+        cy.wait('@copyTemplate')
+          .its('response.body')
+          .then(({ name }: { name: string }) => {
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+            cy.clickTableRowLink('name', jobTemplate.name, {
+              disableFilter: true,
+            });
+            cy.verifyPageTitle(name);
+          });
+      });
     });
 
-    it('can toggle the Job Templates -> Notification on and off for job start', () => {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, {
-        disableFilter: true,
+    describe('Job Templates Tests: Delete', function () {
+      let inventory: Inventory;
+      let deletedInventory: Inventory;
+      let machineCredential: Credential;
+      let jobTemplate: JobTemplate;
+      let jobTemplate2: JobTemplate;
+      let jobTemplateWithDeletedInventory: JobTemplate;
+
+      beforeEach(function () {
+        cy.createAwxInventory(awxOrganization).then((inv) => {
+          inventory = inv;
+          cy.createAWXCredential({
+            kind: 'machine',
+            organization: awxOrganization.id,
+            credential_type: 1,
+          }).then((cred) => {
+            machineCredential = cred;
+            cy.createAwxJobTemplate({
+              organization: awxOrganization.id,
+              project: project.id,
+              inventory: inventory.id,
+            }).then((jt1) => {
+              jobTemplate = jt1;
+            });
+            cy.createAwxJobTemplate({
+              organization: awxOrganization.id,
+              project: project.id,
+              inventory: inventory.id,
+            }).then((jt2) => {
+              jobTemplate2 = jt2;
+            });
+          });
+        });
       });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.clickTab('Notifications', true);
-      toggleNotificationType('start');
+
+      afterEach(function () {
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+        cy.deleteAwxJobTemplate(jobTemplate2, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        cy.deleteAwxCredential(machineCredential, { failOnStatusCode: false });
+        jobTemplateWithDeletedInventory?.id &&
+          cy.deleteAwxJobTemplate(jobTemplateWithDeletedInventory, { failOnStatusCode: false });
+      });
+
+      it('can delete a job template from the list line item', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableBySingleSelect('name', jobTemplate.name);
+        cy.clickTableRowKebabAction(jobTemplate.name, 'delete-template');
+        cy.clickModalConfirmCheckbox();
+        cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as('deleteJT');
+        cy.clickModalButton('Delete template');
+        cy.wait('@deleteJT')
+          .its('response')
+          .then((response) => {
+            expect(response?.statusCode).to.eql(204);
+          });
+        cy.getModal().within(() => {
+          cy.contains(jobTemplate.name);
+          cy.contains('Success');
+          cy.clickButton('Close');
+        });
+      });
+
+      it('can delete a job template from the details page', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name]);
+        cy.clickTableRowLink('name', jobTemplate.name, { disableFilter: true });
+        cy.verifyPageTitle(jobTemplate.name);
+        cy.intercept('OPTIONS', awxAPI`/unified_job_templates/`).as('options');
+        cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
+          'deleteJobTemplate'
+        );
+        cy.selectDetailsPageKebabAction('delete-template');
+        cy.wait('@options');
+        cy.wait('@deleteJobTemplate').then((deleteJobTemplate) => {
+          expect(deleteJobTemplate?.response?.statusCode).to.eql(204);
+        });
+        cy.verifyPageTitle('Templates');
+      });
+
+      it('can delete a resource related to a JT and view warning on the JT', function () {
+        cy.createAwxInventory(awxOrganization).then((inv) => {
+          deletedInventory = inv;
+          cy.createAwxJobTemplate({
+            organization: awxOrganization.id,
+            project: project.id,
+            inventory: deletedInventory.id,
+          }).then((jt) => {
+            jobTemplateWithDeletedInventory = jt;
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jobTemplateWithDeletedInventory.name]);
+            cy.clickTableRowLink('name', jobTemplateWithDeletedInventory.name, {
+              disableFilter: true,
+            });
+            cy.verifyPageTitle(jobTemplateWithDeletedInventory.name);
+            cy.getByDataCy('inventory').contains(deletedInventory.name).click();
+            cy.clickKebabAction('actions-dropdown', 'delete-inventory');
+            cy.clickModalConfirmCheckbox();
+            cy.intercept('DELETE', awxAPI`/inventories/${deletedInventory.id.toString()}/`).as(
+              'deleteInventory'
+            );
+            cy.clickModalButton('Delete inventory');
+            cy.wait('@deleteInventory')
+              .its('response')
+              .then((response) => {
+                expect(response?.statusCode).to.eql(202);
+              });
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [jobTemplateWithDeletedInventory.name]);
+            cy.clickTableRowLink('name', jobTemplateWithDeletedInventory.name, {
+              disableFilter: true,
+            });
+            cy.verifyPageTitle(jobTemplateWithDeletedInventory.name);
+            cy.getByDataCy('inventory').contains('Deleted');
+          });
+        });
+      });
+
+      it('can bulk delete job templates from the list page', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [jobTemplate.name, jobTemplate2.name]);
+        cy.selectTableRow(jobTemplate.name, false);
+        cy.selectTableRow(jobTemplate2.name, false);
+        cy.clickToolbarKebabAction('delete-selected-templates');
+        cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate.id.toString()}/`).as(
+          'deleteJobTemplate1'
+        );
+        cy.intercept('DELETE', awxAPI`/job_templates/${jobTemplate2.id.toString()}/`).as(
+          'deleteJobTemplate2'
+        );
+        cy.clickModalConfirmCheckbox();
+        cy.clickModalButton('Delete template');
+        cy.wait(['@deleteJobTemplate1', '@deleteJobTemplate2']).then((jtArray) => {
+          expect(jtArray[0]?.response?.statusCode).to.eql(204);
+          expect(jtArray[1]?.response?.statusCode).to.eql(204);
+        });
+        cy.assertModalSuccess();
+        cy.clickButton(/^Close$/);
+        cy.clearAllFilters();
+      });
     });
 
-    it('can toggle the Job Templates -> Notification on and off for job success', () => {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, {
-        disableFilter: true,
-      });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.clickTab('Notifications', true);
-      toggleNotificationType('success');
+    describe('Schedules Tab for Job Templates', () => {
+      //These tests live on the schedules.cy.ts spec file
     });
 
-    it('can toggle the Job Templates -> Notification on and off for job failure', () => {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [jobTemplate.name]);
-      cy.clickTableRowLink('name', jobTemplate.name, {
-        disableFilter: true,
-      });
-      cy.verifyPageTitle(jobTemplate.name);
-      cy.clickTab('Notifications', true);
-      toggleNotificationType('failure');
+    describe('Surveys Tab for Job Templates', () => {
+      //These tests live on the jobTemplateSurvey.cy.ts spec file
     });
   });
 });

--- a/cypress/e2e/awx/resources/workflowJobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/workflowJobTemplates.cy.ts
@@ -13,23 +13,30 @@ describe('Workflow Job Templates Tests', () => {
   let organization: Organization;
   let inventory: Inventory;
   let label: Label;
-
-  beforeEach(() => {
-    cy.createAwxOrganization().then((o) => {
-      organization = o;
-      cy.createAwxInventory(organization).then((i) => {
-        inventory = i;
-      });
-      cy.createAwxLabel({ organization: organization.id }).then((l) => {
-        label = l;
-      });
+  before(() => {
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
     });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+  });
+  beforeEach(() => {
+    // cy.createAwxOrganization().then((o) => {
+    //   organization = o;
+    cy.createAwxInventory(organization).then((i) => {
+      inventory = i;
+    });
+    cy.createAwxLabel({ organization: organization.id }).then((l) => {
+      label = l;
+    });
+    // });
   });
 
   afterEach(() => {
     cy.deleteAwxLabel(label, { failOnStatusCode: false });
     cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
   });
 
   describe('Workflow Job Templates: Create', function () {
@@ -117,14 +124,14 @@ describe('Workflow Job Templates Tests', () => {
 
   describe('Workflow Job Templates: Edit', function () {
     let workflowJobTemplate: WorkflowJobTemplate;
-    let newOrganization: Organization;
+    // let newOrganization: Organization;
     let inventory: Inventory;
     let tokenCredential: Credential;
 
     beforeEach(function () {
-      cy.createAwxOrganization().then((orgA) => {
-        newOrganization = orgA;
-      });
+      // cy.createAwxOrganization().then((orgA) => {
+      //   newOrganization = orgA;
+      // });
       cy.createAwxInventory(organization).then((i) => {
         inventory = i;
 
@@ -140,7 +147,7 @@ describe('Workflow Job Templates Tests', () => {
     afterEach(function () {
       cy.deleteAwxWorkflowJobTemplate(workflowJobTemplate, { failOnStatusCode: false });
       cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(newOrganization, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(newOrganization, { failOnStatusCode: false });
     });
 
     it('can edit a workflow job template from the details view', () => {
@@ -153,7 +160,7 @@ describe('Workflow Job Templates Tests', () => {
       cy.clickLink('Edit template');
       cy.get('[data-cy="name"]').clear().type(newName);
       cy.get('[data-cy="description"]').type('this is a new description');
-      cy.singleSelectByDataCy('organization', newOrganization.name);
+      cy.singleSelectByDataCy('organization', organization.name);
       cy.clickButton(/^Save workflow job template$/);
       cy.verifyPageTitle(newName);
       cy.getByDataCy('name').should('contain', newName);
@@ -266,7 +273,7 @@ describe('Workflow Job Templates Tests', () => {
       });
       cy.get('[data-cy="name"]').clear().type(newName);
       cy.get('[data-cy="description"]').type('this is a new description');
-      cy.singleSelectByDataCy('organization', newOrganization.name);
+      cy.singleSelectByDataCy('organization', organization.name);
       cy.clickButton(/^Save workflow job template$/);
       cy.verifyPageTitle(newName);
       cy.getByDataCy('name').should('contain', newName);
@@ -696,30 +703,30 @@ describe('Workflow Job Templates Tests', () => {
   }
 
   describe('Schedules - Create schedule of resource type Workflow job template', () => {
-    let organization: Organization;
+    // let organization: Organization;
     let inventory: Inventory;
     let workflowTemplate: WorkflowJobTemplate;
 
     beforeEach(() => {
-      cy.createAwxOrganization().then((o) => {
-        organization = o;
-        cy.createAwxInventory(organization).then((i) => {
-          inventory = i;
-          cy.createAwxWorkflowJobTemplate({
-            name: 'E2E Workflow Job Template ' + randomString(4),
-            organization: organization.id,
-            inventory: inventory.id,
-          }).then((wfjt) => {
-            workflowTemplate = wfjt;
-          });
+      // cy.createAwxOrganization().then((o) => {
+      //   organization = o;
+      cy.createAwxInventory(organization).then((i) => {
+        inventory = i;
+        cy.createAwxWorkflowJobTemplate({
+          name: 'E2E Workflow Job Template ' + randomString(4),
+          organization: organization.id,
+          inventory: inventory.id,
+        }).then((wfjt) => {
+          workflowTemplate = wfjt;
         });
+        // });
       });
     });
 
     afterEach(() => {
       cy.deleteAwxWorkflowJobTemplate(workflowTemplate, { failOnStatusCode: false });
       cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
     });
 
     it('can create a simple schedule of resource type Workflow job template, then delete the schedule', () => {

--- a/cypress/e2e/awx/resources/workflowVisualizerCRUD.cy.ts
+++ b/cypress/e2e/awx/resources/workflowVisualizerCRUD.cy.ts
@@ -7,21 +7,28 @@ import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { WorkflowJobTemplate } from '../../../../frontend/awx/interfaces/WorkflowJobTemplate';
 import { WorkflowNode } from '../../../../frontend/awx/interfaces/WorkflowNode';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
-
-describe('Workflow Visualizer', () => {
+describe('Wrapper, creates and deletes organization', () => {
   let awxOrganization: Organization;
-  let project: Project;
-  let inventory: Inventory;
-  let inventorySource: InventorySource;
-  let jobTemplate: JobTemplate;
-  let workflowJobTemplate: WorkflowJobTemplate;
-  let projectNode: WorkflowNode;
-  let approvalNode: WorkflowNode;
-  let workflowJtNode: WorkflowNode;
+  before(() => {
+    cy.createAwxOrganization().then((org) => {
+      awxOrganization = org;
+    });
+  });
 
-  before(function () {
-    cy.createAwxOrganization().then((thisAwxOrg) => {
-      awxOrganization = thisAwxOrg;
+  describe('Workflow Visualizer', () => {
+    // let awxOrganization: Organization;
+    let project: Project;
+    let inventory: Inventory;
+    let inventorySource: InventorySource;
+    let jobTemplate: JobTemplate;
+    let workflowJobTemplate: WorkflowJobTemplate;
+    let projectNode: WorkflowNode;
+    let approvalNode: WorkflowNode;
+    let workflowJtNode: WorkflowNode;
+
+    before(function () {
+      // cy.createAwxOrganization().then((thisAwxOrg) => {
+      //   awxOrganization = thisAwxOrg;
 
       cy.createAwxProject(awxOrganization).then((proj) => {
         project = proj;
@@ -41,29 +48,520 @@ describe('Workflow Visualizer', () => {
             }).then((jt) => (jobTemplate = jt));
           });
       });
+      // });
+    });
+
+    beforeEach(function () {
+      cy.createAwxWorkflowJobTemplate({
+        organization: awxOrganization.id,
+        inventory: inventory.id,
+      }).then((wfjt) => (workflowJobTemplate = wfjt));
+    });
+
+    // afterEach(() => {
+    //   cy.deleteAwxWorkflowJobTemplate(workflowJobTemplate, { failOnStatusCode: false });
+    // });
+
+    after(() => {
+      cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
+      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+      cy.deleteAwxProject(project, { failOnStatusCode: false });
+      cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
+    });
+
+    describe('Workflow Visualizer: Add Nodes', () => {
+      it('should render a workflow visualizer view with multiple nodes present', () => {
+        cy.renderWorkflowVisualizerNodesFromFixtureFile(
+          `${workflowJobTemplate.name}`,
+          'wf_vis_testing_A.json'
+        );
+        cy.get('[class*="66-node-label"]')
+          .should('exist')
+          .should('contain', 'Cleanup Activity Stream');
+        cy.get('[class*="43-node-label"]').should('exist').should('contain', 'bar');
+        cy.get('[class*="42-node-label"]').should('exist').should('contain', '1');
+        cy.get('[class*="41-node-label"]').should('exist').should('contain', 'Demo Project');
+      });
+
+      it('Should create a workflow job template and then navigate to the visualizer, and then navigate to the details view after clicking cancel', () => {
+        const jtName = 'E2E ' + randomString(4);
+        // Create workflow job template
+        cy.navigateTo('awx', 'templates');
+        cy.clickButton(/^Create template$/);
+        cy.clickLink(/^Create workflow job template$/);
+        cy.get('[data-cy="name"]').type(jtName);
+        cy.get('[data-cy="description"]').type('this is a description');
+        cy.intercept('POST', awxAPI`/workflow_job_templates/`).as('newWfjt');
+        cy.get('[data-cy="Submit"]').click();
+        cy.wait('@newWfjt')
+          .its('response.body')
+          .then((wfjt: WorkflowJobTemplate) => {
+            expect(wfjt.description).to.eql('this is a description');
+            cy.get('[data-cy="workflow-visualizer"]').should('be.visible');
+            cy.get('h4.pf-v5-c-empty-state__title-text').should(
+              'have.text',
+              'There are currently no nodes in this workflow'
+            );
+            cy.get('div.pf-v5-c-empty-state__actions').within(() => {
+              cy.get('[data-cy="add-node-button"]').should('be.visible');
+            });
+            cy.get('button[data-cy="workflow-visualizer-toolbar-close"]').click();
+            cy.getByDataCy('description').should('contain', wfjt.description);
+            cy.verifyPageTitle(`${jtName}`);
+            cy.deleteAwxWorkflowJobTemplate(wfjt, { failOnStatusCode: false });
+          });
+      });
+    });
+
+    describe('Workflow Visualizer: Add Node to Existing Visualizer', () => {
+      beforeEach(function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then((projNode) => {
+          projectNode = projNode;
+          cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
+            approvalNode = appNode;
+            cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
+          });
+        });
+      });
+
+      it('Adds a new node linked to an existing node with always status, and save the visualizer.', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+        cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+        cy.get('a[href*="/visualizer"]').click();
+        cy.contains('Workflow Visualizer').should('be.visible');
+        cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
+          force: true,
+        });
+        cy.getByDataCy('add-node-and-link').click();
+        cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+        cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+        cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
+        cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+        cy.getByDataCy('node-alias').type('Test Node');
+        cy.clickButton('Next');
+        cy.clickButton('Finish');
+        cy.intercept(
+          'POST',
+          awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/workflow_nodes/`
+        ).as('saved');
+        cy.clickButton('Save');
+        cy.wait('@saved');
+        cy.getByDataCy('alert-toaster').should('be.visible');
+        cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).should(
+          'have.text',
+          'Run on success'
+        );
+        cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
+        cy.get(`g[data-id=${approvalNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
+        cy.getBy('button[id="fit-to-screen"]').click();
+        cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+        cy.verifyPageTitle(`${workflowJobTemplate.name}`);
+      });
+
+      it('Adds a new node specifically linked to an already existing node.', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+        cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+        cy.get('a[href*="/visualizer"]').click();
+        cy.contains('Workflow Visualizer').should('be.visible');
+        cy.get(`g[data-id="${projectNode.id}"]`)
+          .should('be.visible')
+          .and('contain', `${projectNode?.summary_fields?.unified_job_template?.name}`);
+        cy.get(`g[data-id="${approvalNode.id}"] [class*="node-label"]`)
+          .should('be.visible')
+          .click();
+        cy.getByDataCy('workflow-topology-sidebar').should('be.visible');
+        cy.getByDataCy('type').should('contain', 'Workflow approval');
+        cy.getByDataCy('workflow-topology-sidebar').within(() => {
+          cy.getBy('[aria-label="Close"]').click();
+        });
+        cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
+          force: true,
+        });
+        cy.getByDataCy('add-node-and-link').click();
+        cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+        cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+        cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
+        cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+        cy.getByDataCy('node-alias').type('Test Node');
+        cy.clickButton('Next');
+        cy.clickButton('Finish');
+        cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
+        cy.get(`g[data-id=${approvalNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
+        cy.clickButton('Save');
+        cy.getByDataCy('alert-toaster').should(
+          'have.text',
+          'Success alert:Successfully saved workflow visualizer'
+        );
+        cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+        cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
+      });
+    });
+
+    describe('Workflow Visualizer: Edit', () => {
+      it('Can edit a node resource on a workflow visualizer already containing existing nodes', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
+          (projectNode) => {
+            cy.createAwxWorkflowVisualizerInventorySourceNode(
+              workflowJobTemplate,
+              inventorySource
+            ).then((inventorySourceNode) => {
+              cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1)
+                .then((managementNode) => {
+                  cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
+                  cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
+                })
+                .then(() => {
+                  cy.navigateTo('awx', 'templates');
+                  cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+                  cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+                  cy.get('a[href*="/visualizer"]').click();
+                  cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
+                    force: true,
+                  });
+                  cy.getByDataCy('edit-node').click();
+                  cy.getByDataCy('node-type-form-group').should(
+                    'have.text',
+                    'Node type * Project Sync'
+                  );
+                  cy.selectDropdownOptionByResourceName('node-type', 'Inventory Source Sync');
+                  cy.selectDropdownOptionByResourceName(
+                    'inventory-source-select',
+                    `${inventorySource.name}`
+                  );
+                  cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+                  cy.getByDataCy('node-alias').type('Inventory Source Node');
+                  cy.clickButton('Next');
+                  cy.clickButton('Finish');
+                  cy.get(`g[data-id=${projectNode.id}]`).should(
+                    'have.text',
+                    'Inventory Source Node'
+                  );
+                });
+            });
+            cy.clickButton('Save');
+            cy.getByDataCy('alert-toaster').should(
+              'have.text',
+              'Success alert:Successfully saved workflow visualizer'
+            );
+            cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+            cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
+          }
+        );
+      });
+
+      it('Click on edge context menu option to change link type and close visualizer to show unsaved changes modal', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
+          .then((projNode) => {
+            projectNode = projNode;
+            cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
+              approvalNode = appNode;
+              cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
+            });
+          })
+          .then(() => {
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+            cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+            cy.get('a[href*="/visualizer"]').click();
+            cy.contains('Workflow Visualizer').should('be.visible');
+            cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).should(
+              'have.text',
+              'Run on success'
+            );
+            cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).within(() => {
+              cy.getByDataCy('edge-context-menu_kebab').click({ force: true });
+            });
+            cy.getByDataCy('fail').click();
+            cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+            cy.getByDataCy('visualizer-unsaved-changes-modal').click();
+            cy.getByDataCy('exit-without-saving').click();
+            cy.verifyPageTitle(`${workflowJobTemplate.name}`);
+          });
+      });
+
+      it('Create a job template node using a JT with multiple dependencies and then edit the node to use a different resource', function () {
+        cy.navigateTo('awx', 'templates');
+        cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+        cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+        cy.get('a[href*="/visualizer"]').click();
+        cy.contains('Workflow Visualizer').should('be.visible');
+        cy.clickButton('Add step');
+        cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+        cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+        cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+        cy.getByDataCy('node-alias').type('Test Node');
+        cy.clickButton('Next');
+        cy.clickButton('Finish');
+        cy.get('g[data-id="1-unsavedNode"]').should('have.text', 'ALLTest Node');
+        cy.get(`g[data-id="1-unsavedNode"] .pf-topology__node__action-icon`).click({
+          force: true,
+        });
+        cy.getByDataCy('edit-node').click();
+        cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
+        cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+        cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+        cy.getByDataCy('node-alias').type(`Project Node`);
+        cy.clickButton('Next');
+        cy.clickButton('Finish');
+        cy.get('g[data-id="1-unsavedNode"]').should('have.text', 'ALLTest NodeProject Node');
+        cy.clickButton('Save');
+        cy.getByDataCy('alert-toaster').should('be.visible');
+        cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+        cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
+      });
+    });
+
+    describe('Workflow Visualizer: Remove and Add Nodes', () => {
+      it('Can manually delete all nodes, save the visualizer, then add new nodes, and successfully save again.', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
+          .then((projNode) => {
+            projectNode = projNode;
+            cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
+              approvalNode = appNode;
+              cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
+            });
+          })
+          .then(() => {
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+            cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+            cy.get('a[href*="/visualizer"]').click();
+            cy.contains('Workflow Visualizer').should('be.visible');
+            cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
+              force: true,
+            });
+            cy.getByDataCy('remove-node').click();
+            cy.clickModalConfirmCheckbox();
+            cy.clickModalButton('Remove');
+            cy.clickModalButton('Close');
+            cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
+              force: true,
+            });
+            cy.getByDataCy('remove-node').click();
+            cy.clickModalConfirmCheckbox();
+            cy.clickModalButton('Remove');
+            cy.clickModalButton('Close');
+            cy.clickButton('Save');
+            cy.getByDataCy('alert-toaster').should('be.visible');
+            cy.clickButton('Add step');
+            cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+            cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+            cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+            cy.getByDataCy('node-alias').type('Test Node');
+            cy.clickButton('Next');
+            cy.clickButton('Finish');
+            cy.get(`g[class*="unsavedNode-node-label"] .pf-topology__node__action-icon`).click({
+              force: true,
+            });
+            cy.getByDataCy('add-node-and-link').click();
+            cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
+            cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+            cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+            cy.getByDataCy('node-alias').type('Project Node');
+            cy.clickButton('Next');
+            cy.clickButton('Finish');
+            cy.clickButton('Save');
+            cy.getByDataCy('alert-toaster').should(
+              'have.text',
+              'Success alert:Successfully saved workflow visualizer'
+            );
+            cy.getBy('button[id="fit-to-screen"]').click();
+          });
+      });
+
+      it('Can remove all existing nodes on a visualizer using the button in the toolbar kebab, save the visualizer, then add 2 new nodes and save the visualizer again', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
+          (projectNode) => {
+            cy.createAwxWorkflowVisualizerInventorySourceNode(
+              workflowJobTemplate,
+              inventorySource
+            ).then((inventorySourceNode) => {
+              cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1)
+                .then((managementNode) => {
+                  cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
+                  cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
+                })
+                .then(() => {
+                  cy.navigateTo('awx', 'templates');
+                  cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+                  cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+                  cy.get('a[href*="/visualizer"]').click();
+                  cy.get('[data-cy="wf-vzr-name"]')
+                    .should('contain', `${workflowJobTemplate.name}`)
+                    .should('be.visible');
+                  cy.removeAllNodesFromVisualizerToolbar();
+                  cy.contains('button', 'Save').should('be.visible').click();
+                  cy.clickButton('Add step');
+                  cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+                  cy.selectDropdownOptionByResourceName(
+                    'job-template-select',
+                    `${jobTemplate.name}`
+                  );
+                  cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+                  cy.getByDataCy('node-alias').type('Test Node');
+                  cy.clickButton('Next');
+                  cy.clickButton('Finish');
+                  cy.clickButton('Add step');
+                  cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
+                  cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+                  cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+                  cy.clickButton('Next');
+                  cy.clickButton('Finish');
+                  cy.get('g[data-kind="node"]').should('have.length', 3);
+                  cy.clickButton('Save');
+                  cy.getByDataCy('alert-toaster').should(
+                    'have.text',
+                    'Success alert:Successfully saved workflow visualizer'
+                  );
+                  cy.getBy('button[id="fit-to-screen"]').click();
+                });
+            });
+          }
+        );
+      });
+    });
+
+    describe('Workflow Visualizer: Delete Nodes or Links', () => {
+      it('Remove all steps using the kebab menu of the visualizer toolbar and save changes', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
+          (projectNode) => {
+            cy.createAwxWorkflowVisualizerInventorySourceNode(
+              workflowJobTemplate,
+              inventorySource
+            ).then((inventorySourceNode) => {
+              cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1).then(
+                (managementNode) => {
+                  cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
+                  cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
+                }
+              );
+            });
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+            cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+            cy.get('a[href*="/visualizer"]').click();
+            cy.get('[data-cy="wf-vzr-name"]')
+              .should('contain', `${workflowJobTemplate.name}`)
+              .should('be.visible');
+            cy.removeAllNodesFromVisualizerToolbar();
+            cy.contains('button', 'Save').click();
+            cy.get('[data-kind="node"]').should('have.length', 0);
+          }
+        );
+      });
+
+      it('Can delete one single node and save the visualizer', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then((projNode) => {
+          projectNode = projNode;
+          cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then(() => {
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+            cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+            cy.get('a[href*="/visualizer"]').click();
+            cy.contains('Workflow Visualizer').should('be.visible');
+            cy.get('[data-kind="node"]').should('have.length', 3);
+            cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
+              force: true,
+            });
+            cy.getByDataCy('add-node-and-link').click();
+            cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
+            cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+            cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
+            cy.selectDropdownOptionByResourceName('node-convergence', 'All');
+            cy.getByDataCy('node-alias').type('Test Node');
+            cy.clickButton('Next');
+            cy.clickButton('Finish');
+            cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
+            cy.get(`g[data-id=${projectNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
+            cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
+              force: true,
+            });
+            cy.getByDataCy('remove-node').click();
+            cy.clickModalConfirmCheckbox();
+            cy.clickModalButton('Remove');
+            cy.clickModalButton('Close');
+            cy.clickButton('Save');
+            cy.getByDataCy('alert-toaster').should(
+              'have.text',
+              'Success alert:Successfully saved workflow visualizer'
+            );
+            cy.getByDataCy('workflow-visualizer-toolbar-close').click();
+            cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
+          });
+        });
+      });
+
+      it('Can access an existing workflow visualizer and delete the link between two nodes', function () {
+        cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
+          .then((projNode) => {
+            projectNode = projNode;
+            cy.createAwxWorkflowVisualizerWJTNode(workflowJobTemplate).then((wfjtNode) => {
+              workflowJtNode = wfjtNode;
+              cy.createWorkflowJTFailureNodeLink(projectNode, workflowJtNode);
+            });
+          })
+          .then(() => {
+            cy.navigateTo('awx', 'templates');
+            cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
+            cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
+            cy.get('a[href*="/visualizer"]').click();
+            cy.contains('Workflow Visualizer').should('be.visible');
+            cy.contains('Run on fail').should('be.visible');
+            cy.get(`g[data-id="${projectNode.id}-${workflowJtNode.id}"]`).within(() => {
+              cy.getByDataCy('edge-context-menu_kebab').click({ force: true });
+            });
+            cy.getByDataCy('remove-link').click();
+            cy.getModal().within(() => {
+              cy.get('[data-ouia-component-id="confirm"]').click();
+              cy.get('[data-ouia-component-id="submit"]').click();
+              cy.clickButton('Close');
+            });
+            cy.getByDataCy('workflow-visualizer-toolbar-save').click();
+            cy.getByDataCy('alert-toaster').should(
+              'have.text',
+              'Success alert:Successfully saved workflow visualizer'
+            );
+            cy.reload();
+            cy.contains('Workflow Visualizer').should('be.visible');
+            cy.contains('Run on fail').should('not.exist');
+          });
+      });
     });
   });
 
-  beforeEach(function () {
-    cy.createAwxWorkflowJobTemplate({
-      organization: awxOrganization.id,
-      inventory: inventory.id,
-    }).then((wfjt) => (workflowJobTemplate = wfjt));
-  });
-
-  afterEach(() => {
-    cy.deleteAwxWorkflowJobTemplate(workflowJobTemplate, { failOnStatusCode: false });
-  });
-
-  after(() => {
-    cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
-    cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-    cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-    cy.deleteAwxProject(project, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(awxOrganization, { failOnStatusCode: false });
-  });
-
   describe('Workflow Visualizer: Add Nodes', () => {
+    // let organization: Organization;
+    let inventory: Inventory;
+    let workflowJobTemplate: WorkflowJobTemplate;
+
+    before(function () {
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
+      cy.createAwxInventory(awxOrganization).then((i) => {
+        inventory = i;
+        // });
+      });
+    });
+
+    beforeEach(function () {
+      cy.createAwxWorkflowJobTemplate({
+        organization: awxOrganization.id,
+        inventory: inventory.id,
+      }).then((wfjt) => (workflowJobTemplate = wfjt));
+    });
+
+    afterEach(function () {
+      cy.deleteAwxWorkflowJobTemplate(workflowJobTemplate, { failOnStatusCode: false });
+    });
+
+    after(function () {
+      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    });
+
     it('should render a workflow visualizer view with multiple nodes present', () => {
       cy.renderWorkflowVisualizerNodesFromFixtureFile(
         `${workflowJobTemplate.name}`,
@@ -79,510 +577,30 @@ describe('Workflow Visualizer', () => {
 
     it('Should create a workflow job template and then navigate to the visualizer, and then navigate to the details view after clicking cancel', () => {
       const jtName = 'E2E ' + randomString(4);
+      const description = 'this is a description';
       // Create workflow job template
       cy.navigateTo('awx', 'templates');
       cy.clickButton(/^Create template$/);
       cy.clickLink(/^Create workflow job template$/);
-      cy.get('[data-cy="name"]').type(jtName);
-      cy.get('[data-cy="description"]').type('this is a description');
-      cy.intercept('POST', awxAPI`/workflow_job_templates/`).as('newWfjt');
-      cy.get('[data-cy="Submit"]').click();
-      cy.wait('@newWfjt')
-        .its('response.body')
-        .then((wfjt: WorkflowJobTemplate) => {
-          expect(wfjt.description).to.eql('this is a description');
-          cy.get('[data-cy="workflow-visualizer"]').should('be.visible');
-          cy.get('h4.pf-v5-c-empty-state__title-text').should(
-            'have.text',
-            'There are currently no nodes in this workflow'
-          );
-          cy.get('div.pf-v5-c-empty-state__actions').within(() => {
-            cy.get('[data-cy="add-node-button"]').should('be.visible');
-          });
-          cy.get('button[data-cy="workflow-visualizer-toolbar-close"]').click();
-          cy.getByDataCy('description').should('contain', wfjt.description);
-          cy.verifyPageTitle(`${jtName}`);
-          cy.deleteAwxWorkflowJobTemplate(wfjt, { failOnStatusCode: false });
-        });
-    });
-  });
-
-  describe('Workflow Visualizer: Add Node to Existing Visualizer', () => {
-    beforeEach(function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then((projNode) => {
-        projectNode = projNode;
-        cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
-          approvalNode = appNode;
-          cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
-        });
-      });
-    });
-
-    it('Adds a new node linked to an existing node with always status, and save the visualizer.', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-      cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-      cy.get('a[href*="/visualizer"]').click();
-      cy.contains('Workflow Visualizer').should('be.visible');
-      cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
-        force: true,
-      });
-      cy.getByDataCy('add-node-and-link').click();
-      cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-      cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-      cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
-      cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-      cy.getByDataCy('node-alias').type('Test Node');
-      cy.clickButton('Next');
-      cy.clickButton('Finish');
-      cy.intercept(
-        'POST',
-        awxAPI`/workflow_job_templates/${workflowJobTemplate.id.toString()}/workflow_nodes/`
-      ).as('saved');
-      cy.clickButton('Save');
-      cy.wait('@saved');
-      cy.getByDataCy('alert-toaster').should('be.visible');
-      cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).should(
-        'have.text',
-        'Run on success'
-      );
-      cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
-      cy.get(`g[data-id=${approvalNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
-      cy.getBy('button[id="fit-to-screen"]').click();
-      cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-      cy.verifyPageTitle(`${workflowJobTemplate.name}`);
-    });
-
-    it('Adds a new node specifically linked to an already existing node.', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-      cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-      cy.get('a[href*="/visualizer"]').click();
-      cy.contains('Workflow Visualizer').should('be.visible');
-      cy.get(`g[data-id="${projectNode.id}"]`)
+      cy.getByDataCy('name').type(jtName);
+      cy.getByDataCy('description').type(description);
+      cy.getByDataCy('Submit').click();
+      cy.location('pathname').should('match', /\/workflow-job-template\/\d+\/visualizer/);
+      cy.getByDataCy('empty-state-title')
         .should('be.visible')
-        .and('contain', `${projectNode?.summary_fields?.unified_job_template?.name}`);
-      cy.get(`g[data-id="${approvalNode.id}"] [class*="node-label"]`).should('be.visible').click();
-      cy.getByDataCy('workflow-topology-sidebar').should('be.visible');
-      cy.getByDataCy('type').should('contain', 'Workflow approval');
-      cy.getByDataCy('workflow-topology-sidebar').within(() => {
-        cy.getBy('[aria-label="Close"]').click();
-      });
-      cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
-        force: true,
-      });
-      cy.getByDataCy('add-node-and-link').click();
-      cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-      cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-      cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
-      cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-      cy.getByDataCy('node-alias').type('Test Node');
-      cy.clickButton('Next');
-      cy.clickButton('Finish');
-      cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
-      cy.get(`g[data-id=${approvalNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
-      cy.clickButton('Save');
-      cy.getByDataCy('alert-toaster').should(
-        'have.text',
-        'Success alert:Successfully saved workflow visualizer'
-      );
+        .contains('There are currently no nodes in this workflow');
+      cy.getByDataCy('add-node-button').should('be.visible').contains('Add step');
       cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-      cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
+      cy.location('pathname').should('match', /\/workflow-job-template\/\d+\/details/);
+      cy.verifyPageTitle(jtName);
+      cy.getByDataCy('label-name').should('contain', 'Name');
+      cy.getByDataCy('name').should('contain', jtName);
+      cy.getByDataCy('label-description').should('contain', 'Description');
+      cy.getByDataCy('description').should('contain', description);
+      cy.getByDataCy('actions-dropdown').click();
+      cy.getByDataCy('delete-template').click();
+      cy.clickModalConfirmCheckbox();
+      cy.clickModalButton('Delete template');
     });
-  });
-
-  describe('Workflow Visualizer: Edit', () => {
-    it('Can edit a node resource on a workflow visualizer already containing existing nodes', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
-        (projectNode) => {
-          cy.createAwxWorkflowVisualizerInventorySourceNode(
-            workflowJobTemplate,
-            inventorySource
-          ).then((inventorySourceNode) => {
-            cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1)
-              .then((managementNode) => {
-                cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
-                cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
-              })
-              .then(() => {
-                cy.navigateTo('awx', 'templates');
-                cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-                cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-                cy.get('a[href*="/visualizer"]').click();
-                cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
-                  force: true,
-                });
-                cy.getByDataCy('edit-node').click();
-                cy.getByDataCy('node-type-form-group').should(
-                  'have.text',
-                  'Node type * Project Sync'
-                );
-                cy.selectDropdownOptionByResourceName('node-type', 'Inventory Source Sync');
-                cy.selectDropdownOptionByResourceName(
-                  'inventory-source-select',
-                  `${inventorySource.name}`
-                );
-                cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-                cy.getByDataCy('node-alias').type('Inventory Source Node');
-                cy.clickButton('Next');
-                cy.clickButton('Finish');
-                cy.get(`g[data-id=${projectNode.id}]`).should('have.text', 'Inventory Source Node');
-              });
-          });
-          cy.clickButton('Save');
-          cy.getByDataCy('alert-toaster').should(
-            'have.text',
-            'Success alert:Successfully saved workflow visualizer'
-          );
-          cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-          cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
-        }
-      );
-    });
-
-    it('Click on edge context menu option to change link type and close visualizer to show unsaved changes modal', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
-        .then((projNode) => {
-          projectNode = projNode;
-          cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
-            approvalNode = appNode;
-            cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
-          });
-        })
-        .then(() => {
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-          cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-          cy.get('a[href*="/visualizer"]').click();
-          cy.contains('Workflow Visualizer').should('be.visible');
-          cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).should(
-            'have.text',
-            'Run on success'
-          );
-          cy.get(`g[data-id="${projectNode.id}-${approvalNode.id}"]`).within(() => {
-            cy.getByDataCy('edge-context-menu_kebab').click({ force: true });
-          });
-          cy.getByDataCy('fail').click();
-          cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-          cy.getByDataCy('visualizer-unsaved-changes-modal').click();
-          cy.getByDataCy('exit-without-saving').click();
-          cy.verifyPageTitle(`${workflowJobTemplate.name}`);
-        });
-    });
-
-    it('Create a job template node using a JT with multiple dependencies and then edit the node to use a different resource', function () {
-      cy.navigateTo('awx', 'templates');
-      cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-      cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-      cy.get('a[href*="/visualizer"]').click();
-      cy.contains('Workflow Visualizer').should('be.visible');
-      cy.clickButton('Add step');
-      cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-      cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-      cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-      cy.getByDataCy('node-alias').type('Test Node');
-      cy.clickButton('Next');
-      cy.clickButton('Finish');
-      cy.get('g[data-id="1-unsavedNode"]').should('have.text', 'ALLTest Node');
-      cy.get(`g[data-id="1-unsavedNode"] .pf-topology__node__action-icon`).click({
-        force: true,
-      });
-      cy.getByDataCy('edit-node').click();
-      cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
-      cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-      cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-      cy.getByDataCy('node-alias').type(`Project Node`);
-      cy.clickButton('Next');
-      cy.clickButton('Finish');
-      cy.get('g[data-id="1-unsavedNode"]').should('have.text', 'ALLTest NodeProject Node');
-      cy.clickButton('Save');
-      cy.getByDataCy('alert-toaster').should('be.visible');
-      cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-      cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
-    });
-  });
-
-  describe('Workflow Visualizer: Remove and Add Nodes', () => {
-    it('Can manually delete all nodes, save the visualizer, then add new nodes, and successfully save again.', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
-        .then((projNode) => {
-          projectNode = projNode;
-          cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then((appNode) => {
-            approvalNode = appNode;
-            cy.createWorkflowJTSuccessNodeLink(projectNode, appNode);
-          });
-        })
-        .then(() => {
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-          cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-          cy.get('a[href*="/visualizer"]').click();
-          cy.contains('Workflow Visualizer').should('be.visible');
-          cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
-            force: true,
-          });
-          cy.getByDataCy('remove-node').click();
-          cy.clickModalConfirmCheckbox();
-          cy.clickModalButton('Remove');
-          cy.clickModalButton('Close');
-          cy.get(`g[data-id=${approvalNode.id}] .pf-topology__node__action-icon`).click({
-            force: true,
-          });
-          cy.getByDataCy('remove-node').click();
-          cy.clickModalConfirmCheckbox();
-          cy.clickModalButton('Remove');
-          cy.clickModalButton('Close');
-          cy.clickButton('Save');
-          cy.getByDataCy('alert-toaster').should('be.visible');
-          cy.clickButton('Add step');
-          cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-          cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-          cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-          cy.getByDataCy('node-alias').type('Test Node');
-          cy.clickButton('Next');
-          cy.clickButton('Finish');
-          cy.get(`g[class*="unsavedNode-node-label"] .pf-topology__node__action-icon`).click({
-            force: true,
-          });
-          cy.getByDataCy('add-node-and-link').click();
-          cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
-          cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-          cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-          cy.getByDataCy('node-alias').type('Project Node');
-          cy.clickButton('Next');
-          cy.clickButton('Finish');
-          cy.clickButton('Save');
-          cy.getByDataCy('alert-toaster').should(
-            'have.text',
-            'Success alert:Successfully saved workflow visualizer'
-          );
-          cy.getBy('button[id="fit-to-screen"]').click();
-        });
-    });
-
-    it('Can remove all existing nodes on a visualizer using the button in the toolbar kebab, save the visualizer, then add 2 new nodes and save the visualizer again', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
-        (projectNode) => {
-          cy.createAwxWorkflowVisualizerInventorySourceNode(
-            workflowJobTemplate,
-            inventorySource
-          ).then((inventorySourceNode) => {
-            cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1)
-              .then((managementNode) => {
-                cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
-                cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
-              })
-              .then(() => {
-                cy.navigateTo('awx', 'templates');
-                cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-                cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-                cy.get('a[href*="/visualizer"]').click();
-                cy.get('[data-cy="wf-vzr-name"]')
-                  .should('contain', `${workflowJobTemplate.name}`)
-                  .should('be.visible');
-                cy.removeAllNodesFromVisualizerToolbar();
-                cy.contains('button', 'Save').should('be.visible').click();
-                cy.clickButton('Add step');
-                cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-                cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-                cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-                cy.getByDataCy('node-alias').type('Test Node');
-                cy.clickButton('Next');
-                cy.clickButton('Finish');
-                cy.clickButton('Add step');
-                cy.selectDropdownOptionByResourceName('node-type', 'Project Sync');
-                cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-                cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-                cy.clickButton('Next');
-                cy.clickButton('Finish');
-                cy.get('g[data-kind="node"]').should('have.length', 3);
-                cy.clickButton('Save');
-                cy.getByDataCy('alert-toaster').should(
-                  'have.text',
-                  'Success alert:Successfully saved workflow visualizer'
-                );
-                cy.getBy('button[id="fit-to-screen"]').click();
-              });
-          });
-        }
-      );
-    });
-  });
-
-  describe('Workflow Visualizer: Delete Nodes or Links', () => {
-    it('Remove all steps using the kebab menu of the visualizer toolbar and save changes', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then(
-        (projectNode) => {
-          cy.createAwxWorkflowVisualizerInventorySourceNode(
-            workflowJobTemplate,
-            inventorySource
-          ).then((inventorySourceNode) => {
-            cy.createAwxWorkflowVisualizerManagementNode(workflowJobTemplate, 1).then(
-              (managementNode) => {
-                cy.createWorkflowJTSuccessNodeLink(projectNode, inventorySourceNode);
-                cy.createWorkflowJTAlwaysNodeLink(inventorySourceNode, managementNode);
-              }
-            );
-          });
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-          cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-          cy.get('a[href*="/visualizer"]').click();
-          cy.get('[data-cy="wf-vzr-name"]')
-            .should('contain', `${workflowJobTemplate.name}`)
-            .should('be.visible');
-          cy.removeAllNodesFromVisualizerToolbar();
-          cy.contains('button', 'Save').click();
-          cy.get('[data-kind="node"]').should('have.length', 0);
-        }
-      );
-    });
-
-    it('Can delete one single node and save the visualizer', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project).then((projNode) => {
-        projectNode = projNode;
-        cy.createAwxWorkflowVisualizerApprovalNode(workflowJobTemplate).then(() => {
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-          cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-          cy.get('a[href*="/visualizer"]').click();
-          cy.contains('Workflow Visualizer').should('be.visible');
-          cy.get('[data-kind="node"]').should('have.length', 3);
-          cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
-            force: true,
-          });
-          cy.getByDataCy('add-node-and-link').click();
-          cy.selectDropdownOptionByResourceName('node-type', 'Job Template');
-          cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-          cy.selectDropdownOptionByResourceName('node-status-type', 'Always');
-          cy.selectDropdownOptionByResourceName('node-convergence', 'All');
-          cy.getByDataCy('node-alias').type('Test Node');
-          cy.clickButton('Next');
-          cy.clickButton('Finish');
-          cy.get('g[data-id="3-unsavedNode"]').should('have.text', 'ALLTest Node');
-          cy.get(`g[data-id=${projectNode.id}-3-unsavedNode]`).should('have.text', 'Run always');
-          cy.get(`g[data-id=${projectNode.id}] .pf-topology__node__action-icon`).click({
-            force: true,
-          });
-          cy.getByDataCy('remove-node').click();
-          cy.clickModalConfirmCheckbox();
-          cy.clickModalButton('Remove');
-          cy.clickModalButton('Close');
-          cy.clickButton('Save');
-          cy.getByDataCy('alert-toaster').should(
-            'have.text',
-            'Success alert:Successfully saved workflow visualizer'
-          );
-          cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-          cy.getByDataCy('page-title').should('have.text', `${workflowJobTemplate.name}`);
-        });
-      });
-    });
-
-    it('Can access an existing workflow visualizer and delete the link between two nodes', function () {
-      cy.createAwxWorkflowVisualizerProjectNode(workflowJobTemplate, project)
-        .then((projNode) => {
-          projectNode = projNode;
-          cy.createAwxWorkflowVisualizerWJTNode(workflowJobTemplate).then((wfjtNode) => {
-            workflowJtNode = wfjtNode;
-            cy.createWorkflowJTFailureNodeLink(projectNode, workflowJtNode);
-          });
-        })
-        .then(() => {
-          cy.navigateTo('awx', 'templates');
-          cy.filterTableByMultiSelect('name', [workflowJobTemplate.name]);
-          cy.clickTableRowLink('name', workflowJobTemplate.name, { disableFilter: true });
-          cy.get('a[href*="/visualizer"]').click();
-          cy.contains('Workflow Visualizer').should('be.visible');
-          cy.contains('Run on fail').should('be.visible');
-          cy.get(`g[data-id="${projectNode.id}-${workflowJtNode.id}"]`).within(() => {
-            cy.getByDataCy('edge-context-menu_kebab').click({ force: true });
-          });
-          cy.getByDataCy('remove-link').click();
-          cy.getModal().within(() => {
-            cy.get('[data-ouia-component-id="confirm"]').click();
-            cy.get('[data-ouia-component-id="submit"]').click();
-            cy.clickButton('Close');
-          });
-          cy.getByDataCy('workflow-visualizer-toolbar-save').click();
-          cy.getByDataCy('alert-toaster').should(
-            'have.text',
-            'Success alert:Successfully saved workflow visualizer'
-          );
-          cy.reload();
-          cy.contains('Workflow Visualizer').should('be.visible');
-          cy.contains('Run on fail').should('not.exist');
-        });
-    });
-  });
-});
-
-describe('Workflow Visualizer: Add Nodes', () => {
-  let organization: Organization;
-  let inventory: Inventory;
-  let workflowJobTemplate: WorkflowJobTemplate;
-
-  before(function () {
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
-      cy.createAwxInventory(organization).then((i) => {
-        inventory = i;
-      });
-    });
-  });
-
-  beforeEach(function () {
-    cy.createAwxWorkflowJobTemplate({
-      organization: organization.id,
-      inventory: inventory.id,
-    }).then((wfjt) => (workflowJobTemplate = wfjt));
-  });
-
-  afterEach(function () {
-    cy.deleteAwxWorkflowJobTemplate(workflowJobTemplate, { failOnStatusCode: false });
-  });
-
-  after(function () {
-    cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
-
-  it('should render a workflow visualizer view with multiple nodes present', () => {
-    cy.renderWorkflowVisualizerNodesFromFixtureFile(
-      `${workflowJobTemplate.name}`,
-      'wf_vis_testing_A.json'
-    );
-    cy.get('[class*="66-node-label"]').should('exist').should('contain', 'Cleanup Activity Stream');
-    cy.get('[class*="43-node-label"]').should('exist').should('contain', 'bar');
-    cy.get('[class*="42-node-label"]').should('exist').should('contain', '1');
-    cy.get('[class*="41-node-label"]').should('exist').should('contain', 'Demo Project');
-  });
-
-  it('Should create a workflow job template and then navigate to the visualizer, and then navigate to the details view after clicking cancel', () => {
-    const jtName = 'E2E ' + randomString(4);
-    const description = 'this is a description';
-    // Create workflow job template
-    cy.navigateTo('awx', 'templates');
-    cy.clickButton(/^Create template$/);
-    cy.clickLink(/^Create workflow job template$/);
-    cy.getByDataCy('name').type(jtName);
-    cy.getByDataCy('description').type(description);
-    cy.getByDataCy('Submit').click();
-    cy.location('pathname').should('match', /\/workflow-job-template\/\d+\/visualizer/);
-    cy.getByDataCy('empty-state-title')
-      .should('be.visible')
-      .contains('There are currently no nodes in this workflow');
-    cy.getByDataCy('add-node-button').should('be.visible').contains('Add step');
-    cy.getByDataCy('workflow-visualizer-toolbar-close').click();
-    cy.location('pathname').should('match', /\/workflow-job-template\/\d+\/details/);
-    cy.verifyPageTitle(jtName);
-    cy.getByDataCy('label-name').should('contain', 'Name');
-    cy.getByDataCy('name').should('contain', jtName);
-    cy.getByDataCy('label-description').should('contain', 'Description');
-    cy.getByDataCy('description').should('contain', description);
-    cy.getByDataCy('actions-dropdown').click();
-    cy.getByDataCy('delete-template').click();
-    cy.clickModalConfirmCheckbox();
-    cy.clickModalButton('Delete template');
   });
 });

--- a/cypress/e2e/awx/views/schedules.cy.ts
+++ b/cypress/e2e/awx/views/schedules.cy.ts
@@ -7,270 +7,285 @@ import { Project } from '../../../../frontend/awx/interfaces/Project';
 import { Schedule } from '../../../../frontend/awx/interfaces/Schedule';
 import { awxAPI } from '../../../support/formatApiPathForAwx';
 
-describe('Schedules - Create and Delete', () => {
-  describe('Schedules - Create schedule of resource type Job template', () => {
-    let organization: Organization;
-    let jobTemplate: JobTemplate;
-    let project: Project;
-    let inventory: Inventory;
+describe('Wrapper, creates and deletes organization', () => {
+  let organization: Organization;
+  let project: Project;
 
-    beforeEach(() => {
-      cy.createAwxOrganization().then((o) => {
-        organization = o;
-        cy.createAwxProject(organization).then((proj) => {
-          project = proj;
-          cy.createAwxInventory(organization).then((i) => {
-            inventory = i;
-            cy.createAwxJobTemplate({
-              name: 'E2E Schedules Create ' + randomString(4),
-              organization: organization.id,
-              project: project.id,
-              inventory: inventory.id,
-            }).then((jt) => {
-              jobTemplate = jt;
-            });
+  before(() => {
+    cy.createAwxOrganization().then((org) => {
+      organization = org;
+    });
+    cy.createAwxProject(organization).then((proj) => {
+      project = proj;
+    });
+  });
+  after(() => {
+    cy.deleteAwxOrganization(organization);
+    cy.deleteAwxProject(project);
+  });
+  describe('Schedules - Create and Delete', () => {
+    describe('Schedules - Create schedule of resource type Job template', () => {
+      let organization: Organization;
+      let jobTemplate: JobTemplate;
+      // let project: Project;
+      let inventory: Inventory;
+      beforeEach(() => {
+        // cy.createAwxOrganization().then((o) => {
+        // organization = o;
+        // cy.createAwxProject(organization).then((proj) => {
+        //   project = proj;
+        cy.createAwxInventory(organization).then((i) => {
+          inventory = i;
+          cy.createAwxJobTemplate({
+            name: 'E2E Schedules Create ' + randomString(4),
+            organization: organization.id,
+            project: project.id,
+            inventory: inventory.id,
+          }).then((jt) => {
+            jobTemplate = jt;
           });
+          // });
+          // });
         });
       });
-    });
 
-    afterEach(() => {
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxProject(project, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    });
-
-    it('can create a simple schedule or resource type Job template, navigate to schedule details, then delete the schedule from the details page', () => {
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      const scheduleName = 'E2E Simple Schedule' + randomString(4);
-      cy.getBy('[data-cy="create-schedule"]').click();
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
-      cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.singleSelectByDataCy('timezone', 'Zulu');
-      cy.clickButton(/^Next$/);
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('interval').clear().type('100');
-      cy.getByDataCy('count-form-group').type('17');
-      cy.getByDataCy('add-rule-button').click();
-      cy.getByDataCy('rrule-column-cell').then(($text) => {
-        cy.wrap($text).should('contains.text', 'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU');
+      afterEach(() => {
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        cy.deleteAwxProject(project, { failOnStatusCode: false });
+        // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
       });
 
-      cy.clickButton(/^Next$/);
-      cy.clickButton(/^Next$/);
-      cy.get('tr[data-cy="row-id-1"]').should('be.visible');
-      cy.clickButton(/^Finish$/);
-      cy.verifyPageTitle(`${scheduleName}`);
-      cy.get('button[data-cy="actions-dropdown"]').click();
-      cy.getBy('[data-cy="delete-schedule"]').click();
-      cy.clickModalConfirmCheckbox();
-      cy.clickModalButton('Delete schedule');
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-    });
-
-    it("can't create a schedule with missing resources", () => {
-      const scheduleName = 'E2E Schedule With Missing Resources' + randomString(4);
-      cy.deleteAwxInventory(inventory);
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      cy.getByDataCy('create-schedule').click();
-      cy.verifyPageTitle('Create schedule');
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
-      cy.selectDropdownOptionByResourceName('job-template-select', jobTemplate.name);
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.clickButton('Next');
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('interval').clear().type('100');
-      cy.clickButton('Save rule');
-      cy.clickButton('Next');
-      cy.clickButton('Next');
-      cy.clickButton('Finish');
-      cy.contains('Job Template inventory is missing or undefined.');
-    });
-  });
-
-  describe('Schedules - Create schedule of resource type Project', () => {
-    let organization: Organization;
-    let project: Project;
-
-    beforeEach(() => {
-      cy.createAwxOrganization().then((org) => {
-        organization = org;
-        cy.createAwxProject(organization).then((proj) => {
-          project = proj;
+      it('can create a simple schedule or resource type Job template, navigate to schedule details, then delete the schedule from the details page', () => {
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        const scheduleName = 'E2E Simple Schedule' + randomString(4);
+        cy.getBy('[data-cy="create-schedule"]').click();
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
+        cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.singleSelectByDataCy('timezone', 'Zulu');
+        cy.clickButton(/^Next$/);
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('interval').clear().type('100');
+        cy.getByDataCy('count-form-group').type('17');
+        cy.getByDataCy('add-rule-button').click();
+        cy.getByDataCy('rrule-column-cell').then(($text) => {
+          cy.wrap($text).should('contains.text', 'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU');
         });
+
+        cy.clickButton(/^Next$/);
+        cy.clickButton(/^Next$/);
+        cy.get('tr[data-cy="row-id-1"]').should('be.visible');
+        cy.clickButton(/^Finish$/);
+        cy.verifyPageTitle(`${scheduleName}`);
+        cy.get('button[data-cy="actions-dropdown"]').click();
+        cy.getBy('[data-cy="delete-schedule"]').click();
+        cy.clickModalConfirmCheckbox();
+        cy.clickModalButton('Delete schedule');
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+      });
+
+      it("can't create a schedule with missing resources", () => {
+        const scheduleName = 'E2E Schedule With Missing Resources' + randomString(4);
+        cy.deleteAwxInventory(inventory);
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        cy.getByDataCy('create-schedule').click();
+        cy.verifyPageTitle('Create schedule');
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
+        cy.selectDropdownOptionByResourceName('job-template-select', jobTemplate.name);
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.clickButton('Next');
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('interval').clear().type('100');
+        cy.clickButton('Save rule');
+        cy.clickButton('Next');
+        cy.clickButton('Next');
+        cy.clickButton('Finish');
+        cy.contains('Job Template inventory is missing or undefined.');
       });
     });
 
-    afterEach(() => {
-      cy.deleteAwxProject(project, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    describe('Schedules - Create schedule of resource type Project', () => {
+      // let organization: Organization;
+      // let project: Project;
+
+      // beforeEach(() => {
+      //   cy.createAwxOrganization().then((org) => {
+      //     organization = org;
+      //     cy.createAwxProject(organization).then((proj) => {
+      //       project = proj;
+      //     });
+      //   });
+      // });
+
+      // afterEach(() => {
+      //   cy.deleteAwxProject(project, { failOnStatusCode: false });
+      //   cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+      // });
+
+      it('can create a simple schedule of resource type Project and then delete the schedule', () => {
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        const scheduleName = 'E2E Simple Schedule Project' + randomString(4);
+        cy.getBy('[data-cy="create-schedule"]').click();
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Project Sync');
+        cy.selectDropdownOptionByResourceName('project', `${project.name}`);
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.singleSelectByDataCy('timezone', 'Zulu');
+        cy.clickButton(/^Next$/);
+        cy.getByDataCy('interval').clear().type('100');
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('count-form-group').type('17');
+        cy.getByDataCy('add-rule-button').click();
+        cy.get('tr[data-cy="row-id-1"]').within(() => {
+          cy.get('td[data-cy="rrule-column-cell"]').should(
+            'contains.text',
+            'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+          );
+        });
+        cy.clickButton(/^Next$/);
+        cy.clickButton(/^Next$/);
+        cy.get('tr[data-cy="row-id-1"]').should('be.visible');
+        cy.clickButton(/^Finish$/);
+        cy.get(`[data-cy="page-title"]`, { timeout: 60000 }).should('contain', `${scheduleName}`);
+        cy.get('button[data-cy="actions-dropdown"]').click();
+        cy.getBy('[data-cy="delete-schedule"]').click();
+        cy.clickModalConfirmCheckbox();
+        cy.clickModalButton('Delete schedule');
+      });
     });
 
-    it('can create a simple schedule of resource type Project and then delete the schedule', () => {
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      const scheduleName = 'E2E Simple Schedule Project' + randomString(4);
-      cy.getBy('[data-cy="create-schedule"]').click();
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Project Sync');
-      cy.selectDropdownOptionByResourceName('project', `${project.name}`);
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.singleSelectByDataCy('timezone', 'Zulu');
-      cy.clickButton(/^Next$/);
-      cy.getByDataCy('interval').clear().type('100');
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('count-form-group').type('17');
-      cy.getByDataCy('add-rule-button').click();
-      cy.get('tr[data-cy="row-id-1"]').within(() => {
-        cy.get('td[data-cy="rrule-column-cell"]').should(
-          'contains.text',
-          'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+    describe('Schedules - Create schedule of resource type Management job template', () => {
+      it('can create a simple schedule of resource type Management job template, then delete the schedule', () => {
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        const scheduleName = 'E2E Simple Schedule MJT' + randomString(4);
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        cy.getByDataCy('create-schedule').click();
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Management job template');
+        cy.selectDropdownOptionByResourceName(
+          'management-job-template-select',
+          'Cleanup Activity Stream'
         );
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.getByDataCy('description').type(`description ${scheduleName}`);
+        cy.singleSelectByDataCy('timezone', 'Zulu');
+        cy.getByDataCy('schedule-days-to-keep').type('33');
+        cy.clickButton(/^Next$/);
+        cy.getByDataCy('interval').clear().type('100');
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('count-form-group').type('17');
+        cy.getByDataCy('add-rule-button').click();
+        cy.get('tr[data-cy="row-id-1"]').within(() => {
+          cy.get('td[data-cy="rrule-column-cell"]').should(
+            'contains.text',
+            'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+          );
+        });
+        cy.clickButton(/^Next$/);
+        cy.clickButton(/^Next$/);
+        cy.get('tr[data-cy="row-id-1"]').should('be.visible');
+        cy.clickButton(/^Finish$/);
+
+        //Check details page
+        cy.verifyPageTitle(`${scheduleName}`);
+        cy.url().then((currentUrl) => {
+          expect(currentUrl.includes('details')).to.be.true;
+          expect(currentUrl.includes('administration/management-jobs')).to.be.true;
+        });
+        cy.getByDataCy('name').should('have.text', scheduleName);
+        cy.getByDataCy('description').should('have.text', `description ${scheduleName}`);
+        cy.getByDataCy('time-zone').should('have.text', 'Etc/Zulu');
+        cy.getByDataCy('days-of-data-to-keep').should('have.text', '33');
+
+        cy.get('button[data-cy="actions-dropdown"]').click();
+        cy.getByDataCy('delete-schedule').click();
+        cy.clickModalConfirmCheckbox();
+        cy.clickModalButton('Delete schedule');
       });
-      cy.clickButton(/^Next$/);
-      cy.clickButton(/^Next$/);
-      cy.get('tr[data-cy="row-id-1"]').should('be.visible');
-      cy.clickButton(/^Finish$/);
-      cy.get(`[data-cy="page-title"]`, { timeout: 60000 }).should('contain', `${scheduleName}`);
-      cy.get('button[data-cy="actions-dropdown"]').click();
-      cy.getBy('[data-cy="delete-schedule"]').click();
-      cy.clickModalConfirmCheckbox();
-      cy.clickModalButton('Delete schedule');
     });
-  });
 
-  describe('Schedules - Create schedule of resource type Management job template', () => {
-    it('can create a simple schedule of resource type Management job template, then delete the schedule', () => {
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      const scheduleName = 'E2E Simple Schedule MJT' + randomString(4);
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      cy.getByDataCy('create-schedule').click();
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Management job template');
-      cy.selectDropdownOptionByResourceName(
-        'management-job-template-select',
-        'Cleanup Activity Stream'
-      );
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.getByDataCy('description').type(`description ${scheduleName}`);
-      cy.singleSelectByDataCy('timezone', 'Zulu');
-      cy.getByDataCy('schedule-days-to-keep').type('33');
-      cy.clickButton(/^Next$/);
-      cy.getByDataCy('interval').clear().type('100');
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('count-form-group').type('17');
-      cy.getByDataCy('add-rule-button').click();
-      cy.get('tr[data-cy="row-id-1"]').within(() => {
-        cy.get('td[data-cy="rrule-column-cell"]').should(
-          'contains.text',
-          'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
-        );
-      });
-      cy.clickButton(/^Next$/);
-      cy.clickButton(/^Next$/);
-      cy.get('tr[data-cy="row-id-1"]').should('be.visible');
-      cy.clickButton(/^Finish$/);
-
-      //Check details page
-      cy.verifyPageTitle(`${scheduleName}`);
-      cy.url().then((currentUrl) => {
-        expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes('administration/management-jobs')).to.be.true;
-      });
-      cy.getByDataCy('name').should('have.text', scheduleName);
-      cy.getByDataCy('description').should('have.text', `description ${scheduleName}`);
-      cy.getByDataCy('time-zone').should('have.text', 'Etc/Zulu');
-      cy.getByDataCy('days-of-data-to-keep').should('have.text', '33');
-
-      cy.get('button[data-cy="actions-dropdown"]').click();
-      cy.getByDataCy('delete-schedule').click();
-      cy.clickModalConfirmCheckbox();
-      cy.clickModalButton('Delete schedule');
+    describe.skip('Schedules - Create schedule of resource type Workflow job template', () => {
+      //These tests live in the workflowJobTemplates.cy.ts spec file
     });
-  });
 
-  describe.skip('Schedules - Create schedule of resource type Workflow job template', () => {
-    //These tests live in the workflowJobTemplates.cy.ts spec file
-  });
+    describe('Schedules - Create schedule of resource type Inventory source', () => {
+      let organization: Organization;
+      let inventory: Inventory;
+      let project: Project;
+      let inventorySource: InventorySource;
 
-  describe('Schedules - Create schedule of resource type Inventory source', () => {
-    let organization: Organization;
-    let inventory: Inventory;
-    let project: Project;
-    let inventorySource: InventorySource;
-
-    before(() => {
-      cy.createAwxOrganization().then((o) => {
-        organization = o;
-        cy.createAwxProject(organization).then((proj) => {
-          project = proj;
-          cy.createAwxInventory(organization).then((i) => {
-            inventory = i;
-            cy.createAwxInventorySource(i, project).then((invSrc) => {
-              inventorySource = invSrc;
-            });
+      before(() => {
+        // cy.createAwxOrganization().then((o) => {
+        //   organization = o;
+        //   cy.createAwxProject(organization).then((proj) => {
+        //     project = proj;
+        cy.createAwxInventory(organization).then((i) => {
+          inventory = i;
+          cy.createAwxInventorySource(i, project).then((invSrc) => {
+            inventorySource = invSrc;
           });
+          //   });
+          // });
         });
       });
-    });
 
-    after(() => {
-      cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxProject(project, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    });
-
-    it('can create a simple schedule of resource type Inventory source, then delete the schedule', () => {
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      const scheduleName = 'E2E Simple Schedule Inventory ' + randomString(4);
-      cy.getBy('[data-cy="create-schedule"]').click();
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Inventory source');
-      cy.selectDropdownOptionByResourceName('inventory', `${inventory.name}`);
-      cy.selectDropdownOptionByResourceName('inventory-source-select', `${inventorySource.name}`);
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.singleSelectByDataCy('timezone', 'Zulu');
-      cy.clickButton(/^Next$/);
-      cy.getByDataCy('interval').clear().type('100');
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('count-form-group').type('17');
-      cy.getByDataCy('add-rule-button').click();
-      cy.get('tr[data-cy="row-id-1"]').within(() => {
-        cy.get('td[data-cy="rrule-column-cell"]').should(
-          'contains.text',
-          'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
-        );
+      after(() => {
+        cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        // cy.deleteAwxProject(project, { failOnStatusCode: false });
+        // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
       });
-      cy.clickButton(/^Next$/);
-      cy.clickButton(/^Next$/);
-      cy.get('tr[data-cy="row-id-1"]').should('be.visible');
-      cy.clickButton(/^Finish$/);
-      cy.verifyPageTitle(`${scheduleName}`);
-      cy.get('button[data-cy="actions-dropdown"]').click();
-      cy.getBy('[data-cy="delete-schedule"]').click();
-      cy.clickModalConfirmCheckbox();
-      cy.clickModalButton('Delete schedule');
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
+
+      it('can create a simple schedule of resource type Inventory source, then delete the schedule', () => {
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        const scheduleName = 'E2E Simple Schedule Inventory ' + randomString(4);
+        cy.getBy('[data-cy="create-schedule"]').click();
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Inventory source');
+        cy.selectDropdownOptionByResourceName('inventory', `${inventory.name}`);
+        cy.selectDropdownOptionByResourceName('inventory-source-select', `${inventorySource.name}`);
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.singleSelectByDataCy('timezone', 'Zulu');
+        cy.clickButton(/^Next$/);
+        cy.getByDataCy('interval').clear().type('100');
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('count-form-group').type('17');
+        cy.getByDataCy('add-rule-button').click();
+        cy.get('tr[data-cy="row-id-1"]').within(() => {
+          cy.get('td[data-cy="rrule-column-cell"]').should(
+            'contains.text',
+            'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+          );
+        });
+        cy.clickButton(/^Next$/);
+        cy.clickButton(/^Next$/);
+        cy.get('tr[data-cy="row-id-1"]').should('be.visible');
+        cy.clickButton(/^Finish$/);
+        cy.verifyPageTitle(`${scheduleName}`);
+        cy.get('button[data-cy="actions-dropdown"]').click();
+        cy.getBy('[data-cy="delete-schedule"]').click();
+        cy.clickModalConfirmCheckbox();
+        cy.clickModalButton('Delete schedule');
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        cy.deleteAwxInventorySource(inventorySource, { failOnStatusCode: false });
+      });
     });
-  });
 
-  describe('Schedules - Create Schedule with Prompts, Surveys and Exceptions', () => {
-    const scheduleName = 'E2E Complex Schedule' + randomString(4);
-    const surveyAnswer = 'E2E survey answer' + randomString(4);
-    let organization: Organization;
-    let jobTemplate: JobTemplate;
-    let project: Project;
-    let inventory: Inventory;
+    describe('Schedules - Create Schedule with Prompts, Surveys and Exceptions', () => {
+      const scheduleName = 'E2E Complex Schedule' + randomString(4);
+      const surveyAnswer = 'E2E survey answer' + randomString(4);
+      let organization: Organization;
+      let jobTemplate: JobTemplate;
+      let project: Project;
+      let inventory: Inventory;
 
-    beforeEach(() => {
-      cy.createAwxOrganization().then((o) => {
-        organization = o;
+      beforeEach(() => {
+        // cy.createAwxOrganization().then((o) => {
+        //   organization = o;
         cy.createAwxProject(organization).then((proj) => {
           project = proj;
           cy.createAwxInventory(organization).then((i) => {
@@ -307,374 +322,254 @@ describe('Schedules - Create and Delete', () => {
               cy.createAwxSurvey(surveySpec, jobTemplate);
             });
           });
-        });
-      });
-    });
-
-    afterEach(() => {
-      cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-      cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
-      cy.deleteAwxProject(project, { failOnStatusCode: false });
-      cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    });
-
-    it('can create a complex schedule and navigate to details page', () => {
-      cy.navigateTo('awx', 'schedules');
-      cy.verifyPageTitle('Schedules');
-      cy.getByDataCy('create-schedule').click();
-      cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
-      cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
-      cy.getByDataCy('name').type(`${scheduleName}`);
-      cy.singleSelectByDataCy('timezone', 'America/Mexico_City');
-      cy.clickButton(/^Next$/);
-
-      cy.getByDataCy('wizard-nav').within(() => {
-        ['Details', 'Prompts', 'Survey', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-          cy.get('li')
-            .eq(index)
-            .should((el) => expect(el.text().trim()).to.equal(text));
+          // });
         });
       });
 
-      //Prompts step
-      cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Prompts');
-      cy.get('input[placeholder="Select or create job tags"]').type('test_job_tag');
-      cy.get('[id="prompt.job_tags"]').find('button').click();
-      cy.get('input[placeholder="Select or create skip tags"]').type('test_skip_tag');
-      cy.get('[id="prompt.skip_tags"]').find('button').click();
-      cy.clickButton(/^Next$/);
-
-      //Survey step
-      cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Survey');
-      cy.getByDataCy('survey-test').type(surveyAnswer);
-      cy.clickButton(/^Next$/);
-
-      //Rules step
-      cy.get('[data-cy="wizard-nav"] li').eq(3).should('contain.text', 'Rules');
-      cy.selectDropdownOptionByResourceName('freq', 'Hourly');
-      cy.getByDataCy('interval').clear().type('100');
-      cy.getByDataCy('count-form-group').type('17');
-      cy.getByDataCy('add-rule-button').click();
-      cy.get('tr[data-cy="row-id-1"]').within(() => {
-        cy.get('td[data-cy="rrule-column-cell"]').should(
-          'contains.text',
-          'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
-        );
+      afterEach(() => {
+        cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
+        cy.deleteAwxInventory(inventory, { failOnStatusCode: false });
+        cy.deleteAwxProject(project, { failOnStatusCode: false });
+        // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
       });
-      cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-        cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
-        cy.get('tbody tr').should('have.length', 1);
-      });
-      cy.clickButton(/^Next$/);
 
-      //Exception step
-      cy.get('[data-cy="wizard-nav"] li').eq(4).should('contain.text', 'Exceptions');
-      cy.getByDataCy('page-title').contains('Schedule Exceptions');
-      cy.getByDataCy('empty-state-title').contains('No exceptions yet');
-      cy.getByDataCy('To get started, create an exception.').should('be.visible');
-      cy.getByDataCy('create-exception').click();
-      cy.getByDataCy('interval').clear().type('200');
-      cy.selectDropdownOptionByResourceName('freq', 'Yearly');
-      cy.getByDataCy('count-form-group').type('27');
-      cy.getByDataCy('add-rule-button').click();
-      cy.get('tr[data-cy="row-id-1"]').within(() => {
-        cy.get('td[data-cy="rrule-column-cell"]').should(
-          'contains.text',
-          'RRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU'
-        );
-      });
-      cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.getByDataCy('exceptions-column-header')
-          .should('be.visible')
-          .and('contain', 'Exceptions');
-        cy.getByDataCy('exceptions-column-cell').should('have.descendants', 'ul');
-        cy.get('tbody tr').should('have.length', 1);
-      });
-      cy.clickButton(/^Next$/);
+      it('can create a complex schedule and navigate to details page', () => {
+        cy.navigateTo('awx', 'schedules');
+        cy.verifyPageTitle('Schedules');
+        cy.getByDataCy('create-schedule').click();
+        cy.selectDropdownOptionByResourceName('schedule_type', 'Job template');
+        cy.selectDropdownOptionByResourceName('job-template-select', `${jobTemplate.name}`);
+        cy.getByDataCy('name').type(`${scheduleName}`);
+        cy.singleSelectByDataCy('timezone', 'America/Mexico_City');
+        cy.clickButton(/^Next$/);
 
-      //Review step
-      cy.get('[data-cy="wizard-nav"] li').eq(5).should('contain.text', 'Review');
-      cy.getByDataCy('resource-type').contains('Job Template');
-      cy.getByDataCy('name').contains(scheduleName);
-      cy.getByDataCy('local-time-zone').contains('America/Mexico_City');
-      cy.getByDataCy('inventory').contains(inventory.name);
-      cy.getByDataCy('project').contains(project.name);
-      cy.getByDataCy('code-block-value').contains(`test: ${surveyAnswer}`);
-      cy.intercept('POST', awxAPI`/job_templates/*/schedules/`).as('scheduleCreated');
-
-      cy.clickButton(/^Finish$/);
-      cy.wait('@scheduleCreated')
-        .then((response) => {
-          expect(response?.response?.statusCode).to.eql(201);
-        })
-        .its('response.body')
-        .then((response: Schedule) => {
-          expect(response.rrule).contains('DTSTART;TZID=America/Mexico_City');
-          expect(response.rrule).contains('RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU;COUNT=17');
-          expect(response.rrule).contains('EXRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU;COUNT=27');
-          expect(response.skip_tags).contains('test_skip_tag');
-          expect(response.enabled).to.be.true;
+        cy.getByDataCy('wizard-nav').within(() => {
+          ['Details', 'Prompts', 'Survey', 'Rules', 'Exceptions', 'Review'].forEach(
+            (text, index) => {
+              cy.get('li')
+                .eq(index)
+                .should((el) => expect(el.text().trim()).to.equal(text));
+            }
+          );
         });
 
-      //Check details page
-      cy.verifyPageTitle(`${scheduleName}`);
-      cy.url().then((currentUrl) => {
-        expect(currentUrl.includes('details')).to.be.true;
-        expect(currentUrl.includes('/templates/job-template/')).to.be.true;
-      });
-      cy.getByDataCy('name').should('have.text', scheduleName);
-      cy.getByDataCy('time-zone').should('have.text', 'America/Mexico_City');
-      cy.getByDataCy('job-tags').should('have.text', 'test_job_tag');
-      cy.getByDataCy('skip-tags').should('have.text', 'test_skip_tag');
-      cy.getByDataCy('rruleset').contains('DTSTART;TZID=America/Mexico_City');
-      cy.getByDataCy('rruleset').contains('RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU;COUNT=17');
-      cy.getByDataCy('rruleset').contains('EXRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU;COUNT=27');
-      cy.getByDataCy('code-block-value').should('have.text', `test: ${surveyAnswer}`);
-      cy.get('[data-ouia-component-id="simple-table"]')
-        .first()
-        .scrollIntoView()
-        .within(() => {
+        //Prompts step
+        cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Prompts');
+        cy.get('input[placeholder="Select or create job tags"]').type('test_job_tag');
+        cy.get('[id="prompt.job_tags"]').find('button').click();
+        cy.get('input[placeholder="Select or create skip tags"]').type('test_skip_tag');
+        cy.get('[id="prompt.skip_tags"]').find('button').click();
+        cy.clickButton(/^Next$/);
+
+        //Survey step
+        cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Survey');
+        cy.getByDataCy('survey-test').type(surveyAnswer);
+        cy.clickButton(/^Next$/);
+
+        //Rules step
+        cy.get('[data-cy="wizard-nav"] li').eq(3).should('contain.text', 'Rules');
+        cy.selectDropdownOptionByResourceName('freq', 'Hourly');
+        cy.getByDataCy('interval').clear().type('100');
+        cy.getByDataCy('count-form-group').type('17');
+        cy.getByDataCy('add-rule-button').click();
+        cy.get('tr[data-cy="row-id-1"]').within(() => {
+          cy.get('td[data-cy="rrule-column-cell"]').should(
+            'contains.text',
+            'RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU'
+          );
+        });
+        cy.get('[data-ouia-component-id="simple-table"]').within(() => {
           cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
           cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 1);
         });
+        cy.clickButton(/^Next$/);
 
-      cy.get('[data-ouia-component-id="simple-table"]')
-        .last()
-        .scrollIntoView()
-        .within(() => {
+        //Exception step
+        cy.get('[data-cy="wizard-nav"] li').eq(4).should('contain.text', 'Exceptions');
+        cy.getByDataCy('page-title').contains('Schedule Exceptions');
+        cy.getByDataCy('empty-state-title').contains('No exceptions yet');
+        cy.getByDataCy('To get started, create an exception.').should('be.visible');
+        cy.getByDataCy('create-exception').click();
+        cy.getByDataCy('interval').clear().type('200');
+        cy.selectDropdownOptionByResourceName('freq', 'Yearly');
+        cy.getByDataCy('count-form-group').type('27');
+        cy.getByDataCy('add-rule-button').click();
+        cy.get('tr[data-cy="row-id-1"]').within(() => {
+          cy.get('td[data-cy="rrule-column-cell"]').should(
+            'contains.text',
+            'RRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU'
+          );
+        });
+        cy.get('[data-ouia-component-id="simple-table"]').within(() => {
           cy.getByDataCy('exceptions-column-header')
             .should('be.visible')
             .and('contain', 'Exceptions');
           cy.getByDataCy('exceptions-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 1);
         });
-    });
-  });
-});
+        cy.clickButton(/^Next$/);
 
-describe('Schedules - Bulk deletion', () => {
-  let project: Project;
-  let organization: Organization;
-  const arrayOfElementText: string[] = [];
+        //Review step
+        cy.get('[data-cy="wizard-nav"] li').eq(5).should('contain.text', 'Review');
+        cy.getByDataCy('resource-type').contains('Job Template');
+        cy.getByDataCy('name').contains(scheduleName);
+        cy.getByDataCy('local-time-zone').contains('America/Mexico_City');
+        cy.getByDataCy('inventory').contains(inventory.name);
+        cy.getByDataCy('project').contains(project.name);
+        cy.getByDataCy('code-block-value').contains(`test: ${surveyAnswer}`);
+        cy.intercept('POST', awxAPI`/job_templates/*/schedules/`).as('scheduleCreated');
 
-  const testSignature: string = randomString(5, undefined, { isLowercase: true });
-  function generateScheduleName(): string {
-    return `test-${testSignature}-schedule-${randomString(5, undefined, { isLowercase: true })}`;
-  }
-
-  before(() => {
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
-      cy.createAwxProject(organization).then((proj) => {
-        project = proj;
-        for (let i = 0; i < 5; i++) {
-          const scheduleName = generateScheduleName();
-          cy.createAWXSchedule({
-            name: scheduleName,
-            unified_job_template: project.id,
-            rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
+        cy.clickButton(/^Finish$/);
+        cy.wait('@scheduleCreated')
+          .then((response) => {
+            expect(response?.response?.statusCode).to.eql(201);
+          })
+          .its('response.body')
+          .then((response: Schedule) => {
+            expect(response.rrule).contains('DTSTART;TZID=America/Mexico_City');
+            expect(response.rrule).contains('RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU;COUNT=17');
+            expect(response.rrule).contains('EXRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU;COUNT=27');
+            expect(response.skip_tags).contains('test_skip_tag');
+            expect(response.enabled).to.be.true;
           });
-          arrayOfElementText.push(scheduleName);
-        }
+
+        //Check details page
+        cy.verifyPageTitle(`${scheduleName}`);
+        cy.url().then((currentUrl) => {
+          expect(currentUrl.includes('details')).to.be.true;
+          expect(currentUrl.includes('/templates/job-template/')).to.be.true;
+        });
+        cy.getByDataCy('name').should('have.text', scheduleName);
+        cy.getByDataCy('time-zone').should('have.text', 'America/Mexico_City');
+        cy.getByDataCy('job-tags').should('have.text', 'test_job_tag');
+        cy.getByDataCy('skip-tags').should('have.text', 'test_skip_tag');
+        cy.getByDataCy('rruleset').contains('DTSTART;TZID=America/Mexico_City');
+        cy.getByDataCy('rruleset').contains('RRULE:FREQ=HOURLY;INTERVAL=100;WKST=SU;COUNT=17');
+        cy.getByDataCy('rruleset').contains('EXRULE:FREQ=YEARLY;INTERVAL=200;WKST=SU;COUNT=27');
+        cy.getByDataCy('code-block-value').should('have.text', `test: ${surveyAnswer}`);
+        cy.get('[data-ouia-component-id="simple-table"]')
+          .first()
+          .scrollIntoView()
+          .within(() => {
+            cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
+            cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+            cy.get('tbody tr').should('have.length', 1);
+          });
+
+        cy.get('[data-ouia-component-id="simple-table"]')
+          .last()
+          .scrollIntoView()
+          .within(() => {
+            cy.getByDataCy('exceptions-column-header')
+              .should('be.visible')
+              .and('contain', 'Exceptions');
+            cy.getByDataCy('exceptions-column-cell').should('have.descendants', 'ul');
+            cy.get('tbody tr').should('have.length', 1);
+          });
       });
     });
   });
 
-  after(() => {
-    cy.deleteAwxProject(project, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-  });
+  describe('Schedules - Bulk deletion', () => {
+    // let project: Project;
+    // let organization: Organization;
+    const arrayOfElementText: string[] = [];
 
-  it('user can bulk delete schedules from the Schedules list page ', () => {
-    cy.intercept('DELETE', awxAPI`/schedules/*`).as('deletedSchedule');
+    const testSignature: string = randomString(5, undefined, { isLowercase: true });
+    function generateScheduleName(): string {
+      return `test-${testSignature}-schedule-${randomString(5, undefined, { isLowercase: true })}`;
+    }
 
-    cy.navigateTo('awx', 'schedules');
-    cy.verifyPageTitle('Schedules');
-    cy.filterTableByMultiSelect('name', arrayOfElementText);
-    cy.get('tbody tr').should('have.length', 5);
-    cy.getByDataCy('select-all').click();
-    cy.clickToolbarKebabAction('delete-schedules');
-    cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
-      cy.get('header').contains('Permanently delete schedule');
-      cy.get('button').contains('Delete schedule').should('have.attr', 'aria-disabled', 'true');
-      cy.get('input[id="confirm"]').click();
-      cy.get('button').contains('Delete schedule').click();
-    });
-    cy.wait('@deletedSchedule')
-      .its('response')
-      .then((response) => {
-        expect(response?.statusCode).to.eql(204);
-      });
-  });
-});
-
-describe('Schedules - Edit', () => {
-  let schedule: Schedule;
-  let project: Project;
-  let organization: Organization;
-  let jobTemplate: JobTemplate;
-
-  beforeEach(() => {
-    const name = 'E2E Edit Schedule ' + randomString(4);
-    cy.createAwxOrganization().then((org) => {
-      organization = org;
-      cy.createAwxProject(organization).then((proj) => {
-        project = proj;
+    before(() => {
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
+      //   cy.createAwxProject(organization).then((proj) => {
+      //     project = proj;
+      for (let i = 0; i < 5; i++) {
+        const scheduleName = generateScheduleName();
         cy.createAWXSchedule({
-          name,
+          name: scheduleName,
           unified_job_template: project.id,
           rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
-        }).then((sched: Schedule) => {
-          schedule = sched;
         });
-      });
+        arrayOfElementText.push(scheduleName);
+      }
+      //   });
+      // });
     });
 
-    cy.navigateTo('awx', 'schedules');
-    cy.verifyPageTitle('Schedules');
+    // after(() => {
+    //   cy.deleteAwxProject(project, { failOnStatusCode: false });
+    //   cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+    // });
+
+    it('user can bulk delete schedules from the Schedules list page ', () => {
+      cy.intercept('DELETE', awxAPI`/schedules/*`).as('deletedSchedule');
+
+      cy.navigateTo('awx', 'schedules');
+      cy.verifyPageTitle('Schedules');
+      cy.filterTableByMultiSelect('name', arrayOfElementText);
+      cy.get('tbody tr').should('have.length', 5);
+      cy.getByDataCy('select-all').click();
+      cy.clickToolbarKebabAction('delete-schedules');
+      cy.get('[data-ouia-component-type="PF5/ModalContent"]').within(() => {
+        cy.get('header').contains('Permanently delete schedule');
+        cy.get('button').contains('Delete schedule').should('have.attr', 'aria-disabled', 'true');
+        cy.get('input[id="confirm"]').click();
+        cy.get('button').contains('Delete schedule').click();
+      });
+      cy.wait('@deletedSchedule')
+        .its('response')
+        .then((response) => {
+          expect(response?.statusCode).to.eql(204);
+        });
+    });
   });
 
-  afterEach(() => {
-    cy.deleteAWXSchedule(schedule, { failOnStatusCode: false });
-    cy.deleteAwxProject(project, { failOnStatusCode: false });
-    cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
-    jobTemplate?.id && cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
-  });
-
-  it('can edit a simple schedule from details page', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('name-column-cell').click();
-    cy.getByDataCy('edit-schedule').click();
-    cy.getByDataCy('wizard-nav').within(() => {
-      ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-        cy.get('li')
-          .eq(index)
-          .should((el) => expect(el.text().trim()).to.equal(text));
+  describe('Schedules - Edit', () => {
+    let schedule: Schedule;
+    // let project: Project;
+    // let organization: Organization;
+    let jobTemplate: JobTemplate;
+    // before(() => {
+    //   cy.createAwxOrganization().then((org) => {
+    //     organization = org;
+    //   });
+    // });
+    // after(() => {
+    //   cy.deleteAwxOrganization(organization);
+    // });
+    beforeEach(() => {
+      const name = 'E2E Edit Schedule ' + randomString(4);
+      // cy.createAwxOrganization().then((org) => {
+      //   organization = org;
+      // cy.createAwxProject(organization).then((proj) => {
+      //   project = proj;
+      cy.createAWXSchedule({
+        name,
+        unified_job_template: project.id,
+        rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
+      }).then((sched: Schedule) => {
+        schedule = sched;
       });
-    });
-    cy.getByDataCy('description').type('-edited');
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.getByDataCy('description').contains('-edited');
-    cy.clickButton(/^Finish$/);
-    cy.verifyPageTitle(schedule.name);
-  });
+      // });
+      // });
 
-  it('can edit a simple schedule from the schedules list row', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('edit-schedule').click();
-    cy.getByDataCy('wizard-nav').within(() => {
-      ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-        cy.get('li')
-          .eq(index)
-          .should((el) => expect(el.text().trim()).to.equal(text));
-      });
+      cy.navigateTo('awx', 'schedules');
+      cy.verifyPageTitle('Schedules');
     });
-    cy.getByDataCy('description').type('-edited');
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.getByDataCy('description').contains('-edited');
-    cy.clickButton(/^Finish$/);
-    cy.verifyPageTitle(schedule.name);
-  });
 
-  it('can edit a schedule to add rules', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('edit-schedule').click();
-    cy.getByDataCy('wizard-nav').within(() => {
-      ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-        cy.get('li')
-          .eq(index)
-          .should((el) => expect(el.text().trim()).to.equal(text));
-      });
+    afterEach(() => {
+      cy.deleteAWXSchedule(schedule, { failOnStatusCode: false });
+      // cy.deleteAwxProject(project, { failOnStatusCode: false });
+      // cy.deleteAwxOrganization(organization, { failOnStatusCode: false });
+      jobTemplate?.id && cy.deleteAwxJobTemplate(jobTemplate, { failOnStatusCode: false });
     });
-    cy.singleSelectByDataCy('timezone', 'America/Mexico_City');
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Add rule$/);
-    cy.clickButton(/^Save rule$/);
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.getByDataCy('row-id-1').should('exist');
-    cy.getByDataCy('row-id-1').contains('FREQ=WEEKLY');
-    cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-      cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-      cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
-      cy.get('tbody tr').should('have.length', 2);
-    });
-    cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
-    cy.clickButton(/^Finish$/);
 
-    cy.wait('@editedSchedule')
-      .its('response.statusCode')
-      .then((statusCode) => {
-        expect(statusCode).to.eql(200);
-      });
-    cy.verifyPageTitle(schedule.name);
-  });
-
-  it('can edit a schedule to add exceptions', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('edit-schedule').click();
-    cy.getByDataCy('wizard-nav').within(() => {
-      ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-        cy.get('li')
-          .eq(index)
-          .should((el) => expect(el.text().trim()).to.equal(text));
-      });
-    });
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Create exception$/);
-    cy.getByDataCy('freq-form-group').click();
-    cy.getByDataCy('freq').within(() => {
-      cy.clickButton('Yearly');
-    });
-    cy.clickButton(/^Save exception$/);
-    cy.clickButton(/^Next$/);
-    cy.getByDataCy('row-id-1').contains('FREQ=YEARLY');
-    cy.clickButton(/^Finish$/);
-    cy.verifyPageTitle(schedule.name);
-  });
-
-  it('can edit a schedule to remove rules', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('edit-schedule').click();
-    cy.getByDataCy('wizard-nav').within(() => {
-      ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
-        cy.get('li')
-          .eq(index)
-          .should((el) => expect(el.text().trim()).to.equal(text));
-      });
-    });
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Add rule$/);
-    cy.getBy('[data-cy="row-id-1"]').within(() => {
-      cy.getBy('[data-cy="delete-rule"]').click();
-    });
-    cy.clickButton(/^Save rule$/);
-    cy.clickButton(/^Next$/);
-    cy.clickButton(/^Next$/);
-    cy.getByDataCy('row-id-1').should('not.contain', 'FREQ=DAILY');
-    cy.clickButton(/^Finish$/);
-    cy.verifyPageTitle(schedule.name);
-  });
-
-  it('can edit a schedule remove exceptions from row action', () => {
-    cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
-
-    let schedToEdit: Schedule;
-    cy.createAWXSchedule({
-      name: 'E2E Edit Remove Exception' + randomString(4),
-      unified_job_template: project.id,
-      rrule:
-        'DTSTART;TZID=America/New_York:20250430T171500 RRULE:FREQ=YEARLY;INTERVAL=1;WKST=SU;BYMONTH=4;BYMONTHDAY=30;BYHOUR=11;BYMINUTE=15;BYSECOND=0 EXRULE:FREQ=WEEKLY;INTERVAL=50;WKST=TU;BYDAY=WE;BYHOUR=11;BYMINUTE=15;BYSECOND=0',
-    }).then((sched: Schedule) => {
-      schedToEdit = sched;
-      cy.filterTableBySingleSelect('name', schedToEdit.name);
+    it('can edit a simple schedule from details page', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.getByDataCy('name-column-cell').click();
       cy.getByDataCy('edit-schedule').click();
       cy.getByDataCy('wizard-nav').within(() => {
         ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
@@ -683,16 +578,58 @@ describe('Schedules - Edit', () => {
             .should((el) => expect(el.text().trim()).to.equal(text));
         });
       });
+      cy.getByDataCy('description').type('-edited');
       cy.clickButton(/^Next$/);
       cy.clickButton(/^Next$/);
-      cy.getBy('[data-cy="row-id-1"]').within(() => {
-        cy.getByDataCy('delete-exception').click();
+      cy.clickButton(/^Next$/);
+      cy.getByDataCy('description').contains('-edited');
+      cy.clickButton(/^Finish$/);
+      cy.verifyPageTitle(schedule.name);
+    });
+
+    it('can edit a simple schedule from the schedules list row', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.getByDataCy('edit-schedule').click();
+      cy.getByDataCy('wizard-nav').within(() => {
+        ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
+          cy.get('li')
+            .eq(index)
+            .should((el) => expect(el.text().trim()).to.equal(text));
+        });
       });
-      cy.getByDataCy('empty-state-title').contains('No exceptions yet');
-      cy.getByDataCy('To get started, create an exception.').should('be.visible');
+      cy.getByDataCy('description').type('-edited');
       cy.clickButton(/^Next$/);
-      cy.get('[data-cy="exclusions-column-header"]').should('not.exist');
-      cy.get('[data-cy="exclusions-column-cell"]').should('not.exist');
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Next$/);
+      cy.getByDataCy('description').contains('-edited');
+      cy.clickButton(/^Finish$/);
+      cy.verifyPageTitle(schedule.name);
+    });
+
+    it('can edit a schedule to add rules', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.getByDataCy('edit-schedule').click();
+      cy.getByDataCy('wizard-nav').within(() => {
+        ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
+          cy.get('li')
+            .eq(index)
+            .should((el) => expect(el.text().trim()).to.equal(text));
+        });
+      });
+      cy.singleSelectByDataCy('timezone', 'America/Mexico_City');
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Add rule$/);
+      cy.clickButton(/^Save rule$/);
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Next$/);
+      cy.getByDataCy('row-id-1').should('exist');
+      cy.getByDataCy('row-id-1').contains('FREQ=WEEKLY');
+      cy.get('[data-ouia-component-id="simple-table"]').within(() => {
+        cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
+        cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+        cy.get('tbody tr').should('have.length', 2);
+      });
+      cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
       cy.clickButton(/^Finish$/);
 
       cy.wait('@editedSchedule')
@@ -700,21 +637,11 @@ describe('Schedules - Edit', () => {
         .then((statusCode) => {
           expect(statusCode).to.eql(200);
         });
-      cy.getByDataCy('rruleset').should('not.include.text', 'EXRULE');
-      cy.deleteAWXSchedule(schedToEdit, { failOnStatusCode: false });
+      cy.verifyPageTitle(schedule.name);
     });
-  });
 
-  it('can edit a simple schedule to remove a rule and an exception', () => {
-    let schedToEdit: Schedule;
-    cy.createAWXSchedule({
-      name: 'E2E Edit Remove Exception' + randomString(4),
-      unified_job_template: project.id,
-      rrule:
-        'DTSTART;TZID=Etc/Zulu:20240507T230000 RRULE:FREQ=WEEKLY;INTERVAL=1;WKST=SU;BYDAY=TU;BYHOUR=17;BYMINUTE=0;BYSECOND=0 EXRULE:FREQ=YEARLY;INTERVAL=1;WKST=SU;BYMONTH=5;BYMONTHDAY=7;BYHOUR=17;BYMINUTE=0;BYSECOND=0',
-    }).then((sched: Schedule) => {
-      schedToEdit = sched;
-      cy.filterTableBySingleSelect('name', schedToEdit.name);
+    it('can edit a schedule to add exceptions', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
       cy.getByDataCy('edit-schedule').click();
       cy.getByDataCy('wizard-nav').within(() => {
         ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
@@ -724,114 +651,212 @@ describe('Schedules - Edit', () => {
         });
       });
       cy.clickButton(/^Next$/);
-      cy.getByDataCy('row-id-1').within(() => {
-        cy.getByDataCy('delete-rule').click();
-      });
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Create exception$/);
       cy.getByDataCy('freq-form-group').click();
       cy.getByDataCy('freq').within(() => {
-        cy.clickButton('Monthly');
+        cy.clickButton('Yearly');
+      });
+      cy.clickButton(/^Save exception$/);
+      cy.clickButton(/^Next$/);
+      cy.getByDataCy('row-id-1').contains('FREQ=YEARLY');
+      cy.clickButton(/^Finish$/);
+      cy.verifyPageTitle(schedule.name);
+    });
+
+    it('can edit a schedule to remove rules', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.getByDataCy('edit-schedule').click();
+      cy.getByDataCy('wizard-nav').within(() => {
+        ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
+          cy.get('li')
+            .eq(index)
+            .should((el) => expect(el.text().trim()).to.equal(text));
+        });
+      });
+      cy.clickButton(/^Next$/);
+      cy.clickButton(/^Add rule$/);
+      cy.getBy('[data-cy="row-id-1"]').within(() => {
+        cy.getBy('[data-cy="delete-rule"]').click();
       });
       cy.clickButton(/^Save rule$/);
-
       cy.clickButton(/^Next$/);
-      cy.getByDataCy('row-id-1').within(() => {
-        cy.getByDataCy('delete-exception').click();
-      });
       cy.clickButton(/^Next$/);
-      cy.get('[data-cy="row-id-1"] > [data-cy="rrule-column-cell"]').should(
-        'not.contain',
-        'RRULE:FREQ=WEEKLY'
-      );
-      cy.get('[data-cy="row-id-1"] > [data-cy="rrule-column-cell"]').should(
-        'contain',
-        'RRULE:FREQ=MONTHLY'
-      );
-      cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.get('[data-cy="exceptions-column-header"]').should('not.exist');
-        cy.get('tbody tr').should('have.length', 1);
-      });
-      cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
+      cy.getByDataCy('row-id-1').should('not.contain', 'FREQ=DAILY');
       cy.clickButton(/^Finish$/);
-      cy.getByDataCy('rruleset').should('not.contain', 'EXRULE');
-      cy.getByDataCy('rruleset').should('not.contain', 'RRULE:FREQ=WEEKLY');
-      cy.getByDataCy('rruleset').should('contain', 'RRULE:FREQ=MONTHLY;');
-      cy.deleteAWXSchedule(schedToEdit, { failOnStatusCode: false });
+      cy.verifyPageTitle(schedule.name);
     });
-  });
 
-  it('can toggle a schedule from the details page and confirm the change on the list view', () => {
-    cy.intercept('PATCH', awxAPI`/schedules/*`).as('toggleSchedule');
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.getByDataCy('name-column-cell').click();
+    it('can edit a schedule remove exceptions from row action', () => {
+      cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
 
-    cy.get('input[aria-label="Click to disable schedule"]').should('exist');
-    cy.getByDataCy('toggle-switch').should('be.visible').click();
-    cy.wait('@toggleSchedule')
-      .its('response.body.enabled')
-      .then((enabled: string) => {
-        expect(enabled).to.be.false;
-      });
-    cy.get('input[aria-label="Click to enable schedule"]').should('exist');
-
-    cy.getByDataCy('toggle-switch').should('be.visible').click();
-    cy.wait('@toggleSchedule')
-      .its('response.body.enabled')
-      .then((enabled: string) => {
-        expect(enabled).to.be.true;
-      });
-    cy.get('input[aria-label="Click to disable schedule"]').should('exist');
-  });
-
-  it('can toggle a schedule from the list view', () => {
-    cy.filterTableBySingleSelect('name', schedule.name);
-    cy.get(`tr[data-cy="row-id-${schedule.id}"]`).within(() => {
-      cy.getByDataCy('toggle-switch').click();
-    });
-    cy.get('input[aria-label="Click to enable schedule"]').should('exist');
-    cy.get(`tr[data-cy="row-id-${schedule.id}"]`).within(() => {
-      cy.getByDataCy('toggle-switch').click();
-    });
-    cy.get('input[aria-label="Click to disable schedule"]').should('exist');
-  });
-
-  it("can't edit a schedule with missing resources", () => {
-    const name = 'E2E Edit Schedule With Missing Resources' + randomString(4);
-
-    cy.createAwxInventory(organization).then((inv) => {
-      cy.createAwxJobTemplate({
-        name: 'E2E Job Template ' + randomString(4),
-        organization: organization.id,
-        project: project.id,
-        inventory: inv.id,
-      }).then((jt) => {
-        jobTemplate = jt;
-        cy.createAWXSchedule({
-          name,
-          unified_job_template: jt.id,
-          rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
-        }).then((sched: Schedule) => {
-          schedule = sched;
-          cy.deleteAwxInventory(inv);
-
-          cy.navigateTo('awx', 'templates');
-          cy.verifyPageTitle('Templates');
-          cy.filterTableByMultiSelect('name', [jt.name]);
-          cy.get('[data-cy="name-column-cell"]').within(() => {
-            cy.get('a').click();
+      let schedToEdit: Schedule;
+      cy.createAWXSchedule({
+        name: 'E2E Edit Remove Exception' + randomString(4),
+        unified_job_template: project.id,
+        rrule:
+          'DTSTART;TZID=America/New_York:20250430T171500 RRULE:FREQ=YEARLY;INTERVAL=1;WKST=SU;BYMONTH=4;BYMONTHDAY=30;BYHOUR=11;BYMINUTE=15;BYSECOND=0 EXRULE:FREQ=WEEKLY;INTERVAL=50;WKST=TU;BYDAY=WE;BYHOUR=11;BYMINUTE=15;BYSECOND=0',
+      }).then((sched: Schedule) => {
+        schedToEdit = sched;
+        cy.filterTableBySingleSelect('name', schedToEdit.name);
+        cy.getByDataCy('edit-schedule').click();
+        cy.getByDataCy('wizard-nav').within(() => {
+          ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
+            cy.get('li')
+              .eq(index)
+              .should((el) => expect(el.text().trim()).to.equal(text));
           });
-          cy.verifyPageTitle(jt.name);
-          cy.clickTab('Schedules', true);
-          cy.get('[data-cy="create-schedule"]').should('have.attr', 'aria-disabled', 'true');
-          cy.get('[data-cy="name-column-cell"]').within(() => {
-            cy.get('a').click();
+        });
+        cy.clickButton(/^Next$/);
+        cy.clickButton(/^Next$/);
+        cy.getBy('[data-cy="row-id-1"]').within(() => {
+          cy.getByDataCy('delete-exception').click();
+        });
+        cy.getByDataCy('empty-state-title').contains('No exceptions yet');
+        cy.getByDataCy('To get started, create an exception.').should('be.visible');
+        cy.clickButton(/^Next$/);
+        cy.get('[data-cy="exclusions-column-header"]').should('not.exist');
+        cy.get('[data-cy="exclusions-column-cell"]').should('not.exist');
+        cy.clickButton(/^Finish$/);
+
+        cy.wait('@editedSchedule')
+          .its('response.statusCode')
+          .then((statusCode) => {
+            expect(statusCode).to.eql(200);
           });
-          cy.clickLink('Edit schedule');
-          cy.verifyPageTitle('Edit Schedule');
-          cy.clickButton('Next');
-          cy.clickButton('Next');
-          cy.clickButton('Next');
-          cy.clickButton('Finish');
-          cy.contains('Job Template inventory is missing or undefined.');
+        cy.getByDataCy('rruleset').should('not.include.text', 'EXRULE');
+        cy.deleteAWXSchedule(schedToEdit, { failOnStatusCode: false });
+      });
+    });
+
+    it('can edit a simple schedule to remove a rule and an exception', () => {
+      let schedToEdit: Schedule;
+      cy.createAWXSchedule({
+        name: 'E2E Edit Remove Exception' + randomString(4),
+        unified_job_template: project.id,
+        rrule:
+          'DTSTART;TZID=Etc/Zulu:20240507T230000 RRULE:FREQ=WEEKLY;INTERVAL=1;WKST=SU;BYDAY=TU;BYHOUR=17;BYMINUTE=0;BYSECOND=0 EXRULE:FREQ=YEARLY;INTERVAL=1;WKST=SU;BYMONTH=5;BYMONTHDAY=7;BYHOUR=17;BYMINUTE=0;BYSECOND=0',
+      }).then((sched: Schedule) => {
+        schedToEdit = sched;
+        cy.filterTableBySingleSelect('name', schedToEdit.name);
+        cy.getByDataCy('edit-schedule').click();
+        cy.getByDataCy('wizard-nav').within(() => {
+          ['Details', 'Rules', 'Exceptions', 'Review'].forEach((text, index) => {
+            cy.get('li')
+              .eq(index)
+              .should((el) => expect(el.text().trim()).to.equal(text));
+          });
+        });
+        cy.clickButton(/^Next$/);
+        cy.getByDataCy('row-id-1').within(() => {
+          cy.getByDataCy('delete-rule').click();
+        });
+        cy.getByDataCy('freq-form-group').click();
+        cy.getByDataCy('freq').within(() => {
+          cy.clickButton('Monthly');
+        });
+        cy.clickButton(/^Save rule$/);
+
+        cy.clickButton(/^Next$/);
+        cy.getByDataCy('row-id-1').within(() => {
+          cy.getByDataCy('delete-exception').click();
+        });
+        cy.clickButton(/^Next$/);
+        cy.get('[data-cy="row-id-1"] > [data-cy="rrule-column-cell"]').should(
+          'not.contain',
+          'RRULE:FREQ=WEEKLY'
+        );
+        cy.get('[data-cy="row-id-1"] > [data-cy="rrule-column-cell"]').should(
+          'contain',
+          'RRULE:FREQ=MONTHLY'
+        );
+        cy.get('[data-ouia-component-id="simple-table"]').within(() => {
+          cy.get('[data-cy="exceptions-column-header"]').should('not.exist');
+          cy.get('tbody tr').should('have.length', 1);
+        });
+        cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
+        cy.clickButton(/^Finish$/);
+        cy.getByDataCy('rruleset').should('not.contain', 'EXRULE');
+        cy.getByDataCy('rruleset').should('not.contain', 'RRULE:FREQ=WEEKLY');
+        cy.getByDataCy('rruleset').should('contain', 'RRULE:FREQ=MONTHLY;');
+        cy.deleteAWXSchedule(schedToEdit, { failOnStatusCode: false });
+      });
+    });
+
+    it('can toggle a schedule from the details page and confirm the change on the list view', () => {
+      cy.intercept('PATCH', awxAPI`/schedules/*`).as('toggleSchedule');
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.getByDataCy('name-column-cell').click();
+
+      cy.get('input[aria-label="Click to disable schedule"]').should('exist');
+      cy.getByDataCy('toggle-switch').should('be.visible').click();
+      cy.wait('@toggleSchedule')
+        .its('response.body.enabled')
+        .then((enabled: string) => {
+          expect(enabled).to.be.false;
+        });
+      cy.get('input[aria-label="Click to enable schedule"]').should('exist');
+
+      cy.getByDataCy('toggle-switch').should('be.visible').click();
+      cy.wait('@toggleSchedule')
+        .its('response.body.enabled')
+        .then((enabled: string) => {
+          expect(enabled).to.be.true;
+        });
+      cy.get('input[aria-label="Click to disable schedule"]').should('exist');
+    });
+
+    it('can toggle a schedule from the list view', () => {
+      cy.filterTableBySingleSelect('name', schedule.name);
+      cy.get(`tr[data-cy="row-id-${schedule.id}"]`).within(() => {
+        cy.getByDataCy('toggle-switch').click();
+      });
+      cy.get('input[aria-label="Click to enable schedule"]').should('exist');
+      cy.get(`tr[data-cy="row-id-${schedule.id}"]`).within(() => {
+        cy.getByDataCy('toggle-switch').click();
+      });
+      cy.get('input[aria-label="Click to disable schedule"]').should('exist');
+    });
+
+    it("can't edit a schedule with missing resources", () => {
+      const name = 'E2E Edit Schedule With Missing Resources' + randomString(4);
+
+      cy.createAwxInventory(organization).then((inv) => {
+        cy.createAwxJobTemplate({
+          name: 'E2E Job Template ' + randomString(4),
+          organization: organization.id,
+          project: project.id,
+          inventory: inv.id,
+        }).then((jt) => {
+          jobTemplate = jt;
+          cy.createAWXSchedule({
+            name,
+            unified_job_template: jt.id,
+            rrule: 'DTSTART:20240415T124133Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
+          }).then((sched: Schedule) => {
+            schedule = sched;
+            cy.deleteAwxInventory(inv);
+
+            cy.navigateTo('awx', 'templates');
+            cy.verifyPageTitle('Templates');
+            cy.filterTableByMultiSelect('name', [jt.name]);
+            cy.get('[data-cy="name-column-cell"]').within(() => {
+              cy.get('a').click();
+            });
+            cy.verifyPageTitle(jt.name);
+            cy.clickTab('Schedules', true);
+            cy.get('[data-cy="create-schedule"]').should('have.attr', 'aria-disabled', 'true');
+            cy.get('[data-cy="name-column-cell"]').within(() => {
+              cy.get('a').click();
+            });
+            cy.clickLink('Edit schedule');
+            cy.verifyPageTitle('Edit Schedule');
+            cy.clickButton('Next');
+            cy.clickButton('Next');
+            cy.clickButton('Next');
+            cy.clickButton('Finish');
+            cy.contains('Job Template inventory is missing or undefined.');
+          });
         });
       });
     });

--- a/cypress/support/awx-commands.ts
+++ b/cypress/support/awx-commands.ts
@@ -552,14 +552,14 @@ Cypress.Commands.add('clickPageAction', (dataCy: string) => {
 
 Cypress.Commands.add(
   'createAWXCredential',
-  (credential: SetRequired<Partial<Credential>, 'organization' | 'kind' | 'credential_type'>) => {
-    cy.requestPost<
-      SetRequired<Partial<Credential>, 'organization' | 'kind' | 'credential_type'>,
-      Credential
-    >(awxAPI`/credentials/`, {
-      name: 'E2E Credential ' + randomString(4),
-      ...credential,
-    });
+  (credential: SetRequired<Partial<Credential>, 'kind' | 'credential_type'>) => {
+    cy.requestPost<SetRequired<Partial<Credential>, 'kind' | 'credential_type'>, Credential>(
+      awxAPI`/credentials/`,
+      {
+        name: 'E2E Credential ' + randomString(4),
+        ...credential,
+      }
+    );
   }
 );
 

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -683,10 +683,7 @@ declare global {
 
       /** Creates a credential in AWX */
       createAWXCredential(
-        credential: SetRequired<
-          Partial<Omit<Credential, 'id'>>,
-          'organization' | 'kind' | 'credential_type'
-        >
+        credential: SetRequired<Partial<Omit<Credential, 'id'>>, 'kind' | 'credential_type'>
       ): Chainable<Credential>;
       /** Creates a credential type in AWX */
       createAwxCredentialType(): Chainable<CredentialType>;


### PR DESCRIPTION
We know that org creation in the gateway takes lots of resources during testing.  This PR removes as many org create calls as possible while still keeping tests green.  Generally, doing that involves wrapping the whole test suite in a call to create and then delete the org in a `before` and `after` functions.  