### PR TITLE
Skipping tests due to 401 logout issue AAP-28586

### DIFF
--- a/cypress/e2e/awx/access/organizations.cy.ts
+++ b/cypress/e2e/awx/access/organizations.cy.ts
@@ -138,7 +138,7 @@ describe('Organizations: Edit and Delete', function () {
       });
   });
 
-  it('can delete an organization from the organizations list toolbar', function () {
+  it.skip('can delete an organization from the organizations list toolbar', function () {
     cy.navigateTo('awx', 'organizations');
     cy.filterTableByMultiSelect('name', [organization.name]);
     cy.selectTableRow(organization.name, false);

--- a/cypress/e2e/awx/access/teams.cy.ts
+++ b/cypress/e2e/awx/access/teams.cy.ts
@@ -200,7 +200,7 @@ describe('Teams: Add and Remove users', () => {
     cy.getModal().should('not.exist');
   });
 
-  it('can add users to the team via the team access tab toolbar', () => {
+  it.skip('can add users to the team via the team access tab toolbar', () => {
     cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowLink('name', team.name, { disableFilter: true });
     cy.verifyPageTitle(team.name);
@@ -246,7 +246,7 @@ describe('Teams: Add and Remove users', () => {
     cy.get(`tr[data-cy=row-id-${user1.id}]`).should('not.exist');
   });
 
-  it('can remove a role from a user via the team access tab row action', () => {
+  it.skip('can remove a role from a user via the team access tab row action', () => {
     cy.filterTableBySingleSelect('name', team.name);
     cy.clickTableRowLink('name', team.name, { disableFilter: true });
     cy.verifyPageTitle(team.name);

--- a/cypress/e2e/awx/administration/instanceGroups.cy.ts
+++ b/cypress/e2e/awx/administration/instanceGroups.cy.ts
@@ -788,7 +788,7 @@ describe(`Instance Groups`, () => {
       cy.deleteAwxUser(user, { failOnStatusCode: false });
     });
 
-    it(`can visit the instance group -> user access tab, add a user, view the user on the user list and then delete user`, () => {
+    it.skip(`can visit the instance group -> user access tab, add a user, view the user on the user list and then delete user`, () => {
       cy.navigateTo('awx', 'instance-groups');
       cy.verifyPageTitle('Instance Groups');
       cy.filterTableBySingleSelect('name', instanceGroup.name);
@@ -869,7 +869,7 @@ describe(`Instance Groups`, () => {
         });
     });
 
-    it(`can visit the container group -> user access tab, add a user, view the user on the user list and then delete user`, () => {
+    it.skip(`can visit the container group -> user access tab, add a user, view the user on the user list and then delete user`, () => {
       cy.navigateTo('awx', 'instance-groups');
       cy.verifyPageTitle('Instance Groups');
       cy.filterTableBySingleSelect('name', containerGroup.name);

--- a/cypress/e2e/awx/resources/inventories.cy.ts
+++ b/cypress/e2e/awx/resources/inventories.cy.ts
@@ -118,7 +118,7 @@ describe('Inventories Tests', () => {
           //Assert the presence of the original and the copy by performing a search on the list of inventories
         });
 
-        it('can copy an inventory on the list view and assert that the copy has been successful', () => {
+        it.skip('can copy an inventory on the list view and assert that the copy has been successful', () => {
           //Refactor this test to match the updated test case and improve the assertions
           cy.navigateTo('awx', 'inventories'); //Add assertion to verify the user is on the inventories list view
           cy.filterTableBySingleSelect('name', inventory.name);

--- a/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
+++ b/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
@@ -151,7 +151,8 @@ describe('Constructed Inventories CRUD Tests', () => {
       "groups": {
       "is_shutdown": "state | default('running') == 'shutdown'",
       "product_dev": "account_alias == 'product_dev'"
-      }}`
+      }}`,
+      { delay: 200 }
     );
     cy.clickButton(/^Save inventory$/);
     cy.verifyPageTitle(newInventory.name);

--- a/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
+++ b/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
@@ -53,7 +53,6 @@ describe('Constructed Inventories CRUD Tests', () => {
     const cacheTimeoutValue = generateRandom(0, 15);
     // which combination should be used to test verbosity from 1 to 5 - UI forces to use only 0-2
     const verbosityValue = generateRandom(0, 2);
-
     cy.navigateTo('awx', 'inventories');
     cy.verifyPageTitle('Inventories');
     cy.clickButton(/^Create inventory$/);
@@ -64,7 +63,6 @@ describe('Constructed Inventories CRUD Tests', () => {
     // this can be simplified if we include data-cy to the search button of instance groups
     cy.multiSelectByDataCy('instance-group-select-form-group', [instanceGroup.name]);
     cy.multiSelectByDataCy('inventories', [inventory.name]);
-
     cy.getByDataCy('update_cache_timeout').clear().type(String(cacheTimeoutValue));
     cy.singleSelectByDataCy('verbosity', String(verbosityValue));
     cy.getByDataCy('limit').type('5');
@@ -77,7 +75,6 @@ describe('Constructed Inventories CRUD Tests', () => {
         cy.verifyPageTitle(constInvName);
       });
     cy.clickKebabAction('actions-dropdown', 'delete-inventory');
-
     cy.getModal().within(() => {
       cy.get('header').contains('Permanently delete inventory');
       cy.get('button').contains('Delete inventory').should('have.attr', 'aria-disabled', 'true');
@@ -85,7 +82,6 @@ describe('Constructed Inventories CRUD Tests', () => {
       cy.get('input[id="confirm"]').click();
       cy.clickButton(/^Delete inventory/);
     });
-
     // Assert the inventory doesn't exist anymore
     cy.filterTableBySingleSelect('name', constInvName, true);
     cy.contains('No results found');
@@ -139,15 +135,12 @@ describe('Constructed Inventories CRUD Tests', () => {
     cy.verifyPageTitle('Inventories');
     cy.filterTableBySingleSelect('name', newInventory.name);
     cy.clickTableRowLink('name', newInventory.name, { disableFilter: true });
-
     //Assert the original details of the inventory
     cy.verifyPageTitle(newInventory.name);
     cy.getByDataCy('organization').contains(organization.name);
-
     //Assert the user navigating to the edit constructed inventory form
     cy.getByDataCy('edit-inventory').click();
     cy.verifyPageTitle('Edit Constructed Inventory');
-
     cy.getByDataCy('toggle-json').click();
     //Assert the change to the strict setting
     //Add bad variables
@@ -160,9 +153,7 @@ describe('Constructed Inventories CRUD Tests', () => {
       "product_dev": "account_alias == 'product_dev'"
       }}`
     );
-
     cy.clickButton(/^Save inventory$/);
-
     cy.verifyPageTitle(newInventory.name);
     cy.intercept('POST', awxAPI`/inventory_sources/*/update`).as('syncInventory');
     cy.clickButton('Sync inventory');
@@ -224,9 +215,7 @@ describe('Constructed Inventories CRUD Tests - reorder input inventories', () =>
     cy.contains('a', constructedInv.name).click();
 
     let expectedOrder: string[] = [];
-
     cy.getByDataCy('input-inventories');
-
     // get initial order
     cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
       .should(($lis) => {
@@ -234,25 +223,20 @@ describe('Constructed Inventories CRUD Tests - reorder input inventories', () =>
       })
       .then(() => {
         cy.getByDataCy('edit-inventory').click();
-
         // remove one item
         cy.contains(`[aria-label="Chip group category"] li`, expectedOrder[0]).within(() => {
           cy.get('button').click();
         });
-
         const deletedItem = expectedOrder[0];
         expectedOrder = expectedOrder.slice(1);
         expectedOrder.push(deletedItem);
-
         // now add it also in GUI
         cy.get(`[aria-label="Search input"]`).type(deletedItem);
         cy.contains('label', deletedItem).within(() => {
           cy.get('input').click();
         });
-
         cy.clickButton(/^Save inventory$/);
         cy.getByDataCy('input-inventories');
-
         cy.navigateTo('awx', 'inventories');
         cy.verifyPageTitle('Inventories');
         cy.filterTableByMultiSelect('name', [constructedInv.name]);
@@ -260,7 +244,6 @@ describe('Constructed Inventories CRUD Tests - reorder input inventories', () =>
         cy.contains('a', constructedInv.name).click();
         // verify order
         cy.getByDataCy('input-inventories');
-
         cy.get(`[data-cy="input-inventories"] ul > li`) // Adjust the selector to match your list items
           .should(($lis) => {
             const actualOrder = $lis.map((index, el) => Cypress.$(el).text()).get();
@@ -279,6 +262,5 @@ function generateRandom(min = 0, max = 5) {
   rand = Math.floor(rand * difference);
   // add with min value
   rand = rand + min;
-
   return rand;
 }

--- a/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
+++ b/cypress/e2e/awx/resources/inventoriesConstructed.cy.ts
@@ -129,7 +129,7 @@ describe('Constructed Inventories CRUD Tests', () => {
       });
   });
 
-  it('shows a failed sync on the constructed inventory if the user sets strict to true and enters bad variables', () => {
+  it.skip('shows a failed sync on the constructed inventory if the user sets strict to true and enters bad variables', () => {
     //Run a sync and assert failure of the job
     cy.navigateTo('awx', 'inventories');
     cy.verifyPageTitle('Inventories');


### PR DESCRIPTION
'can visit the instance group -> user access tab, add a user, view the user on the user list and then delete user'
'can visit the container group -> user access tab, add a user, view the user on the user list and then delete user'
'can copy an inventory on the list view and assert that the copy has been successful'
'can add users to the team via the team access tab toolbar'
'can remove a role from a user via the team access tab row action'
'can delete an organization from the organizations list toolbar'
'shows a failed sync on the constructed inventory if the user sets strict to true and enters bad variables'

these tests are being skipped due to AAP-28586