### PR TITLE
[AAP-29149] Collection version switch bugfix

### DIFF
--- a/cypress/e2e/hub/collections-detail.cy.ts
+++ b/cypress/e2e/hub/collections-detail.cy.ts
@@ -175,7 +175,7 @@ describe('Collections Details', () => {
     });
   });
 
-  it.skip('can sign a selected version of a collection', () => {
+  it('can sign a selected version of a collection', () => {
     cy.uploadCollection(collectionName, namespace.name).then(() => {
       cy.galaxykit(
         'collection move',

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -12,6 +12,7 @@ import {
   PageHeader,
   PageLayout,
   useGetPageUrl,
+  usePageAlertToaster,
 } from '../../../../framework';
 import {
   PageAsyncSelectQueryOptions,
@@ -34,10 +35,12 @@ import { useSelectCollectionVersionSingle } from '../hooks/useCollectionVersionS
 
 export function CollectionPage() {
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { name, namespace, repository } = useParams();
   const context = useHubContext();
   const [collection, setCollection] = useState<null | Partial<CollectionVersionSearch>>(null);
+  const [versionsCount, setVersionsCount] = useState<undefined | number>(undefined);
+  const getPageUrl = useGetPageUrl();
 
   const { display_signatures } = context.featureFlags;
 
@@ -47,15 +50,54 @@ export function CollectionPage() {
     repository: repository || '',
   });
 
+  const getRequest = useGetRequest<HubItemsResponse<CollectionVersionSearch>>();
+
   const singleSelectorBrowser = singleSelectBrowseAdapter<CollectionVersionSearch>(
     singleSelector.openBrowse,
     (item) => {
       return item?.collection_version?.version || '';
     },
-    (name) => {
-      return { collection_version: { version: name } };
+    async (name) => {
+      const collectionRequest = await getRequest(
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}&version=${name}`
+      );
+      return collectionRequest.data;
     }
   );
+
+  useEffect(() => {
+    async function getCollectionData() {
+      const version = searchParams.get('version');
+      let queryFilter;
+      if (version) {
+        queryFilter = '&version=' + version;
+      } else if (collection) {
+        queryFilter = '&version=' + collection?.collection_version?.version;
+      } else {
+        queryFilter = '&is_highest=true';
+      }
+
+      const collectionRequest = await getRequest(
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}` +
+          queryFilter
+      );
+
+      const collectionData: null | CollectionVersionSearch =
+        collectionRequest?.data && collectionRequest?.data?.length > 0
+          ? collectionRequest.data[0]
+          : null;
+
+      // only set collection when collection has updated this avoids infinite loop
+      if (
+        !collection ||
+        collection?.collection_version?.version !== collectionData?.collection_version?.version
+      ) {
+        setCollection(collectionData);
+      }
+    }
+
+    void getCollectionData();
+  }, [collection, getRequest, name, namespace, repository, searchParams]);
 
   let queryFilter;
   const version = searchParams.get('version');
@@ -72,38 +114,57 @@ export function CollectionPage() {
 
   const itemActions = useCollectionActions(() => void collectionRequest.refresh(), true);
 
-  const getRequest = useGetRequest<HubItemsResponse<CollectionVersionSearch>>();
-  useEffect(() => {
-    async function getCollectionData() {
-      const version = searchParams.get('version');
-      let queryFilter;
-      if (version) {
-        queryFilter = '&version=' + version;
-      } else if (collection) {
-        queryFilter = '&version=' + collection?.collection_version?.version;
-      } else {
-        queryFilter = '&is_highest=true';
-      }
-      const collectionRequest = await getRequest(
-        hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}` +
-          queryFilter
-      );
-
-      const collectionData: null | CollectionVersionSearch =
-        collectionRequest?.data && collectionRequest?.data?.length > 0
-          ? collectionRequest.data[0]
-          : null;
-
-      if (
-        !collection ||
-        collection?.collection_version?.version !== collectionData?.collection_version?.version
-      ) {
-        setCollection(collectionData);
-      }
+  function setVersionParams(collection: Partial<CollectionVersionSearch> | null) {
+    if (!collection) {
+      return;
     }
 
-    void getCollectionData();
-  }, [collection, getRequest, name, namespace, repository, searchParams, collectionRequest]);
+    setTimeout(() => {
+      setSearchParams((params) => {
+        params.set('version', collection?.collection_version?.version ?? '');
+        return params;
+      });
+    }, 0);
+  }
+
+  const { data: versions } = useGet<HubItemsResponse<CollectionVersionSearch>>(
+    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}`,
+    undefined,
+    { refreshInterval: 1000 }
+  );
+
+  const alertToaster = usePageAlertToaster();
+
+  useEffect(() => {
+    if (!versionsCount && versions?.meta.count) {
+      setVersionsCount(versions?.meta.count);
+    } else if (versions?.meta.count && versionsCount && versions?.meta.count > versionsCount) {
+      setVersionsCount(versions?.meta.count);
+      alertToaster.addAlert({
+        variant: 'success',
+        title: (
+          <span>
+            {t(`A new version of this collection has been uploaded. Please `)}
+            <Button style={{ padding: 0 }} variant="link" onClick={() => window.location.reload()}>
+              {t(`refresh`)}
+            </Button>
+            {t(` the page to see the latest version.`)}
+          </span>
+        ),
+        timeout: false,
+      });
+    }
+  }, [
+    alertToaster,
+    collection?.collection_version?.name,
+    collection?.collection_version?.namespace,
+    collection?.repository?.name,
+    collectionRequest,
+    getPageUrl,
+    t,
+    versions,
+    versionsCount,
+  ]);
 
   // load collection versions
   const queryOptions = useCallback(
@@ -148,8 +209,6 @@ export function CollectionPage() {
     [name, namespace, repository, t, display_signatures]
   );
 
-  const getPageUrl = useGetPageUrl();
-
   if (collectionRequest.error) {
     return <HubError error={collectionRequest.error} handleRefresh={collectionRequest.refresh} />;
   }
@@ -193,6 +252,7 @@ export function CollectionPage() {
               queryOptions={queryOptions}
               onSelect={(value) => {
                 setCollection(value);
+                setVersionParams(value);
               }}
               placeholder={t('Select version')}
               value={collection}
@@ -205,6 +265,9 @@ export function CollectionPage() {
                         context.setOpen(false);
                         singleSelectorBrowser?.((selection) => {
                           setCollection({
+                            collection_version: { version: selection },
+                          } as Partial<CollectionVersionSearch>);
+                          setVersionParams({
                             collection_version: { version: selection },
                           } as Partial<CollectionVersionSearch>);
                         }, collection.collection_version?.version);

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -115,7 +115,15 @@ export function CollectionPage() {
     hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}${queryFilter}`
   );
 
-  const itemActions = useCollectionActions(() => void collectionRequest.refresh(), true);
+  const itemActions = useCollectionActions((collections) => {
+    async function getCollectionData() {
+      const collectionRequest = await getRequest(
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}&version=${collections[0]?.collection_version?.version}`
+      );
+      setCollection(collectionRequest?.data[0]);
+    }
+    void getCollectionData();
+  }, true);
 
   function setVersionParams(collection: Partial<CollectionVersionSearch> | null) {
     if (!collection) {

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -2,10 +2,11 @@ import { Button, Label } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/dist/esm/deprecated';
 import { CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { DateTime } from 'luxon';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router-dom';
 import {
+  IPageAction,
   LoadingPage,
   PageActions,
   PageHeader,
@@ -21,7 +22,7 @@ import { PageSingleSelectContext } from '../../../../framework/PageInputs/PageSi
 import { singleSelectBrowseAdapter } from '../../../../framework/PageToolbar/PageToolbarFilters/ToolbarAsyncSingleSelectFilter';
 import { PageRoutedTabs } from '../../../common/PageRoutedTabs';
 import { requestGet } from '../../../common/crud/Data';
-import { useGet } from '../../../common/crud/useGet';
+import { useGet, useGetRequest } from '../../../common/crud/useGet';
 import { HubError } from '../../common/HubError';
 import { hubAPI } from '../../common/api/formatPath';
 import { useHubContext } from '../../common/useHubContext';
@@ -33,22 +34,12 @@ import { useSelectCollectionVersionSingle } from '../hooks/useCollectionVersionS
 
 export function CollectionPage() {
   const { t } = useTranslation();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { name, namespace, repository } = useParams();
   const context = useHubContext();
+  const [collection, setCollection] = useState<null | Partial<CollectionVersionSearch>>(null);
 
   const { display_signatures } = context.featureFlags;
-  // load collection by search params
-  const version = searchParams.get('version');
-
-  let queryFilter = '';
-
-  if (!version) {
-    // for unspecified version, load highest
-    queryFilter = '&is_highest=true';
-  } else {
-    queryFilter = '&version=' + version;
-  }
 
   const singleSelector = useSelectCollectionVersionSingle({
     collection: name || '',
@@ -59,40 +50,66 @@ export function CollectionPage() {
   const singleSelectorBrowser = singleSelectBrowseAdapter<CollectionVersionSearch>(
     singleSelector.openBrowse,
     (item) => {
-      return item.collection_version?.version || '';
+      return item?.collection_version?.version || '';
     },
     (name) => {
       return { collection_version: { version: name } };
     }
   );
 
+  let queryFilter;
+  const version = searchParams.get('version');
+  if (version) {
+    queryFilter = '&version=' + version;
+  } else if (collection) {
+    queryFilter = '&version=' + collection?.collection_version?.version;
+  } else {
+    queryFilter = '&is_highest=true';
+  }
   const collectionRequest = useGet<HubItemsResponse<CollectionVersionSearch>>(
-    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}` +
-      queryFilter
+    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}${queryFilter}`
   );
-
-  const collection =
-    collectionRequest?.data?.data && collectionRequest?.data?.data?.length > 0
-      ? collectionRequest.data?.data[0]
-      : undefined;
 
   const itemActions = useCollectionActions(() => void collectionRequest.refresh(), true);
 
-  function setVersionParams(version: string | null) {
-    if (version === null) {
-      return;
+  const getRequest = useGetRequest<HubItemsResponse<CollectionVersionSearch>>();
+  useEffect(() => {
+    async function getCollectionData() {
+      const version = searchParams.get('version');
+      let queryFilter;
+      if (version) {
+        queryFilter = '&version=' + version;
+      } else if (collection) {
+        queryFilter = '&version=' + collection?.collection_version?.version;
+      } else {
+        queryFilter = '&is_highest=true';
+      }
+      const collectionRequest = await getRequest(
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}` +
+          queryFilter
+      );
+
+      const collectionData: null | CollectionVersionSearch =
+        collectionRequest?.data && collectionRequest?.data?.length > 0
+          ? collectionRequest.data[0]
+          : null;
+
+      if (
+        !collection ||
+        collection?.collection_version?.version !== collectionData?.collection_version?.version
+      ) {
+        setCollection(collectionData);
+      }
     }
-    setTimeout(() => {
-      setSearchParams((params) => {
-        params.set('version', version);
-        return params;
-      });
-    }, 0);
-  }
+
+    void getCollectionData();
+  }, [collection, getRequest, name, namespace, repository, searchParams, collectionRequest]);
 
   // load collection versions
   const queryOptions = useCallback(
-    (options: PageAsyncSelectQueryOptions): Promise<PageAsyncSelectQueryResult<string>> => {
+    (
+      options: PageAsyncSelectQueryOptions
+    ): Promise<PageAsyncSelectQueryResult<CollectionVersionSearch>> => {
       const pageSize = 10;
       const page = options.next ? Number(options.next) : 1;
 
@@ -114,11 +131,11 @@ export function CollectionPage() {
               `${DateTime.fromISO(item.collection_version?.pulp_created || '').toRelative()} ${
                 display_signatures ? (item.is_signed ? t('signed') : t('unsigned')) : ''
               }`;
-            if (item.is_highest) {
+            if (item === data.data[0]) {
               label += ' (' + t('latest') + ')';
             }
             return {
-              value: item.collection_version?.version || '',
+              value: item,
               label,
             };
           }),
@@ -157,8 +174,8 @@ export function CollectionPage() {
         ]}
         headerActions={
           collection && (
-            <PageActions<CollectionVersionSearch>
-              actions={itemActions}
+            <PageActions<Partial<CollectionVersionSearch>>
+              actions={itemActions as IPageAction<Partial<CollectionVersionSearch>>[]}
               position={DropdownPosition.right}
               selectedItem={collection}
             />
@@ -171,11 +188,14 @@ export function CollectionPage() {
             style={{ display: 'flex', alignItems: 'center', gridGap: '8px' }}
           >
             {t('Version')}
-            <PageAsyncSingleSelect<string>
+            <PageAsyncSingleSelect<Partial<CollectionVersionSearch>>
+              isRequired
               queryOptions={queryOptions}
-              onSelect={setVersionParams}
+              onSelect={(value) => {
+                setCollection(value);
+              }}
               placeholder={t('Select version')}
-              value={collection?.collection_version?.version || version || ''}
+              value={collection}
               footer={
                 <PageSingleSelectContext.Consumer>
                   {(context) => (
@@ -183,12 +203,11 @@ export function CollectionPage() {
                       variant="link"
                       onClick={() => {
                         context.setOpen(false);
-                        singleSelectorBrowser?.(
-                          (selection) => {
-                            setVersionParams(selection);
-                          },
-                          collection?.collection_version?.version || version || ''
-                        );
+                        singleSelectorBrowser?.((selection) => {
+                          setCollection({
+                            collection_version: { version: selection },
+                          } as Partial<CollectionVersionSearch>);
+                        }, collection.collection_version?.version);
                       }}
                     >
                       {t`Browse`}
@@ -196,7 +215,7 @@ export function CollectionPage() {
                   )}
                 </PageSingleSelectContext.Consumer>
               }
-              queryLabel={(value) => value}
+              queryLabel={(value) => `${value.collection_version?.version}`}
             />
             {collection?.collection_version &&
               t('Last updated') +

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -138,7 +138,12 @@ export function CollectionPage() {
   useEffect(() => {
     if (!versionsCount && versions?.meta.count) {
       setVersionsCount(versions?.meta.count);
-    } else if (versions?.meta.count && versionsCount && versions?.meta.count > versionsCount) {
+    } else if (
+      collection &&
+      versions?.meta.count &&
+      versionsCount &&
+      versions?.meta.count > versionsCount
+    ) {
       setVersionsCount(versions?.meta.count);
       alertToaster.addAlert({
         variant: 'success',
@@ -154,17 +159,7 @@ export function CollectionPage() {
         timeout: false,
       });
     }
-  }, [
-    alertToaster,
-    collection?.collection_version?.name,
-    collection?.collection_version?.namespace,
-    collection?.repository?.name,
-    collectionRequest,
-    getPageUrl,
-    t,
-    versions,
-    versionsCount,
-  ]);
+  }, [collection, alertToaster, getPageUrl, t, versions, versionsCount]);
 
   // load collection versions
   const queryOptions = useCallback(

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -182,7 +182,7 @@ export function CollectionPage() {
         );
 
         return {
-          remaining: data.meta.count - pageSize * page,
+          remaining: data.meta.count - pageSize * page < 0 ? 0 : data.meta.count - pageSize * page,
           options: data.data.map((item) => {
             let label =
               item.collection_version?.version +
@@ -192,7 +192,7 @@ export function CollectionPage() {
               `${DateTime.fromISO(item.collection_version?.pulp_created || '').toRelative()} ${
                 display_signatures ? (item.is_signed ? t('signed') : t('unsigned')) : ''
               }`;
-            if (item === data.data[0]) {
+            if (item.is_highest) {
               label += ' (' + t('latest') + ')';
             }
             return {

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -13,6 +13,7 @@ import {
   PageLayout,
   useGetPageUrl,
   usePageAlertToaster,
+  usePageNavigate,
 } from '../../../../framework';
 import {
   PageAsyncSelectQueryOptions,
@@ -41,6 +42,8 @@ export function CollectionPage() {
   const [collection, setCollection] = useState<null | Partial<CollectionVersionSearch>>(null);
   const [versionsCount, setVersionsCount] = useState<undefined | number>(undefined);
   const getPageUrl = useGetPageUrl();
+  const alertToaster = usePageAlertToaster();
+  const pageNavigate = usePageNavigate();
 
   const { display_signatures } = context.featureFlags;
 
@@ -133,8 +136,6 @@ export function CollectionPage() {
     { refreshInterval: 1000 }
   );
 
-  const alertToaster = usePageAlertToaster();
-
   useEffect(() => {
     if (!versionsCount && versions?.meta.count) {
       setVersionsCount(versions?.meta.count);
@@ -144,22 +145,43 @@ export function CollectionPage() {
       versionsCount &&
       versions?.meta.count > versionsCount
     ) {
+      const sortedversion: CollectionVersionSearch[] = versions.data.sort((a, b) => {
+        const dateA = new Date(String(a.collection_version?.pulp_created));
+        const dateB = new Date(String(b.collection_version?.pulp_created));
+        return dateA < dateB ? 1 : -1;
+      });
       setVersionsCount(versions?.meta.count);
       alertToaster.addAlert({
         variant: 'success',
         title: (
           <span>
-            {t(`A new version of this collection has been uploaded. Please `)}
-            <Button style={{ padding: 0 }} variant="link" onClick={() => window.location.reload()}>
-              {t(`refresh`)}
+            {t(`A new version of this collection has been uploaded. Click `)}
+            <Button
+              style={{ padding: 0 }}
+              variant="link"
+              onClick={() => {
+                pageNavigate(HubRoute.CollectionDetails, {
+                  params: {
+                    name: collection?.collection_version?.name,
+                    namespace: collection.collection_version?.namespace,
+                    repository: collection.repository?.name,
+                  },
+                  query: {
+                    version: sortedversion[0].collection_version?.version,
+                  },
+                });
+                alertToaster.removeAlerts();
+              }}
+            >
+              {t(`here`)}
             </Button>
-            {t(` the page to see the latest version.`)}
+            {t(` to switch to it.`)}
           </span>
         ),
         timeout: false,
       });
     }
-  }, [collection, alertToaster, getPageUrl, t, versions, versionsCount]);
+  }, [collection, alertToaster, t, versions, versionsCount, pageNavigate]);
 
   // load collection versions
   const queryOptions = useCallback(


### PR DESCRIPTION
This PR is for AAP-29149, it fixes the issue with the collection version automatically switching when a new one is created. In addition, the user is notified with an alert that allows them to refresh the page if there is a new collection version available.

Test Steps:

1. Create a new collection under the `community` repo on hub (don't have to deal with approvals after upload when uploading to community repo). Use this tar file to make the collection version
[redhat-ansible_on_clouds-2.5.0.tar.gz](https://github.com/user-attachments/files/16682921/redhat-ansible_on_clouds-2.5.0.tar.gz)

2. Navigate to the collection named `ansible_on_clouds` (the default version may be different from the version you uploaded) 
3. In another tab, upload another version of the collection also to the `community` repo. Use this tar file to make the collection version  
[redhat-ansible_on_clouds-2.6.0.tar.gz](https://github.com/user-attachments/files/16682936/redhat-ansible_on_clouds-2.6.0.tar.gz)

4. Go back to the the first collection details tab wait for a notification to pop-up which will allow you to navigate to the newly uploaded collection. (In addition, note that the version has not automatically changed even with there being a new version available). You should be able to click on the link in the notification and it should take you to the newly uploaded version 