### PR TITLE
AAP-28425: Add download buttons to Remotes

### DIFF
--- a/frontend/hub/administration/remotes/hooks/useRemoteActions.tsx
+++ b/frontend/hub/administration/remotes/hooks/useRemoteActions.tsx
@@ -1,5 +1,5 @@
 import { ButtonVariant } from '@patternfly/react-core';
-import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { DownloadIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -11,6 +11,7 @@ import {
 import { HubRoute } from '../../../main/HubRoutes';
 import { HubRemote } from '../Remotes';
 import { useDeleteRemotes } from './useDeleteRemotes';
+import { downloadTextFile } from '../../../../../framework/utils/download-file';
 
 export function useRemoteActions(options: { onRemotesDeleted: (remotes: HubRemote[]) => void }) {
   const { onRemotesDeleted } = options;
@@ -27,6 +28,34 @@ export function useRemoteActions(options: { onRemotesDeleted: (remotes: HubRemot
         selection: PageActionSelection.Single,
         type: PageActionType.Button,
         variant: ButtonVariant.primary,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        isHidden: (remotes) => !remotes.requirements_file,
+        icon: DownloadIcon,
+        label: t('Download requirement file'),
+        onClick: (remotes) =>
+          downloadTextFile('requirement', remotes.requirements_file ?? '', 'yaml'),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        isHidden: (remotes) => !remotes.client_cert,
+        icon: DownloadIcon,
+        label: t('Download client certificate'),
+        onClick: (remotes) => downloadTextFile('client_cert', remotes.client_cert ?? ''),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        variant: ButtonVariant.primary,
+        isHidden: (remotes) => !remotes.ca_cert,
+        icon: DownloadIcon,
+        label: t('Download CA certificate'),
+        onClick: (remotes) => downloadTextFile('ca_cert', remotes.ca_cert ?? ''),
       },
       {
         type: PageActionType.Seperator,


### PR DESCRIPTION
- If a remote has YAML requirements it has Download requirements button
- If a remote has CA certification it has Download CA certification button
- If a remote has client certification it has Download client certification button

Note: CA certification and client certification can be any text file

<img width="1429" alt="Screenshot 2024-08-06 at 16 08 00" src="https://github.com/user-attachments/assets/b36f43bf-c59c-410f-9888-324b2277e59d">
<img width="1422" alt="Screenshot 2024-08-06 at 16 07 49" src="https://github.com/user-attachments/assets/927fd404-fb56-42de-aae7-d3ecb537c8a8">
