### PR TITLE
UI-E2E Image for testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,10 +6,7 @@
 /.vscode
 /Dockerfile
 /coverage
-/cypress
 /docs
-/framework
-/frontend
 /locales
 /node_modules
 /playbooks
@@ -17,4 +14,3 @@
 /rulebooks
 /scripts
 /stories
-/webpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /certs/cert.key 
 # directories and files that are written to by processes in the image must be owned by the root group
 # and be read/writable by that group. Files to be executed must also have group execute permissions.
 #
-FROM --platform=${TARGETPLATFORM:-linux/amd64} nginx:alpine AS base
+FROM nginx:alpine AS base
 COPY --from=certificate /certs/cert.pem /certs/cert.pem
 COPY --from=certificate /certs/cert.pem /certs/CA.pem
 COPY --from=certificate /certs/cert.key /certs/cert.key
@@ -43,3 +43,9 @@ ENV EDA_WEBHOOK_SERVER=${EDA_WEBHOOK_SERVER:-http://example.com}
 ENV EDA_SERVER_UUID=${EDA_SERVER_UUID:-sample_uuid}
 COPY /nginx/eda.conf /etc/nginx/templates/default.conf.template
 COPY /build/eda /usr/share/nginx/html
+
+# ui-e2e
+FROM cypress/base AS ui-e2e
+WORKDIR /app
+COPY . .
+RUN npm ci

--- a/cypress.base.config.ts
+++ b/cypress.base.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import pkg from 'webpack';
 import env from './webpack/environment.cjs';
 const { DefinePlugin } = pkg;
@@ -13,6 +14,15 @@ export const baseConfig: Cypress.ConfigOptions = {
   e2e: {
     testIsolation: false,
     setupNodeEvents(on, config) {
+      on('before:browser:launch', (browser, launchOptions) => {
+        if (browser?.isHeadless) {
+          launchOptions.args.push('--no-sandbox');
+          launchOptions.args.push('--disable-gl-drawing-for-tests');
+          launchOptions.args.push('--disable-gpu');
+        }
+        launchOptions.args.push('--js-flags=--max-old-space-size=3500');
+        return launchOptions;
+      });
       return config;
     },
     retries: { runMode: 2, openMode: 0 },

--- a/cypress/support/auth.ts
+++ b/cypress/support/auth.ts
@@ -16,6 +16,7 @@ Cypress.Commands.add('requiredVariablesAreSet', (requiredVariables: string[]) =>
 
 Cypress.Commands.add('login', () => {
   const devBaseUrlPort = Cypress.config().baseUrl?.split(':').slice(-1).toString();
+
   switch (devBaseUrlPort) {
     case '4101':
       cy.awxLogin();
@@ -28,6 +29,20 @@ Cypress.Commands.add('login', () => {
     case '4103':
       cy.edaLogin();
       break;
+    default:
+      switch (Cypress.env('PRODUCT')) {
+        case 'AWX':
+          cy.awxLogin();
+          cy.createGlobalOrganization();
+          cy.createGlobalProject();
+          break;
+        case 'HUB':
+          cy.hubLogin();
+          break;
+        case 'EDA':
+          cy.edaLogin();
+          break;
+      }
   }
 });
 
@@ -43,6 +58,18 @@ Cypress.Commands.add('logout', () => {
     case '4103':
       cy.edaLogout();
       break;
+    default:
+      switch (Cypress.env('PRODUCT')) {
+        case 'AWX':
+          cy.awxLogout();
+          break;
+        case 'HUB':
+          cy.hubLogout();
+          break;
+        case 'EDA':
+          cy.edaLogout();
+          break;
+      }
   }
 });
 


### PR DESCRIPTION
This will allow testing a UI against an API.
- EDA may use this to validate API changes

```
docker run --rm \
  -e EDA_SERVER=XXXXX \
  -e EDA_USERNAME=XXXXX \
  -e EDA_PASSWORD=XXXXX \
  -e CYPRESS_baseUrl=XXXXX \
  -e CYPRESS_PRODUCT=EDA \
  ui-e2e \
  ./node_modules/.bin/cypress run --config-file=cypress.eda.config.ts --headless
```
