### PR TITLE
Handle Namespace Create and Edit errors

### DIFF
--- a/frontend/hub/namespaces/HubNamespaceForm.tsx
+++ b/frontend/hub/namespaces/HubNamespaceForm.tsx
@@ -20,8 +20,9 @@ import { HubPageForm } from '../common/HubPageForm';
 import { hubAPI } from '../common/api/formatPath';
 import { HubRoute } from '../main/HubRoutes';
 import { HubNamespace } from './HubNamespace';
-import { UsefulLinksFields } from './UsefulLinksFields';
 import { HubNamespacePage } from './HubNamespacePage/HubNamespacePage';
+import { UsefulLinksFields } from './UsefulLinksFields';
+import { HubNamespaceErrorAdapter } from './components/HubNamespaceErrorAdapter';
 
 export function CreateHubNamespace() {
   const { t } = useTranslation();
@@ -54,6 +55,7 @@ export function CreateHubNamespace() {
         onSubmit={onSubmit}
         onCancel={() => navigate(-1)}
         defaultValue={{ groups: [], links: [{ name: '', url: '' }] }}
+        errorAdapter={HubNamespaceErrorAdapter}
       >
         <HubNamespaceInputs isDisabled={false} isRequired={true} />
         <UsefulLinksFields />
@@ -137,6 +139,7 @@ export function EditHubNamespace() {
         onSubmit={onSubmit}
         onCancel={() => navigate(-1)}
         defaultValue={namespace}
+        errorAdapter={HubNamespaceErrorAdapter}
       >
         <HubNamespaceInputs isDisabled={true} />
         <UsefulLinksFields />

--- a/frontend/hub/namespaces/components/HubNamespaceErrorAdapter.tsx
+++ b/frontend/hub/namespaces/components/HubNamespaceErrorAdapter.tsx
@@ -1,0 +1,25 @@
+import { ErrorOutput } from '../../../../framework/PageForm/typesErrorAdapter';
+import { hubErrorAdapter } from '../../common/adapters/hubErrorAdapter';
+
+export const HubNamespaceErrorAdapter = (
+  error: unknown,
+  mappedKeys?: Record<string, string>
+): ErrorOutput => {
+  const { genericErrors, fieldErrors } = hubErrorAdapter(error, mappedKeys);
+
+  const filteredFieldErrors = fieldErrors.filter(
+    ({ name }) => name !== 'links__url' && name !== 'links__name'
+  );
+
+  // Filter `links__url` and `links__name` errors
+  const linksErrors = fieldErrors.filter(
+    ({ name }) => name === 'links__url' || name === 'links__name'
+  );
+
+  // Convert `links__url` and `links__name` errors to generic errors
+  linksErrors.forEach(({ message }) => {
+    genericErrors.push({ message });
+  });
+
+  return { genericErrors, fieldErrors: filteredFieldErrors };
+};


### PR DESCRIPTION
The Namespace Create and Edit forms would throw an unhandled error if the Useful Links section was incorrectly filled out and sent to the API. Since there is no way for us to index the individual field values and responses from the API - see sample error response below:
```json
{
    "errors": [
        {
            "status": "400",
            "code": "invalid",
            "title": "Invalid input.",
            "detail": "'http://foo' is not a valid url.",
            "source": {
                "parameter": "links__url"
            }
        },
        {
            "status": "400",
            "code": "invalid",
            "title": "Invalid input.",
            "detail": "'http://123' is not a valid url.",
            "source": {
                "parameter": "links__url"
            }
        },
        {
            "status": "400",
            "code": "invalid",
            "title": "Invalid input.",
            "detail": "'http://aasd' is not a valid url.",
            "source": {
                "parameter": "links__url"
            }
        }
    ]
}
```
Create a custom Namespace error adapter to convert those specific errors into generic errors.

Before the form would get stuck into an unusable state since the error keys did not match the form field names:
![Screenshot 2024-08-15 at 1 12 41 PM](https://github.com/user-attachments/assets/280f5348-76f4-47d7-9247-8968c31350f5)

Now the errors are handled as generic errors:
![Screenshot 2024-08-15 at 1 13 01 PM](https://github.com/user-attachments/assets/656974d6-7a85-426f-a0f3-84032732363a)
