### PR TITLE
Hub tests - check feature flags match expectations

### DIFF
--- a/cypress/e2e/hub/feature-flags.cy.ts
+++ b/cypress/e2e/hub/feature-flags.cy.ts
@@ -1,0 +1,21 @@
+import { hubAPI } from '../../support/formatApiPathForHub';
+
+describe('Feature flags', () => {
+  it('match expectations', () => {
+    cy.request(hubAPI`/_ui/v1/feature-flags/`).then(({ body }) => {
+      expect(body).to.deep.include({ _messages: [] });
+      expect(body).to.include({ ai_deny_index: false });
+      expect(body).to.include({ can_create_signatures: true });
+      expect(body).to.include({ can_upload_signatures: false });
+      expect(body).to.include({ collection_auto_sign: true });
+      expect(body).to.include({ collection_signing: true });
+      expect(body).to.include({ container_signing: true });
+      expect(body).to.include({ display_repositories: true });
+      expect(body).to.include({ display_signatures: true });
+      expect(body).to.include({ execution_environments: true });
+      expect(body).to.include({ legacy_roles: false });
+      expect(body).to.include({ require_upload_signatures: false });
+      expect(body).to.include({ signatures_enabled: true });
+    });
+  });
+});


### PR DESCRIPTION
Issue: AAP-28462

Adds a test that fails when the backend is misconfigured or has any configuration errors.

(currently fails downstream on AAP-28477, skipped there)