### PR TITLE
[AAP-28411] Support my imports log scroll to bottom behavior

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionImportLog.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionImportLog.tsx
@@ -2,20 +2,14 @@ import { Alert, CodeBlock, PageSection, Stack, StackItem } from '@patternfly/rea
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
-import styled from 'styled-components';
-import {
-  LoadingPage,
-  PFColorE,
-  PageDetail,
-  PageDetails,
-  Scrollable,
-  getPatternflyColor,
-} from '../../../../framework';
+import { LoadingPage, PFColorE, PageDetail, PageDetails, Scrollable } from '../../../../framework';
 import { StatusCell } from '../../../common/Status';
 import { useGet } from '../../../common/crud/useGet';
 import { HubError } from '../../common/HubError';
 import { hubAPI } from '../../common/api/formatPath';
 import { HubItemsResponse } from '../../common/useHubView';
+import { getLogMessageColor } from '../../common/utils/getLogMessageColor';
+import { NavigationArrow } from '../../common/ImportLogNavigationArrow';
 import { CollectionImport, CollectionVersionSearch } from '../Collection';
 
 export function CollectionImportLog() {
@@ -138,7 +132,7 @@ export function CollectionImportLog() {
                   <div
                     key={index}
                     style={{
-                      color: getColor(message.level),
+                      color: getLogMessageColor(message.level),
                     }}
                   >
                     {message.message}
@@ -157,68 +151,5 @@ export function CollectionImportLog() {
         </PageSection>
       </div>
     </Scrollable>
-  );
-}
-
-function getColor(messageLevel: string) {
-  const res = getPatternflyColor(
-    messageLevel === 'WARNING'
-      ? PFColorE.Warning
-      : messageLevel === 'ERROR'
-        ? PFColorE.Danger
-        : PFColorE.Disabled
-  );
-
-  if (messageLevel === 'INFO') {
-    return 'white';
-  }
-  return res;
-}
-
-const arrowStyle = `
-  color: white;
-  &:hover {
-    cursor: pointer;
-  }
-  position: absolute;
-  margin-bottom: 10px;
-  margin-right: 10px;
-  font-size: 120%;
-`;
-
-const StyledArrowDown = styled.div`
-  ${arrowStyle}
-  right: 0; /* Aligns the icon to the right */
-  top: 0; /* Aligns the icon to the top */
-`;
-
-const StyledArrowUp = styled.div`
-  ${arrowStyle}
-  right: 0;
-  bottom: 0;
-`;
-
-function NavigationArrow(props: { direction: 'up' | 'down'; onClick: () => void }) {
-  const className = `fa fa-arrow-circle-${props.direction} clickable`;
-
-  const Component = props.direction === 'up' ? StyledArrowUp : StyledArrowDown;
-
-  return (
-    <Component>
-      <span
-        role="button"
-        onClick={() => {
-          props.onClick();
-        }}
-        onKeyDown={(event) => {
-          // Trigger click on Enter key
-          if (event.key === 'Enter') {
-            props.onClick();
-          }
-        }}
-        tabIndex={props.direction === 'up' ? 0 : 1} // Make the element focusable
-        className={className}
-      />
-    </Component>
   );
 }

--- a/frontend/hub/common/ImportLogNavigationArrow.tsx
+++ b/frontend/hub/common/ImportLogNavigationArrow.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+const arrowStyle = `
+  color: white;
+  &:hover {
+    cursor: pointer;
+  }
+  position: absolute;
+  margin-bottom: 10px;
+  margin-right: 10px;
+  font-size: 120%;
+`;
+
+const StyledArrowDown = styled.div`
+  ${arrowStyle}
+  right: 0; /* Aligns the icon to the right */
+  top: 0; /* Aligns the icon to the top */
+`;
+
+const StyledArrowUp = styled.div`
+  ${arrowStyle}
+  right: 0;
+  bottom: 0;
+`;
+
+export function NavigationArrow(props: { direction: 'up' | 'down'; onClick: () => void }) {
+  const className = `fa fa-arrow-circle-${props.direction} clickable`;
+
+  const Component = props.direction === 'up' ? StyledArrowUp : StyledArrowDown;
+
+  return (
+    <Component>
+      <span
+        role="button"
+        onClick={() => {
+          props.onClick();
+        }}
+        onKeyDown={(event) => {
+          // Trigger click on Enter key
+          if (event.key === 'Enter') {
+            props.onClick();
+          }
+        }}
+        tabIndex={props.direction === 'up' ? 0 : 1} // Make the element focusable
+        className={className}
+      />
+    </Component>
+  );
+}

--- a/frontend/hub/common/utils/getLogMessageColor.tsx
+++ b/frontend/hub/common/utils/getLogMessageColor.tsx
@@ -1,0 +1,16 @@
+import { getPatternflyColor, PFColorE } from '../../../../framework';
+
+export function getLogMessageColor(messageLevel: string) {
+  const res = getPatternflyColor(
+    messageLevel === 'WARNING'
+      ? PFColorE.Warning
+      : messageLevel === 'ERROR'
+        ? PFColorE.Danger
+        : PFColorE.Disabled
+  );
+
+  if (messageLevel === 'INFO') {
+    return 'white';
+  }
+  return res;
+}

--- a/frontend/hub/my-imports/MyImports.tsx
+++ b/frontend/hub/my-imports/MyImports.tsx
@@ -5,21 +5,13 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  Flex,
-  FlexItem,
   PageSection,
   Title,
 } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router-dom';
