### PR TITLE
Revert "HubMasthead - link to full experience approvals"

### DIFF
--- a/frontend/hub/main/HubMasthead.tsx
+++ b/frontend/hub/main/HubMasthead.tsx
@@ -18,6 +18,7 @@ import { hubAPI } from '../common/api/formatPath';
 import { useHubActiveUser } from '../common/useHubActiveUser';
 import { useHubContext } from '../common/useHubContext';
 import { HubItemsResponse } from '../common/useHubView';
+import { HubRoute } from './HubRoutes';
 
 export function HubMasthead() {
   const { t } = useTranslation();
@@ -110,10 +111,7 @@ export function useHubNotifications() {
             variant: 'info',
 
             // TODO to should goto the specific approval page instead of the approvals page
-            // to: getPageUrl(HubRoute.Approvals, { query: { status: 'pipeline=staging' } }),
-
-            // go to full experience approvals
-            to: '/ui/approval-dashboard/',
+            to: getPageUrl(HubRoute.Approvals, { query: { status: 'pipeline=staging' } }),
           })) ?? [],
       };
       return { ...groups };


### PR DESCRIPTION
Reverts ansible/ansible-ui#2759

Old Hub UI is no longer going to be a part of the next release.

Therefore, the notification should link to new UI approvals again :)