### PR TITLE
Change all /api/automation-hub to /api/galaxy, except console.redhat.com references

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ UI projects for [Ansible](https://www.ansible.com).
 |            `HUB_SERVER` | The HUB server (protocol://host:port).              |
 |          `HUB_USERNAME` | The HUB server username. (only used by Cypress)     |
 |          `HUB_PASSWORD` | The HUB server password. (only used by Cypress)     |
-|        `HUB_API_PREFIX` | The HUB server API prefix. (`/api/automation-hub`)  |
+|        `HUB_API_PREFIX` | The HUB server API prefix. (`/api/galaxy`)          |
 | `HUB_GALAXYKIT_COMMAND` | The galaxykit command. (`galaxykit --ignore-certs`) |
 
 ```zsh

--- a/cypress/fixtures/application_collection_versions.json
+++ b/cypress/fixtures/application_collection_versions.json
@@ -3,28 +3,28 @@
     "count": 4
   },
   "links": {
-    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=application",
+    "first": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=application",
     "previous": null,
     "next": null,
-    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=application"
+    "last": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=application"
   },
   "data": [
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/26d5c6ff-f150-4485-9d4d-57af2bb41aee/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/26d5c6ff-f150-4485-9d4d-57af2bb41aee/",
         "namespace": "redhat",
         "name": "redhat_csp_download",
         "version": "1.2.2",
@@ -67,7 +67,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/4e07a845-8fa6-42f7-8ba1-0dfce62c1c90/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/4e07a845-8fa6-42f7-8ba1-0dfce62c1c90/",
         "name": "redhat",
         "company": "",
         "description": "",
@@ -79,20 +79,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/2be74034-bb6a-46ec-8ef7-52d7ccb49264/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/2be74034-bb6a-46ec-8ef7-52d7ccb49264/",
         "namespace": "vn_namespace",
         "name": "vntest_appcollection2",
         "version": "1.0.0",
@@ -109,7 +109,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
         "name": "vn_namespace",
         "company": "",
         "description": "",
@@ -121,20 +121,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/cfa2f870-4888-4009-9818-5388c08644f8/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/cfa2f870-4888-4009-9818-5388c08644f8/",
         "namespace": "vn_namespace",
         "name": "vntest_cloudappcollection2",
         "version": "1.0.0",
@@ -154,7 +154,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
         "name": "vn_namespace",
         "company": "",
         "description": "",
@@ -166,20 +166,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/22117583-d0c1-4519-891c-0f8bbff89668/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/22117583-d0c1-4519-891c-0f8bbff89668/",
         "namespace": "vn_namespace",
         "name": "vntest_cloudcollection1",
         "version": "1.0.0",
@@ -199,7 +199,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
         "name": "vn_namespace",
         "company": "",
         "description": "",

--- a/cypress/fixtures/collection_versions_eda.json
+++ b/cypress/fixtures/collection_versions_eda.json
@@ -3,28 +3,28 @@
     "count": 10
   },
   "links": {
-    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda",
+    "first": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda",
     "previous": null,
     "next": null,
-    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda"
+    "last": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=eda"
   },
   "data": [
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
         "namespace": "test_ns",
         "name": "test_collection10",
         "version": "1.0.0",
@@ -41,7 +41,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -53,20 +53,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
         "namespace": "test_ns",
         "name": "test_collection9",
         "version": "1.0.0",
@@ -83,7 +83,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -95,20 +95,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
         "namespace": "test_ns",
         "name": "test_collection8",
         "version": "1.0.0",
@@ -125,7 +125,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -137,20 +137,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
         "namespace": "test_ns",
         "name": "test_collection7",
         "version": "1.0.0",
@@ -167,7 +167,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -179,20 +179,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
         "namespace": "test_ns",
         "name": "test_collection6",
         "version": "1.0.0",
@@ -209,7 +209,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -221,20 +221,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
         "namespace": "test_ns",
         "name": "test_collection2",
         "version": "1.0.0",
@@ -251,7 +251,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -263,20 +263,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
         "namespace": "test_ns",
         "name": "test_collection1",
         "version": "1.0.0",
@@ -293,7 +293,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -305,20 +305,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
         "namespace": "test_ns",
         "name": "test_collection",
         "version": "1.0.0",
@@ -335,7 +335,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -347,20 +347,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
         "namespace": "e2e_namespace_shkb",
         "name": "e2e_collection_1yfo",
         "version": "1.0.0",
@@ -383,20 +383,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
         "namespace": "e2e_namespace_shkb",
         "name": "e2e_collection_ficu",
         "version": "1.0.0",

--- a/cypress/fixtures/collection_versions_offset0.json
+++ b/cypress/fixtures/collection_versions_offset0.json
@@ -3,28 +3,28 @@
     "count": 16
   },
   "links": {
-    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
+    "first": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
     "previous": null,
-    "next": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=10&repository_label=%21hide_from_search",
-    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
+    "next": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=10&repository_label=%21hide_from_search",
+    "last": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
   },
   "data": [
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/d7678469-4808-4bf3-bf66-8e91f73f3625/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/d7678469-4808-4bf3-bf66-8e91f73f3625/",
         "namespace": "test_ns",
         "name": "test_collection3",
         "version": "1.0.0",
@@ -41,7 +41,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -53,20 +53,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e5efd402-0022-4ad9-9dbf-82dd1607b910/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/e5efd402-0022-4ad9-9dbf-82dd1607b910/",
         "namespace": "test_ns",
         "name": "test_collection4",
         "version": "1.0.0",
@@ -83,7 +83,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -95,20 +95,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/0a0e3f4e-4e2f-4f97-8d35-3cf8fdd8fdfd/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/0a0e3f4e-4e2f-4f97-8d35-3cf8fdd8fdfd/",
         "namespace": "test_ns",
         "name": "test_collection5",
         "version": "1.0.0",
@@ -125,7 +125,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -137,20 +137,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/fc723cff-d356-4e6c-9f21-e1216c54ee95/",
         "namespace": "test_ns",
         "name": "test_collection6",
         "version": "1.0.0",
@@ -167,7 +167,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -179,20 +179,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/9033ba51-f68d-46c0-b595-6003c3d1830e/",
         "namespace": "test_ns",
         "name": "test_collection7",
         "version": "1.0.0",
@@ -209,7 +209,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -221,20 +221,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/c1e55b3a-f65c-4a68-b975-3b2fa3cd3759/",
         "namespace": "test_ns",
         "name": "test_collection8",
         "version": "1.0.0",
@@ -251,7 +251,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -263,20 +263,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/b9af5149-7ebc-4565-bf59-3dc01ea908c8/",
         "namespace": "test_ns",
         "name": "test_collection9",
         "version": "1.0.0",
@@ -293,7 +293,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -305,20 +305,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/1de5270b-0981-4db8-a92c-74a5370d69fa/",
         "namespace": "test_ns",
         "name": "test_collection10",
         "version": "1.0.0",
@@ -335,7 +335,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -347,20 +347,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/2a32d31d-5241-449c-8660-926c98ad0e8e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/2a32d31d-5241-449c-8660-926c98ad0e8e/",
         "namespace": "test_ns",
         "name": "test_collection11",
         "version": "1.0.0",
@@ -377,7 +377,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -389,20 +389,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/b7132f91-6efb-4057-866b-c38e70acd026/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/b7132f91-6efb-4057-866b-c38e70acd026/",
         "namespace": "test_ns",
         "name": "test_collection12",
         "version": "1.0.0",
@@ -419,7 +419,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",

--- a/cypress/fixtures/collection_versions_offset10.json
+++ b/cypress/fixtures/collection_versions_offset10.json
@@ -3,28 +3,28 @@
     "count": 16
   },
   "links": {
-    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
-    "previous": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&repository_label=%21hide_from_search",
+    "first": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=0&repository_label=%21hide_from_search",
+    "previous": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&repository_label=%21hide_from_search",
     "next": null,
-    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
+    "last": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?is_deprecated=false&is_highest=true&limit=10&offset=6&repository_label=%21hide_from_search"
   },
   "data": [
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/a10be89c-a127-4d84-951b-b9ab872e42d6/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/a10be89c-a127-4d84-951b-b9ab872e42d6/",
         "namespace": "test_ns",
         "name": "test_collection13",
         "version": "1.0.0",
@@ -41,7 +41,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -53,20 +53,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/1dbff0e2-c83a-46fb-b0a5-1902181e88be/",
         "namespace": "e2e_namespace_shkb",
         "name": "e2e_collection_ficu",
         "version": "1.0.0",
@@ -89,20 +89,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/36512dbe-b196-4deb-bc0b-586936880d5c/",
         "namespace": "e2e_namespace_shkb",
         "name": "e2e_collection_1yfo",
         "version": "1.0.0",
@@ -125,20 +125,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/c1571918-9a5a-4161-a45d-3e96a520b7dd/",
         "namespace": "test_ns",
         "name": "test_collection",
         "version": "1.0.0",
@@ -155,7 +155,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -167,20 +167,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/e875c20f-8577-4023-bbf5-ea19bf079fd4/",
         "namespace": "test_ns",
         "name": "test_collection1",
         "version": "1.0.0",
@@ -197,7 +197,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",
@@ -209,20 +209,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/",
         "pulp_created": "2023-08-24T16:00:10.249391Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/75d1d03c-a32a-4842-8bcb-ee4868dc327b/versions/458/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/3ebca64a-b7c3-4a3a-b278-04ec905bcda0/",
         "namespace": "test_ns",
         "name": "test_collection2",
         "version": "1.0.0",
@@ -239,7 +239,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/1673e649-6cd4-4873-a079-44e81e4df842/",
         "name": "test_ns",
         "company": "",
         "description": "",

--- a/cypress/fixtures/hub_roles.json
+++ b/cypress/fixtures/hub_roles.json
@@ -1,10 +1,10 @@
 {
   "count": 18,
-  "next": "http://localhost:8002/api/automation-hub/pulp/api/v3/roles/?limit=10&name__startswith=galaxy.&offset=10&ordering=name",
+  "next": "http://localhost:8002/api/galaxy/pulp/api/v3/roles/?limit=10&name__startswith=galaxy.&offset=10&ordering=name",
   "previous": null,
   "results": [
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/aba4a87c-1447-47cb-9bd3-bf9f609f18fa/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/aba4a87c-1447-47cb-9bd3-bf9f609f18fa/",
       "pulp_created": "2023-10-11T16:00:44.179570Z",
       "name": "galaxy.ansible_repository_owner",
       "description": null,
@@ -21,7 +21,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/9915ca45-f055-4a96-aa70-0dfaf3f5930c/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/9915ca45-f055-4a96-aa70-0dfaf3f5930c/",
       "pulp_created": "2023-10-11T16:00:44.090955Z",
       "name": "galaxy.collection_admin",
       "description": null,
@@ -48,7 +48,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/bdb8c2f0-b793-4a2e-886b-e670c84729d0/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/bdb8c2f0-b793-4a2e-886b-e670c84729d0/",
       "pulp_created": "2023-10-11T16:00:44.134557Z",
       "name": "galaxy.collection_curator",
       "description": null,
@@ -70,7 +70,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/f185c939-6175-48cc-8902-c9c3b784bf0f/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/f185c939-6175-48cc-8902-c9c3b784bf0f/",
       "pulp_created": "2023-10-11T16:00:44.195992Z",
       "name": "galaxy.collection_namespace_owner",
       "description": null,
@@ -78,7 +78,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/f07946be-b33d-4464-85ea-9513bf8eae73/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/f07946be-b33d-4464-85ea-9513bf8eae73/",
       "pulp_created": "2023-10-11T16:00:44.105462Z",
       "name": "galaxy.collection_publisher",
       "description": null,
@@ -90,7 +90,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/65687b29-84fd-4954-93bc-c8f7a05a2551/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/65687b29-84fd-4954-93bc-c8f7a05a2551/",
       "pulp_created": "2023-10-11T16:00:44.155819Z",
       "name": "galaxy.collection_remote_owner",
       "description": null,
@@ -104,7 +104,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/19398b5e-d23e-484d-948c-483b16503844/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/19398b5e-d23e-484d-948c-483b16503844/",
       "pulp_created": "2023-10-11T16:00:44.053831Z",
       "name": "galaxy.content_admin",
       "description": null,
@@ -142,7 +142,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/75ed025c-1c13-469b-83bd-9b718063645f/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/75ed025c-1c13-469b-83bd-9b718063645f/",
       "pulp_created": "2023-11-28T19:36:03.557948Z",
       "name": "galaxy.demorole",
       "description": "Demo Role",
@@ -154,7 +154,7 @@
       "locked": false
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/6d45575d-c319-42bc-821b-a8a57fda9e79/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/6d45575d-c319-42bc-821b-a8a57fda9e79/",
       "pulp_created": "2023-10-11T16:00:44.228674Z",
       "name": "galaxy.execution_environment_admin",
       "description": null,
@@ -174,7 +174,7 @@
       "locked": true
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/roles/411a4573-3685-4989-93c3-0cf77d78da63/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/roles/411a4573-3685-4989-93c3-0cf77d78da63/",
       "pulp_created": "2023-10-11T16:00:44.301041Z",
       "name": "galaxy.execution_environment_collaborator",
       "description": null,

--- a/cypress/fixtures/storage_collection_versions.json
+++ b/cypress/fixtures/storage_collection_versions.json
@@ -3,28 +3,28 @@
     "count": 2
   },
   "links": {
-    "first": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=storage",
+    "first": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=storage",
     "previous": null,
     "next": null,
-    "last": "/api/automation-hub/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=storage"
+    "last": "/api/galaxy/v3/plugin/ansible/search/collection-versions/?limit=12&offset=0&order_by=-pulp_created&tags=storage"
   },
   "data": [
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/ab4aee29-df22-412e-8de5-a7f0c10c4ae6/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/ab4aee29-df22-412e-8de5-a7f0c10c4ae6/",
         "namespace": "vn_namespace",
         "name": "vncollection1",
         "version": "1.0.0",
@@ -44,7 +44,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
         "name": "vn_namespace",
         "company": "",
         "description": "",
@@ -56,20 +56,20 @@
     },
     {
       "repository": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/",
         "pulp_created": "2023-05-17T14:19:45.572339Z",
-        "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
+        "versions_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/",
         "pulp_labels": {
           "pipeline": "approved"
         },
-        "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
+        "latest_version_href": "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/098ee4df-0e85-4478-8d82-488e29209ae9/versions/36/",
         "name": "published",
         "description": "Certified content repository",
         "retain_repo_versions": 1,
         "remote": null
       },
       "collection_version": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/8818a823-a7af-4c42-a04c-02e161d3f898/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/8818a823-a7af-4c42-a04c-02e161d3f898/",
         "namespace": "vn_namespace",
         "name": "vntest_collection12",
         "version": "1.0.0",
@@ -86,7 +86,7 @@
       },
       "repository_version": "latest",
       "namespace_metadata": {
-        "pulp_href": "/api/automation-hub/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
+        "pulp_href": "/api/galaxy/pulp/api/v3/content/ansible/namespaces/29178d8e-7ee5-4e77-83e6-86abdf722c2e/",
         "name": "vn_namespace",
         "company": "",
         "description": "",

--- a/cypress/fixtures/tasks.json
+++ b/cypress/fixtures/tasks.json
@@ -1,10 +1,10 @@
 {
   "count": 53,
-  "next": "http://localhost:5001/api/automation-hub/pulp/api/v3/tasks/?limit=10&offset=10&ordering=-pulp_created",
+  "next": "http://localhost:5001/api/galaxy/pulp/api/v3/tasks/?limit=10&offset=10&ordering=-pulp_created",
   "previous": null,
   "results": [
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c358a-a78c-713e-9b78-a5ea5b6a5fbd/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c358a-a78c-713e-9b78-a5ea5b6a5fbd/",
       "pulp_created": "2023-12-04T15:55:28.526297Z",
       "state": "completed",
       "name": "pulpcore.app.tasks.analytics.post_analytics",
@@ -13,7 +13,7 @@
       "started_at": "2023-12-04T15:55:28.580188Z",
       "finished_at": "2023-12-04T15:55:29.069852Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
       "child_tasks": [],
       "task_group": null,
@@ -22,7 +22,7 @@
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c3064-6abd-7873-947a-881bea87950a/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c3064-6abd-7873-947a-881bea87950a/",
       "pulp_created": "2023-12-03T15:55:36.511659Z",
       "state": "completed",
       "name": "pulpcore.app.tasks.analytics.post_analytics",
@@ -31,7 +31,7 @@
       "started_at": "2023-12-03T15:55:36.564786Z",
       "finished_at": "2023-12-03T15:55:37.016888Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
       "child_tasks": [],
       "task_group": null,
@@ -40,7 +40,7 @@
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2b3e-090c-794b-ad04-8625b99c7250/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2b3e-090c-794b-ad04-8625b99c7250/",
       "pulp_created": "2023-12-02T15:55:35.053653Z",
       "state": "completed",
       "name": "pulpcore.app.tasks.analytics.post_analytics",
@@ -49,7 +49,7 @@
       "started_at": "2023-12-02T15:55:35.106248Z",
       "finished_at": "2023-12-02T15:55:35.601120Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
       "child_tasks": [],
       "task_group": null,
@@ -58,7 +58,7 @@
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2617-8e50-72df-bf2a-1307c44a7bd5/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2617-8e50-72df-bf2a-1307c44a7bd5/",
       "pulp_created": "2023-12-01T15:55:27.185947Z",
       "state": "completed",
       "name": "pulpcore.app.tasks.analytics.post_analytics",
@@ -67,7 +67,7 @@
       "started_at": "2023-12-01T15:55:27.241158Z",
       "finished_at": "2023-12-01T15:55:27.722306Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
       "child_tasks": [],
       "task_group": null,
@@ -76,7 +76,7 @@
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c21f2-d56a-76c0-8510-534aa226e94a/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c21f2-d56a-76c0-8510-534aa226e94a/",
       "pulp_created": "2023-11-30T20:36:51.691672Z",
       "state": "completed",
       "name": "pulpcore.app.tasks.base.general_delete",
@@ -85,18 +85,18 @@
       "started_at": "2023-11-30T20:36:51.753298Z",
       "finished_at": "2023-11-30T20:36:51.813814Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
       "child_tasks": [],
       "task_group": null,
       "progress_reports": [],
       "created_resources": [],
       "reserved_resources_record": [
-        "/api/automation-hub/pulp/api/v3/remotes/ansible/collection/018c21f2-c65b-73b0-97cd-372b1a59e127/"
+        "/api/galaxy/pulp/api/v3/remotes/ansible/collection/018c21f2-c65b-73b0-97cd-372b1a59e127/"
       ]
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2181-8bde-77bf-a3df-260a7989bc75/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2181-8bde-77bf-a3df-260a7989bc75/",
       "pulp_created": "2023-11-30T18:33:07.296689Z",
       "state": "completed",
       "name": "pulp_ansible.app.tasks.copy.move_collection",
@@ -105,22 +105,22 @@
       "started_at": "2023-11-30T18:33:07.360473Z",
       "finished_at": "2023-11-30T18:33:07.805163Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
-      "parent_task": "/api/automation-hub/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "parent_task": "/api/galaxy/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/",
       "child_tasks": [],
       "task_group": null,
       "progress_reports": [],
       "created_resources": [
-        "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d94a-790c-bfd9-98376981182b/versions/1/",
-        "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/versions/3/"
+        "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d94a-790c-bfd9-98376981182b/versions/1/",
+        "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/versions/3/"
       ],
       "reserved_resources_record": [
-        "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d94a-790c-bfd9-98376981182b/",
-        "shared:/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/"
+        "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d94a-790c-bfd9-98376981182b/",
+        "shared:/api/galaxy/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/"
       ]
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/",
       "pulp_created": "2023-11-30T18:33:06.321930Z",
       "state": "completed",
       "name": "galaxy_ng.app.tasks.promotion.auto_approve",
@@ -129,12 +129,10 @@
       "started_at": "2023-11-30T18:33:06.387468Z",
       "finished_at": "2023-11-30T18:33:07.302715Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
-      "parent_task": "/api/automation-hub/pulp/api/v3/tasks/018c2181-7aa3-770d-8a8d-a3e4f2b1bee5/",
-      "child_tasks": [
-        "/api/automation-hub/pulp/api/v3/tasks/018c2181-8bde-77bf-a3df-260a7989bc75/"
-      ],
-      "task_group": "/api/automation-hub/pulp/api/v3/task-groups/018c2181-7a9b-7fe2-8419-c65d6ba0641b/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "parent_task": "/api/galaxy/pulp/api/v3/tasks/018c2181-7aa3-770d-8a8d-a3e4f2b1bee5/",
+      "child_tasks": ["/api/galaxy/pulp/api/v3/tasks/018c2181-8bde-77bf-a3df-260a7989bc75/"],
+      "task_group": "/api/galaxy/pulp/api/v3/task-groups/018c2181-7a9b-7fe2-8419-c65d6ba0641b/",
       "progress_reports": [
         {
           "message": "Signing new CollectionVersions",
@@ -163,11 +161,11 @@
       ],
       "created_resources": [null, null],
       "reserved_resources_record": [
-        "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/"
+        "/api/galaxy/pulp/api/v3/repositories/ansible/ansible/018bd8d7-d52e-70bd-90a9-812d90a2c027/"
       ]
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2181-7aa3-770d-8a8d-a3e4f2b1bee5/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2181-7aa3-770d-8a8d-a3e4f2b1bee5/",
       "pulp_created": "2023-11-30T18:33:02.886766Z",
       "state": "completed",
       "name": "galaxy_ng.app.tasks.publishing.import_and_auto_approve",
@@ -176,20 +174,18 @@
       "started_at": "2023-11-30T18:33:02.965666Z",
       "finished_at": "2023-11-30T18:33:06.330265Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
-      "child_tasks": [
-        "/api/automation-hub/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/"
-      ],
-      "task_group": "/api/automation-hub/pulp/api/v3/task-groups/018c2181-7a9b-7fe2-8419-c65d6ba0641b/",
+      "child_tasks": ["/api/galaxy/pulp/api/v3/tasks/018c2181-8811-7d7a-8b61-ef18130f0d0c/"],
+      "task_group": "/api/galaxy/pulp/api/v3/task-groups/018c2181-7a9b-7fe2-8419-c65d6ba0641b/",
       "progress_reports": [],
       "created_resources": [
-        "/api/automation-hub/pulp/api/v3/content/ansible/collection_versions/018c2181-8785-722a-a810-0c4ee0d7636b/"
+        "/api/galaxy/pulp/api/v3/content/ansible/collection_versions/018c2181-8785-722a-a810-0c4ee0d7636b/"
       ],
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2180-e4c1-77d0-b825-a2e95dcc56ee/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2180-e4c1-77d0-b825-a2e95dcc56ee/",
       "pulp_created": "2023-11-30T18:32:24.515798Z",
       "state": "completed",
       "name": "galaxy_ng.app.tasks.namespaces._add_namespace_metadata_to_repos",
@@ -198,8 +194,8 @@
       "started_at": "2023-11-30T18:32:24.611780Z",
       "finished_at": "2023-11-30T18:32:24.617303Z",
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
-      "parent_task": "/api/automation-hub/pulp/api/v3/tasks/018c2180-e3ca-73eb-a452-979ebbe03441/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "parent_task": "/api/galaxy/pulp/api/v3/tasks/018c2180-e3ca-73eb-a452-979ebbe03441/",
       "child_tasks": [],
       "task_group": null,
       "progress_reports": [],
@@ -207,7 +203,7 @@
       "reserved_resources_record": []
     },
     {
-      "pulp_href": "/api/automation-hub/pulp/api/v3/tasks/018c2180-e3ca-73eb-a452-979ebbe03441/",
+      "pulp_href": "/api/galaxy/pulp/api/v3/tasks/018c2180-e3ca-73eb-a452-979ebbe03441/",
       "pulp_created": "2023-11-30T18:32:24.267335Z",
       "state": "running",
       "name": "galaxy_ng.app.tasks.namespaces._create_pulp_namespace",
@@ -216,11 +212,9 @@
       "started_at": "2023-11-30T18:32:24.381064Z",
       "finished_at": null,
       "error": null,
-      "worker": "/api/automation-hub/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
+      "worker": "/api/galaxy/pulp/api/v3/workers/018c1d26-ba64-731c-a839-1d8c10cbb98d/",
       "parent_task": null,
-      "child_tasks": [
-        "/api/automation-hub/pulp/api/v3/tasks/018c2180-e4c1-77d0-b825-a2e95dcc56ee/"
-      ],
+      "child_tasks": ["/api/galaxy/pulp/api/v3/tasks/018c2180-e4c1-77d0-b825-a2e95dcc56ee/"],
       "task_group": null,
       "progress_reports": [],
       "created_resources": [],

--- a/frontend/hub/access/roles/RolePage/RoleDetails.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleDetails.cy.tsx
@@ -9,7 +9,7 @@ const mockRole: Role = {
   name: 'galaxy.mockRole',
   description: 'mock role description',
   permissions: ['galaxy.upload_to_namespace', 'galaxy.add_user'],
-  pulp_href: '/api/automation-hub/pulp/api/v3/roles/53759f26-ca33-4619-8fe7-8ebb2ca37996/',
+  pulp_href: '/api/galaxy/pulp/api/v3/roles/53759f26-ca33-4619-8fe7-8ebb2ca37996/',
   pulp_created: '2023-12-06T17:07:47.687445Z',
   locked: false,
 };

--- a/frontend/hub/access/roles/RolePage/RoleForm.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/RoleForm.cy.tsx
@@ -23,7 +23,7 @@ const mockRole: Role = {
   name: 'galaxy.mockRole',
   description: 'mock role description',
   permissions: ['galaxy.upload_to_namespace', 'galaxy.add_user'],
-  pulp_href: '/api/automation-hub/pulp/api/v3/roles/53759f26-ca33-4619-8fe7-8ebb2ca37996/',
+  pulp_href: '/api/galaxy/pulp/api/v3/roles/53759f26-ca33-4619-8fe7-8ebb2ca37996/',
   pulp_created: '2023-12-06T17:07:47.687445Z',
   locked: false,
 };

--- a/webpack/environment.cjs
+++ b/webpack/environment.cjs
@@ -25,7 +25,7 @@ const HUB_SERVER =
 const HUB_USERNAME = process.env.HUB_USERNAME || process.env.CYPRESS_HUB_USERNAME || 'admin';
 const HUB_PASSWORD = process.env.HUB_PASSWORD || process.env.CYPRESS_HUB_PASSWORD || 'password';
 const HUB_API_PREFIX =
-  process.env.HUB_API_PREFIX || process.env.HUB_API_BASE_PATH || '/api/automation-hub';
+  process.env.HUB_API_PREFIX || process.env.HUB_API_BASE_PATH || '/api/galaxy';
 
 const ROUTE_PREFIX = process.env.ROUTE_PREFIX || '/';
 


### PR DESCRIPTION
`/api/automation-hub` is only used by c.r.c now
(previously it was also used by the default hub dev env, but that changed to galaxy too)

Changing all `/api/automation-hub` to `/api/galaxy`, except console.redhat.com references :)

(AAP-28462)