-import {
-  IFilterState,
-  PageHeader,
-  PageLayout,
-  Scrollable,
-  useGetPageUrl,
-} from '../../../framework';
+import { IFilterState, PageHeader, PageLayout, useGetPageUrl } from '../../../framework';
 import { useGet } from '../../common/crud/useGet';
 import { CollectionImport, CollectionVersionSearch } from '../collections/Collection';
 import { hubAPI } from '../common/api/formatPath';
@@ -40,7 +32,7 @@ export function MyImports() {
   const pageQP = Number(searchParams.get('page')) || 1;
   const perPageQP = Number(searchParams.get('perPage')) || 10;
 
-  const [isDrawerExpanded, setIsDrawerExpanded] = useState(false);
+  const [isDrawerExpanded, setIsDrawerExpanded] = useState(true);
   const [selectedImport, setSelectedImport] = useState('');
   const [collectionFilter, setCollectionFilter] = useState<IFilterState>({
     name: nameQP ? [nameQP] : undefined,
@@ -175,16 +167,12 @@ export function MyImports() {
         )}
       </DrawerHead>
       <DrawerPanelBody>
-        <Flex spaceItems={{ default: 'spaceItemsLg' }} direction={{ default: 'column' }}>
-          <FlexItem>
-            <ImportLog
-              isLoading={importLogLoading}
-              error={importLogError}
-              collectionImport={collectionImportResp}
-              collection={collection}
-            />
-          </FlexItem>
-        </Flex>
+        <ImportLog
+          isLoading={importLogLoading}
+          error={importLogError}
+          collectionImport={collectionImportResp}
+          collection={collection}
+        />
       </DrawerPanelBody>
     </DrawerPanelContent>
   );
@@ -192,37 +180,35 @@ export function MyImports() {
   return (
     <PageLayout>
       <PageHeader title={t('My imports')} description={t('Imported collections')} />
-      <Scrollable>
-        <PageSection variant="light">
-          <Drawer isExpanded={isDrawerExpanded} isStatic>
-            <DrawerContent panelContent={panelContent}>
-              <DrawerContentBody>
-                <ImportList
-                  isLoading={collectionImportsLoading}
-                  error={collectionImportsError}
-                  collectionImports={collectionImports}
-                  selectedImport={selectedImport}
-                  setSelectedImport={setSelectedImport}
-                  setSelectedNamespace={setNamespaceQP}
-                  queryParams={{
-                    status: statusQP,
-                    name: nameQP,
-                    namespace: namespaceQP,
-                    perPage: perPageQP,
-                    page: pageQP,
-                  }}
-                  setPage={setPage}
-                  setPerPage={setPerPage}
-                  itemCount={collectionImportsCount}
-                  setDrawerExpanded={() => setIsDrawerExpanded(true)}
-                  collectionFilter={collectionFilter}
-                  setCollectionFilter={setCollectionFilter}
-                />
-              </DrawerContentBody>
-            </DrawerContent>
-          </Drawer>
-        </PageSection>
-      </Scrollable>
+      <PageSection variant="light" hasOverflowScroll hasShadowTop={false} hasShadowBottom={false}>
+        <Drawer isExpanded={isDrawerExpanded} isInline>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>
+              <ImportList
+                isLoading={collectionImportsLoading}
+                error={collectionImportsError}
+                collectionImports={collectionImports}
+                selectedImport={selectedImport}
+                setSelectedImport={setSelectedImport}
+                setSelectedNamespace={setNamespaceQP}
+                queryParams={{
+                  status: statusQP,
+                  name: nameQP,
+                  namespace: namespaceQP,
+                  perPage: perPageQP,
+                  page: pageQP,
+                }}
+                setPage={setPage}
+                setPerPage={setPerPage}
+                itemCount={collectionImportsCount}
+                setDrawerExpanded={() => setIsDrawerExpanded(true)}
+                collectionFilter={collectionFilter}
+                setCollectionFilter={setCollectionFilter}
+              />
+            </DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </PageSection>
     </PageLayout>
   );
 }

--- a/frontend/hub/my-imports/components/ImportLog.tsx
+++ b/frontend/hub/my-imports/components/ImportLog.tsx
@@ -1,17 +1,20 @@
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getPatternflyColor, PFColorE } from '../../../../framework';
 import { Alert, CodeBlock, Stack, StackItem } from '@patternfly/react-core';
 import { CollectionImport, CollectionVersionSearch } from '../../collections/Collection';
 import { ImportStatusBar } from './ImportStatusBar';
 import styled from 'styled-components';
 import { LoadingState } from '../../../../framework/components/LoadingState';
 import { EmptyStateError } from '../../../../framework/components/EmptyStateError';
