### PR TITLE
Error handling (RBAC) for collections

### DIFF
--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -147,7 +147,6 @@ export function useCollectionActions(
     ],
     [
       t,
-      context,
       pageNavigate,
       deleteCollections,
       deprecateCollections,

--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -95,9 +95,6 @@ export function useCollectionActions(
         onClick: (collection) => {
           copyToRepository(collection, 'copy');
         },
-        isDisabled: context.featureFlags.display_repositories
-          ? ''
-          : t`You do not have rights to this operation`,
       },
       {
         type: PageActionType.Button,
@@ -119,9 +116,6 @@ export function useCollectionActions(
           deleteCollectionsVersions([collection]);
         },
         isHidden: () => (detail ? false : true),
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
       },
       {
         type: PageActionType.Button,
@@ -133,9 +127,6 @@ export function useCollectionActions(
           deleteCollectionsVersionsFromRepository([collection]);
         },
         isHidden: () => (detail ? false : true),
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
       },
       {
         type: PageActionType.Button,
@@ -144,9 +135,6 @@ export function useCollectionActions(
         label: t('Delete entire collection from repository'),
         onClick: (collection) => deleteCollectionsFromRepository([collection]),
         isDanger: true,
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
       },
       {
         type: PageActionType.Button,
@@ -155,9 +143,6 @@ export function useCollectionActions(
         label: t('Delete entire collection from system'),
         onClick: (collection) => deleteCollections([collection]),
         isDanger: true,
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t('You do not have rights to this operation'),
       },
     ],
     [

--- a/frontend/hub/collections/hooks/useCollectionsActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionsActions.tsx
@@ -74,9 +74,6 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
           deleteCollections(newCollections);
         },
         isDanger: true,
-        isDisabled: context.hasPermission('ansible.delete_collection')
-          ? ''
-          : t`You do not have rights to this operation`,
       },
     ],
     [t, deleteCollections, context, pageNavigate, deprecateCollections, signCollection]

--- a/frontend/hub/collections/hooks/useCollectionsActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionsActions.tsx
@@ -8,7 +8,6 @@ import {
   PageActionType,
   usePageNavigate,
 } from '../../../../framework';
-import { useHubContext } from '../../common/useHubContext';
 import { HubRoute } from '../../main/HubRoutes';
 import { CollectionVersionSearch } from '../Collection';
 import { useDeleteCollections } from './useDeleteCollections';
@@ -20,7 +19,6 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
   const pageNavigate = usePageNavigate();
   const deleteCollections = useDeleteCollections(callback);
   const deprecateCollections = useDeprecateCollections(callback);
-  const context = useHubContext();
   const signCollection = useSignCollection(false, callback);
 
   return useMemo<IPageAction<CollectionVersionSearch>[]>(
@@ -76,6 +74,6 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
         isDanger: true,
       },
     ],
-    [t, deleteCollections, context, pageNavigate, deprecateCollections, signCollection]
+    [t, deleteCollections, pageNavigate, deprecateCollections, signCollection]
   );
 }


### PR DESCRIPTION
Copy version to repositories not repaired here, because it was repaired in https://github.com/ansible/ansible-ui/pull/2961.

This PR deleted old RBAC, which should not work.
Other than that, it seems that all errors are correctly handled in actions.