### PR TITLE
[AAP-28442] Add initial roles tab for teams

### DIFF
--- a/frontend/hub/access/teams/TeamPage/TeamUserRole.tsx
+++ b/frontend/hub/access/teams/TeamPage/TeamUserRole.tsx
@@ -1,0 +1,15 @@
+import { useParams } from 'react-router-dom';
+import { ResourceAccess } from '../../../../common/access/components/ResourceAccess';
+import { HubRoute } from '../../../main/HubRoutes';
+
+export function HubTeamRoles(props: { id?: string; addRolesRoute?: string }) {
+  const params = useParams<{ id: string }>();
+  return (
+    <ResourceAccess
+      service="hub"
+      id={props.id || params.id || ''}
+      type="team-roles"
+      addRolesRoute={props.addRolesRoute || HubRoute.TeamAddRoles}
+    />
+  );
+}

--- a/frontend/hub/access/teams/components/HubAddTeamRoles.tsx
+++ b/frontend/hub/access/teams/components/HubAddTeamRoles.tsx
@@ -18,7 +18,7 @@ import { hubAPI } from '../../../common/api/formatPath';
 import { parsePulpIDFromURL } from '../../../common/api/hub-api-utils';
 import { useHubBulkActionDialog } from '../../../common/useHubBulkActionDialog';
 import { HubRbacRole } from '../../../interfaces/expanded/HubRbacRole';
