### PR TITLE
Hub user roles: Updated wizard steps and component tests

### DIFF
--- a/cypress/fixtures/hubNormalUser.json
+++ b/cypress/fixtures/hubNormalUser.json
@@ -1,6 +1,6 @@
 {
-  "id": 4,
-  "username": "dev",
+  "id": 7,
+  "username": "vn2",
   "first_name": "",
   "last_name": "",
   "email": "",

--- a/cypress/fixtures/hubRoleDefinitionsOptions.json
+++ b/cypress/fixtures/hubRoleDefinitionsOptions.json
@@ -1,0 +1,402 @@
+{
+  "name": "Role Definition List",
+  "description": "Role Definitions (roles) contain a list of permissions and can be used to\nassign those permissions to a user or team through the respective\nassignment endpoints.\n\nCustom roles can be created, modified, and deleted through this endpoint.\nSystem-managed roles are shown here, which cannot be edited or deleted,\nbut can be assigned to users.",
+  "renders": ["application/json", "text/html"],
+  "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
+  "actions": {
+    "POST": {
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "url": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Url"
+      },
+      "related": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Related"
+      },
+      "summary_fields": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Summary fields"
+      },
+      "permissions": {
+        "type": "list",
+        "required": true,
+        "read_only": false,
+        "label": "Permissions",
+        "child": {
+          "type": "choice",
+          "required": true,
+          "read_only": false,
+          "choices": [
+            {
+              "value": "galaxy.add_ansiblerepository",
+              "display_name": "galaxy.add_ansiblerepository"
+            },
+            {
+              "value": "galaxy.add_collection",
+              "display_name": "galaxy.add_collection"
+            },
+            {
+              "value": "galaxy.add_collectionimport",
+              "display_name": "galaxy.add_collectionimport"
+            },
+            {
+              "value": "galaxy.add_collectionremote",
+              "display_name": "galaxy.add_collectionremote"
+            },
+            {
+              "value": "galaxy.add_containernamespace",
+              "display_name": "galaxy.add_containernamespace"
+            },
+            {
+              "value": "galaxy.add_containerregistryremote",
+              "display_name": "galaxy.add_containerregistryremote"
+            },
+            {
+              "value": "galaxy.add_containerrepository",
+              "display_name": "galaxy.add_containerrepository"
+            },
+            {
+              "value": "galaxy.add_namespace",
+              "display_name": "galaxy.add_namespace"
+            },
+            {
+              "value": "galaxy.add_task",
+              "display_name": "galaxy.add_task"
+            },
+            {
+              "value": "galaxy.build_image_containerrepository",
+              "display_name": "galaxy.build_image_containerrepository"
+            },
+            {
+              "value": "galaxy.change_ansiblerepository",
+              "display_name": "galaxy.change_ansiblerepository"
+            },
+            {
+              "value": "galaxy.change_collection",
+              "display_name": "galaxy.change_collection"
+            },
+            {
+              "value": "galaxy.change_collectionimport",
+              "display_name": "galaxy.change_collectionimport"
+            },
+            {
+              "value": "galaxy.change_collectionremote",
+              "display_name": "galaxy.change_collectionremote"
+            },
+            {
+              "value": "galaxy.change_containernamespace",
+              "display_name": "galaxy.change_containernamespace"
+            },
+            {
+              "value": "galaxy.change_containerregistryremote",
+              "display_name": "galaxy.change_containerregistryremote"
+            },
+            {
+              "value": "galaxy.change_containerrepository",
+              "display_name": "galaxy.change_containerrepository"
+            },
+            {
+              "value": "galaxy.change_namespace",
+              "display_name": "galaxy.change_namespace"
+            },
+            {
+              "value": "galaxy.change_task",
+              "display_name": "galaxy.change_task"
+            },
+            {
+              "value": "galaxy.delete_ansiblerepository",
+              "display_name": "galaxy.delete_ansiblerepository"
+            },
+            {
+              "value": "galaxy.delete_collection",
+              "display_name": "galaxy.delete_collection"
+            },
+            {
+              "value": "galaxy.delete_collectionimport",
+              "display_name": "galaxy.delete_collectionimport"
+            },
+            {
+              "value": "galaxy.delete_collectionremote",
+              "display_name": "galaxy.delete_collectionremote"
+            },
+            {
+              "value": "galaxy.delete_containernamespace",
+              "display_name": "galaxy.delete_containernamespace"
+            },
+            {
+              "value": "galaxy.delete_containerregistryremote",
+              "display_name": "galaxy.delete_containerregistryremote"
+            },
+            {
+              "value": "galaxy.delete_containerrepository",
+              "display_name": "galaxy.delete_containerrepository"
+            },
+            {
+              "value": "galaxy.delete_containerrepository_versions",
+              "display_name": "galaxy.delete_containerrepository_versions"
+            },
+            {
+              "value": "galaxy.delete_namespace",
+              "display_name": "galaxy.delete_namespace"
+            },
+            {
+              "value": "galaxy.delete_task",
+              "display_name": "galaxy.delete_task"
+            },
+            {
+              "value": "galaxy.manage_roles_ansiblerepository",
+              "display_name": "galaxy.manage_roles_ansiblerepository"
+            },
+            {
+              "value": "galaxy.manage_roles_collectionremote",
+              "display_name": "galaxy.manage_roles_collectionremote"
+            },
+            {
+              "value": "galaxy.manage_roles_containernamespace",
+              "display_name": "galaxy.manage_roles_containernamespace"
+            },
+            {
+              "value": "galaxy.manage_roles_containerrepository",
+              "display_name": "galaxy.manage_roles_containerrepository"
+            },
+            {
+              "value": "galaxy.manage_roles_task",
+              "display_name": "galaxy.manage_roles_task"
+            },
+            {
+              "value": "galaxy.modify_ansible_repo_content",
+              "display_name": "galaxy.modify_ansible_repo_content"
+            },
+            {
+              "value": "galaxy.modify_content_containerrepository",
+              "display_name": "galaxy.modify_content_containerrepository"
+            },
+            {
+              "value": "galaxy.namespace_add_containerdistribution",
+              "display_name": "galaxy.namespace_add_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_change_containerdistribution",
+              "display_name": "galaxy.namespace_change_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_change_containerpushrepository",
+              "display_name": "galaxy.namespace_change_containerpushrepository"
+            },
+            {
+              "value": "galaxy.namespace_delete_containerdistribution",
+              "display_name": "galaxy.namespace_delete_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_modify_content_containerpushrepository",
+              "display_name": "galaxy.namespace_modify_content_containerpushrepository"
+            },
+            {
+              "value": "galaxy.namespace_pull_containerdistribution",
+              "display_name": "galaxy.namespace_pull_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_push_containerdistribution",
+              "display_name": "galaxy.namespace_push_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_view_containerdistribution",
+              "display_name": "galaxy.namespace_view_containerdistribution"
+            },
+            {
+              "value": "galaxy.namespace_view_containerpushrepository",
+              "display_name": "galaxy.namespace_view_containerpushrepository"
+            },
+            {
+              "value": "galaxy.rebuild_metadata_ansiblerepository",
+              "display_name": "galaxy.rebuild_metadata_ansiblerepository"
+            },
+            {
+              "value": "galaxy.repair_ansiblerepository",
+              "display_name": "galaxy.repair_ansiblerepository"
+            },
+            {
+              "value": "galaxy.sign_ansiblerepository",
+              "display_name": "galaxy.sign_ansiblerepository"
+            },
+            {
+              "value": "galaxy.sync_ansiblerepository",
+              "display_name": "galaxy.sync_ansiblerepository"
+            },
+            {
+              "value": "galaxy.sync_containerrepository",
+              "display_name": "galaxy.sync_containerrepository"
+            },
+            {
+              "value": "galaxy.upload_to_namespace",
+              "display_name": "galaxy.upload_to_namespace"
+            },
+            {
+              "value": "galaxy.view_ansiblerepository",
+              "display_name": "galaxy.view_ansiblerepository"
+            },
+            {
+              "value": "galaxy.view_collection",
+              "display_name": "galaxy.view_collection"
+            },
+            {
+              "value": "galaxy.view_collectionimport",
+              "display_name": "galaxy.view_collectionimport"
+            },
+            {
+              "value": "galaxy.view_collectionremote",
+              "display_name": "galaxy.view_collectionremote"
+            },
+            {
+              "value": "galaxy.view_containernamespace",
+              "display_name": "galaxy.view_containernamespace"
+            },
+            {
+              "value": "galaxy.view_containerregistryremote",
+              "display_name": "galaxy.view_containerregistryremote"
+            },
+            {
+              "value": "galaxy.view_containerrepository",
+              "display_name": "galaxy.view_containerrepository"
+            },
+            {
+              "value": "galaxy.view_namespace",
+              "display_name": "galaxy.view_namespace"
+            },
+            {
+              "value": "galaxy.view_task",
+              "display_name": "galaxy.view_task"
+            },
+            {
+              "value": "shared.add_team",
+              "display_name": "shared.add_team"
+            },
+            {
+              "value": "shared.change_team",
+              "display_name": "shared.change_team"
+            },
+            {
+              "value": "shared.delete_team",
+              "display_name": "shared.delete_team"
+            },
+            {
+              "value": "shared.member_team",
+              "display_name": "shared.member_team"
+            },
+            {
+              "value": "shared.view_team",
+              "display_name": "shared.view_team"
+            }
+          ]
+        }
+      },
+      "content_type": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Content type",
+        "help_text": "The type of resource this applies to",
+        "choices": [
+          {
+            "value": "galaxy.ansiblerepository",
+            "display_name": "Ansible Repository"
+          },
+          {
+            "value": "galaxy.collection",
+            "display_name": "Collection"
+          },
+          {
+            "value": "galaxy.collectionimport",
+            "display_name": "Collection Import"
+          },
+          {
+            "value": "galaxy.collectionremote",
+            "display_name": "Collection Remote"
+          },
+          {
+            "value": "galaxy.containernamespace",
+            "display_name": "Container Namespace"
+          },
+          {
+            "value": "galaxy.containerregistryremote",
+            "display_name": "Container Registry Remote"
+          },
+          {
+            "value": "galaxy.containerrepository",
+            "display_name": "Container Repository"
+          },
+          {
+            "value": "galaxy.namespace",
+            "display_name": "Namespace"
+          },
+          {
+            "value": "galaxy.task",
+            "display_name": "Task"
+          },
+          {
+            "value": "shared.team",
+            "display_name": "Team"
+          }
+        ]
+      },
+      "modified": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified",
+        "help_text": "The date/time this resource was created"
+      },
+      "created": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created",
+        "help_text": "The date/time this resource was created"
+      },
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name"
+      },
+      "description": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Description"
+      },
+      "managed": {
+        "type": "boolean",
+        "required": false,
+        "read_only": true,
+        "label": "Managed"
+      },
+      "modified_by": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Modified by",
+        "help_text": "The user who last modified this resource"
+      },
+      "created_by": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Created by",
+        "help_text": "The user who created this resource"
+      }
+    }
+  }
+}