+import { getLogMessageColor } from '../../common/utils/getLogMessageColor';
+import { NavigationArrow } from '../../common/ImportLogNavigationArrow';
 
 const EmptyImportConsole = styled.div`
   height: 500px;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: white;
 `;
 
 interface IProps {
@@ -23,13 +26,14 @@ interface IProps {
 
 export function ImportLog({ isLoading, collectionImport, collection, error }: IProps) {
   const { t } = useTranslation();
+  const ref = useRef<HTMLDivElement>(null);
 
   if (error) return <EmptyStateError titleProp={error.name} message={error.message} />;
 
   if (isLoading) return <LoadingState />;
 
   return (
-    <>
+    <div ref={ref}>
       {collectionImport && (
         <ImportStatusBar collection={collection} collectionImport={collectionImport} />
       )}
@@ -51,22 +55,29 @@ export function ImportLog({ isLoading, collectionImport, collection, error }: IP
           <pre style={{ whiteSpace: 'pre-wrap' }}>{collectionImport?.error?.traceback}</pre>
         </Alert>
       )}
-      <CodeBlock style={{ marginTop: '10px' }} data-cy="import-console">
+      <CodeBlock
+        style={{
+          marginTop: '10px',
+          backgroundColor: 'var(--pf-v5-global--palette--black-850)',
+          position: 'relative',
+        }}
+        data-cy="import-console"
+      >
+        <NavigationArrow
+          direction="down"
+          onClick={() => ref.current?.scrollIntoView({ block: 'end', behavior: 'smooth' })}
+        />
+        <NavigationArrow
+          direction="up"
+          onClick={() => ref.current?.scrollIntoView({ block: 'start', behavior: 'smooth' })}
+        />
         {collectionImport ? (
           <>
             {collectionImport.messages?.map((message, index) => (
               <div
                 key={index}
                 style={{
-                  color: getPatternflyColor(
-                    message.level === 'INFO'
-                      ? PFColorE.Default
-                      : message.level === 'WARNING'
-                        ? PFColorE.Warning
-                        : message.level === 'ERROR'
-                          ? PFColorE.Danger
-                          : PFColorE.Disabled
-                  ),
+                  color: getLogMessageColor(message.level),
                 }}
               >
                 {message.message}
@@ -77,6 +88,6 @@ export function ImportLog({ isLoading, collectionImport, collection, error }: IP
           <EmptyImportConsole>{t`No data`}</EmptyImportConsole>
         )}
       </CodeBlock>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAP-28411

* Add my imports code block scroll to bottom and scroll to top buttons
* Support scrollable functionality in my imports drawer panel 
* Add a common "getLogMessageColor" helper function and Navigation Arrows component to share between Collections > Import Log and Namespaces > My Imports

After:
![scroll-panel-body](https://github.com/user-attachments/assets/7ea703b5-b67b-4418-8f03-7373ae487580)


Before: 
![Screenshot 2024-08-06 at 12 32 22 PM](https://github.com/user-attachments/assets/14a63ad2-879d-4407-9a48-a0830666f00d)
