### PR TITLE
[UXD][AAP-28389] AWX - fix to the popovers on templates

### DIFF
--- a/frontend/awx/resources/templates/JobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.tsx
@@ -151,7 +151,7 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
         placeholder={t('Select credentials')}
         labelHelpTitle={t('Credentials')}
         labelHelp={t(
-          'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch," the selected credential(s) become the defaults that can be updated at run time.'
+          'Select credentials for accessing the nodes this job will be ran against. You can only select one credential of each type. For machine credentials (SSH), checking "Prompt on launch" without selecting credentials will require you to select a machine credential at run time. If you select credentials and check "Prompt on launch", the selected credential(s) become the defaults that can be updated at run time.'
         )}
         isMultiple
         queryParams={{ credential_type__kind__in: acceptableCredentialKinds.join(',') }}
@@ -159,7 +159,7 @@ export function JobTemplateInputs(props: { jobtemplate?: JobTemplateForm }) {
       <PageFormLabelSelect
         labelHelpTitle={t('Labels')}
         labelHelp={t(
-          `Optional labels that describe this job template, such as 'dev' or 'test.' Labels can be used to group and filter job templates and completed jobs.`
+          `Optional labels that describe this job template, such as "dev" or "test". Labels can be used to group and filter job templates and completed jobs.`
         )}
         name="labels"
         additionalControls={


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-28389
Fix to the popovers on templates to match IBM's guidelines:
-punctuation should be outside of quotation mark
-use " " instead of ' '