### PR TITLE
[AAP-28398][AAP-29018] Update event streams columns and test mode action menu changes. Event stream activations page

### DIFF
--- a/cypress/fixtures/edaRulebookActivationOptions.json
+++ b/cypress/fixtures/edaRulebookActivationOptions.json
@@ -1,0 +1,1016 @@
+{
+  "name": "Activation List",
+  "description": "",
+  "renders": ["application/json", "text/html"],
+  "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
+  "actions": {
+    "GET": {
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name"
+      },
+      "description": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Description"
+      },
+      "is_enabled": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Is enabled"
+      },
+      "status": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Status",
+        "choices": [
+          {
+            "value": "starting",
+            "display_name": "starting"
+          },
+          {
+            "value": "running",
+            "display_name": "running"
+          },
+          {
+            "value": "pending",
+            "display_name": "pending"
+          },
+          {
+            "value": "failed",
+            "display_name": "failed"
+          },
+          {
+            "value": "stopping",
+            "display_name": "stopping"
+          },
+          {
+            "value": "stopped",
+            "display_name": "stopped"
+          },
+          {
+            "value": "deleting",
+            "display_name": "deleting"
+          },
+          {
+            "value": "completed",
+            "display_name": "completed"
+          },
+          {
+            "value": "unresponsive",
+            "display_name": "unresponsive"
+          },
+          {
+            "value": "error",
+            "display_name": "error"
+          },
+          {
+            "value": "workers offline",
+            "display_name": "workers offline"
+          }
+        ]
+      },
+      "git_hash": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Git hash"
+      },
+      "extra_var": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Extra var"
+      },
+      "decision_environment_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Decision environment id"
+      },
+      "project_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Project id"
+      },
+      "rulebook_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Rulebook id"
+      },
+      "organization_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization id"
+      },
+      "restart_policy": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Restart policy",
+        "choices": [
+          {
+            "value": "always",
+            "display_name": "always"
+          },
+          {
+            "value": "on-failure",
+            "display_name": "on-failure"
+          },
+          {
+            "value": "never",
+            "display_name": "never"
+          }
+        ]
+      },
+      "restart_count": {
+        "type": "integer",
+        "required": false,
+        "read_only": false,
+        "label": "Restart count",
+        "min_value": -2147483648,
+        "max_value": 2147483647
+      },
+      "rulebook_name": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Rulebook name",
+        "help_text": "Name of the referenced rulebook"
+      },
+      "ruleset_stats": {
+        "type": "field",
+        "required": false,
+        "read_only": false,
+        "label": "Ruleset stats"
+      },
+      "current_job_id": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Current job id"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "status_message": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Status message"
+      },
+      "awx_token_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Awx token id"
+      },
+      "eda_credentials": {
+        "type": "list",
+        "required": false,
+        "read_only": false,
+        "label": "Eda credentials",
+        "child": {
+          "type": "nested object",
+          "required": true,
+          "read_only": false,
+          "children": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "read_only": false,
+              "label": "Name"
+            },
+            "description": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Description"
+            },
+            "inputs": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Inputs"
+            },
+            "credential_type": {
+              "type": "nested object",
+              "required": false,
+              "read_only": false,
+              "label": "Credential type",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name"
+                },
+                "namespace": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Namespace"
+                },
+                "kind": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Kind"
+                }
+              }
+            },
+            "references": {
+              "type": "field",
+              "required": false,
+              "read_only": false,
+              "label": "References"
+            },
+            "id": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "ID"
+            },
+            "created_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Created at"
+            },
+            "modified_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Modified at"
+            },
+            "managed": {
+              "type": "boolean",
+              "required": false,
+              "read_only": true,
+              "label": "Managed"
+            },
+            "organization": {
+              "type": "nested object",
+              "required": true,
+              "read_only": false,
+              "label": "Organization",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name",
+                  "help_text": "The name of this resource",
+                  "max_length": 512
+                },
+                "description": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Description",
+                  "help_text": "The organization description."
+                }
+              }
+            }
+          }
+        }
+      },
+      "log_level": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Log level",
+        "choices": [
+          {
+            "value": "debug",
+            "display_name": "debug"
+          },
+          {
+            "value": "info",
+            "display_name": "info"
+          },
+          {
+            "value": "error",
+            "display_name": "error"
+          }
+        ]
+      },
+      "event_streams": {
+        "type": "list",
+        "required": false,
+        "read_only": false,
+        "label": "Event streams",
+        "child": {
+          "type": "nested object",
+          "required": true,
+          "read_only": false,
+          "children": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "read_only": false,
+              "label": "Name",
+              "help_text": "The name of the webhook"
+            },
+            "test_mode": {
+              "type": "boolean",
+              "required": false,
+              "read_only": false,
+              "label": "Test mode",
+              "help_text": "Enable test mode"
+            },
+            "additional_data_headers": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Additional data headers",
+              "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+            },
+            "organization": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Organization"
+            },
+            "eda_credential": {
+              "type": "nested object",
+              "required": true,
+              "read_only": false,
+              "label": "Eda credential",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name"
+                },
+                "description": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Description"
+                },
+                "inputs": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Inputs"
+                },
+                "managed": {
+                  "type": "boolean",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Managed"
+                },
+                "credential_type_id": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Credential type id"
+                },
+                "organization_id": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Organization id"
+                }
+              }
+            },
+            "event_stream_type": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Event stream type",
+              "help_text": "The type of the event stream based on credential type"
+            },
+            "id": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "ID"
+            },
+            "owner": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Owner"
+            },
+            "url": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Url",
+              "help_text": "The URL which will be used to post to the event stream"
+            },
+            "created_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Created at"
+            },
+            "modified_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Modified at"
+            },
+            "test_content_type": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test content type",
+              "help_text": "The content type of test data, when in test mode"
+            },
+            "test_content": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test content",
+              "help_text": "The content recieved, when in test mode, stored as a yaml string"
+            },
+            "test_error_message": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test error message",
+              "help_text": "The error message,  when in test mode"
+            },
+            "test_headers": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test headers",
+              "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+            },
+            "events_received": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "Events received",
+              "help_text": "The total number of events received by event stream"
+            },
+            "last_event_received_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Last event received at",
+              "help_text": "The date/time when the last event was received"
+            }
+          }
+        }
+      },
+      "skip_audit_events": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Skip audit events",
+        "help_text": "Skip audit events for activation"
+      }
+    },
+    "POST": {
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name"
+      },
+      "description": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Description"
+      },
+      "is_enabled": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Is enabled"
+      },
+      "status": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Status",
+        "choices": [
+          {
+            "value": "starting",
+            "display_name": "starting"
+          },
+          {
+            "value": "running",
+            "display_name": "running"
+          },
+          {
+            "value": "pending",
+            "display_name": "pending"
+          },
+          {
+            "value": "failed",
+            "display_name": "failed"
+          },
+          {
+            "value": "stopping",
+            "display_name": "stopping"
+          },
+          {
+            "value": "stopped",
+            "display_name": "stopped"
+          },
+          {
+            "value": "deleting",
+            "display_name": "deleting"
+          },
+          {
+            "value": "completed",
+            "display_name": "completed"
+          },
+          {
+            "value": "unresponsive",
+            "display_name": "unresponsive"
+          },
+          {
+            "value": "error",
+            "display_name": "error"
+          },
+          {
+            "value": "workers offline",
+            "display_name": "workers offline"
+          }
+        ]
+      },
+      "git_hash": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Git hash"
+      },
+      "extra_var": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Extra var"
+      },
+      "decision_environment_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Decision environment id"
+      },
+      "project_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Project id"
+      },
+      "rulebook_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Rulebook id"
+      },
+      "organization_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization id"
+      },
+      "restart_policy": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Restart policy",
+        "choices": [
+          {
+            "value": "always",
+            "display_name": "always"
+          },
+          {
+            "value": "on-failure",
+            "display_name": "on-failure"
+          },
+          {
+            "value": "never",
+            "display_name": "never"
+          }
+        ]
+      },
+      "restart_count": {
+        "type": "integer",
+        "required": false,
+        "read_only": false,
+        "label": "Restart count",
+        "min_value": -2147483648,
+        "max_value": 2147483647
+      },
+      "rulebook_name": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Rulebook name",
+        "help_text": "Name of the referenced rulebook"
+      },
+      "ruleset_stats": {
+        "type": "field",
+        "required": false,
+        "read_only": false,
+        "label": "Ruleset stats"
+      },
+      "current_job_id": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Current job id"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "status_message": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Status message"
+      },
+      "awx_token_id": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Awx token id"
+      },
+      "eda_credentials": {
+        "type": "list",
+        "required": false,
+        "read_only": false,
+        "label": "Eda credentials",
+        "child": {
+          "type": "nested object",
+          "required": true,
+          "read_only": false,
+          "children": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "read_only": false,
+              "label": "Name"
+            },
+            "description": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Description"
+            },
+            "inputs": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Inputs"
+            },
+            "credential_type": {
+              "type": "nested object",
+              "required": false,
+              "read_only": false,
+              "label": "Credential type",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name"
+                },
+                "namespace": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Namespace"
+                },
+                "kind": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Kind"
+                }
+              }
+            },
+            "references": {
+              "type": "field",
+              "required": false,
+              "read_only": false,
+              "label": "References"
+            },
+            "id": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "ID"
+            },
+            "created_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Created at"
+            },
+            "modified_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Modified at"
+            },
+            "managed": {
+              "type": "boolean",
+              "required": false,
+              "read_only": true,
+              "label": "Managed"
+            },
+            "organization": {
+              "type": "nested object",
+              "required": true,
+              "read_only": false,
+              "label": "Organization",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name",
+                  "help_text": "The name of this resource",
+                  "max_length": 512
+                },
+                "description": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Description",
+                  "help_text": "The organization description."
+                }
+              }
+            }
+          }
+        }
+      },
+      "log_level": {
+        "type": "choice",
+        "required": false,
+        "read_only": false,
+        "label": "Log level",
+        "choices": [
+          {
+            "value": "debug",
+            "display_name": "debug"
+          },
+          {
+            "value": "info",
+            "display_name": "info"
+          },
+          {
+            "value": "error",
+            "display_name": "error"
+          }
+        ]
+      },
+      "event_streams": {
+        "type": "list",
+        "required": false,
+        "read_only": false,
+        "label": "Event streams",
+        "child": {
+          "type": "nested object",
+          "required": true,
+          "read_only": false,
+          "children": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "read_only": false,
+              "label": "Name",
+              "help_text": "The name of the webhook"
+            },
+            "test_mode": {
+              "type": "boolean",
+              "required": false,
+              "read_only": false,
+              "label": "Test mode",
+              "help_text": "Enable test mode"
+            },
+            "additional_data_headers": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Additional data headers",
+              "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+            },
+            "organization": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Organization"
+            },
+            "eda_credential": {
+              "type": "nested object",
+              "required": true,
+              "read_only": false,
+              "label": "Eda credential",
+              "children": {
+                "id": {
+                  "type": "integer",
+                  "required": false,
+                  "read_only": true,
+                  "label": "ID"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "read_only": false,
+                  "label": "Name"
+                },
+                "description": {
+                  "type": "string",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Description"
+                },
+                "inputs": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Inputs"
+                },
+                "managed": {
+                  "type": "boolean",
+                  "required": false,
+                  "read_only": false,
+                  "label": "Managed"
+                },
+                "credential_type_id": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Credential type id"
+                },
+                "organization_id": {
+                  "type": "field",
+                  "required": false,
+                  "read_only": true,
+                  "label": "Organization id"
+                }
+              }
+            },
+            "event_stream_type": {
+              "type": "string",
+              "required": false,
+              "read_only": false,
+              "label": "Event stream type",
+              "help_text": "The type of the event stream based on credential type"
+            },
+            "id": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "ID"
+            },
+            "owner": {
+              "type": "field",
+              "required": false,
+              "read_only": true,
+              "label": "Owner"
+            },
+            "url": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Url",
+              "help_text": "The URL which will be used to post to the event stream"
+            },
+            "created_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Created at"
+            },
+            "modified_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Modified at"
+            },
+            "test_content_type": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test content type",
+              "help_text": "The content type of test data, when in test mode"
+            },
+            "test_content": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test content",
+              "help_text": "The content recieved, when in test mode, stored as a yaml string"
+            },
+            "test_error_message": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test error message",
+              "help_text": "The error message,  when in test mode"
+            },
+            "test_headers": {
+              "type": "string",
+              "required": false,
+              "read_only": true,
+              "label": "Test headers",
+              "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+            },
+            "events_received": {
+              "type": "integer",
+              "required": false,
+              "read_only": true,
+              "label": "Events received",
+              "help_text": "The total number of events received by event stream"
+            },
+            "last_event_received_at": {
+              "type": "datetime",
+              "required": false,
+              "read_only": true,
+              "label": "Last event received at",
+              "help_text": "The date/time when the last event was received"
+            }
+          }
+        }
+      },
+      "skip_audit_events": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Skip audit events",
+        "help_text": "Skip audit events for activation"
+      }
+    }
+  }
+}

