### PR TITLE
Hub User Roles

### DIFF
--- a/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
+++ b/frontend/common/access/RolesWizard/steps/SelectRolesStep.tsx
@@ -22,6 +22,7 @@ interface SelectRolesStepHeaderProps<
   labelForSelectedItemsFromPreviousStep?: string;
   descriptionForRoleSelection?: string;
   title?: string;
+  resourceType?: string;
 }
 
 const StyledTitle = styled(Title)`
@@ -87,6 +88,7 @@ export function SelectRolesStep<T extends object>(props: SelectRolesStepProps<T>
         labelForSelectedItemsFromPreviousStep={labelForSelectedItemsFromPreviousStep}
         descriptionForRoleSelection={descriptionForRoleSelection}
         title={title}
+        resourceType={resourceType ? (resourceType as string) : undefined}
       ></SelectRolesStepHeader>
       <PageMultiSelectList
         view={view}
@@ -110,27 +112,30 @@ function SelectRolesStepHeader<
     labelForSelectedItemsFromPreviousStep,
     descriptionForRoleSelection,
     title,
+    resourceType,
   } = props;
   const { t } = useTranslation();
   return (
     <>
       <StyledTitle headingLevel="h1">{title ?? t('Select roles to apply')}</StyledTitle>
-      <Split hasGutter>
-        <SplitItem style={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-          {labelForSelectedItemsFromPreviousStep ?? t('Selected')}
-        </SplitItem>
-        {selectedItemsFromPreviousStep && selectedItemsFromPreviousStep.length > 0 && (
-          <LabelGroup>
-            {selectedItemsFromPreviousStep?.map((item, i) => {
-              return (
-                <Label key={i}>
-                  <TextCell text={item.name ? item.name : item.username} />
-                </Label>
-              );
-            })}
-          </LabelGroup>
-        )}
-      </Split>
+      {resourceType !== 'system' ? (
+        <Split hasGutter>
+          <SplitItem style={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+            {labelForSelectedItemsFromPreviousStep ?? t('Selected')}
+          </SplitItem>
+          {selectedItemsFromPreviousStep && selectedItemsFromPreviousStep.length > 0 && (
+            <LabelGroup>
+              {selectedItemsFromPreviousStep?.map((item, i) => {
+                return (
+                  <Label key={i}>
+                    <TextCell text={item.name ? item.name : item.username} />
+                  </Label>
+                );
+              })}
+            </LabelGroup>
+          )}
+        </Split>
+      ) : null}
       {descriptionForRoleSelection && (
         <h2 style={{ marginTop: '1rem', marginBottom: '1rem' }}>{descriptionForRoleSelection}</h2>
       )}

--- a/frontend/common/access/components/ResourceAccess.tsx
+++ b/frontend/common/access/components/ResourceAccess.tsx
@@ -10,6 +10,7 @@ import { awxAPI } from '../../../awx/common/api/awx-utils';
 import { Access } from './Access';
 import { useGetLinkToResourcePage } from '../hooks/useGetLinkToResourcePage';
 import { PageSelectOption } from '../../../../framework/PageInputs/PageSelectOption';
+import { hubAPI } from '../../../hub/common/api/formatPath';
 
 interface ContentTypeOption {
   value: string;
@@ -29,11 +30,23 @@ export function ResourceAccess(props: {
   const { t } = useTranslation();
   const getDisplayName = useMapContentTypeToDisplayName();
   const roleDefinitionsURL =
-    service === 'awx' ? awxAPI`/role_definitions/` : edaAPI`/role_definitions/`;
+    service === 'awx'
+      ? awxAPI`/role_definitions/`
+      : service === 'eda'
+        ? edaAPI`/role_definitions/`
+        : hubAPI`/_ui/v2/role_definitions/`;
   const roleUserAssignmentsURL =
-    service === 'awx' ? awxAPI`/role_user_assignments/` : edaAPI`/role_user_assignments/`;
+    service === 'awx'
+      ? awxAPI`/role_user_assignments/`
+      : service === 'eda'
+        ? edaAPI`/role_user_assignments/`
+        : hubAPI`/_ui/v2/role_user_assignments/`;
   const roleTeamAssignmentsURL =
-    service === 'awx' ? awxAPI`/role_team_assignments/` : edaAPI`/role_team_assignments/`;
+    service === 'awx'
+      ? awxAPI`/role_team_assignments/`
+      : service === 'eda'
+        ? edaAPI`/role_team_assignments/`
+        : hubAPI`/_ui/v2/role_team_assignments/`;
   const { data, isLoading } = useOptions<{
     actions: { POST: { content_type: { choices: ContentTypeOption[] } } };
   }>(roleDefinitionsURL);
@@ -79,7 +92,10 @@ export function ResourceAccess(props: {
           to: (assignment: TeamAssignment | UserAssignment) =>
             getLinkToResourcePage({
               contentType: assignment.content_type,
-              objectId: assignment.object_id,
+              objectId:
+                service === 'hub'
+                  ? assignment.summary_fields?.content_object?.name
+                  : assignment.object_id,
             }),
         },
       }}

--- a/frontend/common/access/hooks/useGetLinkToResourcePage.tsx
+++ b/frontend/common/access/hooks/useGetLinkToResourcePage.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useGetPageUrl } from '../../../../framework';
 import { AwxRoute } from '../../../awx/main/AwxRoutes';
 import { EdaRoute } from '../../../eda/main/EdaRoutes';
+import { HubRoute } from '../../../hub/main/HubRoutes';
 
 export function useGetLinkToResourcePage() {
   const getPageUrl = useGetPageUrl();
@@ -44,6 +45,14 @@ export function useGetLinkToResourcePage() {
           params: { id: objectId },
         }),
         'awx.project': getPageUrl(AwxRoute.ProjectDetails, { params: { id: objectId } }),
+        'galaxy.namespace': getPageUrl(HubRoute.NamespaceDetails, { params: { id: objectId } }),
+        'galaxy.ansiblerepository': getPageUrl(HubRoute.RepositoryDetails, {
+          params: { id: objectId },
+        }),
+        'galaxy.containernamespace': getPageUrl(HubRoute.ExecutionEnvironmentDetails, {
+          params: { id: objectId },
+        }),
+        'galaxy.collectionremote': getPageUrl(HubRoute.RemoteDetails, { params: { id: objectId } }),
       };
       return resourceToEndpointMapping[contentType] ?? undefined;
     },

--- a/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
+++ b/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
@@ -37,6 +37,13 @@ export function useMapContentTypeToDisplayName() {
           : t('notification template'),
         instancegroup: options?.isTitleCase ? t('Instance Group') : t('instance group'),
         inventory: options?.isTitleCase ? t('Inventory') : t('inventory'),
+        namespace: options?.isTitleCase ? t('Namespace') : t('namespace'),
+        collectionremote: options?.isTitleCase ? t('Remote') : t('remote'),
+        containernamespace: options?.isTitleCase
+          ? t('Execution Environment')
+          : t('execution environment'),
+        ansiblerepository: options?.isTitleCase ? t('Repository') : t('repository'),
+        system: options?.isTitleCase ? t('System') : t('system'),
       };
       const shortType = contentType?.split('.').pop() || contentType;
 

--- a/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
+++ b/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
@@ -44,6 +44,7 @@ export function useMapContentTypeToDisplayName() {
           : t('execution environment'),
         ansiblerepository: options?.isTitleCase ? t('Repository') : t('repository'),
         system: options?.isTitleCase ? t('System') : t('system'),
+        null: options?.isTitleCase ? t('System') : t('system'),
       };
       const shortType = contentType?.split('.').pop() || contentType;
 

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next';
+import { usePageWizard } from '../../../../../framework/PageWizard/PageWizardProvider';
+import { PageFormSelect } from '../../../../../framework';
+
+export function HubSelectResourceTypeStep() {
+  const { t } = useTranslation();
+  const { wizardData, setStepData, setWizardData } = usePageWizard();
+
+  return (
+    <PageFormSelect
+      label={t('Resource type')}
+      name="resourceType"
+      options={[
+        { value: 'galaxy.ansiblerepository', label: t('Ansible Repository') },
+        { value: 'galaxy.collectionremote', label: t('Collection Remote') },
+        { value: 'galaxy.containernamespace', label: t('Execution Environment') },
+        { value: 'galaxy.namespace', label: t('Namespace') },
+        // { value: 'galaxy.namespace', label: t('Namespace') },
+      ]}
+      onChange={(option?: string) => {
+        // Reset wizard/step data if the resource type selection was changed
+        if ((wizardData as { [key: string]: unknown })['resourceType'] !== option) {
+          setWizardData({});
+          setStepData({});
+        }
+      }}
+      placeholderText={t('Select a resource type')}
+      isRequired
+    />
+  );
+}

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
@@ -11,8 +11,8 @@ export function HubSelectResourceTypeStep() {
       label={t('Resource type')}
       name="resourceType"
       options={[
-        { value: 'galaxy.ansiblerepository', label: t('Ansible Repository') },
-        { value: 'galaxy.collectionremote', label: t('Collection Remote') },
+        { value: 'galaxy.ansiblerepository', label: t('Repository') },
+        { value: 'galaxy.collectionremote', label: t('Remote') },
         { value: 'galaxy.containernamespace', label: t('Execution Environment') },
         { value: 'galaxy.namespace', label: t('Namespace') },
         { value: 'system', label: t('System') },

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourceTypeStep.tsx
@@ -15,7 +15,7 @@ export function HubSelectResourceTypeStep() {
         { value: 'galaxy.collectionremote', label: t('Collection Remote') },
         { value: 'galaxy.containernamespace', label: t('Execution Environment') },
         { value: 'galaxy.namespace', label: t('Namespace') },
-        // { value: 'galaxy.namespace', label: t('Namespace') },
+        { value: 'system', label: t('System') },
       ]}
       onChange={(option?: string) => {
         // Reset wizard/step data if the resource type selection was changed

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
@@ -1,0 +1,91 @@
+import styled from 'styled-components';
+import { HubRemote } from '../../../administration/remotes/Remotes';
+import { Repository } from '../../../administration/repositories/Repository';
+import { hubAPI, pulpAPI } from '../../../common/api/formatPath';
+import { ExecutionEnvironment } from '../../../execution-environments/ExecutionEnvironment';
+import { usePageWizard } from '../../../../../framework/PageWizard/PageWizardProvider';
+import { useTranslation } from 'react-i18next';
+import { Title } from '@patternfly/react-core';
+import { useMemo } from 'react';
+import { ITableColumn, IToolbarFilter, ToolbarFilterType } from '../../../../../framework';
+import { useHubMultiSelectListView } from '../../../common/useHubMultiSelectListView';
+import { HubNamespace } from '../../../namespaces/HubNamespace';
+import { PageMultiSelectList } from '../../../../../framework/PageTable/PageMultiSelectList';
+
+export type HubResourceType = HubNamespace | ExecutionEnvironment | HubRemote | Repository;
+
+const resourceToEndpointMapping: { [key: string]: string } = {
+  'galaxy.namespace': hubAPI`/_ui/v1/namespaces/`,
+  'galaxy.ansiblerepository': pulpAPI`/repositories/ansible/ansible/`,
+  'galaxy.containernamespace': hubAPI`/v3/plugin/execution-environments/repositories/`,
+  'galaxy.collectionremote': pulpAPI`/remotes/ansible/collection/`,
+};
+
+const StyledTitle = styled(Title)`
+  margin-bottom: 1rem;
+`;
+
+/** Roles wizard step for selecting resources based on the resourceType selected */
+export function HubSelectResourcesStep() {
+  const { wizardData } = usePageWizard();
+  const { t } = useTranslation();
+  const { resourceType } = wizardData as { [key: string]: unknown };
+
+  const resourceToTitleMapping = useMemo<{ [key: string]: string }>(() => {
+    return {
+      'galaxy.namespace': t('Select namespaces'),
+      'galaxy.ansiblerepository': t('Select repositories'),
+      'galaxy.containernamespace': t('Select execution environments'),
+      'galaxy.collectionremote': t('Select remotes'),
+    };
+  }, [t]);
+  const tableColumns = useMemo<ITableColumn<HubResourceType>[]>(
+    () => [
+      {
+        header: t('Name'),
+        type: 'text',
+        value: (item: HubResourceType) => item.name,
+        sort: 'name',
+      },
+    ],
+    [t]
+  );
+  const toolbarFilters = useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'name',
+        label: t('Name'),
+        type: ToolbarFilterType.MultiText,
+        query: 'name__contains',
+        comparison: 'contains',
+      },
+    ],
+    [t]
+  );
+
+  const view = useHubMultiSelectListView<HubResourceType>(
+    {
+      url: resourceToEndpointMapping[resourceType as string],
+      toolbarFilters,
+      tableColumns,
+    },
+    'resources'
+  );
+
+  return (
+    <>
+      <StyledTitle headingLevel="h1">{resourceToTitleMapping[resourceType as string]}</StyledTitle>
+      <h2 style={{ marginTop: '1rem', marginBottom: '1rem' }}>
+        {t(
+          "Choose the resources that will be receiving new roles. You'll be able to select the roles to apply in the next step. Note that the resources chosen here will receive all roles chosen in the next step."
+        )}
+      </h2>
+      <PageMultiSelectList
+        view={view}
+        tableColumns={tableColumns}
+        toolbarFilters={toolbarFilters}
+        labelForSelectedItems={t('Selected')}
+      />
+    </>
+  );
+}

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
@@ -51,16 +51,27 @@ export function HubSelectResourcesStep() {
     [t]
   );
   const toolbarFilters = useMemo<IToolbarFilter[]>(
-    () => [
-      {
-        key: 'name',
-        label: t('Name'),
-        type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
-        comparison: 'contains',
-      },
-    ],
-    [t]
+    () =>
+      resourceType === 'galaxy.namespace'
+        ? [
+            {
+              key: 'keywords',
+              label: t('Name'),
+              type: ToolbarFilterType.SingleText,
+              query: 'keywords',
+              comparison: 'contains',
+            },
+          ]
+        : [
+            {
+              key: 'name',
+              label: t('Name'),
+              type: ToolbarFilterType.MultiText,
+              query: 'name__contains',
+              comparison: 'contains',
+            },
+          ],
+    [resourceType, t]
   );
 
   const view = useHubMultiSelectListView<HubResourceType>(

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
@@ -31,7 +31,12 @@ export function HubSelectRolesStep(props: {
     switch (resourceType as string) {
       case 'galaxy.namespace':
         return t('Select roles to apply to all of your selected namespaces.');
-      // TODO more resource types to be added later
+      case 'galaxy.ansiblerepository':
+        return t('Select roles to apply to all of your selected repositories.');
+      case 'galaxy.collectionremote':
+        return t('Select roles to apply to all of your selected remotes.');
+      case 'galaxy.containernamespace':
+        return t('Select roles to apply to all of your selected execution environments.');
       default:
         return t('Select roles to apply to all of your selected resources.');
     }
@@ -60,7 +65,11 @@ export function HubSelectRolesStep(props: {
       url: hubAPI`/_ui/v2/role_definitions/`,
       toolbarFilters,
       tableColumns,
-      queryParams: { content_type__model: contentType, name__startswith: 'galaxy.' },
+      queryParams: {
+        ...(contentType !== 'system' && { content_type__model: contentType }),
+        ...(contentType === 'system' && { content_type__isnull: 'true' }),
+        name__startswith: 'galaxy.',
+      },
     },
     'hubRoles'
   );
@@ -71,7 +80,9 @@ export function HubSelectRolesStep(props: {
       tableColumns={tableColumns}
       toolbarFilters={toolbarFilters}
       fieldNameForPreviousStep={fieldNameForPreviousStep}
-      descriptionForRoleSelection={descriptionForRoleSelection}
+      descriptionForRoleSelection={
+        resourceType !== 'system' ? descriptionForRoleSelection : undefined
+      }
       title={title}
     />
   );

--- a/frontend/hub/access/roles/RolePage/HubRoleDetails.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/HubRoleDetails.cy.tsx
@@ -36,7 +36,7 @@ describe('HubRoleDetails', () => {
     cy.get('[data-cy="description"]').should('have.text', mockHubCustomRole.description);
     cy.get('[data-cy="created"]').should('contain', formatDateString(mockHubCustomRole.created));
     cy.get('[data-cy="modified"]').should('contain', formatDateString(mockHubCustomRole.modified));
-    cy.get('[data-cy="galaxy.ansiblerepository"]').should('contain', 'Ansible Repository');
+    cy.get('[data-cy="galaxy.ansiblerepository"]').should('contain', 'Repository');
     cy.get('[data-cy="permissions"]').should('contain', 'View Ansible repository');
   });
 });

--- a/frontend/hub/access/roles/RolePage/HubRoleForm.cy.tsx
+++ b/frontend/hub/access/roles/RolePage/HubRoleForm.cy.tsx
@@ -11,7 +11,7 @@ describe('HubRoleForm', () => {
       cy.contains('Name is required.').should('be.visible');
       cy.contains('Content type is required.').should('be.visible');
       cy.get('[data-cy="name"]').type('galaxy.test_custom_role');
-      cy.selectDropdownOptionByResourceName('content-type', 'Ansible Repository');
+      cy.selectDropdownOptionByResourceName('content-type', 'Repository');
       cy.clickButton(/^Create role$/);
       cy.contains('Permissions is required.').should('be.visible');
     });
@@ -23,7 +23,7 @@ describe('HubRoleForm', () => {
       cy.mountHub(<CreateRole />);
       cy.get('[data-cy="name"]').type('galaxy.test_custom_role');
       cy.get('[data-cy="description"]').type('View repository');
-      cy.selectDropdownOptionByResourceName('content-type', 'Ansible Repository');
+      cy.selectDropdownOptionByResourceName('content-type', 'Repository');
       cy.get('#permissions').click();
       cy.selectMultiSelectOption('#permissions-select', 'View Ansible repository');
       cy.clickButton(/^Create role$/);
@@ -40,7 +40,7 @@ describe('HubRoleForm', () => {
       cy.mountHub(<CreateRole />);
       cy.get('[data-cy="name"]').type('galaxy.test_custom_role');
       cy.get('[data-cy="description"]').type('View repository');
-      cy.selectDropdownOptionByResourceName('content-type', 'Ansible Repository');
+      cy.selectDropdownOptionByResourceName('content-type', 'Repository');
       cy.get('#permissions').click();
       cy.selectMultiSelectOption('#permissions-select', 'View Ansible repository');
       cy.intercept(
@@ -71,7 +71,7 @@ describe('HubRoleForm', () => {
       cy.get('[data-cy="description"]').should('have.value', mockHubCustomRole.description);
       cy.get('[data-cy="description"]').clear();
       cy.get('[data-cy="description"]').type('Edited Description');
-      cy.get('[data-cy="content-type-form-group"]').contains('Ansible Repository');
+      cy.get('[data-cy="content-type-form-group"]').contains('Repository');
       cy.get('[data-cy="content-type-form-group"]')
         .should('be.visible')
         .within(() => {

--- a/frontend/hub/access/roles/hooks/useHubRoleMetadata.tsx
+++ b/frontend/hub/access/roles/hooks/useHubRoleMetadata.tsx
@@ -53,7 +53,7 @@ export function useHubRoleMetadata(): HubRoleMetadata {
           },
         },
         'galaxy.collectionremote': {
-          displayName: t('Collection Remote'),
+          displayName: t('Remote'),
           permissions: {
             'galaxy.manage_roles_collectionremote': t('Manage remote roles'),
             'galaxy.change_collectionremote': t('Change collection remote'),
@@ -62,7 +62,7 @@ export function useHubRoleMetadata(): HubRoleMetadata {
           },
         },
         'galaxy.ansiblerepository': {
-          displayName: t('Ansible Repository'),
+          displayName: t('Repository'),
           permissions: {
             'galaxy.rebuild_metadata_ansiblerepository': t('Rebuild Ansible repository metadata'),
             'galaxy.repair_ansiblerepository': t('Repair Ansible repository'),

--- a/frontend/hub/access/users/UserPage/HubUserRoles.tsx
+++ b/frontend/hub/access/users/UserPage/HubUserRoles.tsx
@@ -1,0 +1,15 @@
+import { useParams } from 'react-router-dom';
+import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
+import { HubRoute } from '../../../main/HubRoutes';
+
+export function HubUserRoles(props: { id?: string; addRolesRoute?: string }) {
+  const params = useParams<{ id: string }>();
+  return (
+    <ResourceAccess
+      service="hub"
+      id={props.id || params.id || ''}
+      type="user-roles"
+      addRolesRoute={props.addRolesRoute || HubRoute.UserAddRoles}
+    />
+  );
+}

--- a/frontend/hub/access/users/components/HubAddUserRoles.tsx
+++ b/frontend/hub/access/users/components/HubAddUserRoles.tsx
@@ -1,0 +1,154 @@
+import { useTranslation } from 'react-i18next';
+import { HubRbacRole } from '../../../interfaces/expanded/HubRbacRole';
+import {
+  HubResourceType,
+  HubSelectResourcesStep,
+} from '../../common/HubRoleWizardSteps/HubSelectResourcesStep';
+import { useParams } from 'react-router-dom';
+import {
+  LoadingPage,
+  PageHeader,
+  PageLayout,
+  PageWizard,
+  PageWizardStep,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../../framework';
+import { useHubBulkActionDialog } from '../../../common/useHubBulkActionDialog';
+import { hubAPI } from '../../../common/api/formatPath';
+import { useGet } from '../../../../common/crud/useGet';
+import { HubUser } from '../../../interfaces/expanded/HubUser';
+import { HubSelectResourceTypeStep } from '../../common/HubRoleWizardSteps/HubSelectResourceTypeStep';
+import { HubSelectRolesStep } from '../../common/HubRoleWizardSteps/HubSelectRolesStep';
+import { RoleAssignmentsReviewStep } from '../../../../common/access/RolesWizard/steps/RoleAssignmentsReviewStep';
+import { parsePulpIDFromURL } from '../../../common/api/hub-api-utils';
+import { postRequest } from '../../../../common/crud/Data';
+import { HubRoute } from '../../../main/HubRoutes';
+import { hubErrorAdapter } from '../../../common/adapters/hubErrorAdapter';
+
+type ResourceTypeWithID = { id: number | string };
+type ResourceTypeWithPulpHref = { pulp_href: string };
+
+interface WizardFormValues {
+  resourceType: string;
+  resources: HubResourceType[];
+  hubRoles: HubRbacRole[];
+}
+
+interface ResourceRolePair {
+  resource: HubResourceType;
+  role: HubRbacRole;
+}
+
+export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string }) {
+  const { t } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const getPageUrl = useGetPageUrl();
+  const pageNavigate = usePageNavigate();
+  const progressDialog = useHubBulkActionDialog<ResourceRolePair>();
+
+  const { data: user, isLoading } = useGet<HubUser>(
+    hubAPI`/_ui/v2/users/${props.id || params.id || ''}/`
+  );
+
+  if (isLoading || !user) return <LoadingPage />;
+
+  const steps: PageWizardStep[] = [
+    {
+      id: 'resource-type',
+      label: t('Select a resource type'),
+      inputs: <HubSelectResourceTypeStep />,
+    },
+    {
+      id: 'resources',
+      label: t('Select resources'),
+      inputs: <HubSelectResourcesStep />,
+      validate: (formData, _) => {
+        const { resources } = formData as { resources: HubResourceType[] };
+        if (!resources?.length) {
+          throw new Error(t('Select at least one resource.'));
+        }
+      },
+    },
+    {
+      id: 'roles',
+      label: t('Select roles to apply'),
+      inputs: <HubSelectRolesStep fieldNameForPreviousStep="resources" />,
+      validate: (formData, _) => {
+        const { hubRoles } = formData as { hubRoles: HubRbacRole[] };
+        if (!hubRoles?.length) {
+          throw new Error(t('Select at least one role.'));
+        }
+      },
+    },
+    { id: 'review', label: t('Review'), element: <RoleAssignmentsReviewStep /> },
+  ];
+
+  const onSubmit = (data: WizardFormValues) => {
+    const { resources, hubRoles, resourceType } = data;
+    const items: ResourceRolePair[] = [];
+    for (const resource of resources) {
+      for (const role of hubRoles) {
+        items.push({ resource, role });
+      }
+    }
+    return new Promise<void>((resolve) => {
+      progressDialog({
+        title: t('Add roles'),
+        keyFn: ({ resource, role }) =>
+          `${(resource as ResourceTypeWithID).id ?? parsePulpIDFromURL((resource as ResourceTypeWithPulpHref)?.pulp_href)}_${role.id}`,
+        items,
+        actionColumns: [
+          { header: t('Resource name'), cell: ({ resource }) => resource.name },
+          { header: t('Role'), cell: ({ role }) => role.name },
+        ],
+        actionFn: ({ resource, role }) =>
+          postRequest(hubAPI`/_ui/v2/role_user_assignments/`, {
+            user: user.id,
+            role_definition: role.id,
+            content_type: resourceType,
+            object_id:
+              (resource as ResourceTypeWithID).id ??
+              parsePulpIDFromURL((resource as ResourceTypeWithPulpHref)?.pulp_href),
+          }),
+        onComplete: () => {
+          resolve();
+        },
+        onClose: () => {
+          pageNavigate(props.userRolesRoute || HubRoute.UserRoles, {
+            params: { id: params.id },
+          });
+        },
+      });
+    });
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Add roles')}
+        breadcrumbs={[
+          { label: t('Users'), to: getPageUrl(HubRoute.Users) },
+          {
+            label: user?.username,
+            to: getPageUrl(HubRoute.UserDetails, { params: { id: user?.id } }),
+          },
+          {
+            label: t('Roles'),
+            to: getPageUrl(HubRoute.UserRoles, { params: { id: user?.id } }),
+          },
+          { label: t('Add roles') },
+        ]}
+      />
+      <PageWizard<WizardFormValues>
+        errorAdapter={hubErrorAdapter}
+        steps={steps}
+        onSubmit={onSubmit}
+        onCancel={() => {
+          pageNavigate(props.userRolesRoute || HubRoute.UserRoles, { params: { id: params.id } });
+        }}
+        disableGrid
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/hub/common/useHubMultiSelectListView.tsx
+++ b/frontend/hub/common/useHubMultiSelectListView.tsx
@@ -4,7 +4,6 @@ import { QueryParams } from './api/hub-api-utils';
 import { usePageWizard } from '../../../framework/PageWizard/PageWizardProvider';
 import { useHubView } from './useHubView';
 import { useEffect } from 'react';
-import { getItemKey } from '../../common/crud/Data';
 
 /**
  * Hook for defining the view for a multi-select list in the context of a wizard. The selections made in the list
@@ -13,7 +12,10 @@ import { getItemKey } from '../../common/crud/Data';
  * @param fieldName Specific field in the wizard that represents the selected items from the list
  * @returns The view that can be used to pass to the PageMultiSelectList component within a wizard
  */
-export function useHubMultiSelectListView<T extends { id: string | number }>(
+type ResourceTypeWithID = { id: number | string };
+type ResourceTypeWithPulpHref = { pulp_href: string };
+
+export function useHubMultiSelectListView<T extends ResourceTypeWithID | ResourceTypeWithPulpHref>(
   viewOptions: {
     url: string;
     viewPage?: number;
@@ -24,6 +26,7 @@ export function useHubMultiSelectListView<T extends { id: string | number }>(
     disableQueryString?: boolean;
     defaultSort?: string | undefined;
     defaultSortDirection?: 'asc' | 'desc' | undefined;
+    keyFn?: (item: T) => string | number;
   },
   fieldName: string
 ) {
@@ -32,7 +35,12 @@ export function useHubMultiSelectListView<T extends { id: string | number }>(
 
   const view = useHubView<T>({
     ...viewOptions,
-    keyFn: getItemKey,
+    keyFn: (item) => {
+      if ((item as ResourceTypeWithID).id) {
+        return (item as ResourceTypeWithID).id;
+      }
+      return (item as ResourceTypeWithPulpHref).pulp_href;
+    },
     defaultSelection: ((wizardData as { [key: string]: [] })[fieldName] ||
       stepData[fieldName] ||
       []) as T[],

--- a/frontend/hub/main/HubRoutes.tsx
+++ b/frontend/hub/main/HubRoutes.tsx
@@ -88,6 +88,10 @@ export enum HubRoute {
   Organizations = 'hub-organizations',
   Teams = 'hub-teams',
   Users = 'hub-users',
+  UserPage = 'hub-user-page',
+  UserRoles = 'hub-user-roles',
+  UserAddRoles = 'hub-user-add-roles',
+
   APIToken = 'hub-api-token',
   MyImports = 'hub-my-imports',
   Roles = 'hub-roles',

--- a/frontend/hub/main/useHubNavigation.tsx
+++ b/frontend/hub/main/useHubNavigation.tsx
@@ -81,6 +81,8 @@ import { HubRolePage } from '../access/roles/RolePage/HubRolePage';
 import { RepositoryUserAccess } from '../administration/repositories/RepositoryPage/RepositoryUserAccess';
 import { RepositoryAddTeams } from '../administration/repositories/RepositoryPage/RepositoryAddTeam';
 import { RepositoryAddUsers } from '../administration/repositories/RepositoryPage/RepositoryAddUser';
+import { HubUserRoles } from '../access/users/UserPage/HubUserRoles';
+import { HubAddUserRoles } from '../access/users/components/HubAddUserRoles';
 
 export function useHubNavigation() {
   const { t } = useTranslation();
@@ -566,7 +568,29 @@ export function useHubNavigation() {
           id: HubRoute.Users,
           label: t('Users'),
           path: 'users',
-          element: <PageNotImplemented />,
+          children: [
+            {
+              id: HubRoute.UserPage,
+              path: ':id',
+              children: [
+                {
+                  id: HubRoute.UserDetails,
+                  path: 'details',
+                  element: <PageNotImplemented />,
+                },
+                {
+                  id: HubRoute.UserRoles,
+                  path: 'roles',
+                  element: <HubUserRoles />,
+                },
+              ],
+            },
+            {
+              id: HubRoute.UserAddRoles,
+              path: ':id/roles/add-roles',
+              element: <HubAddUserRoles />,
+            },
+          ],
         },
         {
           id: HubRoute.Roles,


### PR DESCRIPTION
[AAP-28446](https://issues.redhat.com/browse/AAP-28446)

Content for User -> Roles tab
- Display role assignments for the user.
- System-level roles do not have a content-type, hence the Resource Name column will be empty.
- In the `Add roles` wizard, if the Resource Type selected is "System" then the step to select resources will be hidden.

Since there is no upstream implementation of users pages, this can be tested with the following steps:
1. Get the user ID you want to test with using `<server>/api/galaxy/_ui/v2/users/`
2. Access `https://localhost:4102/access/users/<user_id_from_above>/roles`

Note: The step number on the wizard does not update when a step is hidden. I see this in other wizards too. This can be a separate investigation from this PR.

https://github.com/user-attachments/assets/0b7aa3cf-6e78-4138-9094-551d793d6248

