### PR TITLE
[AAH-3313] Fix collection links in Repository - Versions - Collections

### DIFF
--- a/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionCollections.tsx
+++ b/frontend/hub/administration/repositories/RepositoryVersionPage/RepositoryVersionCollections.tsx
@@ -21,9 +21,14 @@ export function RepositoryVersionCollections() {
         cell: (collection) => (
           <TextCell
             text={`${collection.namespace}.${collection.name} v${collection.version}`}
-            to={`${getPageUrl(HubRoute.CollectionPage)}?name=${collection.name}&namespace=${
-              collection.namespace
-            }&repository=${repository.name}&version=${collection.version}`}
+            to={getPageUrl(HubRoute.CollectionDetails, {
+              params: {
+                name: collection.name,
+                namespace: collection.namespace,
+                repository: repository.name,
+              },
+              query: { version: collection.version },
+            })}
           />
         ),
       },


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-3313

Steps to Reproduce:
- Repository detail page
- Versions tab
- Click on a version
- Click on Collections tab
- Click on a collection

Before: 
`/collections/:repository/:namespace/:name?name=eos&namespace=arista&repository=published&version=6.2.2`

After: 
Correct URL
`/collections/published/arista/eos/details?version=6.2.1`