### PR TITLE
[AAP-27745] Clear the resource field when the node_ type changes, not when node_type is dirty

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
@@ -79,10 +79,6 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
 
     setValue('node_type', nodeType, { shouldTouch: true });
 
-    if (isDirty) {
-      setValue('resource', null);
-    }
-
     if (isTouched && !isDirty && isApprovalType) {
       reset(undefined, {
         keepDefaultValues: true,
@@ -91,6 +87,10 @@ export function NodeTypeStep(props: { hasSourceNode?: boolean }) {
       setStepData({ nodeTypeStep: currentFormValues });
     }
   }, [nodeType, getFieldState, setValue, reset, allSteps, setWizardData, setStepData, getValues]);
+
+  useEffect(() => {
+    setValue('resource', null);
+  }, [nodeType, setValue]);
 
   useEffect(() => {
     const setLaunchToWizardData = async () => {


### PR DESCRIPTION
 Clear the resource field when the node_ type changes, not when node_type is dirty