### PR TITLE
[AAP-28713] Hub collections documentation

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
@@ -99,7 +99,6 @@ export function CollectionDocumentation() {
       .sort((l, r) => l.name.localeCompare(r.name));
   }, [data, searchText, t]);
 
-  const [isDrawerOpen, setDrawerOpen] = useState(true);
   const lg = useBreakpoint('lg');
 
   if (!data && !error) {
@@ -147,18 +146,15 @@ export function CollectionDocumentation() {
   }
 
   return (
-    <Drawer isExpanded={isDrawerOpen} isInline={lg} position="left">
+    <Drawer isExpanded isInline={lg} position="left">
       <DrawerContent
         panelContent={
-          isDrawerOpen ? (
-            <CollectionDocumentationTabPanel
-              setDrawerOpen={setDrawerOpen}
-              groups={groups}
-              setSearchText={setSearchText}
-              searchText={searchText}
-              docs={docsFiles}
-            />
-          ) : undefined
+          <CollectionDocumentationTabPanel
+            groups={groups}
+            setSearchText={setSearchText}
+            searchText={searchText}
+            docs={docsFiles}
+          />
         }
       >
         <DrawerContentBody className="body hub-docs-content pf-v5-c-content hub-content-alert-fix">

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
@@ -74,6 +74,31 @@ export function CollectionDocumentation() {
     return Object.values(groups);
   }, [data, searchText]);
 
+  const docsFiles = useMemo(() => {
+    let files:
+      | {
+          label: string;
+          name: string;
+        }[]
+      | [] = [];
+    if (data?.results[0].docs_blob) {
+      const { docs_blob } = data.results[0];
+      files = docs_blob.documentation_files.map(({ name }) => ({
+        label: name.charAt(0).toUpperCase() + name.slice(1).split('.')[0],
+        name: name.split('.')[0],
+      }));
+    }
+    return [
+      ...files,
+      {
+        name: 'readme',
+        label: t('Readme'),
+      },
+    ]
+      ?.filter(({ name }) => name.startsWith(searchText.toLowerCase()))
+      .sort((l, r) => l.name.localeCompare(r.name));
+  }, [data, searchText, t]);
+
   const [isDrawerOpen, setDrawerOpen] = useState(true);
   const lg = useBreakpoint('lg');
 
@@ -100,8 +125,13 @@ export function CollectionDocumentation() {
 
   // for readme, use the root html of all contents
   let html = '';
-  if (!content_type) {
+  if (!content_type && !content_name) {
     html = dataItem?.docs_blob?.collection_readme?.html || '';
+  }
+  if (!content_type && content_name) {
+    html =
+      data.results[0].docs_blob.documentation_files.find((c) => c.name.startsWith(content_name))
+        ?.html || '';
   }
 
   // if the content has html, lets use that instead of content frontent generation
@@ -126,6 +156,7 @@ export function CollectionDocumentation() {
               groups={groups}
               setSearchText={setSearchText}
               searchText={searchText}
+              docs={docsFiles}
             />
           ) : undefined
         }
@@ -213,6 +244,7 @@ export type CollectionVersionContentItem = {
       html: string;
       name: string;
     };
+    documentation_files: { name: string; html: string }[];
   };
   license: string[];
 };

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -235,6 +235,7 @@ export function CollectionPage() {
         params={{
           name: collection?.collection_version?.name || '',
           namespace: collection?.collection_version?.namespace || '',
+          content_name: '',
           version: collection?.collection_version?.version || '',
           repository: collection?.repository?.name || '',
         }}

--- a/frontend/hub/collections/CollectionPage/documentationComponents/CollectionDocumentationTabPanel.tsx
+++ b/frontend/hub/collections/CollectionPage/documentationComponents/CollectionDocumentationTabPanel.tsx
@@ -1,8 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import React, { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import {
-  DrawerActions,
-  DrawerCloseButton,
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
@@ -18,7 +16,6 @@ import { HubRoute } from '../../../main/HubRoutes';
 import { usePageNavigate } from '../../../../../framework';
 
 export function CollectionDocumentationTabPanel(props: {
-  setDrawerOpen: Dispatch<SetStateAction<boolean>>;
   setSearchText: Dispatch<SetStateAction<string>>;
   searchText: string;
   groups: {
@@ -27,7 +24,7 @@ export function CollectionDocumentationTabPanel(props: {
   }[];
   docs: { name: string; label: string }[];
 }) {
-  const { groups, setDrawerOpen, setSearchText, docs } = props;
+  const { groups, setSearchText, docs } = props;
   const [searchParams] = useSearchParams();
   const navigate = usePageNavigate();
   const params = useParams();
@@ -43,9 +40,6 @@ export function CollectionDocumentationTabPanel(props: {
           placeholder={t('Find content')}
           onChange={(event, value) => setSearchText(value)}
         />
-        <DrawerActions style={{ alignSelf: 'center' }}>
-          <DrawerCloseButton onClick={() => setDrawerOpen(false)} />
-        </DrawerActions>
       </DrawerHead>
       <DrawerPanelBody style={{ borderTop: 'thin solid var(--pf-v5-global--BorderColor--100)' }}>
         <Nav theme="light">

--- a/frontend/hub/collections/CollectionPage/documentationComponents/CollectionDocumentationTabPanel.tsx
+++ b/frontend/hub/collections/CollectionPage/documentationComponents/CollectionDocumentationTabPanel.tsx
@@ -25,8 +25,9 @@ export function CollectionDocumentationTabPanel(props: {
     name: string;
     contents: IContents[];
   }[];
+  docs: { name: string; label: string }[];
 }) {
-  const { groups, setDrawerOpen, setSearchText } = props;
+  const { groups, setDrawerOpen, setSearchText, docs } = props;
   const [searchParams] = useSearchParams();
   const navigate = usePageNavigate();
   const params = useParams();
@@ -49,20 +50,30 @@ export function CollectionDocumentationTabPanel(props: {
       <DrawerPanelBody style={{ borderTop: 'thin solid var(--pf-v5-global--BorderColor--100)' }}>
         <Nav theme="light">
           <NavList>
-            <NavExpandable key="documentation" title={t('Documentation')} isExpanded>
-              {t('Readme').startsWith(props.searchText) && (
-                <NavItem
-                  key="readme"
-                  onClick={() => {
-                    navigate(HubRoute.CollectionDocumentation, {
-                      query,
-                      params: { repository, namespace, name },
-                    });
-                  }}
-                >
-                  {t('Readme')}
-                </NavItem>
-              )}
+            <NavExpandable
+              key="documentation"
+              title={t('Documentation ({{docs}})', { docs: docs.length })}
+              isExpanded
+            >
+              {docs.length > 0 &&
+                docs.map(({ name: docName, label }) => (
+                  <NavItem
+                    key={docName}
+                    onClick={() =>
+                      navigate(HubRoute.CollectionDocumentation, {
+                        query,
+                        params: {
+                          repository,
+                          namespace,
+                          content_name: docName === 'readme' ? '' : docName,
+                          name,
+                        },
+                      })
+                    }
+                  >
+                    {label}
+                  </NavItem>
+                ))}
             </NavExpandable>
             {groups.map((group) => (
               <NavExpandable

--- a/frontend/hub/main/useHubNavigation.tsx
+++ b/frontend/hub/main/useHubNavigation.tsx
@@ -161,6 +161,11 @@ export function useHubNavigation() {
               element: <CollectionDocumentation />,
             },
             {
+              id: HubRoute.CollectionDocumentation,
+              path: 'documentation/:content_name',
+              element: <CollectionDocumentation />,
+            },
+            {
               id: HubRoute.CollectionDocumentationContent,
               path: 'documentation/:content_type/:content_name',
               element: <CollectionDocumentation />,


### PR DESCRIPTION
This addresses 2 things:
1. First commit (98fb0a35db6cf078aa7399e7f150bf54f67e949d) addresses AAP-28713.
2. The second commit (5d076b96d47d4289e3ba837f90f87438eb5ef444) removes the drawer close button because it can't be reopened without navigating away from the view and returning, or refreshing the page.  Also, this button does not seem to be present on the old UI.  Its a POC and I put it in a separate commit to easily remove that work if we decide we want to keep it.