### PR TITLE
AAP-28087 Fix jobTemplate test failure when server is not compliant

### DIFF
--- a/cypress/e2e/awx/resources/jobTemplates.cy.ts
+++ b/cypress/e2e/awx/resources/jobTemplates.cy.ts
@@ -401,6 +401,7 @@ describe('Job Templates Tests', function () {
           .then((webhook_key: string) => {
             let webhookKey: string = webhook_key;
 
+            cy.get('[data-cy="webhook_credential"]').scrollIntoView();
             cy.getByDataCy('webhook_credential').should('have.text', ghCred.name);
             cy.getByDataCy('webhook-service-form-group').contains('GitHub');
             cy.getByDataCy('webhook-key').should('have.value', webhookKey);


### PR DESCRIPTION
Related to failure https://cloud.cypress.io/projects/iq7cj4/runs/1799/overview/767c99fc-ffee-4e27-ba34-c4417e2e617f?roarHideRunsWithDiffGroupsAndTags=1

Steps to reproduce:
- Run `cypress/awx/resources/jobTemplates.cy.ts` on a server that is not compliant

Before:
`Timed out retrying after 30000ms: expected '<button#webhook_credential.pf-v5-c-menu-toggle.pf-m-full-width>' not to be 'hidden'`
After:
Test run successfully :)

