### PR TITLE
[AAP-26594] unskip bulk delete test in projects-list.cy.ts

### DIFF
--- a/cypress/e2e/eda/Projects/projects-list.cy.ts
+++ b/cypress/e2e/eda/Projects/projects-list.cy.ts
@@ -31,9 +31,7 @@ describe('EDA Projects List', () => {
     });
   });
 
-  // Disabling this test as it is randomly failing because the backend randomly returns a 500
-  it.skip('can bulk delete Projects from the Projects list', () => {
-    //re-enable this test when bulk deletion in fixed in the EDA API
+  it('can bulk delete Projects from the Projects list', () => {
     cy.createEdaProject().then((edaProject) => {
       cy.createEdaProject().then((testProject) => {
         cy.navigateTo('eda', 'projects');


### PR DESCRIPTION
This pr unskips test `  it.skip('can bulk delete Projects from the Projects list', () => { ` in `cypress/e2e/eda/Projects/projects-list.cy.ts`