--- a/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
+++ b/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
@@ -43,7 +43,7 @@ export function PageFormSingleSelectEdaResource<
         const queryParams = props.url.split('?')[1];
         const urlSearchParameters = new URLSearchParams(queryParams);
         urlSearchParameters.delete('page_size');
-        urlSearchParameters.set('page_size', '10');
+        urlSearchParameters.set('page_size', options?.next ? `${options.next}` : '10');
         urlSearchParameters.delete('order_by');
         urlSearchParameters.set('order_by', 'name');
         if (props.queryParams) {
@@ -57,7 +57,7 @@ export function PageFormSingleSelectEdaResource<
             }
           }
         }
-        if (options.search) urlSearchParameters.set('name__icontains', options.search);
+        if (options.search) urlSearchParameters.set('name', options.search);
         const response = await requestGet<EdaItemsResponse<Resource>>(
           baseUrl + '?' + decodeURIComponent(urlSearchParameters.toString()),
           options.signal

--- a/frontend/eda/event-streams/EventStreamForm.tsx
+++ b/frontend/eda/event-streams/EventStreamForm.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import useSWR, { useSWRConfig } from 'swr';
 import {
-  PageFormCheckbox,
   PageFormSubmitHandler,
+  PageFormSwitch,
   PageFormTextInput,
   PageHeader,
   PageLayout,
@@ -97,13 +97,14 @@ function EventStreamInputs() {
             'To include all headers in teh event payload, leave the field empty.'
         )}
       />
-      <PageFormCheckbox<IEdaEventStreamCreate>
-        label={t`Test mode`}
+      <PageFormSwitch<IEdaEventStreamCreate>
+        label={t`Forward events`}
+        labelOn={t('Enabled')}
+        labelOff={t('Disabled')}
         labelHelp={t(
-          'Event streams in test mode do not forward events to the rulebook activation where they are configured. ' +
-            'Use this mode to pause the event stream.'
+          'Enable the event stream to forward events to the rulebook activation where it is configured. '
         )}
-        name="test_mode"
+        name="enabled"
       />
     </>
   );
@@ -147,13 +148,14 @@ function EventStreamEditInputs() {
             'To include all headers in teh event payload, leave the field empty.'
         )}
       />
-      <PageFormCheckbox<IEdaEventStreamCreate>
-        label={t`Test mode`}
+      <PageFormSwitch<IEdaEventStreamCreate>
+        label={t`Forward events`}
+        labelOn={t('Enabled')}
+        labelOff={t('Disabled')}
         labelHelp={t(
-          'Event streams in test mode do not forward events to the rulebook activation where they are configured. ' +
-            'Use this mode to pause the event stream.'
+          'Enable the event stream to forward events to the rulebook activation where it is configured. '
         )}
-        name="test_mode"
+        name="enabled"
       />
     </>
   );
