### PR TITLE
Fix access UI filters

### DIFF
--- a/frontend/common/access/components/TeamAccess.tsx
+++ b/frontend/common/access/components/TeamAccess.tsx
@@ -38,7 +38,7 @@ export function TeamAccess(props: {
           label: t('Team name'),
         },
       }}
-      toolbarNameColumnFiltersValues={{ label: t('Team name'), query: 'team__name' }}
+      toolbarNameColumnFiltersValues={{ label: t('Team name'), query: 'team__name__icontains' }}
       url={roleTeamAssignmentsURL}
       content_type_model={type}
       accessListType={'team'}

--- a/frontend/common/access/components/UserAccess.tsx
+++ b/frontend/common/access/components/UserAccess.tsx
@@ -47,7 +47,7 @@ export function UserAccess(props: {
           sort: 'last_name',
         },
       ]}
-      toolbarNameColumnFiltersValues={{ label: t('Username'), query: 'user__username' }}
+      toolbarNameColumnFiltersValues={{ label: t('Username'), query: 'user__username__icontains' }}
       url={roleUserAssignmentsURL}
       content_type_model={type}
       accessListType={'user'}


### PR DESCRIPTION
The team/user access list filters are currently equality filters and need to support the `__icontains` query.