### PR TITLE
[AAP-29018] Update source-event mappings options lists

### DIFF
--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -248,7 +248,9 @@ export function RulebookActivationInputs() {
                 />
               )
             }
-          >{`${t('Manage event streams')}`}</Button>
+          >
+            {t('Manage event streams')}
+          </Button>
         }
       />
       {sourceMappings && sourceMappings.length > 0 && (

--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -45,6 +45,7 @@ import { EdaSourceEventMapping } from '../interfaces/EdaSource';
 import { PageFormGroup } from '../../../framework/PageForm/Inputs/PageFormGroup';
 import jsyaml from 'js-yaml';
 import { LabelGroupWrapper } from '../../common/label-group-wrapper';
+import { EdaWebhook } from '../interfaces/EdaWebhook';
 
 export function CreateRulebookActivation() {
   const { t } = useTranslation();
@@ -146,6 +147,8 @@ export function RulebookActivationInputs() {
     edaAPI`/users/me/awx-tokens/?page=1&page_size=200`
   );
 
+  const { data: eventStreams } = useGet<EdaResult<EdaWebhook>>(edaAPI`/webhooks/`);
+
   const [_, setDialog] = usePageDialog();
   const RESTART_OPTIONS = [
     { label: t('On failure'), value: 'on-failure' },
@@ -238,7 +241,7 @@ export function RulebookActivationInputs() {
           <Button
             variant="link"
             data-cy={'manage_event_stream'}
-            isDisabled={!rulebook}
+            isDisabled={!rulebook || !eventStreams || eventStreams.count < 1}
             onClick={() =>
               setDialog(
                 <SourceEventStreamMappingModal

--- a/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
+++ b/frontend/eda/rulebook-activations/RulebookActivationForm.tsx
@@ -112,7 +112,9 @@ export function CreateRulebookActivation() {
 export function RulebookActivationInputs() {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
-  const [sourceMappings, setSourceMappings] = useState<EdaSourceEventMapping[] | undefined>([]);
+  const [sourceMappings, setSourceMappings] = useState<EdaSourceEventMapping[] | undefined>(
+    undefined
+  );
   const { register, setValue } = useFormContext();
   const restartPolicyHelpBlock = (
     <>
@@ -190,6 +192,14 @@ export function RulebookActivationInputs() {
     setSourceMappings(undefined);
   }, [rulebook, setSourceMappings]);
 
+  const removeMapping = (webhook_name: string) => {
+    if (sourceMappings) {
+      const map = sourceMappings.filter((ev) => ev.webhook_name !== webhook_name);
+      setSourceMappings(map);
+      if (sourceMappings.length === 0) setSourceMappings(undefined);
+    }
+  };
+
   return (
     <>
       <PageFormTextInput<IEdaRulebookActivationInputs>
@@ -256,13 +266,13 @@ export function RulebookActivationInputs() {
           </Button>
         }
       />
-      {sourceMappings && sourceMappings.length > 0 && (
-        <PageFormGroup label={t('Event streams')}>
+      {!!sourceMappings && sourceMappings.length > 0 && (
+        <PageFormGroup label={t('Event streams')} fieldId={'source_event_mappings'}>
           <LabelGroupWrapper>
             {sourceMappings.map((map) => (
               <>
                 <Tooltip content={<div>{map.source_name}</div>}>
-                  <Label>{map.webhook_name}</Label>
+                  <Label onClose={() => removeMapping(map.webhook_name)}>{map.webhook_name} </Label>
                 </Tooltip>
               </>
             ))}

--- a/frontend/eda/rulebook-activations/components/SourceEventMapFields.tsx
+++ b/frontend/eda/rulebook-activations/components/SourceEventMapFields.tsx
@@ -1,4 +1,4 @@
-import { Button, FormFieldGroupExpandable, FormFieldGroupHeader } from '@patternfly/react-core';
+import { Button, FormFieldGroup, FormFieldGroupHeader } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { useFormContext, useWatch } from 'react-hook-form';
@@ -7,7 +7,93 @@ import { EdaSource, EdaSourceEventMapping } from '../../interfaces/EdaSource';
 import { EdaRulebook } from '../../interfaces/EdaRulebook';
 import { EdaWebhook } from '../../interfaces/EdaWebhook';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
-import { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
+
+export function FormSingleSelectEventStream(props: {
+  name: string;
+  eventOptions: EdaWebhook[] | undefined;
+  selectedEvent: number;
+}) {
+  const { name, eventOptions, selectedEvent } = props;
+  const { t } = useTranslation();
+  const { getValues } = useFormContext();
+
+  const getEventOptions = () => {
+    let events = eventOptions;
+    const mappingsNow = getValues('mappings') as EdaSourceEventMapping[];
+    if (eventOptions && mappingsNow && mappingsNow.length > 1) {
+      events = eventOptions.filter((ev) => {
+        return !mappingsNow.find((item) => {
+          return parseInt(item.webhook_id, 10) === selectedEvent
+            ? false
+            : item?.webhook_name === ev.name;
+        });
+      });
+    }
+    return events
+      ? events.map((item: { name: string; id: number }) => ({
+          label: item.name,
+          value: item.id,
+        }))
+      : [];
+  };
+
+  return (
+    <PageFormSingleSelect
+      name={name}
+      label={t('Event stream')}
+      placeholder={t('Select event stream')}
+      isRequired
+      labelHelp={t('Event streams to swap with the selected source.')}
+      labelHelpTitle={t('Event stream')}
+      options={getEventOptions()}
+    />
+  );
+}
+
+export function FormSingleSelectSource(props: {
+  name: string;
+  sourceOptions: EdaSource[] | undefined;
+  selectedSource: string;
+}) {
+  const { name, sourceOptions, selectedSource } = props;
+  const { t } = useTranslation();
+  const { getValues } = useFormContext();
+
+  const getSourceOptions = useCallback(() => {
+    const mappingsNow = getValues('mappings') as EdaSourceEventMapping[];
+    let sources = sourceOptions;
+    if (sourceOptions && mappingsNow && mappingsNow.length > 1) {
+      sources = sourceOptions.filter((src) => {
+        return !mappingsNow.find((item) => {
+          return item.source_name === selectedSource ? false : item?.source_name === src.name;
+        });
+      });
+    }
+    return sources
+      ? sources.map((item: { name: string }) => ({
+          label: item.name,
+          value: item.name,
+        }))
+      : [];
+  }, [getValues, selectedSource, sourceOptions]);
+
+  return (
+    <PageFormSingleSelect
+      name={name}
+      label={t('Rulebook source')}
+      placeholder={t('Select rulebook source')}
+      isRequired
+      labelHelp={t(
+        'A rulebook can contain multiple sources across multiple rulesets. You can map the same rulebook in ' +
+          'multiple activations to multiple event streams. While managing event streams, unnamed sources are assigned ' +
+          'temporary names (__SOURCE {n}) for identification purposes.'
+      )}
+      labelHelpTitle={t('Rulebook source')}
+      options={getSourceOptions()}
+    />
+  );
+}
 
 export function SourceEventMapFields(props: {
   index: number;
@@ -19,9 +105,9 @@ export function SourceEventMapFields(props: {
 }) {
   const { t } = useTranslation();
   const { index, sourceOptions, eventOptions, onDelete } = props;
-  const { register, setValue, getValues } = useFormContext();
+  const { register, setValue } = useFormContext();
   const selectedSource = useWatch({ name: `mappings.${index}.source_name` }) as string;
-  const mappings: EdaSourceEventMapping[] = getValues('mappings') as EdaSourceEventMapping[];
+  //const mappings: EdaSourceEventMapping[] = getValues('mappings') as EdaSourceEventMapping[];
 
   const setSourceInfo = useCallback(() => {
     let srcIndex = -1;
@@ -56,52 +142,8 @@ export function SourceEventMapFields(props: {
     setEventInfo();
   }, [setEventInfo]);
 
-  const getSourceOptions = useCallback(() => {
-    let sources = sourceOptions;
-    if (sourceOptions && mappings && mappings.length > 1) {
-      sources = sourceOptions.filter((src) => {
-        return !mappings.find((item) => {
-          return item.source_name === selectedSource ? false : item?.source_name === src.name;
-        });
-      });
-    }
-    return sources
-      ? sources.map((item: { name: string }) => ({
-          label: item.name,
-          value: item.name,
-        }))
-      : [];
-  }, [mappings, selectedSource, sourceOptions]);
-
-  const getEventOptions = useCallback(() => {
-    let events = eventOptions;
-
-    if (eventOptions && mappings && mappings.length > 1) {
-      events = eventOptions.filter((ev) => {
-        return !mappings.find((item) => {
-          return parseInt(item.webhook_id, 10) === selectedEvent
-            ? false
-            : item?.webhook_name === ev.name;
-        });
-      });
-    }
-
-    return events
-      ? events.map((item: { name: string; id: number }) => ({
-          label: item.name,
-          value: item.id,
-        }))
-      : [];
-  }, [eventOptions, mappings, selectedEvent]);
-
-  useEffect(() => {
-    getEventOptions();
-    getSourceOptions();
-  }, [getEventOptions, getSourceOptions, selectedSource, selectedEvent]);
-
   return (
-    <FormFieldGroupExpandable
-      isExpanded
+    <FormFieldGroup
       header={
         <FormFieldGroupHeader
           titleText={{ text: t('Mapping ') + `${index + 1}`, id: `Mapping ${index}` }}
@@ -118,23 +160,16 @@ export function SourceEventMapFields(props: {
         />
       }
     >
-      <PageFormSingleSelect
+      <FormSingleSelectSource
         name={`mappings.${index}.source_name`}
-        label={t('Source')}
-        placeholder={t('Select source')}
-        isRequired
-        labelHelp={t('Sources in the rulebook.')}
-        labelHelpTitle={t('Sources')}
-        options={getSourceOptions()}
+        sourceOptions={sourceOptions}
+        selectedSource={selectedSource}
       />
-      <PageFormSingleSelect
+
+      <FormSingleSelectEventStream
         name={`mappings.${index}.webhook_id`}
-        label={t('Event stream')}
-        placeholder={t('Select event stream')}
-        isRequired
-        labelHelp={t('Event stream to swap with the source.')}
-        labelHelpTitle={t('Event streams')}
-        options={getEventOptions()}
+        eventOptions={eventOptions}
+        selectedEvent={selectedEvent}
       />
       <PageFormTextArea
         name={`${index}.source_info`}
@@ -142,6 +177,6 @@ export function SourceEventMapFields(props: {
         isReadOnly
       />
       <input type="hidden" {...register(`mappings.${index}.rulebook_hash`)} />
-    </FormFieldGroupExpandable>
+    </FormFieldGroup>
   );
 }

--- a/frontend/eda/rulebook-activations/components/SourceEventMapFields.tsx
+++ b/frontend/eda/rulebook-activations/components/SourceEventMapFields.tsx
@@ -4,47 +4,100 @@ import { useTranslation } from 'react-i18next';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { PageFormTextArea } from '../../../../framework';
 import { EdaSource, EdaSourceEventMapping } from '../../interfaces/EdaSource';
-import { edaAPI } from '../../common/eda-utils';
-import { EdaResult } from '../../interfaces/EdaResult';
 import { EdaRulebook } from '../../interfaces/EdaRulebook';
-import { useGet } from '../../../common/crud/useGet';
 import { EdaWebhook } from '../../interfaces/EdaWebhook';
 import { PageFormSingleSelect } from '../../../../framework/PageForm/Inputs/PageFormSingleSelect';
+import { useCallback, useEffect } from 'react';
 
 export function SourceEventMapFields(props: {
   index: number;
   rulebook: EdaRulebook;
   source_mappings: EdaSourceEventMapping;
+  sourceOptions: EdaSource[] | undefined;
+  eventOptions: EdaWebhook[] | undefined;
   onDelete: (id: number) => void;
 }) {
   const { t } = useTranslation();
-  const { index, onDelete } = props;
-  const { register, setValue } = useFormContext();
-
-  const { data: sources } = useGet<EdaResult<EdaSource>>(
-    edaAPI`/rulebooks/` + `${props?.rulebook?.id}/sources/?page=1&page_size=200`
-  );
-  const { data: events } = useGet<EdaResult<EdaWebhook>>(edaAPI`/webhooks/?page=1&page_size=200`);
-
+  const { index, sourceOptions, eventOptions, onDelete } = props;
+  const { register, setValue, getValues } = useFormContext();
   const selectedSource = useWatch({ name: `mappings.${index}.source_name` }) as string;
-  let srcIndex = -1;
-  if (sources?.results) {
-    srcIndex = sources.results.findIndex((source) => source.name === selectedSource);
+  const mappings: EdaSourceEventMapping[] = getValues('mappings') as EdaSourceEventMapping[];
 
-    if (srcIndex > -1) {
-      setValue(`${index}.source_info`, sources.results[srcIndex].source_info);
-      setValue(`mappings.${index}.rulebook_hash`, sources.results[srcIndex].rulebook_hash);
+  const setSourceInfo = useCallback(() => {
+    let srcIndex = -1;
+    if (sourceOptions) {
+      srcIndex = sourceOptions.findIndex((source) => source.name === selectedSource);
+
+      if (srcIndex > -1) {
+        setValue(`${index}.source_info`, sourceOptions[srcIndex].source_info);
+        setValue(`mappings.${index}.rulebook_hash`, sourceOptions[srcIndex].rulebook_hash);
+      }
     }
-  }
+  }, [index, selectedSource, setValue, sourceOptions]);
+
+  useEffect(() => {
+    setSourceInfo();
+  }, [setSourceInfo]);
+
   const selectedEvent = useWatch({ name: `mappings.${index}.webhook_id` }) as number;
-  let evIndex = -1;
-  if (events?.results) {
-    evIndex = events.results.findIndex((event) => event.id === selectedEvent);
 
-    if (evIndex > -1) {
-      setValue(`mappings.${index}.webhook_name`, events.results[evIndex].name);
+  const setEventInfo = useCallback(() => {
+    let evIndex = -1;
+    if (eventOptions) {
+      evIndex = eventOptions.findIndex((event) => event.id === selectedEvent);
+
+      if (evIndex > -1) {
+        setValue(`mappings.${index}.webhook_name`, eventOptions[evIndex].name);
+      }
     }
-  }
+  }, [eventOptions, index, selectedEvent, setValue]);
+
+  useEffect(() => {
+    setEventInfo();
+  }, [setEventInfo]);
+
+  const getSourceOptions = useCallback(() => {
+    let sources = sourceOptions;
+    if (sourceOptions && mappings && mappings.length > 1) {
+      sources = sourceOptions.filter((src) => {
+        return !mappings.find((item) => {
+          return item.source_name === selectedSource ? false : item?.source_name === src.name;
+        });
+      });
+    }
+    return sources
+      ? sources.map((item: { name: string }) => ({
+          label: item.name,
+          value: item.name,
+        }))
+      : [];
+  }, [mappings, selectedSource, sourceOptions]);
+
+  const getEventOptions = useCallback(() => {
+    let events = eventOptions;
+
+    if (eventOptions && mappings && mappings.length > 1) {
+      events = eventOptions.filter((ev) => {
+        return !mappings.find((item) => {
+          return parseInt(item.webhook_id, 10) === selectedEvent
+            ? false
+            : item?.webhook_name === ev.name;
+        });
+      });
+    }
+
+    return events
+      ? events.map((item: { name: string; id: number }) => ({
+          label: item.name,
+          value: item.id,
+        }))
+      : [];
+  }, [eventOptions, mappings, selectedEvent]);
+
+  useEffect(() => {
+    getEventOptions();
+    getSourceOptions();
+  }, [getEventOptions, getSourceOptions, selectedSource, selectedEvent]);
 
   return (
     <FormFieldGroupExpandable
@@ -72,14 +125,7 @@ export function SourceEventMapFields(props: {
         isRequired
         labelHelp={t('Sources in the rulebook.')}
         labelHelpTitle={t('Sources')}
-        options={
-          sources?.results
-            ? sources.results.map((item: { name: string }) => ({
-                label: item.name,
-                value: item.name,
-              }))
-            : []
-        }
+        options={getSourceOptions()}
       />
       <PageFormSingleSelect
         name={`mappings.${index}.webhook_id`}
@@ -88,14 +134,7 @@ export function SourceEventMapFields(props: {
         isRequired
         labelHelp={t('Event stream to swap with the source.')}
         labelHelpTitle={t('Event streams')}
-        options={
-          events?.results
-            ? events.results.map((item: { name: string; id: number }) => ({
-                label: item.name,
-                value: item.id,
-              }))
-            : []
-        }
+        options={getEventOptions()}
       />
       <PageFormTextArea
         name={`${index}.source_info`}

--- a/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
+++ b/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
@@ -56,7 +56,7 @@ export function SourceEventStreamMapping(options: EventStreamMappingProps) {
   useEffect(() => {
     setValue(
       'mappings',
-      options.mappings
+      !!options.mappings && options.mappings.length > 0
         ? options.mappings
         : [
             {

--- a/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
+++ b/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
@@ -1,5 +1,5 @@
-import { Button, Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core';
-import React, { useEffect } from 'react';
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   PageDetail,
@@ -17,6 +17,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useGet } from '../../../common/crud/useGet';
 import { EdaResult } from '../../interfaces/EdaResult';
 import { edaAPI } from '../../common/eda-utils';
+import { EdaWebhook } from '../../interfaces/EdaWebhook';
 
 export interface EventStreamMappingProps {
   rulebook: EdaRulebook;
@@ -26,7 +27,7 @@ export interface EventStreamMappingProps {
 
 export function SourceEventStreamMapping(options: EventStreamMappingProps) {
   const { t } = useTranslation();
-  const { control, setValue } = useFormContext();
+  const { setValue, getFieldState, control } = useFormContext();
 
   const {
     fields: mappings,
@@ -35,10 +36,9 @@ export function SourceEventStreamMapping(options: EventStreamMappingProps) {
   } = useFieldArray({
     control,
     name: 'mappings',
-    shouldUnregister: false,
   });
 
-  const addMapping = () => {
+  const addMapping = useCallback(() => {
     const map: EdaSourceEventMapping = {
       source_name: '',
       webhook_id: '',
@@ -46,10 +46,12 @@ export function SourceEventStreamMapping(options: EventStreamMappingProps) {
       rulebook_hash: '',
     };
     addMap(map);
-  };
+  }, [addMap]);
+
   const { data: sources } = useGet<EdaResult<EdaSource>>(
     edaAPI`/rulebooks/` + `${options?.rulebook?.id}/sources/?page=1&page_size=200`
   );
+  const { data: events } = useGet<EdaResult<EdaWebhook>>(edaAPI`/webhooks/?page=1&page_size=200`);
 
   useEffect(() => {
     setValue('mappings', options.mappings);
@@ -62,27 +64,35 @@ export function SourceEventStreamMapping(options: EventStreamMappingProps) {
           <PageDetail label={t('Rulebook')}>{options?.rulebook?.name}</PageDetail>
           <PageDetail label={t('Number of sources')}>{sources?.count}</PageDetail>
         </PageDetails>
-        {mappings.map((map, i) => (
+        {mappings.map((mapping, i) => (
           <SourceEventMapFields
-            key={i}
+            key={mapping.id}
             index={i}
-            source_mappings={map as unknown as EdaSourceEventMapping}
+            source_mappings={mapping as unknown as EdaSourceEventMapping}
+            sourceOptions={sources?.results}
+            eventOptions={events?.results}
             onDelete={removeMap}
             rulebook={options?.rulebook}
           />
         ))}
       </PageFormSection>
-      <PageFormSection>
-        <Button
-          variant="link"
-          icon={<PlusCircleIcon />}
-          style={{ paddingLeft: 0 }}
-          data-cy={'add_event_stream'}
-          onClick={addMapping}
-        >
-          {t('Add event stream')}
-        </Button>
-      </PageFormSection>
+      {!(
+        mappings &&
+        (mappings.length >= (sources?.count ?? 0) || mappings.length >= (events?.count ?? 0))
+      ) && (
+        <PageFormSection>
+          <Button
+            variant="link"
+            icon={<PlusCircleIcon />}
+            style={{ paddingLeft: 0 }}
+            data-cy={'add_event_stream'}
+            onClick={() => addMapping()}
+            isDisabled={getFieldState('mappings').invalid}
+          >
+            {t('Add event stream')}
+          </Button>
+        </PageFormSection>
+      )}
     </>
   );
 }
@@ -96,8 +106,8 @@ export function SourceEventStreamMappingModal(options: EventStreamMappingProps) 
   const onClose = () => setDialog(undefined);
 
   const onSubmit: PageFormSubmitHandler<{ mappings: EdaSourceEventMapping[] }> = (values) => {
-    options.setSourceMappings(values.mappings);
     onClose();
+    options.setSourceMappings(values.mappings);
     return Promise.resolve();
   };
 
@@ -105,8 +115,8 @@ export function SourceEventStreamMappingModal(options: EventStreamMappingProps) 
     <Modal
       title={t('Event streams')}
       aria-label={t('Event streams')}
-      ouiaId={t('Event streams')}
-      data-cy={t('event-streams')}
+      ouiaId={'Event streams'}
+      data-cy={'event-streams'}
       description={
         <div style={{ fontSize: 'small' }}>
           {t(
@@ -122,11 +132,14 @@ export function SourceEventStreamMappingModal(options: EventStreamMappingProps) 
       onClose={onClose}
       hasNoBodyWrapper
     >
-      <ModalBoxBody style={{ padding: 0 }}>
-        <EdaPageForm onSubmit={onSubmit} submitText={t('Save')}>
-          <SourceEventStreamMapping {...options} />
-        </EdaPageForm>
-      </ModalBoxBody>
+      <EdaPageForm
+        onSubmit={onSubmit}
+        submitText={t('Save')}
+        cancelText={t('Cancel')}
+        onCancel={onClose}
+      >
+        <SourceEventStreamMapping {...options} />
+      </EdaPageForm>
     </Modal>
   );
 }

--- a/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
+++ b/frontend/eda/rulebook-activations/components/SourceEventStreamMapping.tsx
@@ -54,7 +54,19 @@ export function SourceEventStreamMapping(options: EventStreamMappingProps) {
   const { data: events } = useGet<EdaResult<EdaWebhook>>(edaAPI`/webhooks/?page=1&page_size=200`);
 
   useEffect(() => {
-    setValue('mappings', options.mappings);
+    setValue(
+      'mappings',
+      options.mappings
+        ? options.mappings
+        : [
+            {
+              source_name: '',
+              webhook_id: '',
+              webhook_name: '',
+              rulebook_hash: '',
+            },
+          ]
+    );
   }, [setValue, options.mappings]);
 
   return (


### PR DESCRIPTION
Changes for the source-event stream mappings

Rulebook Activation form:

-  The 'Manage event stream' link is disabled if a rulebook is not selected or is there are no event streams
-  The labels for the event stream in the Create Activation form are closable, removing the closed mapping

- ![Screenshot from 2024-08-14 14-03-14](https://github.com/user-attachments/assets/567f679b-82be-487a-a9b4-85567d6c4fc8)

Mapping dialog

-  The Add event stream mapping is hidden if there are no more sources or event streams to select
-  When the dialog open, a blank mapping is displayed if there are no mappings previously created


![Screenshot from 2024-08-15 06-12-00](https://github.com/user-attachments/assets/678da55d-4557-4b64-94f2-114b0734d06c)



