### PR TITLE
[AAP-28050] Do not disable the Delete Rulebook activation button based on the Patch permission

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationPage/RulebookActivationPage.tsx
@@ -27,8 +27,6 @@ import {
   useRestartRulebookActivations,
 } from '../hooks/useControlRulebookActivations';
 import { useDeleteRulebookActivations } from '../hooks/useDeleteRulebookActivations';
-import { useOptions } from '../../../common/crud/useOptions';
-import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
 
 export function RulebookActivationPage() {
   const { t } = useTranslation();
@@ -36,10 +34,7 @@ export function RulebookActivationPage() {
   const pageNavigate = usePageNavigate();
   const getPageUrl = useGetPageUrl();
   const alertToaster = usePageAlertToaster();
-  const { data } = useOptions<OptionsResponse<ActionsResponse>>(
-    edaAPI`/activations/${params.id ?? ''}/`
-  );
-  const canPatchActivation = Boolean(data && data.actions && data.actions['PATCH']);
+
   const { data: rulebookActivation, refresh } = useGet<EdaRulebookActivation>(
     edaAPI`/activations/${params.id ?? ''}/`
   );
@@ -126,10 +121,6 @@ export function RulebookActivationPage() {
             selection: PageActionSelection.Single,
             icon: TrashIcon,
             label: t('Delete rulebook activation'),
-            isDisabled: () =>
-              canPatchActivation
-                ? ''
-                : t(`The rulebook activation cannot be deleted due to insufficient permission.`),
             onClick: (rulebookActivation: EdaRulebookActivation) =>
               deleteRulebookActivations([rulebookActivation]),
             isDanger: true,
@@ -143,7 +134,6 @@ export function RulebookActivationPage() {
     enableRulebookActivation,
     disableRulebookActivation,
     restartRulebookActivation,
-    canPatchActivation,
     deleteRulebookActivations,
   ]);
 


### PR DESCRIPTION
There is no 'Patch' permision for Activations -remove the check for this permission for the 'Delete' button on the Details page.

After:
![Screenshot from 2024-08-08 17-06-29](https://github.com/user-attachments/assets/f2cb7d79-cb25-478a-8daf-68fdc5f4f169)