--- a/cypress/fixtures/hubUserRoles.json
+++ b/cypress/fixtures/hubUserRoles.json
@@ -1,0 +1,151 @@
+{
+  "count": 4,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 30,
+      "url": "",
+      "related": {},
+      "summary_fields": {
+        "created_by": {
+          "id": 4,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "role_definition": {
+          "id": 33,
+          "name": "galaxy.collection_publisher",
+          "description": "Upload and modify collections.",
+          "managed": false
+        },
+        "user": {
+          "id": 7,
+          "username": "usr2",
+          "first_name": "",
+          "last_name": ""
+        },
+        "content_object": {
+          "id": 1,
+          "name": "test"
+        }
+      },
+      "created": "2024-08-09T17:46:37.103800Z",
+      "created_by": 4,
+      "content_type": "galaxy.namespace",
+      "object_id": "1",
+      "object_ansible_id": null,
+      "role_definition": 33,
+      "user": 7,
+      "user_ansible_id": null
+    },
+    {
+      "id": 31,
+      "url": "",
+      "related": {},
+      "summary_fields": {
+        "created_by": {
+          "id": 4,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "role_definition": {
+          "id": 35,
+          "name": "galaxy.collection_remote_owner",
+          "description": "Manage collection remotes.",
+          "managed": false
+        },
+        "user": {
+          "id": 7,
+          "username": "usr2",
+          "first_name": "",
+          "last_name": ""
+        },
+        "content_object": {
+          "id": "0191372d-bec0-7085-b610-e41c6a4296a7",
+          "name": "community"
+        }
+      },
+      "created": "2024-08-09T17:46:48.224083Z",
+      "created_by": 4,
+      "content_type": "galaxy.collectionremote",
+      "object_id": "0191372d-bec0-7085-b610-e41c6a4296a7",
+      "object_ansible_id": null,
+      "role_definition": 35,
+      "user": 7,
+      "user_ansible_id": null
+    },
+    {
+      "id": 32,
+      "url": "",
+      "related": {},
+      "summary_fields": {
+        "created_by": {
+          "id": 4,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "role_definition": {
+          "id": 32,
+          "name": "galaxy.collection_admin",
+          "description": "Create, delete and change collection namespaces. Upload and delete collections. Sync collections from remotes. Approve and reject collections.",
+          "managed": false
+        },
+        "user": {
+          "id": 7,
+          "username": "usr2",
+          "first_name": "",
+          "last_name": ""
+        }
+      },
+      "created": "2024-08-09T17:46:57.265769Z",
+      "created_by": 4,
+      "content_type": null,
+      "object_id": null,
+      "object_ansible_id": null,
+      "role_definition": 32,
+      "user": 7,
+      "user_ansible_id": null
+    },
+    {
+      "id": 33,
+      "url": "",
+      "related": {},
+      "summary_fields": {
+        "created_by": {
+          "id": 4,
+          "username": "dev",
+          "first_name": "",
+          "last_name": ""
+        },
+        "role_definition": {
+          "id": 84,
+          "name": "galaxy.repo_custom_role",
+          "description": "VN",
+          "managed": false
+        },
+        "user": {
+          "id": 7,
+          "username": "usr2",
+          "first_name": "",
+          "last_name": ""
+        },
+        "content_object": {
+          "id": "0191372d-bea9-7a3a-b323-274fcaf0e1f0",
+          "name": "published"
+        }
+      },
+      "created": "2024-08-09T17:47:17.750254Z",
+      "created_by": 4,
+      "content_type": "galaxy.ansiblerepository",
+      "object_id": "0191372d-bea9-7a3a-b323-274fcaf0e1f0",
+      "object_ansible_id": null,
+      "role_definition": 84,
+      "user": 7,
+      "user_ansible_id": null
+    }
+  ]
+}

--- a/frontend/hub/access/users/UserPage/HubUserRoles.cy.tsx
+++ b/frontend/hub/access/users/UserPage/HubUserRoles.cy.tsx
@@ -1,0 +1,67 @@
+import { hubAPI } from '../../../common/api/formatPath';
+import { HubUserRoles } from './HubUserRoles';
+
+describe('Hub user roles', () => {
+  const component = <HubUserRoles />;
+  const path = '/access/users/:id/roles';
+  const initialEntries = [`/access/users/1/roles`];
+  const params = {
+    path,
+    initialEntries,
+  };
+  describe('Non-empty list', () => {
+    beforeEach(() => {
+      cy.intercept('GET', hubAPI`/_ui/v2/role_user_assignments/?user_id=1&page=1&page_size=10`, {
+        fixture: 'hubUserRoles.json',
+      });
+      cy.intercept('OPTIONS', hubAPI`/_ui/v2/role_definitions/`, {
+        fixture: 'hubRoleDefinitionsOptions.json',
+      });
+    });
+    it('Renders the list of role assignments for the user', () => {
+      cy.mount(component, params);
+      cy.get('table tbody').find('tr').should('have.length', 4);
+    });
+    it('Renders the correct columns and action buttons', () => {
+      cy.mount(component, params);
+      cy.get('a[data-cy="add-roles"]').should('contain', 'Add roles');
+      cy.contains('th', 'Resource name');
+      cy.contains('th', 'Role');
+      cy.contains('th', 'Type');
+    });
+    it('can remove role', () => {
+      cy.intercept(
+        { method: 'DELETE', url: hubAPI`/_ui/v2/role_user_assignments/33/` },
+        {
+          statusCode: 204,
+        }
+      );
+      cy.mount(component, params);
+      cy.clickTableRowAction('resource-name', 'published', 'remove-role', {
+        inKebab: false,
+        disableFilter: true,
+      });
+      cy.get('div[role="dialog"]').within(() => {
+        cy.contains('published');
+        cy.get('input[id="confirm"]').click();
+        cy.get('button').contains('Remove role').click();
+      });
+      cy.get('[data-cy="status-column-cell"] > span').contains('Success');
+      cy.clickButton(/^Close$/);
+    });
+  });
+  describe('Empty list', () => {
+    it('Empty state is displayed correctly', () => {
+      cy.intercept('GET', hubAPI`/_ui/v2/role_user_assignments/?user_id=1&page=1&page_size=10`, {
+        fixture: 'emptyList.json',
+      });
+      cy.intercept('OPTIONS', hubAPI`/_ui/v2/role_definitions/`, {
+        fixture: 'hubRoleDefinitionsOptions.json',
+      });
+      cy.mount(component, params);
+      cy.contains(/^There are currently no roles assigned to this user.$/);
+      cy.contains(/^Add a role by clicking the button below.$/);
+      cy.contains('a[data-cy="add-roles"]', /^Add roles$/).should('be.visible');
+    });
+  });
+});

--- a/frontend/hub/access/users/components/HubAddUserRoles.cy.tsx
+++ b/frontend/hub/access/users/components/HubAddUserRoles.cy.tsx
@@ -1,0 +1,122 @@
+import { hubAPI } from '../../../common/api/formatPath';
+import { HubAddUserRoles } from './HubAddUserRoles';
+
+describe('Hub user: Add roles', () => {
+  const component = <HubAddUserRoles />;
+  const path = '/user/:id/roles/add-roles';
+  const initialEntries = [`/user/7/roles/add-roles`];
+  const params = {
+    path,
+    initialEntries,
+  };
+  beforeEach(() => {
+    cy.intercept('GET', hubAPI`/_ui/v2/users/7/`, { fixture: 'hubNormalUser.json' });
+    cy.intercept('GET', hubAPI`/_ui/v2/role_user_assignments/?user_id=*`, {
+      fixture: 'hubUserRoles.json',
+    });
+    cy.intercept('OPTIONS', hubAPI`/_ui/v2/role_definitions/`, {
+      fixture: 'hubRoleDefinitionsOptions.json',
+    });
+    cy.intercept('GET', hubAPI`/_ui/v2/role_definitions/?content_type__model=namespace*`, {
+      fixture: 'hubNamespaceRoles.json',
+    });
+    cy.intercept('GET', hubAPI`/_ui/v1/namespaces/?sort=name*`, { fixture: 'hubNamespace.json' });
+    cy.mount(component, params);
+  });
+  it('should render with correct steps', () => {
+    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select a resource type');
+    cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select roles to apply');
+    cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Review');
+    cy.get('[data-cy="wizard-nav-item-resource-type"] button').should('have.class', 'pf-m-current');
+  });
+  it('should validate that a resource type is selected for moving to next step', () => {
+    cy.contains(/^Select a resource type$/);
+    cy.clickButton(/^Next$/);
+    cy.contains('Resource type is required.').should('be.visible');
+    cy.get('[data-cy="wizard-nav-item-resource-type"] button').should('have.class', 'pf-m-current');
+    cy.get('div[data-cy="resourcetype-form-group"] button').click();
+    cy.get('button[data-cy="namespace"]').click();
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-resource-type"] button').should(
+      'not.have.class',
+      'pf-m-current'
+    );
+    cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select resources');
+    cy.get('[data-cy="wizard-nav-item-resources"] button').should('have.class', 'pf-m-current');
+  });
+  it('the select resources step is hidden for System roles', () => {
+    cy.contains(/^Select a resource type$/);
+    cy.get('div[data-cy="resourcetype-form-group"] button').click();
+    cy.get('button[data-cy="system"]').click();
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-resource-type"] button').should(
+      'not.have.class',
+      'pf-m-current'
+    );
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-resources"]').should('not.exist');
+  });
+  it('should validate that a resource is selected for moving to next step', () => {
+    cy.contains(/^Select a resource type$/);
+    cy.get('div[data-cy="resourcetype-form-group"] button').click();
+    cy.get('button[data-cy="namespace"]').click();
+    cy.clickButton(/^Next$/);
+    cy.contains(/^Select namespaces$/);
+    cy.contains(
+      /^Choose the resources that will be receiving new roles. You'll be able to select the roles to apply in the next step. Note that the resources chosen here will receive all roles chosen in the next step.$/
+    );
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one resource.');
+    cy.selectTableRow('demo', false);
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+  });
+  it('should validate that a role is selected for moving to next step', () => {
+    cy.contains(/^Select a resource type$/);
+    cy.get('div[data-cy="resourcetype-form-group"] button').click();
+    cy.get('button[data-cy="namespace"]').click();
+    cy.clickButton(/^Next$/);
+    cy.contains(/^Select namespaces$/);
+    cy.selectTableRow('demo', false);
+    cy.clickButton(/^Next$/);
+    cy.contains(/^Select roles to apply to all of your selected namespaces.$/);
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+    cy.selectTableRowByCheckbox('name', 'galaxy.collection_namespace_owner', {
+      disableFilter: true,
+    });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+  });
+  it('should display selected resources and roles in the Review step', () => {
+    cy.contains(/^Select a resource type$/);
+    cy.get('div[data-cy="resourcetype-form-group"] button').click();
+    cy.get('button[data-cy="namespace"]').click();
+    cy.clickButton(/^Next$/);
+    cy.contains(/^Select namespaces$/);
+    cy.selectTableRow('demo', false);
+    cy.clickButton(/^Next$/);
+    cy.contains(/^Select roles to apply to all of your selected namespaces.$/);
+    cy.selectTableRowByCheckbox('name', 'galaxy.collection_namespace_owner', {
+      disableFilter: true,
+    });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+    cy.hasDetail(/^Resource type$/, 'Namespace');
+    cy.get('[data-cy="expandable-section-resources"]').should('contain.text', 'Resources');
+    cy.get('[data-cy="expandable-section-resources"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-resources"]').should('contain.text', 'demo');
+    cy.get('[data-cy="expandable-section-hubRoles"]').should('contain.text', 'Roles');
+    cy.get('[data-cy="expandable-section-hubRoles"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-hubRoles"]').should(
+      'contain.text',
+      'galaxy.collection_namespace_owner'
+    );
+    cy.get('[data-cy="expandable-section-hubRoles"]').should(
+      'contain.text',
+      'Change and upload collections to namespaces.'
+    );
+  });
+});

--- a/frontend/hub/access/users/components/HubAddUserRoles.tsx
+++ b/frontend/hub/access/users/components/HubAddUserRoles.tsx
@@ -72,7 +72,7 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
       },
       hidden: (wizardData) => {
         const { resourceType } = wizardData as WizardFormValues;
-        return resourceType === 'system';
+        return !resourceType || resourceType === 'system';
       },
     },
     {


### PR DESCRIPTION
- Update to the wizard behavior based on UXD feedback from Anastasia:
Instead of showing all 4 steps (`Select Resource Type`, `Select Resources`, `Select Roles`, `Review`) and then when `System` is selected a step (`Select resources`) disappears, the logic is reversed where we only show the 3 steps and if something other than `System` is selected, it grows to 4 steps.

- Component tests


https://github.com/user-attachments/assets/ca33b626-05e3-4294-8703-1ec68aee5c63

