### PR TITLE
Collection detail install - fix download failing on empty basePath, hide signature expander when not signed

### DIFF
--- a/cypress/e2e/hub/collections-detail-install.cy.ts
+++ b/cypress/e2e/hub/collections-detail-install.cy.ts
@@ -1,7 +1,6 @@
 import { randomE2Ename } from '../../support/utils';
 import { Collections } from './constants';
 
-// cypress
 describe('collections-detail-install', () => {
   let collectionName: string = '';
   let namespaceName: string = '';
@@ -15,13 +14,18 @@ describe('collections-detail-install', () => {
     cy.getByDataCy('collection-install-tab').click();
   }
 
-  beforeEach(() => {
+  before(() => {
     namespaceName = randomE2Ename();
     collectionName = randomE2Ename();
 
     cy.createHubNamespace({ namespace: { name: namespaceName } }).then(() => {
       cy.uploadCollection(collectionName, namespaceName, '1.0.0');
     });
+  });
+
+  after(() => {
+    cy.deleteHubCollectionByName(collectionName);
+    cy.deleteHubNamespace({ name: namespaceName, failOnStatusCode: false });
   });
 
   it('can download tarball', () => {
@@ -51,11 +55,8 @@ describe('collections-detail-install', () => {
     // for now we test button is rendered
     cy.contains('button', 'Download tarball');
 
-    cy.contains('button', 'Show signature').click();
-    //cy.contains('BEGIN PGP SIGNATURE');
-  });
-
-  afterEach(() => {
-    cy.deleteHubCollectionByName(collectionName);
+    // FIXME: sign collection first
+    // cy.contains('button', 'Show signature').click();
+    // cy.contains('BEGIN PGP SIGNATURE');
   });
 });

--- a/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
@@ -45,7 +45,7 @@ export function CollectionInstall() {
 
   const content = contentResults?.results[0];
 
-  if ((!basePath && !error) || (!content && !contentError)) {
+  if ((!basePath && !error) || (!content && !contentError) || !collection) {
     return <LoadingPage breadcrumbs tabs />;
   }
 
@@ -141,22 +141,18 @@ export function CollectionInstall() {
         </Button>
       </PageDetail>
 
-      <PageDetail label={t('Signature')}>
-        <Button
-          variant="link"
-          icon={<DownloadIcon />}
-          onClick={() => {
-            if (!showSignature) {
-              setShowSignature(true);
-            } else {
-              setShowSignature(false);
-            }
-          }}
-        >
-          {showSignature ? t(`Hide signature`) : t(`Show signature`)}
-        </Button>
-        {showSignature && <ShowSignature collection={collection} />}
-      </PageDetail>
+      {collection?.is_signed ? (
+        <PageDetail label={t('Signature')}>
+          <Button
+            variant="link"
+            icon={<DownloadIcon />}
+            onClick={() => setShowSignature(!showSignature)}
+          >
+            {showSignature ? t(`Hide signature`) : t(`Show signature`)}
+          </Button>
+          {showSignature && <ShowSignature collection={collection} />}
+        </PageDetail>
+      ) : null}
 
       <PageDetail label={t('Requires')}>
         {collection?.collection_version?.requires_ansible &&


### PR DESCRIPTION
Issue: AAP-28589

* when loading, `collection` can be null, making it possible to click "Download tarball" without a valid `basePath`
* when not signed, showing the signature does nothing, hide
