### PR TITLE
EE: Use in Controller

### DIFF
--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
@@ -1,13 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ButtonVariant } from '@patternfly/react-core';
-import {
-  BuilderImageIcon,
-  CheckIcon,
-  PencilAltIcon,
-  SyncAltIcon,
-  TrashIcon,
-} from '@patternfly/react-icons';
+import { CheckIcon, PencilAltIcon, SyncAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { HubRoute } from '../../../main/HubRoutes';
 import {
   IPageAction,
@@ -21,6 +15,7 @@ import {
   useSyncExecutionEnvironments,
   useSignExecutionEnvironments,
 } from '../../hooks/useExecutionEnvironmentsActions';
+import { useController } from '../../hooks/useController';
 
 export function useExecutionEnvironmentPageActions(options: { refresh?: () => undefined }) {
   const { t } = useTranslation();
@@ -44,6 +39,8 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
       ee.pulp?.repository?.remote?.last_sync_task?.state || ''
     );
 
+  const useInController = useController();
+
   return useMemo(() => {
     const actions: IPageAction<ExecutionEnvironment>[] = [
       {
@@ -66,13 +63,7 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
         isDisabled: (ee) => (isSyncRunning(ee) ? t('Sync is already running.') : undefined),
         onClick: (ee: ExecutionEnvironment) => syncExecutionEnvironments([ee]),
       },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: BuilderImageIcon,
-        label: t('Use in controller'),
-        onClick: () => {},
-      },
+      useInController,
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -97,5 +88,6 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
     deleteExecutionEnvironments,
     signExecutionEnvironments,
     syncExecutionEnvironments,
+    useInController,
   ]);
 }

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useImagesToolbarActions.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useImagesToolbarActions.tsx
@@ -5,6 +5,7 @@ import { IPageAction, PageActionType, PageActionSelection } from '../../../../..
 import { ExecutionEnvironmentImage as Image } from '../ExecutionEnvironmentImage';
 import { useDeleteImages } from './useDeleteImages';
 import { useExecutionEnvironmentManageTags } from './useExecutionEnvironmentManageTags';
+import { useController } from '../../hooks/useController';
 import { ExecutionEnvironment } from '../../ExecutionEnvironment';
 
 export function useImagesToolbarActions({
@@ -26,6 +27,7 @@ export function useImagesToolbarActions({
   const executionEnvironmentManageTags = useExecutionEnvironmentManageTags(() => {
     void refresh?.();
   });
+  const useInController = useController(executionEnvironment, /* isImage: */ true);
 
   return useMemo<IPageAction<Image>[]>(
     () => [
@@ -38,12 +40,7 @@ export function useImagesToolbarActions({
         },
         isHidden: () => !!executionEnvironment.pulp?.repository?.remote,
       },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        label: t('Use in Controller'),
-        onClick: () => {},
-      },
+      useInController,
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -55,6 +52,6 @@ export function useImagesToolbarActions({
         },
       },
     ],
-    [t, executionEnvironment, deleteImages, executionEnvironmentManageTags]
+    [t, executionEnvironment, deleteImages, executionEnvironmentManageTags, useInController]
   );
 }

--- a/frontend/hub/execution-environments/hooks/useController.tsx
+++ b/frontend/hub/execution-environments/hooks/useController.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BuilderImageIcon } from '@patternfly/react-icons';
+import {
+  IPageAction,
+  PageActionType,
+  PageActionSelection,
+  usePageNavigate,
+} from '../../../../framework';
+import { AwxRoute } from '../../../awx/main/AwxRoutes';
+import { ExecutionEnvironment } from '../ExecutionEnvironment';
+import { ExecutionEnvironmentImage as Image } from '../ExecutionEnvironmentPage/ExecutionEnvironmentImage';
+
+// returns controller UI URL for the EE add form, prefilling a chosen image from hub
+export function imageURL({
+  image: name,
+  tag,
+  digest,
+}: {
+  image: string;
+  tag?: string;
+  digest?: string;
+}) {
+  if (!digest && !tag) {
+    tag = 'latest';
+  }
+
+  const host = window.location.host;
+
+  return `${host}/${name}${tag ? `:${tag}` : ''}${digest && !tag ? `@${digest}` : ''}`;
+}
+
+// FIXME: remove from upstream in favor of pluggable actions (AAP-26404)
+export function useController(detailEE?: ExecutionEnvironment, isImage = false) {
+  const { t } = useTranslation();
+  const navigate = usePageNavigate();
+
+  return useMemo<IPageAction<ExecutionEnvironment | Image>>(
+    () => ({
+      type: PageActionType.Button,
+      selection: PageActionSelection.Single,
+      icon: BuilderImageIcon,
+      label: t('Use in Controller'),
+      onClick: (listItem?: ExecutionEnvironment | Image) => {
+        const executionEnvironment = (
+          isImage ? detailEE : listItem || detailEE
+        ) as ExecutionEnvironment;
+        const eeImage = isImage ? (listItem as Image) : null;
+
+        const image = eeImage
+          ? imageURL({
+              image: executionEnvironment.name,
+              digest: eeImage.digest,
+              tag: eeImage.tags[0],
+            })
+          : imageURL({ image: executionEnvironment.name });
+
+        navigate(AwxRoute.CreateExecutionEnvironment, {
+          params: {
+            image,
+          },
+        });
+      },
+    }),
+    [t, detailEE, isImage, navigate]
+  );
+}

--- a/frontend/hub/execution-environments/hooks/useController.tsx
+++ b/frontend/hub/execution-environments/hooks/useController.tsx
@@ -56,7 +56,7 @@ export function useController(detailEE?: ExecutionEnvironment, isImage = false) 
           : imageURL({ image: executionEnvironment.name });
 
         navigate(AwxRoute.CreateExecutionEnvironment, {
-          params: {
+          query: {
             image,
           },
         });

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
@@ -15,6 +15,7 @@ import {
   useSignExecutionEnvironments,
   useSyncExecutionEnvironments,
 } from './useExecutionEnvironmentsActions';
+import { useController } from './useController';
 
 export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnvironment[]) => void) {
   const { t } = useTranslation();
@@ -23,6 +24,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
   const syncExecutionEnvironments = useSyncExecutionEnvironments(callback);
   const signExecutionEnvironment = useSignExecutionEnvironments(callback);
   const pageNavigate = usePageNavigate();
+  const useInController = useController();
 
   return useMemo<IPageAction<ExecutionEnvironment>[]>(
     () => [
@@ -61,6 +63,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
             ? ''
             : t`You do not have rights to this operation`,
       },
+      useInController,
       { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,
@@ -81,6 +84,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
       syncExecutionEnvironments,
       signExecutionEnvironment,
       pageNavigate,
+      useInController,
     ]
   );
 }


### PR DESCRIPTION
make sure the "Use in Controller" action is available in EE list row kebabs, EE detail header, and EE detail Images tab list row kebabs, and leads to Automation Controller > Infrastructure > EEs > Add

Issue: AAP-26404

This makes the feature ready for the hackathon,
but does NOT close AAP-26404, because there's still a TODO of moving this to downstream only, and making it possible to inject actions here. (And tests.)
(For now, the feature also appears upstream, but only does a console.error about a missing route.)

(Does close AAH-2515)

---

![20240805190753](https://github.com/user-attachments/assets/1639de84-5436-4ebf-994b-14bbe8ed8b4f)
![20240805190804](https://github.com/user-attachments/assets/10e2bab8-1335-4e2d-a15e-1e56b2a3c9b4)
![20240805190812](https://github.com/user-attachments/assets/9c9b87bb-6a23-4ef5-9eb8-94c10fad858b)