@@ -176,8 +178,11 @@ export function CreateEventStream() {
       ? organizations.results[0]
       : undefined;
 
-  const onSubmit: PageFormSubmitHandler<EdaEventStreamCreate> = async (eventStream) => {
-    const newEventStream = await postRequest(edaAPI`/event-streams/`, eventStream);
+  const onSubmit: PageFormSubmitHandler<IEdaEventStreamCreate> = async (eventStream) => {
+    const newEventStream = await postRequest(edaAPI`/event-streams/`, {
+      ...eventStream,
+      test_mode: !eventStream?.enabled,
+    });
     (cache as unknown as { clear: () => void }).clear?.();
     pageNavigate(EdaRoute.EventStreamPage, { params: { id: newEventStream?.id } });
   };
@@ -198,7 +203,7 @@ export function CreateEventStream() {
         onSubmit={onSubmit}
         cancelText={t('Cancel')}
         onCancel={onCancel}
-        defaultValue={{ organization_id: defaultOrganization?.id }}
+        defaultValue={{ organization_id: defaultOrganization?.id, test_mode: false, enabled: true }}
       >
         <EventStreamInputs />
       </EdaPageForm>
@@ -217,7 +222,10 @@ export function EditEventStream() {
   const patchRequest = usePatchRequest<IEdaEventStreamCreate, EdaEventStream>();
 
   const onSubmit: PageFormSubmitHandler<IEdaEventStreamCreate> = async (eventStream) => {
-    await patchRequest(edaAPI`/event-streams/${id.toString()}/`, eventStream);
+    await patchRequest(edaAPI`/event-streams/${id.toString()}/`, {
+      ...eventStream,
+      test_mode: !eventStream?.enabled,
+    });
     (cache as unknown as { clear: () => void }).clear?.();
     navigate(-1);
   };
@@ -252,6 +260,7 @@ export function EditEventStream() {
           onCancel={onCancel}
           defaultValue={{
             ...eventStream,
+            enabled: !eventStream.test_mode,
             organization_id: eventStream.organization?.id,
             eda_credential_id: eventStream?.eda_credential?.id,
           }}
@@ -266,4 +275,5 @@ export function EditEventStream() {
 type IEdaEventStreamCreate = EdaEventStreamCreate & {
   type_id: number;
   kind: string;
+  enabled: boolean;
 };

--- a/frontend/eda/event-streams/EventStreamForm.tsx
+++ b/frontend/eda/event-streams/EventStreamForm.tsx
@@ -93,12 +93,16 @@ function EventStreamInputs() {
         placeholder={t('Enter include headers')}
         labelHelpTitle={t('Include headers')}
         labelHelp={t(
-          'A comma separated HTTP header keys that you want to include in the event payload.'
+          'Enter comma separated HTTP header keys that you want to include in the event payload. ' +
+            'To include all headers in teh event payload, leave the field empty.'
         )}
       />
       <PageFormCheckbox<IEdaEventStreamCreate>
         label={t`Test mode`}
-        labelHelp={t('Test mode.')}
+        labelHelp={t(
+          'Event streams in test mode do not forward events to the rulebook activation where they are configured. ' +
+            'Use this mode to pause the event stream.'
+        )}
         name="test_mode"
       />
     </>
@@ -139,12 +143,16 @@ function EventStreamEditInputs() {
         placeholder={t('Enter include headers')}
         labelHelpTitle={t('Include headers')}
         labelHelp={t(
-          'A comma separated HTTP header keys that you want to include in the event payload.'
+          'Enter comma separated HTTP header keys that you want to include in the event payload. ' +
+            'To include all headers in teh event payload, leave the field empty.'
         )}
       />
       <PageFormCheckbox<IEdaEventStreamCreate>
         label={t`Test mode`}
-        labelHelp={t('Test mode.')}
+        labelHelp={t(
+          'Event streams in test mode do not forward events to the rulebook activation where they are configured. ' +
+            'Use this mode to pause the event stream.'
+        )}
         name="test_mode"
       />
     </>

--- a/frontend/eda/event-streams/EventStreamForm.tsx
+++ b/frontend/eda/event-streams/EventStreamForm.tsx
@@ -94,7 +94,7 @@ function EventStreamInputs() {
         labelHelpTitle={t('Include headers')}
         labelHelp={t(
           'Enter comma separated HTTP header keys that you want to include in the event payload. ' +
-            'To include all headers in teh event payload, leave the field empty.'
+            'To include all headers in the event payload, leave the field empty.'
         )}
       />
       <PageFormSwitch<IEdaEventStreamCreate>

--- a/frontend/eda/event-streams/EventStreamForm.tsx
+++ b/frontend/eda/event-streams/EventStreamForm.tsx
@@ -89,9 +89,9 @@ function EventStreamInputs() {
       <PageFormTextInput<IEdaEventStreamCreate>
         name="additional_data_headers"
         data-cy="additional_data_headers-form-field"
-        label={t('Include headers')}
-        placeholder={t('Enter include headers')}
-        labelHelpTitle={t('Include headers')}
+        label={t('Headers')}
+        placeholder={t('Enter headers')}
+        labelHelpTitle={t('Headers')}
         labelHelp={t(
           'Enter comma separated HTTP header keys that you want to include in the event payload. ' +
             'To include all headers in the event payload, leave the field empty.'
@@ -140,9 +140,9 @@ function EventStreamEditInputs() {
       <PageFormTextInput<IEdaEventStreamCreate>
         name="additional_data_headers"
         data-cy="additional_data_headers-form-field"
-        label={t('Include headers')}
-        placeholder={t('Enter include headers')}
-        labelHelpTitle={t('Include headers')}
+        label={t('Headers')}
+        placeholder={t('Enter headers')}
+        labelHelpTitle={t('Headers')}
         labelHelp={t(
           'Enter comma separated HTTP header keys that you want to include in the event payload. ' +
             'To include all headers in teh event payload, leave the field empty.'

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.cy.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.cy.tsx
@@ -4,12 +4,29 @@ import { edaAPI } from '../../common/eda-utils';
 describe('EventStreamActivations.cy.ts', () => {
   beforeEach(() => {
     cy.intercept(
-      { method: 'GET', url: edaAPI`/event-streams/1/activations/&page=1&page_size=10` },
+      { method: 'GET', url: edaAPI`/event-streams/1/activations/*` },
       {
-        fixture: 'edaActivations.json',
+        fixture: 'edaRulebookActivations.json',
       }
     );
-
+    cy.intercept(
+      {
+        method: 'OPTIONS',
+        url: edaAPI`/activations/*`,
+      },
+      {
+        fixture: 'edaRulebookActivationOptions.json',
+      }
+    ).as('activationsOptions');
+    cy.intercept(
+      {
+        method: 'GET',
+        url: edaAPI`/activations/*`,
+      },
+      {
+        fixture: 'edaRulebookActivations.json',
+      }
+    ).as('activations');
     cy.intercept(
       { method: 'GET', url: edaAPI`/event-streams/1/activations/?page=2&page_size=10` },
       {
@@ -59,11 +76,11 @@ describe('EventStreamActivations.cy.ts', () => {
     );
   });
 
-  it('Renders the correct credentials columns', () => {
+  it('Renders the correct activations columns', () => {
     cy.mount(<EventStreamActivations />);
     cy.get('tbody').find('tr').should('have.length', 10);
     cy.contains('th', 'Name');
-    cy.contains('th', 'Event stream');
+    cy.contains('th', 'Status');
   });
 });
 
@@ -79,8 +96,9 @@ describe('Empty list', () => {
       }
     ).as('emptyList');
   });
+
   it('Empty state is displayed correctly', () => {
     cy.mount(<EventStreamActivations />);
-    cy.contains(/^No activationss for this event stream$/);
+    cy.contains(/^No activations for this event stream$/);
   });
 });

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.cy.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.cy.tsx
@@ -1,0 +1,86 @@
+import { EventStreamActivations } from './EventStreamActivations';
+import { edaAPI } from '../../common/eda-utils';
+
+describe('EventStreamActivations.cy.ts', () => {
+  beforeEach(() => {
+    cy.intercept(
+      { method: 'GET', url: edaAPI`/event-streams/1/activations/&page=1&page_size=10` },
+      {
+        fixture: 'edaActivations.json',
+      }
+    );
+
+    cy.intercept(
+      { method: 'GET', url: edaAPI`/event-streams/1/activations/?page=2&page_size=10` },
+      {
+        count: 5,
+        next: null,
+        previous: null,
+        page_size: 10,
+        page: 1,
+        results: [
+          {
+            name: 'E2E Activation N0vX',
+            description: 'E2E Activation N0vX',
+            id: 8,
+            created_at: '2023-07-28T18:29:28.512273Z',
+            modified_at: '2023-07-28T18:29:28.512286Z',
+          },
+          {
+            name: 'E2E Activation aOHl',
+            description: 'E2E Activation aOHl',
+            id: 11,
+            created_at: '2023-07-28T18:32:34.992501Z',
+            modified_at: '2023-07-28T18:32:34.992522Z',
+          },
+          {
+            name: 'E2E Activation kpub',
+            description: 'E2E Activation kpub.',
+            id: 13,
+            created_at: '2023-07-28T18:32:51.739715Z',
+            modified_at: '2023-07-28T18:32:51.739740Z',
+          },
+          {
+            name: 'E2E Activation ZFca',
+            description: 'E2E Activation ZFca',
+            id: 30,
+            created_at: '2023-07-28T19:28:01.687027Z',
+            modified_at: '2023-07-28T19:28:01.687040Z',
+          },
+          {
+            name: 'E2E Activation Y315',
+            description: 'E2E Activation Y315',
+            id: 31,
+            created_at: '2023-07-28T19:28:01.767198Z',
+            modified_at: '2023-07-28T19:28:01.767210Z',
+          },
+        ],
+      }
+    );
+  });
+
+  it('Renders the correct credentials columns', () => {
+    cy.mount(<EventStreamActivations />);
+    cy.get('tbody').find('tr').should('have.length', 10);
+    cy.contains('th', 'Name');
+    cy.contains('th', 'Event stream');
+  });
+});
+
+describe('Empty list', () => {
+  beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: edaAPI`/event-streams/1/activations/*`,
+      },
+      {
+        fixture: 'emptyList.json',
+      }
+    ).as('emptyList');
+  });
+  it('Empty state is displayed correctly', () => {
+    cy.mount(<EventStreamActivations />);
+    cy.contains(/^No activationss for this event stream$/);
+  });
+});

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
@@ -8,7 +8,6 @@ import { useEdaView } from '../../common/useEventDrivenView';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { PageLayout, PageTable } from '../../../../framework';
-import { useRulebookActivationsActions } from '../../rulebook-activations/hooks/useRulebookActivationsActions';
 import { useRulebookActivationActions } from '../../rulebook-activations/hooks/useRulebookActivationActions';
 
 export function EventStreamActivations() {
@@ -22,13 +21,11 @@ export function EventStreamActivations() {
     toolbarFilters,
     tableColumns,
   });
-  const toolbarActions = useRulebookActivationsActions(view);
   const rowActions = useRulebookActivationActions(view);
   return (
     <PageLayout>
       <PageTable
         tableColumns={tableColumns}
-        toolbarActions={toolbarActions}
         toolbarFilters={toolbarFilters}
         rowActions={rowActions}
         errorStateTitle={t('Error loading activations for this event stream')}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
@@ -1,0 +1,43 @@
+import { CubesIcon } from '@patternfly/react-icons';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+import { useEventStreamActivationsColumns } from '../hooks/useEventStreamActivationsColumns';
+import { useEventStreamActivationsFilters } from '../hooks/useEventStreamActivationsFilters';
+import { useEdaView } from '../../common/useEventDrivenView';
+import { edaAPI } from '../../common/eda-utils';
+import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
+import { PageLayout, PageTable } from '../../../../framework';
+import { useRulebookActivationsActions } from '../../rulebook-activations/hooks/useRulebookActivationsActions';
+import { useRulebookActivationActions } from '../../rulebook-activations/hooks/useRulebookActivationActions';
+
+export function EventStreamActivations() {
+  const params = useParams<{ id: string }>();
+  const { t } = useTranslation();
+
+  const toolbarFilters = useEventStreamActivationsFilters();
+  const tableColumns = useEventStreamActivationsColumns();
+  const view = useEdaView<EdaRulebookActivation>({
+    url: edaAPI`/event-streams/${params?.id || ''}/activations/`,
+    toolbarFilters,
+    tableColumns,
+  });
+  const toolbarActions = useRulebookActivationsActions(view);
+  const rowActions = useRulebookActivationActions(view);
+  return (
+    <PageLayout>
+      <PageTable
+        tableColumns={tableColumns}
+        toolbarActions={toolbarActions}
+        toolbarFilters={toolbarFilters}
+        rowActions={rowActions}
+        errorStateTitle={t('Error loading activations for this event stream')}
+        emptyStateTitle={t('No activations for this event stream')}
+        emptyStateIcon={CubesIcon}
+        emptyStateDescription={t('No activations for this event stream')}
+        {...view}
+        defaultSubtitle={t('Activations')}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamActivations.tsx
@@ -8,7 +8,6 @@ import { useEdaView } from '../../common/useEventDrivenView';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
 import { PageLayout, PageTable } from '../../../../framework';
-import { useRulebookActivationActions } from '../../rulebook-activations/hooks/useRulebookActivationActions';
 
 export function EventStreamActivations() {
   const params = useParams<{ id: string }>();
@@ -21,13 +20,11 @@ export function EventStreamActivations() {
     toolbarFilters,
     tableColumns,
   });
-  const rowActions = useRulebookActivationActions(view);
   return (
     <PageLayout>
       <PageTable
         tableColumns={tableColumns}
         toolbarFilters={toolbarFilters}
-        rowActions={rowActions}
         errorStateTitle={t('Error loading activations for this event stream')}
         emptyStateTitle={t('No activations for this event stream')}
         emptyStateIcon={CubesIcon}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
@@ -77,7 +77,7 @@ export function EventStreamDetails() {
           <CopyCell text={eventStream?.url || ''} />
         </PageDetail>
         <PageDetail
-          label={t('Include headers')}
+          label={t('Headers')}
           helpText={t(
             'A comma separated HTTP header keys that you want to include in the event payload.'
           )}
@@ -112,7 +112,7 @@ export function EventStreamDetails() {
             label={t('Test headers')}
             toggleLanguage={false}
             helpText={t(
-              'The HTTP Headers received from the Sender. Any of these can be used in the "Include headers" field.'
+              'The HTTP Headers received from the Sender. Any of these can be used in the "Headers" field.'
             )}
           />
         )}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamDetails.tsx
@@ -13,8 +13,7 @@ import { LastModifiedPageDetail } from '../../../common/LastModifiedPageDetail';
 import { useGet } from '../../../common/crud/useGet';
 import { edaAPI } from '../../common/eda-utils';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
-import { DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
-import { StandardPopover } from '../../../../framework/components/StandardPopover';
+import { Alert } from '@patternfly/react-core';
 import { PageDetailCodeEditor } from '../../../../framework/PageDetails/PageDetailCodeEditor';
 import { EdaRoute } from '../../main/EdaRoutes';
 
@@ -22,13 +21,27 @@ export function EventStreamDetails() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const getPageUrl = useGetPageUrl();
-
   const { data: eventStream } = useGet<EdaEventStream>(edaAPI`/event-streams/${params.id ?? ''}/`);
   if (!eventStream) {
     return <LoadingPage />;
   }
   return (
     <Scrollable>
+      {eventStream?.test_mode && (
+        <Alert
+          variant={'warning'}
+          isInline
+          style={{ marginLeft: '24px', marginTop: '16px', marginRight: '16px' }}
+          title={t('This event stream is disabled.')}
+        >
+          <p>
+            {t(
+              'Event streams that are disabled do not forward events to the rulebook activation where they are ' +
+                'configured. To forward events to the rulebook activation, enable the forwarding of events. '
+            )}
+          </p>
+        </Alert>
+      )}
       <PageDetails disableScroll={true}>
         <PageDetail label={t('Name')}>{eventStream?.name || ''}</PageDetail>
         <PageDetail label={t('Event stream type')}>
@@ -81,21 +94,6 @@ export function EventStreamDetails() {
           {eventStream?.created_at ? formatDateString(eventStream.created_at) : ''}
         </PageDetail>
         <LastModifiedPageDetail value={eventStream?.modified_at ? eventStream.modified_at : ''} />
-        {!!eventStream?.test_mode && (
-          <PageDetail label={t('Mode')}>
-            <DescriptionListGroup>
-              <DescriptionListTerm style={{ opacity: 0.6 }}>
-                {t('Test mode')}
-                <StandardPopover
-                  header={t('Test mode')}
-                  content={t(
-                    ' In Test Mode events are not forwarded to the Activation. This mode helps in viewing the headers and payload'
-                  )}
-                />
-              </DescriptionListTerm>
-            </DescriptionListGroup>
-          </PageDetail>
-        )}
         <PageDetail
           label={t('Test content type')}
           helpText={t('The HTTP Body that was sent from the Sender.')}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -1,6 +1,6 @@
 import { AlertProps, ButtonVariant } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
-import { DatabaseIcon, PencilAltIcon, TaskIcon, TrashIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -22,6 +22,8 @@ import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { EdaRoute } from '../../main/EdaRoutes';
 import { useDeleteEventStreams } from '../hooks/useDeleteEventStreams';
 import { usePatchRequest } from '../../../common/crud/usePatchRequest';
+import { useDisableEventStreams } from '../hooks/useDisableEventStreams';
+import { EdaResult } from '../../interfaces/EdaResult';
 
 export function EventStreamPage() {
   const { t } = useTranslation();
@@ -30,40 +32,56 @@ export function EventStreamPage() {
   const { data: eventStream } = useGet<EdaEventStream>(edaAPI`/event-streams/${params.id ?? ''}/`);
   const patchRequest = usePatchRequest();
   const alertToaster = usePageAlertToaster();
+  const disableEventStreams = useDisableEventStreams();
 
-  const toggleEventStreamMode: (testMode: boolean, eventStream: EdaEventStream) => Promise<void> =
-    useCallback(
-      async (testMode, eventStream) => {
-        const alert: AlertProps = {
-          variant: 'success',
-          title: `${eventStream.name || ''} ${testMode ? t('switched to test mode') : t('switched to production mode')}.`,
-          timeout: 5000,
-        };
-        await patchRequest(
-          edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
-          {
-            test_mode: testMode,
-          }
-        )
-          .then(() => alertToaster.addAlert(alert))
-          .catch(() => {
-            alertToaster.addAlert({
-              variant: 'danger',
-              title: `${t('Failed to switch the mode for')} ${eventStream.name}`,
-              timeout: 5000,
-            });
-          });
-      },
-      [t, patchRequest, alertToaster]
-    );
   const deleteEventStreams = useDeleteEventStreams((deleted) => {
     if (deleted.length > 0) {
       pageNavigate(EdaRoute.EventStreams);
     }
   });
 
+  const enableEventStream: (eventStream: EdaEventStream) => Promise<void> = useCallback(
+    async (eventStream) => {
+      const alert: AlertProps = {
+        variant: 'success',
+        title: `${eventStream.name || ''}  ${t('switched to production mode.')}`,
+        timeout: 5000,
+      };
+      await patchRequest(
+        edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
+        {
+          test_mode: false,
+        }
+      )
+        .then(() => alertToaster.addAlert(alert))
+        .catch(() => {
+          alertToaster.addAlert({
+            variant: 'danger',
+            title: `${t('Failed to enable the forwarding of events for')} ${eventStream.name}`,
+            timeout: 5000,
+          });
+        });
+    },
+    [t, patchRequest, alertToaster]
+  );
+  const { data: esActivations } = useGet<EdaResult<EdaEventStream>>(
+    edaAPI`/event-streams/${params.id ?? ''}/activations/?page=1&page_size=200`
+  );
   const itemActions = useMemo<IPageAction<EdaEventStream>[]>(
     () => [
+      {
+        type: PageActionType.Switch,
+        ariaLabel: (isEnabled) => (isEnabled ? t('Forward events ') : t('Not forwarding events')),
+        selection: PageActionSelection.Single,
+        isPinned: true,
+        label: t('Forward events'),
+        labelOff: t('Forward events'),
+        onToggle: (eventStream: EdaEventStream, mode: boolean) => {
+          if (mode) void enableEventStream(eventStream);
+          else void disableEventStreams([eventStream]);
+        },
+        isSwitchOn: (eventStream: EdaEventStream) => !eventStream.test_mode,
+      },
       {
         type: PageActionType.Button,
         variant: ButtonVariant.primary,
@@ -75,22 +93,6 @@ export function EventStreamPage() {
           pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
       },
       {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TaskIcon,
-        label: t('Switch to test mode'),
-        isHidden: (eventStream: EdaEventStream) => !!eventStream?.test_mode,
-        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(true, eventStream),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: DatabaseIcon,
-        label: t('Switch to production mode'),
-        isHidden: (eventStream: EdaEventStream) => !eventStream?.test_mode,
-        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(false, eventStream),
-      },
-      {
         type: PageActionType.Seperator,
       },
       {
@@ -98,11 +100,22 @@ export function EventStreamPage() {
         selection: PageActionSelection.Single,
         icon: TrashIcon,
         label: t('Delete event stream'),
+        isDisabled: () =>
+          esActivations?.results && esActivations.results.length > 0
+            ? t('To delete this event stream, disconnect it from all rulebook activations')
+            : undefined,
         onClick: (eventStream: EdaEventStream) => deleteEventStreams([eventStream]),
         isDanger: true,
       },
     ],
-    [deleteEventStreams, pageNavigate, t, toggleEventStreamMode]
+    [
+      deleteEventStreams,
+      disableEventStreams,
+      enableEventStream,
+      esActivations?.results,
+      pageNavigate,
+      t,
+    ]
   );
 
   const getPageUrl = useGetPageUrl();

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -29,10 +29,16 @@ export function EventStreamPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
-  const { data: eventStream } = useGet<EdaEventStream>(edaAPI`/event-streams/${params.id ?? ''}/`);
+  const { data: eventStream, refresh } = useGet<EdaEventStream>(
+    edaAPI`/event-streams/${params.id ?? ''}/`
+  );
   const patchRequest = usePatchRequest();
   const alertToaster = usePageAlertToaster();
-  const disableEventStreams = useDisableEventStreams();
+  const disableEventStreams = useDisableEventStreams((disabled) => {
+    if (disabled.length > 0) {
+      refresh();
+    }
+  });
 
   const deleteEventStreams = useDeleteEventStreams((deleted) => {
     if (deleted.length > 0) {
@@ -61,8 +67,9 @@ export function EventStreamPage() {
             timeout: 5000,
           });
         });
+      refresh();
     },
-    [t, patchRequest, alertToaster]
+    [t, patchRequest, refresh, alertToaster]
   );
   const { data: esActivations } = useGet<EdaResult<EdaEventStream>>(
     edaAPI`/event-streams/${params.id ?? ''}/activations/?page=1&page_size=200`

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -129,7 +129,10 @@ export function EventStreamPage() {
           page: EdaRoute.EventStreams,
           persistentFilterKey: 'event-streams',
         }}
-        tabs={[{ label: t('Details'), page: EdaRoute.EventStreamDetails }]}
+        tabs={[
+          { label: t('Details'), page: EdaRoute.EventStreamDetails },
+          { label: t('Activations'), page: EdaRoute.EventStreamActivations },
+        ]}
         params={{ id: eventStream?.id }}
       />
     </PageLayout>

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -29,6 +29,7 @@ export function EventStreamPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
+  const getPageUrl = useGetPageUrl();
   const { data: eventStream, refresh } = useGet<EdaEventStream>(
     edaAPI`/event-streams/${params.id ?? ''}/`
   );
@@ -74,58 +75,65 @@ export function EventStreamPage() {
   const { data: esActivations } = useGet<EdaResult<EdaEventStream>>(
     edaAPI`/event-streams/${params.id ?? ''}/activations/?page=1&page_size=200`
   );
+
+  const isActionTab = location.href.includes(
+    getPageUrl(EdaRoute.EventStreamDetails, { params: { id: eventStream?.id } })
+  );
   const itemActions = useMemo<IPageAction<EdaEventStream>[]>(
-    () => [
-      {
-        type: PageActionType.Switch,
-        ariaLabel: (isEnabled) => (isEnabled ? t('Forward events ') : t('Not forwarding events')),
-        selection: PageActionSelection.Single,
-        isPinned: true,
-        label: t('Forward events'),
-        labelOff: t('Forward events'),
-        onToggle: (eventStream: EdaEventStream, mode: boolean) => {
-          if (mode) void enableEventStream(eventStream);
-          else void disableEventStreams([eventStream]);
-        },
-        isSwitchOn: (eventStream: EdaEventStream) => !eventStream.test_mode,
-      },
-      {
-        type: PageActionType.Button,
-        variant: ButtonVariant.primary,
-        selection: PageActionSelection.Single,
-        icon: PencilAltIcon,
-        isPinned: true,
-        label: t('Edit event stream'),
-        onClick: (eventStream: EdaEventStream) =>
-          pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
-      },
-      {
-        type: PageActionType.Seperator,
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TrashIcon,
-        label: t('Delete event stream'),
-        isDisabled: () =>
-          esActivations?.results && esActivations.results.length > 0
-            ? t('To delete this event stream, disconnect it from all rulebook activations')
-            : undefined,
-        onClick: (eventStream: EdaEventStream) => deleteEventStreams([eventStream]),
-        isDanger: true,
-      },
-    ],
+    () =>
+      isActionTab
+        ? [
+            {
+              type: PageActionType.Switch,
+              ariaLabel: (isEnabled) =>
+                isEnabled ? t('Forward events ') : t('Not forwarding events'),
+              selection: PageActionSelection.Single,
+              isPinned: true,
+              label: t('Forward events'),
+              labelOff: t('Forward events'),
+              onToggle: (eventStream: EdaEventStream, mode: boolean) => {
+                if (mode) void enableEventStream(eventStream);
+                else void disableEventStreams([eventStream]);
+              },
+              isSwitchOn: (eventStream: EdaEventStream) => !eventStream.test_mode,
+            },
+            {
+              type: PageActionType.Button,
+              variant: ButtonVariant.primary,
+              selection: PageActionSelection.Single,
+              icon: PencilAltIcon,
+              isPinned: true,
+              label: t('Edit event stream'),
+              onClick: (eventStream: EdaEventStream) =>
+                pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
+            },
+            {
+              type: PageActionType.Seperator,
+            },
+            {
+              type: PageActionType.Button,
+              selection: PageActionSelection.Single,
+              icon: TrashIcon,
+              label: t('Delete event stream'),
+              isDisabled: () =>
+                esActivations?.results && esActivations.results.length > 0
+                  ? t('To delete this event stream, disconnect it from all rulebook activations')
+                  : undefined,
+              onClick: (eventStream: EdaEventStream) => deleteEventStreams([eventStream]),
+              isDanger: true,
+            },
+          ]
+        : [],
     [
       deleteEventStreams,
       disableEventStreams,
       enableEventStream,
-      esActivations?.results,
+      esActivations,
+      isActionTab,
       pageNavigate,
       t,
     ]
   );
-
-  const getPageUrl = useGetPageUrl();
 
   return (
     <PageLayout>

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -1,7 +1,7 @@
-import { ButtonVariant } from '@patternfly/react-core';
+import { AlertProps, ButtonVariant } from '@patternfly/react-core';
 import { DropdownPosition } from '@patternfly/react-core/deprecated';
-import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
-import { useMemo } from 'react';
+import { DatabaseIcon, PencilAltIcon, TaskIcon, TrashIcon } from '@patternfly/react-icons';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -13,6 +13,7 @@ import {
   PageLayout,
   useGetPageUrl,
   usePageNavigate,
+  usePageAlertToaster,
 } from '../../../../framework';
 import { PageRoutedTabs } from '../../../common/PageRoutedTabs';
 import { useGet } from '../../../common/crud/useGet';
@@ -20,13 +21,41 @@ import { edaAPI } from '../../common/eda-utils';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { EdaRoute } from '../../main/EdaRoutes';
 import { useDeleteEventStreams } from '../hooks/useDeleteEventStreams';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 
 export function EventStreamPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
   const { data: eventStream } = useGet<EdaEventStream>(edaAPI`/event-streams/${params.id ?? ''}/`);
+  const patchRequest = usePatchRequest();
+  const alertToaster = usePageAlertToaster();
 
+  const toggleEventStreamMode: (testMode: boolean, eventStream: EdaEventStream) => Promise<void> =
+    useCallback(
+      async (testMode, eventStream) => {
+        const alert: AlertProps = {
+          variant: 'success',
+          title: `${eventStream.name || ''} ${testMode ? t('switched to test mode') : t('switched to production mode')}.`,
+          timeout: 5000,
+        };
+        await patchRequest(
+          edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
+          {
+            test_mode: testMode,
+          }
+        )
+          .then(() => alertToaster.addAlert(alert))
+          .catch(() => {
+            alertToaster.addAlert({
+              variant: 'danger',
+              title: `${t('Failed to switch the mode for')} ${eventStream.name}`,
+              timeout: 5000,
+            });
+          });
+      },
+      [t, patchRequest, alertToaster]
+    );
   const deleteEventStreams = useDeleteEventStreams((deleted) => {
     if (deleted.length > 0) {
       pageNavigate(EdaRoute.EventStreams);
@@ -46,6 +75,22 @@ export function EventStreamPage() {
           pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
       },
       {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: TaskIcon,
+        label: t('Switch to test mode'),
+        isHidden: (eventStream: EdaEventStream) => !!eventStream?.test_mode,
+        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(true, eventStream),
+      },
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Single,
+        icon: DatabaseIcon,
+        label: t('Switch to production mode'),
+        isHidden: (eventStream: EdaEventStream) => !eventStream?.test_mode,
+        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(false, eventStream),
+      },
+      {
         type: PageActionType.Seperator,
       },
       {
@@ -57,7 +102,7 @@ export function EventStreamPage() {
         isDanger: true,
       },
     ],
-    [deleteEventStreams, pageNavigate, t]
+    [deleteEventStreams, pageNavigate, t, toggleEventStreamMode]
   );
 
   const getPageUrl = useGetPageUrl();

--- a/frontend/eda/event-streams/EventStreams.cy.tsx
+++ b/frontend/eda/event-streams/EventStreams.cy.tsx
@@ -211,7 +211,6 @@ describe('EventStreams.cy.ts', () => {
     cy.contains('th', 'Events received');
     cy.contains('th', 'Last event received');
     cy.contains('th', 'Event stream type');
-    cy.contains('th', 'Event stream mode');
   });
 
   it('Can delete an event stream', () => {

--- a/frontend/eda/event-streams/EventStreams.cy.tsx
+++ b/frontend/eda/event-streams/EventStreams.cy.tsx
@@ -203,27 +203,24 @@ describe('EventStreams.cy.ts', () => {
     );
   });
 
-  it('Renders the correct webhooks columns', () => {
+  it('Renders the correct event streams columns', () => {
     cy.mount(<EventStreams />);
     cy.get('h1').should('contain', 'Event Streams');
     cy.get('tbody').find('tr').should('have.length', 10);
     cy.contains('th', 'Name');
     cy.contains('th', 'Events received');
     cy.contains('th', 'Last event received');
-    cy.contains('th', 'Mode');
+    cy.contains('th', 'Event stream type');
+    cy.contains('th', 'Event stream mode');
   });
 
-  it('Can delete an event stream not in use', () => {
+  it('Can delete an event stream', () => {
     cy.mount(<EventStreams />);
     cy.intercept(
       { method: 'DELETE', url: edaAPI`/event-streams/2/` },
       {
         statusCode: 204,
       }
-    );
-    cy.intercept(
-      { method: 'GET', url: edaAPI`/activations/?webhook_id=1` },
-      { count: 0, next: null, previous: null, page_size: 20, page: 1, results: [] }
     );
     cy.get('[data-cy="checkbox-column-cell"]').first().click();
     cy.get('[data-cy="actions-dropdown"]').first().click();

--- a/frontend/eda/event-streams/EventStreams.tsx
+++ b/frontend/eda/event-streams/EventStreams.tsx
@@ -32,7 +32,7 @@ export function EventStreams() {
         )}
       />
       <PageTable
-        id="eda-webhooks-table"
+        id="eda-event-streams-table"
         tableColumns={tableColumns}
         toolbarActions={toolbarActions}
         toolbarFilters={toolbarFilters}

--- a/frontend/eda/event-streams/hooks/useDisableEventStreams.tsx
+++ b/frontend/eda/event-streams/hooks/useDisableEventStreams.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareStrings } from '../../../../framework';
+import { useNameColumn } from '../../../common/columns';
+import { idKeyFn } from '../../../common/utils/nameKeyFn';
+import { edaAPI } from '../../common/eda-utils';
+import { EdaEventStream } from '../../interfaces/EdaEventStream';
+import { useEventStreamColumns } from './useEventStreamColumns';
+import { useEdaBulkConfirmation } from '../../common/useEdaBulkConfirmation';
+import { usePatchRequest } from '../../../common/crud/usePatchRequest';
+
+export function useDisableEventStreams(onComplete?: (eventStreams: EdaEventStream[]) => void) {
+  const { t } = useTranslation();
+  const confirmationColumns = useEventStreamColumns();
+  const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
+  const patchRequest = usePatchRequest();
+  const bulkAction = useEdaBulkConfirmation<EdaEventStream>();
+  return useCallback(
+    (eventStreams: EdaEventStream[]) => {
+      bulkAction({
+        title: t('Disable forwarding of events?', { count: eventStreams.length }),
+        prompt: t(
+          'Are you sure you want to disable the forwarding of events? ' +
+            'The evens from this event stream will no longer get forwarded to the rulebook activation this event stream is currently configured in.'
+        ),
+        confirmText: t('Yes, I confirm I want to disable the forwarding of events.', {
+          count: eventStreams.length,
+        }),
+        actionButtonText: t('Disable forwarding of events', { count: eventStreams.length }),
+        items: eventStreams.sort((l, r) => compareStrings(l.name, r.name)),
+        keyFn: idKeyFn,
+        isDanger: true,
+        confirmationColumns,
+        actionColumns,
+        onComplete,
+        actionFn: (eventStream: EdaEventStream) => {
+          return patchRequest(
+            edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
+            {
+              test_mode: true,
+            }
+          );
+        },
+      });
+    },
+    [actionColumns, bulkAction, confirmationColumns, onComplete, patchRequest, t]
+  );
+}

--- a/frontend/eda/event-streams/hooks/useDisableEventStreams.tsx
+++ b/frontend/eda/event-streams/hooks/useDisableEventStreams.tsx
@@ -12,9 +12,9 @@ import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 export function useDisableEventStreams(onComplete?: (eventStreams: EdaEventStream[]) => void) {
   const { t } = useTranslation();
   const confirmationColumns = useEventStreamColumns();
-  const deleteActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
-  const actionColumns = useMemo(() => [deleteActionNameColumn], [deleteActionNameColumn]);
-  const patchRequest = usePatchRequest();
+  const disableActionNameColumn = useNameColumn({ disableLinks: true, disableSort: true });
+  const actionColumns = useMemo(() => [disableActionNameColumn], [disableActionNameColumn]);
+  const patchRequest = usePatchRequest<unknown, unknown>();
   const bulkAction = useEdaBulkConfirmation<EdaEventStream>();
   return useCallback(
     (eventStreams: EdaEventStream[]) => {

--- a/frontend/eda/event-streams/hooks/useEventStreamActions.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamActions.tsx
@@ -1,5 +1,5 @@
 import { AlertProps, ButtonVariant } from '@patternfly/react-core';
-import { DatabaseIcon, PencilAltIcon, TaskIcon, TrashIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -15,42 +15,56 @@ import { EdaRoute } from '../../main/EdaRoutes';
 import { useDeleteEventStreams } from './useDeleteEventStreams';
 import { edaAPI } from '../../common/eda-utils';
 import { usePatchRequest } from '../../../common/crud/usePatchRequest';
+import { useDisableEventStreams } from './useDisableEventStreams';
 
 export function useEventStreamActions(view: IEdaView<EdaEventStream>) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
+  const disableEventStreams = useDisableEventStreams(view.unselectItemsAndRefresh);
   const deleteEventStreams = useDeleteEventStreams(view.unselectItemsAndRefresh);
   const patchRequest = usePatchRequest();
   const alertToaster = usePageAlertToaster();
 
-  const toggleEventStreamMode: (testMode: boolean, eventStream: EdaEventStream) => Promise<void> =
-    useCallback(
-      async (testMode, eventStream) => {
-        const alert: AlertProps = {
-          variant: 'success',
-          title: `${eventStream.name || ''} ${testMode ? t('switched to test mode') : t('switched to production mode')}.`,
-          timeout: 5000,
-        };
-        await patchRequest(
-          edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
-          {
-            test_mode: testMode,
-          }
-        )
-          .then(() => alertToaster.addAlert(alert))
-          .catch(() => {
-            alertToaster.addAlert({
-              variant: 'danger',
-              title: `${t('Failed to switch the mode for')} ${eventStream.name}`,
-              timeout: 5000,
-            });
+  const enableEventStream: (eventStream: EdaEventStream) => Promise<void> = useCallback(
+    async (eventStream) => {
+      const alert: AlertProps = {
+        variant: 'success',
+        title: `${eventStream.name || ''}  ${t('switched to production mode.')}`,
+        timeout: 5000,
+      };
+      await patchRequest(
+        edaAPI`/event-streams/${eventStream?.id ? eventStream?.id.toString() : ''}/`,
+        {
+          test_mode: false,
+        }
+      )
+        .then(() => alertToaster.addAlert(alert))
+        .catch(() => {
+          alertToaster.addAlert({
+            variant: 'danger',
+            title: `${t('Failed to enable the forwarding of events for')} ${eventStream.name}`,
+            timeout: 5000,
           });
-        view.unselectItemsAndRefresh([eventStream]);
-      },
-      [t, patchRequest, view, alertToaster]
-    );
+        });
+      view.unselectItemsAndRefresh([eventStream]);
+    },
+    [t, patchRequest, view, alertToaster]
+  );
   return useMemo<IPageAction<EdaEventStream>[]>(
     () => [
+      {
+        type: PageActionType.Switch,
+        ariaLabel: (isEnabled) => (isEnabled ? t('Switch to ') : t('Click to enable instance')),
+        selection: PageActionSelection.Single,
+        isPinned: true,
+        label: t('Events are being forwarded to the rulebook activation.'),
+        labelOff: t('Events are not being forwarded to the rulebook activation.'),
+        onToggle: (eventStream: EdaEventStream, mode: boolean) => {
+          if (mode) void enableEventStream(eventStream);
+          else void disableEventStreams([eventStream]);
+        },
+        isSwitchOn: (eventStream: EdaEventStream) => !eventStream.test_mode,
+      },
       {
         type: PageActionType.Button,
         variant: ButtonVariant.primary,
@@ -60,22 +74,6 @@ export function useEventStreamActions(view: IEdaView<EdaEventStream>) {
         label: t('Edit event stream'),
         onClick: (eventStream: EdaEventStream) =>
           pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: TaskIcon,
-        label: t('Switch to test mode'),
-        isHidden: (eventStream: EdaEventStream) => !!eventStream?.test_mode,
-        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(true, eventStream),
-      },
-      {
-        type: PageActionType.Button,
-        selection: PageActionSelection.Single,
-        icon: DatabaseIcon,
-        label: t('Switch to production mode'),
-        isHidden: (eventStream: EdaEventStream) => !eventStream?.test_mode,
-        onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(false, eventStream),
       },
       {
         type: PageActionType.Seperator,
@@ -89,6 +87,6 @@ export function useEventStreamActions(view: IEdaView<EdaEventStream>) {
         isDanger: true,
       },
     ],
-    [deleteEventStreams, pageNavigate, t, toggleEventStreamMode]
+    [deleteEventStreams, disableEventStreams, enableEventStream, pageNavigate, t]
   );
 }

--- a/frontend/eda/event-streams/hooks/useEventStreamActions.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamActions.tsx
@@ -1,5 +1,5 @@
 import { AlertProps, ButtonVariant } from '@patternfly/react-core';
-import { ConnectedIcon, DisconnectedIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { DatabaseIcon, PencilAltIcon, TaskIcon, TrashIcon } from '@patternfly/react-icons';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -64,7 +64,7 @@ export function useEventStreamActions(view: IEdaView<EdaEventStream>) {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: DisconnectedIcon,
+        icon: TaskIcon,
         label: t('Switch to test mode'),
         isHidden: (eventStream: EdaEventStream) => !!eventStream?.test_mode,
         onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(true, eventStream),
@@ -72,7 +72,7 @@ export function useEventStreamActions(view: IEdaView<EdaEventStream>) {
       {
         type: PageActionType.Button,
         selection: PageActionSelection.Single,
-        icon: ConnectedIcon,
+        icon: DatabaseIcon,
         label: t('Switch to production mode'),
         isHidden: (eventStream: EdaEventStream) => !eventStream?.test_mode,
         onClick: (eventStream: EdaEventStream) => toggleEventStreamMode(false, eventStream),

--- a/frontend/eda/event-streams/hooks/useEventStreamActivations.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamActivations.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ColumnTableOption, ITableColumn, TextCell, useGetPageUrl } from '../../../../framework';
+import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
+import { EdaRoute } from '../../main/EdaRoutes';
+
+export function useEventStreamActivationsColumns() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  return useMemo<ITableColumn<EdaRulebookActivation>[]>(
+    () => [
+      {
+        header: t('Name'),
+        cell: (activation) => (
+          <TextCell
+            text={activation.name}
+            to={getPageUrl(EdaRoute.RulebookActivationPage, {
+              params: { id: activation.id },
+            })}
+          />
+        ),
+        card: 'name',
+        list: 'name',
+      },
+      {
+        header: t('Description'),
+        type: 'description',
+        value: (activation) => activation.description,
+        table: ColumnTableOption.description,
+        card: 'description',
+        list: 'description',
+      },
+      {
+        header: t('Created'),
+        type: 'datetime',
+        value: (activation) => activation.created_at,
+        table: ColumnTableOption.expanded,
+        card: 'hidden',
+        list: 'secondary',
+      },
+      {
+        header: t('Last modified'),
+        type: 'datetime',
+        value: (instance) => instance.modified_at,
+        table: ColumnTableOption.expanded,
+        card: 'hidden',
+        list: 'secondary',
+      },
+    ],
+    [getPageUrl, t]
+  );
+}

--- a/frontend/eda/event-streams/hooks/useEventStreamActivationsColumns.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamActivationsColumns.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ColumnTableOption, ITableColumn, TextCell, useGetPageUrl } from '../../../../framework';
+import { EdaRulebookActivation } from '../../interfaces/EdaRulebookActivation';
+import { EdaRoute } from '../../main/EdaRoutes';
+import { StatusEnum } from '../../interfaces/generated/eda-api';
+import { Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { StatusCell } from '../../../common/Status';
+
+export function useEventStreamActivationsColumns() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  return useMemo<ITableColumn<EdaRulebookActivation>[]>(
+    () => [
+      {
+        header: t('Name'),
+        cell: (activation) => (
+          <TextCell
+            text={activation.name}
+            to={getPageUrl(EdaRoute.RulebookActivationPage, {
+              params: { id: activation.id },
+            })}
+          />
+        ),
+        card: 'name',
+        list: 'name',
+      },
+      {
+        header: t('Description'),
+        type: 'description',
+        value: (activation) => activation.description,
+        table: ColumnTableOption.description,
+        card: 'description',
+        list: 'description',
+      },
+      {
+        header: t('Status'),
+        cell: (activation) =>
+          activation?.status === StatusEnum.Deleting ? (
+            <Label color="red" icon={<InfoCircleIcon />}>
+              {t('Pending delete')}
+            </Label>
+          ) : (
+            <StatusCell status={activation?.status} />
+          ),
+      },
+      {
+        header: t('Created'),
+        type: 'datetime',
+        value: (activation) => activation.created_at,
+        table: ColumnTableOption.expanded,
+        card: 'hidden',
+        list: 'secondary',
+      },
+      {
+        header: t('Last modified'),
+        type: 'datetime',
+        value: (activation) => activation.modified_at,
+        table: ColumnTableOption.expanded,
+        card: 'hidden',
+        list: 'secondary',
+      },
+    ],
+    [getPageUrl, t]
+  );
+}

--- a/frontend/eda/event-streams/hooks/useEventStreamActivationsFilters.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamActivationsFilters.tsx
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IToolbarFilter, ToolbarFilterType } from '../../../../framework';
+
+export function useEventStreamActivationsFilters() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter[]>(
+    () => [
+      {
+        key: 'name',
+        label: t('Name'),
+        type: ToolbarFilterType.MultiText,
+        query: 'name',
+        comparison: 'startsWith',
+      },
+    ],
+    [t]
+  );
+}

--- a/frontend/eda/event-streams/hooks/useEventStreamColumns.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamColumns.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  ColumnModalOption,
   ColumnTableOption,
   CopyCell,
   ITableColumn,
@@ -9,8 +10,8 @@ import {
 } from '../../../../framework';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { EdaRoute } from '../../main/EdaRoutes';
-import { ConnectedIcon, DisconnectedIcon } from '@patternfly/react-icons';
 import { Tooltip } from '@patternfly/react-core';
+import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 
 export function useEventStreamColumns() {
   const { t } = useTranslation();
@@ -41,20 +42,33 @@ export function useEventStreamColumns() {
         value: (eventStream) => eventStream?.last_event_received_at ?? undefined,
       },
       {
-        header: t('Mode'),
+        header: t('Event stream type'),
+        cell: (eventStream) => (
+          <TextCell
+            text={t(capitalizeFirstLetter(eventStream.event_stream_type ?? ''))}
+            to={
+              eventStream?.eda_credential?.credential_type_id
+                ? getPageUrl(EdaRoute.CredentialTypePage, {
+                    params: { id: eventStream?.eda_credential?.credential_type_id },
+                  })
+                : ''
+            }
+          />
+        ),
+        value: (eventStream) => eventStream.event_stream_type,
+        modal: ColumnModalOption.hidden,
+      },
+      {
+        header: t('Event stream mode'),
         cell: (eventStream) => (
           <Tooltip
             content={
               eventStream.test_mode
-                ? t('Test Mode - events are not forwarded to Activation')
-                : t('Connected - events are forwarded to Activation')
+                ? t('Test mode - events are not forwarded to Activation')
+                : t('Production mode - events are forwarded to Activation')
             }
           >
-            <TextCell
-              text={t('')}
-              icon={eventStream.test_mode ? <DisconnectedIcon /> : <ConnectedIcon />}
-              iconColor={eventStream.test_mode ? 'yellow' : 'green'}
-            />
+            <TextCell text={eventStream.test_mode ? t('Test mode') : t('Production mode')} />
           </Tooltip>
         ),
         card: 'name',

--- a/frontend/eda/event-streams/hooks/useEventStreamColumns.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamColumns.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../../../framework';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { EdaRoute } from '../../main/EdaRoutes';
-import { Tooltip } from '@patternfly/react-core';
 import { capitalizeFirstLetter } from '../../../../framework/utils/strings';
 
 export function useEventStreamColumns() {
@@ -39,6 +38,7 @@ export function useEventStreamColumns() {
       {
         header: t('Last event received'),
         type: 'datetime',
+        modal: ColumnModalOption.hidden,
         value: (eventStream) => eventStream?.last_event_received_at ?? undefined,
       },
       {
@@ -57,22 +57,6 @@ export function useEventStreamColumns() {
         ),
         value: (eventStream) => eventStream.event_stream_type,
         modal: ColumnModalOption.hidden,
-      },
-      {
-        header: t('Event stream mode'),
-        cell: (eventStream) => (
-          <Tooltip
-            content={
-              eventStream.test_mode
-                ? t('Test mode - events are not forwarded to Activation')
-                : t('Production mode - events are forwarded to Activation')
-            }
-          >
-            <TextCell text={eventStream.test_mode ? t('Test mode') : t('Production mode')} />
-          </Tooltip>
-        ),
-        card: 'name',
-        list: 'name',
       },
       {
         header: t('URL'),

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -91,6 +91,7 @@ export enum EdaRoute {
   EditEventStream = 'eda-edit-event-stream',
   EventStreamPage = 'eda-event-stream-page',
   EventStreamDetails = 'eda-event-stream-details',
+  EventStreamActivations = 'eda-event-stream-activations',
 
   Settings = 'eda-settings',
   SettingsPreferences = 'eda-settings-preferences',

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -81,6 +81,7 @@ import { EventStreamPage } from '../event-streams/EventStreamPage/EventStreamPag
 import { EventStreams } from '../event-streams/EventStreams';
 import { EdaRoute } from './EdaRoutes';
 import { useEdaOrganizationRoutes } from './routes/useEdaOrganizationsRoutes';
+import { EventStreamActivations } from '../event-streams/EventStreamPage/EventStreamActivations';
 
 export function useEdaNavigation() {
   const { t } = useTranslation();
@@ -340,6 +341,11 @@ export function useEdaNavigation() {
               id: EdaRoute.EventStreamDetails,
               path: 'details',
               element: <EventStreamDetails />,
+            },
+            {
+              id: EdaRoute.EventStreamActivations,
+              path: 'activations',
+              element: <EventStreamActivations />,
             },
             {
               path: '',


### PR DESCRIPTION
- Update event streams columns
- Update Test mode menu actions
- Add Test mode menu to the Event Stream page
- Update help for Test mode and Headers
- Add Activation list Tab


![Screenshot from 2024-08-26 12-33-54](https://github.com/user-attachments/assets/9bfe2068-eed8-4c57-8847-e1a690b9127b)

**Updated 'Include headers' to Headers**
![Screenshot from 2024-08-26 12-33-41](https://github.com/user-attachments/assets/8cd09782-82bd-4927-83c2-3020c24df8a6)
![Screenshot from 2024-08-26 12-45-33](https://github.com/user-attachments/assets/82412a8f-f55b-438b-95d1-42a10f981950)


![Screenshot from 2024-08-25 02-22-46](https://github.com/user-attachments/assets/fdf90c4f-aa38-453d-90d3-1b0068321c34)
![Screenshot from 2024-08-25 02-22-38](https://github.com/user-attachments/assets/0dd9374e-56a1-4118-becd-d72f99c0abe6)
![Screenshot from 2024-08-25 02-22-13](https://github.com/user-attachments/assets/259c5878-0263-4f20-a7d2-3ff73c30b8e8)
![Screenshot from 2024-08-25 02-13-10](https://github.com/user-attachments/assets/addd5681-6c54-49d2-be43-0c771d015039)
![Screenshot from 2024-08-25 02-10-37](https://github.com/user-attachments/assets/22faadfa-f4cd-4f1c-b63a-30abbccd5653)
![Screenshot from 2024-08-25 02-09-53](https://github.com/user-attachments/assets/b132453e-6c1b-4b79-a96a-fbb8b13586cc)
![Screenshot from 2024-08-25 20-22-12](https://github.com/user-attachments/assets/43ce09b5-5528-4f05-af5d-ffd9bfb7916a)


![Screenshot from 2024-08-21 00-25-55](https://github.com/user-attachments/assets/6f554658-2a78-42c4-bf51-275090c04812)
![Screenshot from 2024-08-26 13-05-08](https://github.com/user-attachments/assets/836bd771-cdfc-4092-908f-831b7f843ac5)

