### PR TITLE
AAP-29394 : Replace deleteNamespace that depends on galaxykit and remove it

### DIFF
--- a/cypress/e2e/hub/my-imports.cy.ts
+++ b/cypress/e2e/hub/my-imports.cy.ts
@@ -41,8 +41,8 @@ describe.skip('My imports', () => {
     cy.deleteCollectionsInNamespace(validCollection.namespace);
     cy.deleteCollectionsInNamespace(invalidCollection.namespace);
 
-    cy.deleteNamespace(validCollection.namespace);
-    cy.deleteNamespace(invalidCollection.namespace);
+    cy.deleteHubNamespace({ name: validCollection.namespace });
+    cy.deleteHubNamespace({ name: invalidCollection.namespace });
   });
 
   it('should render empty states', () => {

--- a/cypress/e2e/hub/overview/hub-overview.cy.ts
+++ b/cypress/e2e/hub/overview/hub-overview.cy.ts
@@ -25,7 +25,7 @@ describe('HUB Overview', () => {
   });
   after(() => {
     cy.deleteCollectionsInNamespace(namespaceName);
-    cy.deleteNamespace(namespaceName);
+    cy.deleteHubNamespace({ name: namespaceName });
   });
 
   it.skip('render the hub dashboard', () => {

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -1620,7 +1620,6 @@ declare global {
       ): Cypress.Chainable<void>;
       uploadHubCollectionFile(hubFilePath: string): Cypress.Chainable<void>;
       createNamespace(namespaceName: string): Cypress.Chainable<void>;
-      deleteNamespace(namespaceName: string): Cypress.Chainable<void>;
       deleteCollectionsInNamespace(namespaceName: string): Cypress.Chainable<void>;
       cleanupCollections(namespace: string, repo: string): Cypress.Chainable<void>;
       createRemote(remoteName: string, url?: string): Cypress.Chainable<HubRemote>;

--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -225,12 +225,6 @@ Cypress.Commands.add('createNamespace', (namespaceName: string) => {
   cy.galaxykit('namespace create', namespaceName);
 });
 
-Cypress.Commands.add('deleteNamespace', (namespaceName: string) => {
-  cy.waitForAllTasks();
-  cy.galaxykit('-i namespace delete', namespaceName);
-  cy.waitForAllTasks();
-});
-
 Cypress.Commands.add('deleteCollectionsInNamespace', (namespaceName: string) => {
   cy.requestGet<HubItemsResponse<CollectionVersionSearch>>(
     hubAPI`/v3/plugin/ansible/search/collection-versions/?namespace=${namespaceName}`


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/AAP-29392

Replace `cy.deleteNamespace` by `cy.deleteHubNamespace` to lower dependence on galaxykit and improve test stability.

Both tests need more attention in follow-up PR to be unskipped. See https://github.com/ansible/ansible-ui/pull/2977 for my-imports.