### PR TITLE
Fix issue with wizard step number in case of hidden steps

### DIFF
--- a/framework/PageWizard/PageWizardNavigation.tsx
+++ b/framework/PageWizard/PageWizardNavigation.tsx
@@ -46,7 +46,7 @@ export function PageWizardNavigation() {
             <li
               className="pf-v5-c-wizard__nav-item"
               data-cy={`wizard-nav-item-${step.id}`}
-              key={step.id}
+              key={index}
             >
               <button
                 className={className}


### PR DESCRIPTION
When a step in the wizard is hidden, the step numbers displayed are not accurate. For a wizard with 4 steps, if step 2 is hidden based on a condition, the UI still shows the step numbers as 1, 3, 4 instead of 1, 2, 3.

This PR fixes that. Thank you @jamestalton for this fix!!

Related PR:
https://github.com/ansible/ansible-ui/pull/2924