-import { HubUser } from '../../../interfaces/expanded/HubUser';
+import { HubTeam } from '../../../interfaces/expanded/HubTeam';
 import { HubRoute } from '../../../main/HubRoutes';
 import {
   HubResourceType,
@@ -41,18 +41,18 @@ interface ResourceRolePair {
   role: HubRbacRole;
 }
 
-export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string }) {
+export function HubAddTeamRoles(props: Readonly<{ id?: string; teamRolesRoute?: string }>) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const progressDialog = useHubBulkActionDialog<ResourceRolePair>();
 
-  const { data: user, isLoading } = useGet<HubUser>(
-    hubAPI`/_ui/v2/users/${props.id || params.id || ''}/`
+  const { data: team, isLoading } = useGet<HubTeam>(
+    hubAPI`/_ui/v2/teams/${props.id || params.id || ''}/`
   );
 
-  if (isLoading || !user) return <LoadingPage />;
+  if (isLoading || !team) return <LoadingPage />;
 
   const steps: PageWizardStep[] = [
     {
@@ -72,7 +72,7 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
       },
       hidden: (wizardData) => {
         const { resourceType } = wizardData as WizardFormValues;
-        return resourceType === 'system';
+        return !resourceType || resourceType === 'system';
       },
     },
     {
@@ -120,8 +120,8 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
         items,
         actionColumns,
         actionFn: ({ resource, role }) =>
-          postRequest(hubAPI`/_ui/v2/role_user_assignments/`, {
-            user: user.id,
+          postRequest(hubAPI`/_ui/v2/role_team_assignments/`, {
+            team: team.id,
             role_definition: role.id,
             content_type: resourceType === 'system' ? null : resourceType,
             object_id:
@@ -134,7 +134,7 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
           resolve();
         },
         onClose: () => {
-          pageNavigate(props.userRolesRoute || HubRoute.UserRoles, {
+          pageNavigate(props.teamRolesRoute ?? HubRoute.TeamRoles, {
             params: { id: params.id },
           });
         },
@@ -147,14 +147,14 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
       <PageHeader
         title={t('Add roles')}
         breadcrumbs={[
-          { label: t('Users'), to: getPageUrl(HubRoute.Users) },
+          { label: t('Teams'), to: getPageUrl(HubRoute.Teams) },
           {
-            label: user?.username,
-            to: getPageUrl(HubRoute.UserDetails, { params: { id: user?.id } }),
+            label: team?.name,
+            to: getPageUrl(HubRoute.TeamDetails, { params: { id: team?.id } }),
           },
           {
             label: t('Roles'),
-            to: getPageUrl(HubRoute.UserRoles, { params: { id: user?.id } }),
+            to: getPageUrl(HubRoute.TeamRoles, { params: { id: team?.id } }),
           },
           { label: t('Add roles') },
         ]}
@@ -164,7 +164,7 @@ export function HubAddUserRoles(props: { id?: string; userRolesRoute?: string })
         steps={steps}
         onSubmit={onSubmit}
         onCancel={() => {
-          pageNavigate(props.userRolesRoute || HubRoute.UserRoles, { params: { id: params.id } });
+          pageNavigate(props.teamRolesRoute || HubRoute.TeamRoles, { params: { id: params.id } });
         }}
         disableGrid
       />

--- a/frontend/hub/interfaces/expanded/HubTeam.ts
+++ b/frontend/hub/interfaces/expanded/HubTeam.ts
@@ -1,6 +1,16 @@
-import { Group } from '../generated/Group';
-
-export interface HubTeam extends Group {
+export type HubTeam = {
   id: number;
-  ulp_href: string;
-}
+  name: string;
+  group: {
+    id: number;
+    name: string;
+  };
+  organization: {
+    id: number;
+    name: string;
+  };
+  resource: {
+    resource_type: string;
+    ansible_id: string;
+  };
+};

--- a/frontend/hub/main/HubRoutes.tsx
+++ b/frontend/hub/main/HubRoutes.tsx
@@ -86,11 +86,19 @@ export enum HubRoute {
   // Access
   Access = 'hub-access',
   Organizations = 'hub-organizations',
+  // Teams
   Teams = 'hub-teams',
+  TeamPage = 'hub-team-page',
+  TeamRoles = 'hub-team-roles',
+  TeamAddRoles = 'hub-team-add-roles',
+  TeamDetails = 'hub-team-details',
+
+  // Users
   Users = 'hub-users',
   UserPage = 'hub-user-page',
   UserRoles = 'hub-user-roles',
   UserAddRoles = 'hub-user-add-roles',
+  UserDetails = 'hub-user-details',
 
   APIToken = 'hub-api-token',
   MyImports = 'hub-my-imports',
@@ -99,7 +107,6 @@ export enum HubRoute {
   RolePage = 'hub-role-page',
   RoleDetails = 'hub-role-details',
   EditRole = 'hub-edit-role',
-  UserDetails = 'hub-user-details',
 
   Settings = 'hub-settings',
   SettingsPreferences = 'hub-settings-preferences',

--- a/frontend/hub/main/useHubNavigation.tsx
+++ b/frontend/hub/main/useHubNavigation.tsx
@@ -4,10 +4,15 @@ import { PageNotImplemented } from '../../../framework';
 import { PageNavigationItem } from '../../../framework/PageNavigation/PageNavigationItem';
 import { PageSettingsDetails } from '../../../framework/PageSettings/PageSettingsDetails';
 import { PageSettingsForm } from '../../../framework/PageSettings/PageSettingsForm';
+import { HubRoles } from '../access/roles/HubRoles';
 import { HubRoleDetails } from '../access/roles/RolePage/HubRoleDetails';
 import { CreateRole, EditRole } from '../access/roles/RolePage/HubRoleForm';
-import { HubRoles } from '../access/roles/HubRoles';
+import { HubRolePage } from '../access/roles/RolePage/HubRolePage';
+import { HubTeamRoles } from '../access/teams/TeamPage/TeamUserRole';
+import { HubAddTeamRoles } from '../access/teams/components/HubAddTeamRoles';
 import { Token } from '../access/token/Token';
+import { HubUserRoles } from '../access/users/UserPage/HubUserRoles';
+import { HubAddUserRoles } from '../access/users/components/HubAddUserRoles';
 import { Approvals } from '../administration/collection-approvals/Approvals';
 import { RemoteRegistries } from '../administration/remote-registries/RemoteRegistries';
 import {
@@ -26,11 +31,14 @@ import { RemoteUserAccess } from '../administration/remotes/RemotePage/RemoteUse
 import { Remotes } from '../administration/remotes/Remotes';
 import { Repositories } from '../administration/repositories/Repositories';
 import { RepositoryForm } from '../administration/repositories/RepositoryForm';
-import { RepositoryTeamAccess } from '../administration/repositories/RepositoryPage/RepositoryTeamAccess';
+import { RepositoryAddTeams } from '../administration/repositories/RepositoryPage/RepositoryAddTeam';
+import { RepositoryAddUsers } from '../administration/repositories/RepositoryPage/RepositoryAddUser';
 import { RepositoryCollectionVersion } from '../administration/repositories/RepositoryPage/RepositoryCollectionVersion';
 import { RepositoryDetails } from '../administration/repositories/RepositoryPage/RepositoryDetails';
 import { RepositoryDistributions } from '../administration/repositories/RepositoryPage/RepositoryDistributions';
 import { RepositoryPage } from '../administration/repositories/RepositoryPage/RepositoryPage';
+import { RepositoryTeamAccess } from '../administration/repositories/RepositoryPage/RepositoryTeamAccess';
+import { RepositoryUserAccess } from '../administration/repositories/RepositoryPage/RepositoryUserAccess';
 import { RepositoryVersions } from '../administration/repositories/RepositoryPage/RepositoryVersions';
 import { RepositoryVersionCollections } from '../administration/repositories/RepositoryVersionPage/RepositoryVersionCollections';
 import { RepositoryVersionDetails } from '../administration/repositories/RepositoryVersionPage/RepositoryVersionDetails';
@@ -77,12 +85,6 @@ import { HubNamespaceAddTeams } from '../namespaces/components/HubNamespaceAddTe
 import { HubNamespaceAddUsers } from '../namespaces/components/HubNamespaceAddUsers';
 import { HubOverview } from '../overview/HubOverview';
 import { HubRoute } from './HubRoutes';
-import { HubRolePage } from '../access/roles/RolePage/HubRolePage';
-import { RepositoryUserAccess } from '../administration/repositories/RepositoryPage/RepositoryUserAccess';
-import { RepositoryAddTeams } from '../administration/repositories/RepositoryPage/RepositoryAddTeam';
-import { RepositoryAddUsers } from '../administration/repositories/RepositoryPage/RepositoryAddUser';
-import { HubUserRoles } from '../access/users/UserPage/HubUserRoles';
-import { HubAddUserRoles } from '../access/users/components/HubAddUserRoles';
 
 export function useHubNavigation() {
   const { t } = useTranslation();
@@ -562,7 +564,29 @@ export function useHubNavigation() {
           id: HubRoute.Teams,
           label: t('Teams'),
           path: 'teams',
-          element: <PageNotImplemented />,
+          children: [
+            {
+              id: HubRoute.TeamPage,
+              path: ':id',
+              children: [
+                {
+                  id: HubRoute.TeamDetails,
+                  path: 'details',
+                  element: <PageNotImplemented />,
+                },
+                {
+                  id: HubRoute.TeamRoles,
+                  path: 'roles',
+                  element: <HubTeamRoles />,
+                },
+              ],
+            },
+            {
+              id: HubRoute.TeamAddRoles,
+              path: ':id/roles/add-roles',
+              element: <HubAddTeamRoles />,
+            },
+          ],
         },
         {
           id: HubRoute.Users,


### PR DESCRIPTION
Add initial roles tab for teams

To test this.

1. Create a group using the old ui, get the group id
2.  https://localhost:4102/access/teams/<group_id>/roles
