### PR TITLE
hub - Bump galaxykit to current

### DIFF
--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -107,11 +107,18 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' && !inputs.SKIP_JOB
         run: npm ci
+
+      # galaxykit needs pip 23+, Ubuntu 22.04's default Python uses pip 22
+      - name: "Install python 3.11"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install galaxykit
         run: |
           # pip3 install galaxykit
           # pending a release with https://github.com/ansible/galaxykit/pull/116
           pip3 install git+https://github.com/ansible/galaxykit.git@main
+
       - name: Cypress
         if: ${{ !inputs.SKIP_JOB }}
         uses: cypress-io/github-action@v6

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Install galaxykit
         run: |
           # pip3 install galaxykit
-          # pending https://github.com/ansible/galaxykit/pull/99
-          pip3 install git+https://github.com/himdel/galaxykit.git@skip-upload
+          # pending a release with https://github.com/ansible/galaxykit/pull/116
+          pip3 install git+https://github.com/ansible/galaxykit.git@main
       - name: Cypress
         if: ${{ !inputs.SKIP_JOB }}
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
mostly to include https://github.com/ansible/galaxykit/pull/116 which allows galaxykit to authenticate against the platform.

Cc @jerabekjiri 