### PR TITLE
Hub EE tests - switch from cy.visit to cy.navigateTo

### DIFF
--- a/cypress/e2e/hub/execution-environments.cy.ts
+++ b/cypress/e2e/hub/execution-environments.cy.ts
@@ -4,6 +4,14 @@ import { ExecutionEnvironment } from '../../../frontend/hub/execution-environmen
 import { hubAPI } from '../../support/formatApiPathForHub';
 import { ExecutionEnvironments } from './constants';
 
+function visitEEDetail(name: string) {
+  cy.navigateTo('hub', ExecutionEnvironments.url);
+  cy.verifyPageTitle('Execution Environments');
+  cy.filterTableBySingleText(name);
+  cy.get('a').contains(name).click();
+  cy.verifyPageTitle(name);
+}
+
 describe('Execution Environments', () => {
   it('can render the execution environments page', () => {
     cy.navigateTo('hub', ExecutionEnvironments.url);
@@ -116,11 +124,7 @@ describe('Execution Environment Details tab', () => {
   });
 
   it('should render the execution environment details page', () => {
-    // test navigating by sidebar menu
-    cy.navigateTo('hub', ExecutionEnvironments.url);
-    cy.filterTableBySingleText(executionEnvironment.name);
-    cy.get('a').contains(executionEnvironment.name).click();
-    cy.verifyPageTitle(executionEnvironment.name);
+    visitEEDetail(executionEnvironment.name);
     cy.contains('Unsigned');
 
     const tabs = ['Details', 'Activity', 'Images', 'Access'];
@@ -131,9 +135,7 @@ describe('Execution Environment Details tab', () => {
   });
 
   it('should render details page tab with instructions and empty readme', () => {
-    // test visiting by URL
-    cy.visit(`/execution-environments/${executionEnvironment.name}/`);
-    cy.verifyPageTitle(executionEnvironment.name);
+    visitEEDetail(executionEnvironment.name);
     cy.get('[aria-selected="true"]').contains('Details');
     cy.contains('Instructions');
     cy.contains('Pull this image');
@@ -149,8 +151,7 @@ describe('Execution Environment Details tab', () => {
   });
 
   it('should add readme with markdown editor', () => {
-    cy.visit(`/execution-environments/${executionEnvironment.name}/`);
-    cy.verifyPageTitle(executionEnvironment.name);
+    visitEEDetail(executionEnvironment.name);
     cy.containsBy('button', 'Add').click();
     cy.contains('README');
     cy.get('[data-cy="readme"]').within(() => {
@@ -170,7 +171,7 @@ describe('Execution Environment Details tab', () => {
   });
 
   it('should change readme after editing', () => {
-    cy.visit(`/execution-environments/${executionEnvironment.name}/`);
+    visitEEDetail(executionEnvironment.name);
     cy.get('[data-cy="readme"]').within(() => {
       cy.contains('Heading 1');
       cy.containsBy('button', 'Edit').click();
@@ -188,7 +189,7 @@ describe('Execution Environment Details tab', () => {
   });
 
   it('should not change readme after cancel edit', () => {
-    cy.visit(`/execution-environments/${executionEnvironment.name}/`);
+    visitEEDetail(executionEnvironment.name);
     cy.get('[data-cy="readme"]').within(() => {
       cy.containsBy('button', 'Edit').click();
       cy.getByDataCy('raw-markdown').clear().type('{enter}this should not be saved.');
@@ -202,7 +203,6 @@ describe('Execution Environment Details tab', () => {
     cy.createHubRemoteRegistry().then((remoteRegistry) => {
       cy.createHubExecutionEnvironment({
         executionEnvironment: {
-          include_tags: ['latest'],
           registry: remoteRegistry.id,
         },
       }).then((executionEnvironment) => {
@@ -221,7 +221,9 @@ describe('Execution Environment Activity tab', () => {
       cy.createHubExecutionEnvironment({
         executionEnvironment: { registry: remoteRegistry.id },
       }).then((executionEnvironment) => {
-        cy.visit(`${ExecutionEnvironments.url}/${executionEnvironment.name}/activity`);
+        visitEEDetail(executionEnvironment.name);
+        cy.getByDataCy('execution-environment-activity-tab').click();
+
         cy.contains('No activities yet');
         cy.contains('Activities will appear once you push something');
 
@@ -248,7 +250,10 @@ describe('Execution Environment Activity tab', () => {
           'GET',
           hubAPI`/v3/plugin/execution-environments/repositories/${eeName}/_content/history/*`
         ).as('getActivity');
-        cy.visit(`${ExecutionEnvironments.url}/${eeName}/activity`);
+
+        visitEEDetail(executionEnvironment.name);
+        cy.getByDataCy('execution-environment-activity-tab').click();
+
         cy.contains('Change');
         cy.contains('Date');
         cy.contains(`${eeName} was added`);

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -325,6 +325,7 @@ Cypress.Commands.add(
       body: {
         name: randomE2Ename(),
         upstream_name: 'library/alpine',
+        include_tags: ['latest'],
         ...options?.executionEnvironment,
       },
     });
@@ -349,7 +350,12 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'syncRemoteExecutionEnvironment',
   (executionEnvironment: HubExecutionEnvironment) => {
-    cy.visit(`${ExecutionEnvironments.url}/${executionEnvironment.name}/`);
+    cy.navigateTo('hub', ExecutionEnvironments.url);
+    cy.verifyPageTitle('Execution Environments');
+    cy.filterTableBySingleText(executionEnvironment.name);
+    cy.get('a').contains(executionEnvironment.name).click();
+    cy.verifyPageTitle(executionEnvironment.name);
+
     cy.getByDataCy('actions-dropdown').click();
     cy.getByDataCy('sync-execution-environment').click();
 


### PR DESCRIPTION
Issue: AAP-28462

Tests using `cy.visit` fail downstream (the routes are different, mostly missing `/content/` at the start).

Switch to `cy.navigateTo` + manual navigation to detail screen / specific tab.