### PR TITLE
[AAP-29158] Signing Actions Through Feature Flags

### DIFF
--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -17,6 +17,7 @@ import { useDeleteCollectionsFromRepository } from './useDeleteCollectionsFromRe
 import { useDeprecateCollections } from './useDeprecateCollections';
 import { useSignCollection } from './useSignCollection';
 import { useUploadSignature } from './useUploadSignature';
+import { useCanSignNamespace } from '../../common/utils/canSign';
 
 export function useCollectionActions(
   callback: (collections: CollectionVersionSearch[]) => void,
@@ -46,9 +47,11 @@ export function useCollectionActions(
   const signCollection = useSignCollection(false, callback);
   const uploadSignature = useUploadSignature();
 
-  const context = useHubContext();
+  const { featureFlags } = useHubContext();
 
-  const { can_upload_signatures } = context.featureFlags;
+  const { can_upload_signatures } = featureFlags;
+
+  const canSign = useCanSignNamespace();
 
   return useMemo<IPageAction<CollectionVersionSearch>[]>(
     () => [
@@ -60,13 +63,14 @@ export function useCollectionActions(
         onClick: (collection) => {
           signCollection([collection]);
         },
+        isHidden: () => !canSign,
       },
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: KeyIcon,
         label: t('Sign version'),
-        isHidden: () => (detail ? false : true),
+        isHidden: () => (detail && canSign ? false : true),
         onClick: (collection) => {
           if (can_upload_signatures) {
             // upload signature - it works only in insights, but we can leave it here for now
@@ -147,18 +151,19 @@ export function useCollectionActions(
     ],
     [
       t,
-      pageNavigate,
-      deleteCollections,
-      deprecateCollections,
-      deleteCollectionsVersions,
-      detail,
-      deleteCollectionsVersionsFromRepository,
-      copyToRepository,
-      can_upload_signatures,
       signCollection,
-      signCollectionVersion,
+      canSign,
+      detail,
+      can_upload_signatures,
       uploadSignature,
+      signCollectionVersion,
+      deprecateCollections,
+      copyToRepository,
+      pageNavigate,
+      deleteCollectionsVersions,
+      deleteCollectionsVersionsFromRepository,
       deleteCollectionsFromRepository,
+      deleteCollections,
     ]
   );
 }

--- a/frontend/hub/collections/hooks/useCollectionsActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionsActions.tsx
@@ -13,6 +13,7 @@ import { CollectionVersionSearch } from '../Collection';
 import { useDeleteCollections } from './useDeleteCollections';
 import { useDeprecateCollections } from './useDeprecateCollections';
 import { useSignCollection } from './useSignCollection';
+import { useCanSignNamespace } from '../../common/utils/canSign';
 
 export function useCollectionsActions(callback: (collections: CollectionVersionSearch[]) => void) {
   const { t } = useTranslation();
@@ -20,6 +21,8 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
   const deleteCollections = useDeleteCollections(callback);
   const deprecateCollections = useDeprecateCollections(callback);
   const signCollection = useSignCollection(false, callback);
+
+  const canSign = useCanSignNamespace();
 
   return useMemo<IPageAction<CollectionVersionSearch>[]>(
     () => [
@@ -49,6 +52,8 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
         onClick: (collections) => {
           signCollection(collections);
         },
+        isDisabled: () =>
+          !canSign ? t('You do not have the rights for this operation') : undefined,
       },
       { type: PageActionType.Seperator },
       {
@@ -74,6 +79,6 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
         isDanger: true,
       },
     ],
-    [t, deleteCollections, pageNavigate, deprecateCollections, signCollection]
+    [t, pageNavigate, deprecateCollections, signCollection, canSign, deleteCollections]
   );
 }

--- a/frontend/hub/common/utils/canSign.tsx
+++ b/frontend/hub/common/utils/canSign.tsx
@@ -1,0 +1,22 @@
+import { useHubContext } from '../useHubContext';
+
+export const useCanSignNamespace = () => {
+  const { featureFlags, hasPermission } = useHubContext();
+  const { can_create_signatures } = featureFlags;
+
+  const canSign =
+    can_create_signatures &&
+    hasPermission('galaxy.change_namespace') &&
+    hasPermission('galaxy.upload_to_namespace');
+
+  return canSign;
+};
+
+export const useCanSignEE = () => {
+  const { featureFlags, hasPermission } = useHubContext();
+  const { container_signing } = featureFlags;
+
+  const canSign = container_signing && hasPermission('container.change_containernamespace');
+
+  return canSign;
+};

--- a/frontend/hub/common/utils/canSign.tsx
+++ b/frontend/hub/common/utils/canSign.tsx
@@ -1,22 +1,19 @@
 import { useHubContext } from '../useHubContext';
 
 export const useCanSignNamespace = () => {
-  const { featureFlags, hasPermission } = useHubContext();
+  const { featureFlags } = useHubContext();
   const { can_create_signatures } = featureFlags;
 
-  const canSign =
-    can_create_signatures &&
-    hasPermission('galaxy.change_namespace') &&
-    hasPermission('galaxy.upload_to_namespace');
+  const canSign = can_create_signatures;
 
   return canSign;
 };
 
 export const useCanSignEE = () => {
-  const { featureFlags, hasPermission } = useHubContext();
+  const { featureFlags } = useHubContext();
   const { container_signing } = featureFlags;
 
-  const canSign = container_signing && hasPermission('container.change_containernamespace');
+  const canSign = container_signing;
 
   return canSign;
 };

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.tsx
@@ -20,6 +20,7 @@ import { HubRoute } from '../../main/HubRoutes';
 import { ExecutionEnvironment } from '../ExecutionEnvironment';
 import { SignStatus } from './components/SignStatus';
 import { useExecutionEnvironmentPageActions } from './hooks/useExecutionEnvironmentPageActions';
+import { useCanSignEE } from '../../common/utils/canSign';
 
 export function ExecutionEnvironmentPage() {
   const { t } = useTranslation();
@@ -36,6 +37,7 @@ export function ExecutionEnvironmentPage() {
 
   const getPageUrl = useGetPageUrl();
   const pageActions = useExecutionEnvironmentPageActions({ refresh });
+  const canSignEE = useCanSignEE();
 
   if (error) {
     return <HubError error={error} handleRefresh={refresh} />;
@@ -58,9 +60,11 @@ export function ExecutionEnvironmentPage() {
         description={ee?.description}
         footer={
           <Stack hasGutter>
-            <div>
-              <SignStatus state={ee?.pulp?.repository?.sign_state} />
-            </div>
+            {canSignEE && (
+              <div>
+                <SignStatus state={ee?.pulp?.repository?.sign_state} />
+              </div>
+            )}
             {!!lastSyncTask?.state && (
               <Flex gap={{ default: 'gapSm' }}>
                 <FlexItem>

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
@@ -16,6 +16,7 @@ import {
   useSignExecutionEnvironments,
 } from '../../hooks/useExecutionEnvironmentsActions';
 import { useController } from '../../hooks/useController';
+import { useCanSignEE } from '../../../common/utils/canSign';
 
 export function useExecutionEnvironmentPageActions(options: { refresh?: () => undefined }) {
   const { t } = useTranslation();
@@ -40,6 +41,7 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
     );
 
   const useInController = useController();
+  const canSignEE = useCanSignEE();
 
   return useMemo(() => {
     const actions: IPageAction<ExecutionEnvironment>[] = [
@@ -69,6 +71,7 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
         selection: PageActionSelection.Single,
         icon: CheckIcon,
         label: t('Sign execution environment'),
+        isDisabled: () => (canSignEE ? undefined : t('You do not have rights to this operation')),
         onClick: (ee) => signExecutionEnvironments([ee]),
       },
       { type: PageActionType.Seperator },
@@ -83,11 +86,12 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
     ];
     return actions;
   }, [
-    pageNavigate,
     t,
-    deleteExecutionEnvironments,
-    signExecutionEnvironments,
-    syncExecutionEnvironments,
     useInController,
+    pageNavigate,
+    syncExecutionEnvironments,
+    canSignEE,
+    signExecutionEnvironments,
+    deleteExecutionEnvironments,
   ]);
 }

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentActions.tsx
@@ -16,6 +16,7 @@ import {
   useSyncExecutionEnvironments,
 } from './useExecutionEnvironmentsActions';
 import { useController } from './useController';
+import { useCanSignEE } from '../../common/utils/canSign';
 
 export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnvironment[]) => void) {
   const { t } = useTranslation();
@@ -25,6 +26,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
   const signExecutionEnvironment = useSignExecutionEnvironments(callback);
   const pageNavigate = usePageNavigate();
   const useInController = useController();
+  const canSignEE = useCanSignEE();
 
   return useMemo<IPageAction<ExecutionEnvironment>[]>(
     () => [
@@ -57,11 +59,7 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
         icon: CheckIcon,
         label: t('Sign execution environment'),
         onClick: (ee) => signExecutionEnvironment([ee]),
-        isDisabled:
-          context.hasPermission('container.change_containernamespace') &&
-          context.featureFlags.container_signing
-            ? ''
-            : t`You do not have rights to this operation`,
+        isDisabled: canSignEE ? '' : t`You do not have rights to this operation`,
       },
       useInController,
       { type: PageActionType.Seperator },
@@ -80,11 +78,12 @@ export function useExecutionEnvironmentActions(callback?: (ees: ExecutionEnviron
     [
       t,
       context,
-      deleteExecutionEnvironments,
+      canSignEE,
+      useInController,
+      pageNavigate,
       syncExecutionEnvironments,
       signExecutionEnvironment,
-      pageNavigate,
-      useInController,
+      deleteExecutionEnvironments,
     ]
   );
 }

--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
@@ -21,6 +21,7 @@ import { HubRoute } from '../../main/HubRoutes';
 import { ExecutionEnvironment } from '../ExecutionEnvironment';
 import { useExecutionEnvironmentsColumns } from './useExecutionEnvironmentsColumns';
 import { AAPDocsURL } from '../../common/constants';
+import { useCanSignEE } from '../../common/utils/canSign';
 
 export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnvironment[]) => void) {
   const { t } = useTranslation();
@@ -28,6 +29,7 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
   const deleteExecutionEnvironments = useDeleteExecutionEnvironments(callback);
   const signExecutionEnvironments = useSignExecutionEnvironments(callback);
   const pageNavigate = usePageNavigate();
+  const canSignEE = useCanSignEE();
 
   return useMemo<IPageAction<ExecutionEnvironment>[]>(
     () => [
@@ -59,11 +61,7 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
         icon: CheckIcon,
         label: t('Sign execution environments'),
         onClick: signExecutionEnvironments,
-        isDisabled:
-          context.hasPermission('container.change_containernamespace') &&
-          context.featureFlags.container_signing
-            ? ''
-            : t`You do not have rights to this operation`,
+        isDisabled: canSignEE ? '' : t`You do not have rights to this operation`,
       },
       { type: PageActionType.Seperator },
       {
@@ -78,7 +76,7 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
           : t`You do not have rights to this operation`,
       },
     ],
-    [t, context, deleteExecutionEnvironments, signExecutionEnvironments, pageNavigate]
+    [t, signExecutionEnvironments, canSignEE, deleteExecutionEnvironments, context, pageNavigate]
   );
 }
 

--- a/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
+++ b/frontend/hub/namespaces/hooks/useHubNamespaceActions.tsx
@@ -14,6 +14,7 @@ import { useDeleteHubNamespaces } from './useDeleteHubNamespaces';
 import { useWindowLocation } from '../../../../framework/components/useWindowLocation';
 import { useSignAllCollections } from '../../collections/hooks/useSignAllCollections';
 import { useHubContext } from '../../common/useHubContext';
+import { useCanSignNamespace } from '../../common/utils/canSign';
 
 export function useHubNamespaceActions(options?: {
   onHubNamespacesDeleted: (namespaces: HubNamespace[]) => void;
@@ -27,16 +28,16 @@ export function useHubNamespaceActions(options?: {
   const { settings, featureFlags } = useHubContext();
   const signing_service = settings.GALAXY_COLLECTION_SIGNING_SERVICE;
   const can_upload_signatures = featureFlags.can_upload_signatures;
-  const can_create_signatures = featureFlags.can_create_signatures;
   const pageNavigate = usePageNavigate();
   const deleteHubNamespaces = useDeleteHubNamespaces(options.onHubNamespacesDeleted);
   const { location } = useWindowLocation();
   const signCollection = useSignAllCollections();
+  const canSignNamespace = useCanSignNamespace();
 
   return useMemo(() => {
     const isRepoSelected = () => location?.search.includes('repository=');
 
-    const canSignAllCollections = () => can_create_signatures && !can_upload_signatures;
+    const canSignAllCollections = () => canSignNamespace && !can_upload_signatures;
 
     const actions: IPageAction<HubNamespace>[] = [
       {
@@ -90,9 +91,9 @@ export function useHubNamespaceActions(options?: {
     return actions;
   }, [
     t,
-    can_upload_signatures,
-    can_create_signatures,
     location?.search,
+    canSignNamespace,
+    can_upload_signatures,
     pageNavigate,
     signCollection,
     options.onHubNamespacesSignAllCollections,


### PR DESCRIPTION
This PR is for AAP-29158 which dynamically hides and displays signing actions and information based on user permissions and feature flags. The logic for hiding and displaying these actions and info was based on what was implemented in the old UI. To test these changes, you can update the hub context in `useHubContext.tsx` to manipulate the featureflag and model permission values like shown below. 
<img width="691" alt="Screenshot 2024-08-13 at 4 28 18 PM" src="https://github.com/user-attachments/assets/8004f8a2-5907-469b-8a6c-9f7eaea98c11">
