### PR TITLE
fixes to inconsistencies in hub buttons

### DIFF
--- a/frontend/hub/collections/hooks/useCollectionActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionActions.tsx
@@ -86,7 +86,7 @@ export function useCollectionActions(
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: BanIcon,
-        label: t('Deprecate'),
+        label: t('Deprecate collection'),
         onClick: (collection) => {
           deprecateOrUndeprecateCollections([collection], 'deprecate');
         },
@@ -98,7 +98,7 @@ export function useCollectionActions(
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
         icon: BanIcon,
-        label: t('Undeprecate'),
+        label: t('Undeprecate collection'),
         onClick: (collection) => {
           deprecateOrUndeprecateCollections([collection], 'undeprecate');
         },

--- a/frontend/hub/collections/hooks/useCollectionsActions.tsx
+++ b/frontend/hub/collections/hooks/useCollectionsActions.tsx
@@ -38,15 +38,6 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Multiple,
-        icon: BanIcon,
-        label: t('Deprecate collections'),
-        onClick: (collections) => {
-          deprecateOrUndeprecateCollections(collections, 'deprecate');
-        },
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Multiple,
         icon: KeyIcon,
         label: t('Sign collections'),
         onClick: (collections) => {
@@ -54,6 +45,15 @@ export function useCollectionsActions(callback: (collections: CollectionVersionS
         },
         isDisabled: () =>
           !canSign ? t('You do not have the rights for this operation') : undefined,
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        icon: BanIcon,
+        label: t('Deprecate collections'),
+        onClick: (collections) => {
+          deprecateOrUndeprecateCollections(collections, 'deprecate');
+        },
       },
       { type: PageActionType.Seperator },
       {

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/hooks/useExecutionEnvironmentPageActions.tsx
@@ -63,7 +63,6 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
         isDisabled: (ee) => (isSyncRunning(ee) ? t('Sync is already running.') : undefined),
         onClick: (ee: ExecutionEnvironment) => syncExecutionEnvironments([ee]),
       },
-      useInController,
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
@@ -72,6 +71,7 @@ export function useExecutionEnvironmentPageActions(options: { refresh?: () => un
         isDisabled: () => (canSignEE ? undefined : t('You do not have rights to this operation')),
         onClick: (ee) => signExecutionEnvironments([ee]),
       },
+      useInController,
       { type: PageActionType.Seperator },
       {
         type: PageActionType.Button,


### PR DESCRIPTION
Part of this PR: https://github.com/ansible/ansible-ui/pull/2669
Noticed some additional inconsistencies in my review of Hub after the above PR was merged:

Collections:
-the bulk action order was different from the row level
Execution Environment:
-the row level action order was different than on the details page