### PR TITLE
Allow full width and word wrap for settings detail columns.

### DIFF
--- a/framework/PageFramework.css
+++ b/framework/PageFramework.css
@@ -123,3 +123,7 @@ tr.selected:hover {
   /* padding: 10px; */
   border-right: unset;
 }
+
+pre {
+  white-space: pre-wrap;
+}

--- a/frontend/awx/administration/settings/AwxSettingsCategoryDetails.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsCategoryDetails.tsx
@@ -129,7 +129,7 @@ export function AwxSettingsCategoryDetail(props: {
     case 'nested object':
       if (Object.keys(props.data[props.name] as object).length === 0) return null;
       return (
-        <PageDetail label={option.label}>
+        <PageDetail label={option.label} fullWidth>
           <pre>{jsyaml.dump(props.data[props.name])}</pre>
         </PageDetail>
       );


### PR DESCRIPTION
Before:
![Screenshot 2024-08-20 at 11 58 14 AM](https://github.com/user-attachments/assets/f1d6bb5c-f446-4b1f-a6af-41b4eb368f61)

Full-width w/out wrapping:
![Screenshot 2024-08-20 at 12 02 54 PM](https://github.com/user-attachments/assets/9e28c7ad-03e6-40ed-82a1-f6f21d1d0db6)

Full width w/wrapping:
![Screenshot 2024-08-20 at 1 07 27 PM](https://github.com/user-attachments/assets/9267b12e-50d4-43a8-a70c-d258d87270be)
