### PR TITLE
Use hub's v2 APIs for creating users and teams in Cypress

### DIFF
--- a/cypress/e2e/hub/remotes-access.cy.ts
+++ b/cypress/e2e/hub/remotes-access.cy.ts
@@ -73,11 +73,7 @@ describe('Remotes User Access tab', () => {
         cy.clickButton(/^Next/);
         cy.contains('h1', 'Review').should('be.visible');
         cy.verifyReviewStepWizardDetails('users', [hubUser.username], '1');
-        cy.verifyReviewStepWizardDetails(
-          'hubRoles',
-          [role.name, 'Manage collection remotes.'],
-          '1'
-        );
+        cy.verifyReviewStepWizardDetails('hubRoles', [role.name, role.description], '1');
         cy.clickButton(/^Finish/);
         cy.wait('@userRoleAssignment')
           .its('response')
@@ -119,11 +115,7 @@ describe('Remotes User Access tab', () => {
         cy.clickButton(/^Next/);
         cy.contains('h1', 'Review').should('be.visible');
         cy.verifyReviewStepWizardDetails('teams', [hubTeam.name], '1');
-        cy.verifyReviewStepWizardDetails(
-          'hubRoles',
-          [role.name, 'Manage collection remotes.'],
-          '1'
-        );
+        cy.verifyReviewStepWizardDetails('hubRoles', [role.name, role.description], '1');
         cy.clickButton(/^Finish/);
         cy.wait('@teamRoleAssignment')
           .its('response')

--- a/cypress/e2e/hub/remotes-access.cy.ts
+++ b/cypress/e2e/hub/remotes-access.cy.ts
@@ -1,10 +1,29 @@
 import { hubAPI } from '../../support/formatApiPathForHub';
 import { Remotes } from './constants';
 import { HubRemote } from '../../../frontend/hub/administration/remotes/Remotes';
+import { randomString } from '../../../framework/utils/random-string';
+import { ContentTypeEnum } from '../../../frontend/hub/interfaces/expanded/ContentType';
+import { HubRbacRole } from '../../../frontend/hub/interfaces/expanded/HubRbacRole';
 
-describe.skip('Remotes User Access tab', () => {
+describe('Remotes User Access tab', () => {
   let remote: HubRemote;
+  let role: HubRbacRole;
+  const customRole = {
+    roleName: 'galaxy.' + `${randomString(5)}`,
+    roleDescription: 'Manage collection remotes.',
+    contentType: ContentTypeEnum.CollectionRemote,
+    permission: 'galaxy.view_collectionremote',
+  };
+
   before(() => {
+    cy.createHubRoleAPI({
+      roleName: customRole.roleName,
+      description: customRole.roleDescription,
+      content_type: ContentTypeEnum.CollectionRemote,
+      permissions: [customRole.permission],
+    }).then((createdRole) => {
+      role = createdRole;
+    });
     cy.createHubRemote().then((createdRemote) => {
       remote = createdRemote;
     });
@@ -12,6 +31,7 @@ describe.skip('Remotes User Access tab', () => {
 
   after(() => {
     cy.deleteHubRemote(remote);
+    cy.deleteHubRoleAPI(role);
   });
 
   beforeEach(() => {
@@ -44,10 +64,10 @@ describe.skip('Remotes User Access tab', () => {
         cy.selectTableRow(hubUser.username);
         cy.clickButton(/^Next/);
         cy.contains('h1', 'Select roles to apply').should('be.visible');
-        cy.filterTableByTextFilter('name', 'galaxy.collection_remote_owner', {
+        cy.filterTableByTextFilter('name', role.name, {
           disableFilterSelection: true,
         });
-        cy.selectTableRowByCheckbox('name', 'galaxy.collection_remote_owner', {
+        cy.selectTableRowByCheckbox('name', role.name, {
           disableFilter: true,
         });
         cy.clickButton(/^Next/);
@@ -55,7 +75,7 @@ describe.skip('Remotes User Access tab', () => {
         cy.verifyReviewStepWizardDetails('users', [hubUser.username], '1');
         cy.verifyReviewStepWizardDetails(
           'hubRoles',
-          ['galaxy.collection_remote_owner', 'Manage collection remotes.'],
+          [role.name, 'Manage collection remotes.'],
           '1'
         );
         cy.clickButton(/^Finish/);
@@ -73,7 +93,7 @@ describe.skip('Remotes User Access tab', () => {
       cy.selectTableRowByCheckbox('username', hubUser.username, {
         disableFilter: true,
       });
-      removeRoleFromListRow('galaxy.collection_remote_owner');
+      removeRoleFromListRow(role.name);
       cy.deleteHubUser(hubUser, { failOnStatusCode: false });
     });
   });
@@ -90,10 +110,10 @@ describe.skip('Remotes User Access tab', () => {
         cy.selectTableRow(hubTeam.name);
         cy.clickButton(/^Next/);
         cy.contains('h1', 'Select roles to apply').should('be.visible');
-        cy.filterTableByTextFilter('name', 'galaxy.collection_remote_owner', {
+        cy.filterTableByTextFilter('name', role.name, {
           disableFilterSelection: true,
         });
-        cy.selectTableRowByCheckbox('name', 'galaxy.collection_remote_owner', {
+        cy.selectTableRowByCheckbox('name', role.name, {
           disableFilter: true,
         });
         cy.clickButton(/^Next/);
@@ -101,7 +121,7 @@ describe.skip('Remotes User Access tab', () => {
         cy.verifyReviewStepWizardDetails('teams', [hubTeam.name], '1');
         cy.verifyReviewStepWizardDetails(
           'hubRoles',
-          ['galaxy.collection_remote_owner', 'Manage collection remotes.'],
+          [role.name, 'Manage collection remotes.'],
           '1'
         );
         cy.clickButton(/^Finish/);
@@ -119,7 +139,7 @@ describe.skip('Remotes User Access tab', () => {
       cy.selectTableRowByCheckbox('team-name', hubTeam.name, {
         disableFilter: false,
       });
-      removeRoleFromListRow('galaxy.collection_remote_owner');
+      removeRoleFromListRow(role.name);
       cy.deleteHubTeam(hubTeam, { failOnStatusCode: false });
     });
   });

--- a/cypress/support/hub-access-commands.ts
+++ b/cypress/support/hub-access-commands.ts
@@ -5,7 +5,7 @@ import { HubTeam } from '../../frontend/hub/interfaces/expanded/HubTeam';
 
 Cypress.Commands.add('createHubUser', (hubUser?: Partial<HubUser>) => {
   cy.requestPost<HubUser, Partial<HubUser> & { username?: string; password?: string }>(
-    hubAPI`/_ui/v1/users/`,
+    hubAPI`/_ui/v2/users/`,
     {
       username: `hub-user${randomString(4)}`,
       password: `${randomString(10)}`,
@@ -21,11 +21,11 @@ Cypress.Commands.add('createHubUser', (hubUser?: Partial<HubUser>) => {
 });
 
 Cypress.Commands.add('deleteHubUser', (user: HubUser, options?: { failOnStatusCode?: boolean }) => {
-  cy.requestDelete(hubAPI`/_ui/v1/users/${user.id.toString()}/`, options);
+  cy.requestDelete(hubAPI`/_ui/v2/users/${user.id.toString()}/`, options);
 });
 
 Cypress.Commands.add('createHubTeam', () => {
-  cy.requestPost<HubTeam>(hubAPI`/_ui/v1/groups/`, {
+  cy.requestPost<HubTeam>(hubAPI`/_ui/v2/teams/`, {
     name: `hub-team${randomString(4)}`,
   }).then((hubTeam) => {
     Cypress.log({
@@ -37,5 +37,5 @@ Cypress.Commands.add('createHubTeam', () => {
 });
 
 Cypress.Commands.add('deleteHubTeam', (team: HubTeam, options?: { failOnStatusCode?: boolean }) => {
-  cy.requestDelete(hubAPI`/_ui/v1/groups/${team.id.toString()}/`, options);
+  cy.requestDelete(hubAPI`/_ui/v2/teams/${team.id.toString()}/`, options);
 });

--- a/frontend/hub/administration/remotes/RemotePage/RemoteAddTeam.tsx
+++ b/frontend/hub/administration/remotes/RemotePage/RemoteAddTeam.tsx
@@ -144,7 +144,7 @@ export function RemoteAddTeams() {
   return (
     <PageLayout>
       <PageHeader
-        title={t('Add teams')}
+        title={t('Add roles')}
         breadcrumbs={[
           { label: t('Remotes'), to: getPageUrl(HubRoute.Remotes) },
           {


### PR DESCRIPTION
Swaps out the v1 APIs for creating/deleting users and teams with the new v2 APIs.

This can be tested with `remote-access.cy.ts`. This PR also un-skips this spec file.

Note there are still 4 remaining usages of `/api/galaxy/_ui/v1/users/` in `cypress/support/e2e.ts`. We can swap those out after the following API bug is addressed: [AAP-29429](https://issues.redhat.com/browse/AAP-29429)