### PR TITLE
update to repository column

### DIFF
--- a/frontend/hub/administration/repositories/hooks/useRepositoriesColumns.tsx
+++ b/frontend/hub/administration/repositories/hooks/useRepositoriesColumns.tsx
@@ -63,7 +63,7 @@ export function useRepositoriesColumns(_options?: {
         },
       },
       {
-        header: t('Created at'),
+        header: t('Created'),
         cell: (repository) => <DateTimeCell value={repository.pulp_created} />,
         sort: 'pulp_created',
         defaultSortDirection: 'desc',


### PR DESCRIPTION
Part of this PR: https://github.com/ansible/ansible-ui/pull/2830
Noticed some additional inconsistencies in my review of Hub after the above PR was merged:

Repository column was titled "Created at" but the pattern throughout AAP is that this field is just "Created"