### PR TITLE
Change test EE source from dockerhub to quay, use pulp/pulp-fixtures instead of alpine

### DIFF
--- a/cypress/support/hub-commands.ts
+++ b/cypress/support/hub-commands.ts
@@ -352,7 +352,7 @@ Cypress.Commands.add(
       url: hubAPI`/_ui/v1/execution-environments/remotes/`,
       body: {
         name: randomE2Ename(),
-        upstream_name: 'library/alpine',
+        upstream_name: 'pulp/pulp-fixtures',
         include_tags: ['latest'],
         ...options?.executionEnvironment,
       },
@@ -416,7 +416,7 @@ Cypress.Commands.add('createHubRemoteRegistry', (options?: HubCreateRemoteRegist
     url: hubAPI`/_ui/v1/execution-environments/registries/`,
     body: {
       name: randomE2Ename(),
-      url: 'https://registry.hub.docker.com/',
+      url: 'https://quay.io/',
       ...options?.remoteRegistry,
     },
   });


### PR DESCRIPTION
Issue AAP-29477

Should prevent tests failing on 429 Too Many Request for registry.hub.docker.com

Hoping it doesn't start happening with quay too, else we'd have to find some public EE on ghcr