### PR TITLE
Skip test because it deletes wrong version of collection

### DIFF
--- a/cypress/e2e/hub/collections-detail.cy.ts
+++ b/cypress/e2e/hub/collections-detail.cy.ts
@@ -113,7 +113,7 @@ describe('Collections Details', () => {
     cy.deleteHubCollectionByName(collectionName);
   });
 
-  it('user can delete version from repository', () => {
+  it.skip('user can delete version from repository', () => {
     cy.uploadCollection(collectionName, namespace.name, '1.0.0');
     cy.uploadCollection(collectionName, namespace.name, '1.1.0');
     cy.approveCollection(collectionName, namespace.name, '1.0.0');


### PR DESCRIPTION
Cypress error:

`Timed out retrying after 30000ms: Expected to find content: '1.1.0' within the element: <span.pf-v5-c-menu__item-text> but never did.`

```
  120 |         cy.url().should('contain', "/collections/validated/".concat(namespace.name, "/").concat(collectionName, "/details"));
  121 |         cy.get("[data-cy=\"browse-collection-version\"] button").first().click();
> 122 |         cy.get('.pf-v5-c-menu__item-text').should('have.length', '1').contains('1.1.0');
      | ^
  123 |         cy.deleteHubCollectionByName(collectionName);
  124 |     });
  125 |     it('can copy a version to repository', function () { 
```
Screenshot:
<img width="966" alt="Screenshot 2024-08-21 at 16 42 21" src="https://github.com/user-attachments/assets/81d634c9-e0f0-4d29-8717-106930fad3ad">

Test deletes 1.1.0 version instead of 1.0.0

There needs to be a check that correct version is selected before it's deleted.