### PR TITLE
Select Dialog Fixes

### DIFF
--- a/cypress/e2e/awx/infrastructure/hosts/hosts.cy.ts
+++ b/cypress/e2e/awx/infrastructure/hosts/hosts.cy.ts
@@ -40,15 +40,6 @@ describe('Host Tests', () => {
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
     cy.singleSelectByDataCy('inventory', inventory.name);
-    // cy.getByDataCy('inventory').click();
-    // cy.contains('button', 'Browse').click();
-    // cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
-    // cy.getModal().within(() => {
-    //   cy.filterTableBySingleSelect('name', inventory.name);
-    //   cy.wait('@inventories');
-    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-    //   cy.contains('button', 'Confirm').click();
-    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);
@@ -95,15 +86,6 @@ describe('Host Tests', () => {
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
     cy.singleSelectByDataCy('inventory', inventory.name);
-    // cy.getByDataCy('inventory').click();
-    // cy.contains('button', 'Browse').click();
-    // cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
-    // cy.getModal().within(() => {
-    //   cy.filterTableBySingleSelect('name', inventory.name);
-    //   cy.wait('@inventories');
-    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-    //   cy.contains('button', 'Confirm').click();
-    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);

--- a/cypress/e2e/awx/infrastructure/hosts/hosts.cy.ts
+++ b/cypress/e2e/awx/infrastructure/hosts/hosts.cy.ts
@@ -1,13 +1,13 @@
+import { randomString } from '../../../../../framework/utils/random-string';
 import { Inventory } from '../../../../../frontend/awx/interfaces/Inventory';
 import { Organization } from '../../../../../frontend/awx/interfaces/Organization';
 import { Project } from '../../../../../frontend/awx/interfaces/Project';
-import { randomString } from '../../../../../framework/utils/random-string';
+import { awxAPI } from '../../../../support/formatApiPathForAwx';
 import {
   checkHostGroup,
   createHostAndCancelJob,
   launchHostJob,
 } from '../../../../support/hostsfunctions';
-import { awxAPI } from '../../../../support/formatApiPathForAwx';
 
 describe('Host Tests', () => {
   let organization: Organization;
@@ -39,15 +39,16 @@ describe('Host Tests', () => {
     cy.verifyPageTitle('Create Host');
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
-    cy.getByDataCy('inventory').click();
-    cy.contains('button', 'Browse').click();
-    cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
-    cy.getModal().within(() => {
-      cy.filterTableBySingleSelect('name', inventory.name);
-      cy.wait('@inventories');
-      cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-      cy.contains('button', 'Confirm').click();
-    });
+    cy.singleSelectByDataCy('inventory', inventory.name);
+    // cy.getByDataCy('inventory').click();
+    // cy.contains('button', 'Browse').click();
+    // cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
+    // cy.getModal().within(() => {
+    //   cy.filterTableBySingleSelect('name', inventory.name);
+    //   cy.wait('@inventories');
+    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
+    //   cy.contains('button', 'Confirm').click();
+    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);
@@ -93,15 +94,16 @@ describe('Host Tests', () => {
     cy.verifyPageTitle('Create Host');
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
-    cy.getByDataCy('inventory').click();
-    cy.contains('button', 'Browse').click();
-    cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
-    cy.getModal().within(() => {
-      cy.filterTableBySingleSelect('name', inventory.name);
-      cy.wait('@inventories');
-      cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-      cy.contains('button', 'Confirm').click();
-    });
+    cy.singleSelectByDataCy('inventory', inventory.name);
+    // cy.getByDataCy('inventory').click();
+    // cy.contains('button', 'Browse').click();
+    // cy.intercept('GET', awxAPI`/inventories/?*`).as('inventories');
+    // cy.getModal().within(() => {
+    //   cy.filterTableBySingleSelect('name', inventory.name);
+    //   cy.wait('@inventories');
+    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
+    //   cy.contains('button', 'Confirm').click();
+    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);

--- a/cypress/e2e/awx/inventories/inventories.cy.ts
+++ b/cypress/e2e/awx/inventories/inventories.cy.ts
@@ -180,20 +180,6 @@ describe('Inventories Tests', () => {
             cy.getByDataCy('name').type(name);
             cy.getByDataCy('description').type('description');
             cy.singleSelectByDataCy('organization', org.name);
-            // cy.getByDataCy('organization').click();
-            // cy.contains('button', 'Browse').click();
-            // cy.get(`[role="dialog"]`).within(() => {
-            //   cy.get(`[aria-label="Simple table"] tr`);
-            //   cy.contains('button', 'Cancel');
-            //   cy.contains('button', 'Confirm');
-            //   cy.get('#filter');
-            // });
-            // cy.get(`[role="dialog"]`).within(() => {
-            //   cy.filterTableByMultiSelect('name', [org.name]);
-            //   cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
-            //   cy.get(`input[type="radio"]`).click();
-            //   cy.contains('button', 'Confirm').click();
-            // });
             cy.getByDataCy('host-filter').type('name=host1');
             cy.getByDataCy('Submit').click();
             cy.getByDataCy('name').should('have.text', name);

--- a/cypress/e2e/awx/inventories/inventories.cy.ts
+++ b/cypress/e2e/awx/inventories/inventories.cy.ts
@@ -179,20 +179,21 @@ describe('Inventories Tests', () => {
             cy.getByDataCy('create-smart-inventory').click();
             cy.getByDataCy('name').type(name);
             cy.getByDataCy('description').type('description');
-            cy.getByDataCy('organization').click();
-            cy.contains('button', 'Browse').click();
-            cy.get(`[role="dialog"]`).within(() => {
-              cy.get(`[aria-label="Simple table"] tr`);
-              cy.contains('button', 'Cancel');
-              cy.contains('button', 'Confirm');
-              cy.get('#filter');
-            });
-            cy.get(`[role="dialog"]`).within(() => {
-              cy.filterTableByMultiSelect('name', [org.name]);
-              cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
-              cy.get(`input[type="radio"]`).click();
-              cy.contains('button', 'Confirm').click();
-            });
+            cy.singleSelectByDataCy('organization', org.name);
+            // cy.getByDataCy('organization').click();
+            // cy.contains('button', 'Browse').click();
+            // cy.get(`[role="dialog"]`).within(() => {
+            //   cy.get(`[aria-label="Simple table"] tr`);
+            //   cy.contains('button', 'Cancel');
+            //   cy.contains('button', 'Confirm');
+            //   cy.get('#filter');
+            // });
+            // cy.get(`[role="dialog"]`).within(() => {
+            //   cy.filterTableByMultiSelect('name', [org.name]);
+            //   cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
+            //   cy.get(`input[type="radio"]`).click();
+            //   cy.contains('button', 'Confirm').click();
+            // });
             cy.getByDataCy('host-filter').type('name=host1');
             cy.getByDataCy('Submit').click();
             cy.getByDataCy('name').should('have.text', name);

--- a/cypress/e2e/awx/inventory-host/inventoryHostRegular.cy.ts
+++ b/cypress/e2e/awx/inventory-host/inventoryHostRegular.cy.ts
@@ -65,13 +65,6 @@ describe('Inventory Host Tab Tests for regular inventory', () => {
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
     cy.singleSelectByDataCy('inventory', inventory.name);
-    // cy.getByDataCy('inventory').click();
-    // cy.contains('button', 'Browse').click();
-    // cy.getModal().within(() => {
-    //   cy.filterTableBySingleSelect('name', inventory.name);
-    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-    //   cy.contains('button', 'Confirm').click();
-    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);

--- a/cypress/e2e/awx/inventory-host/inventoryHostRegular.cy.ts
+++ b/cypress/e2e/awx/inventory-host/inventoryHostRegular.cy.ts
@@ -64,13 +64,14 @@ describe('Inventory Host Tab Tests for regular inventory', () => {
     cy.verifyPageTitle('Create Host');
     cy.getByDataCy('name').type(hostName);
     cy.getByDataCy('description').type('This is the description');
-    cy.getByDataCy('inventory').click();
-    cy.contains('button', 'Browse').click();
-    cy.getModal().within(() => {
-      cy.filterTableBySingleSelect('name', inventory.name);
-      cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-      cy.contains('button', 'Confirm').click();
-    });
+    cy.singleSelectByDataCy('inventory', inventory.name);
+    // cy.getByDataCy('inventory').click();
+    // cy.contains('button', 'Browse').click();
+    // cy.getModal().within(() => {
+    //   cy.filterTableBySingleSelect('name', inventory.name);
+    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
+    //   cy.contains('button', 'Confirm').click();
+    // });
     cy.getByDataCy('variables').type('test: true');
     cy.clickButton(/^Create host/);
     cy.hasDetail(/^Name$/, hostName);

--- a/cypress/e2e/awx/notifiers/notifiersSharedFunctions.ts
+++ b/cypress/e2e/awx/notifiers/notifiersSharedFunctions.ts
@@ -91,24 +91,6 @@ export function testDelete(name: string, options?: { details?: boolean }) {
 
 export function selectOrganization(orgName: string) {
   cy.singleSelectByDataCy('organization', orgName);
-  // cy.get(`[data-cy="organization"]`).click();
-  // cy.contains('button', 'Browse').click();
-
-  // // sync dialog
-  // cy.intercept('GET', awxAPI`/organizations/*`).as('orgList');
-  // cy.get(`[role="dialog"]`).within(() => {
-  //   cy.contains('button', 'Confirm');
-  //   cy.contains('button', 'Cancel');
-  //   cy.wait('@orgList');
-  //   cy.get(`[aria-label="Simple table"]`);
-  // });
-
-  // cy.filterTableByMultiSelect('name', [orgName]);
-  // cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
-
-  // cy.contains(`[aria-label="Simple table"]`, orgName);
-  // cy.get(`[aria-label="Select row 0"]`).click();
-  // cy.contains('button', 'Confirm').click();
 }
 
 function fillBasicData(notificationName: string, type: string) {

--- a/cypress/e2e/awx/notifiers/notifiersSharedFunctions.ts
+++ b/cypress/e2e/awx/notifiers/notifiersSharedFunctions.ts
@@ -90,24 +90,25 @@ export function testDelete(name: string, options?: { details?: boolean }) {
 }
 
 export function selectOrganization(orgName: string) {
-  cy.get(`[data-cy="organization"]`).click();
-  cy.contains('button', 'Browse').click();
+  cy.singleSelectByDataCy('organization', orgName);
+  // cy.get(`[data-cy="organization"]`).click();
+  // cy.contains('button', 'Browse').click();
 
-  // sync dialog
-  cy.intercept('GET', awxAPI`/organizations/*`).as('orgList');
-  cy.get(`[role="dialog"]`).within(() => {
-    cy.contains('button', 'Confirm');
-    cy.contains('button', 'Cancel');
-    cy.wait('@orgList');
-    cy.get(`[aria-label="Simple table"]`);
-  });
+  // // sync dialog
+  // cy.intercept('GET', awxAPI`/organizations/*`).as('orgList');
+  // cy.get(`[role="dialog"]`).within(() => {
+  //   cy.contains('button', 'Confirm');
+  //   cy.contains('button', 'Cancel');
+  //   cy.wait('@orgList');
+  //   cy.get(`[aria-label="Simple table"]`);
+  // });
 
-  cy.filterTableByMultiSelect('name', [orgName]);
-  cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
+  // cy.filterTableByMultiSelect('name', [orgName]);
+  // cy.get(`[aria-label="Simple table"] tr`).should('have.length', 2);
 
-  cy.contains(`[aria-label="Simple table"]`, orgName);
-  cy.get(`[aria-label="Select row 0"]`).click();
-  cy.contains('button', 'Confirm').click();
+  // cy.contains(`[aria-label="Simple table"]`, orgName);
+  // cy.get(`[aria-label="Select row 0"]`).click();
+  // cy.contains('button', 'Confirm').click();
 }
 
 function fillBasicData(notificationName: string, type: string) {

--- a/cypress/support/hostsfunctions.ts
+++ b/cypress/support/hostsfunctions.ts
@@ -27,13 +27,6 @@ export function createAndCheckHost(host_type: string, inventory: string) {
 
   if (host_type === 'stand_alone_host') {
     cy.singleSelectByDataCy('inventory', inventory);
-    // cy.getByDataCy('inventory').click();
-    // cy.contains('button', 'Browse').click();
-    // cy.getModal().within(() => {
-    //   cy.filterTableBySingleSelect('name', inventory);
-    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-    //   cy.contains('button', 'Confirm').click();
-    // });
   }
 
   // after creation - verify data is currect

--- a/cypress/support/hostsfunctions.ts
+++ b/cypress/support/hostsfunctions.ts
@@ -26,13 +26,14 @@ export function createAndCheckHost(host_type: string, inventory: string) {
   cy.getByDataCy('description').type('This is the description');
 
   if (host_type === 'stand_alone_host') {
-    cy.getByDataCy('inventory').click();
-    cy.contains('button', 'Browse').click();
-    cy.getModal().within(() => {
-      cy.filterTableBySingleSelect('name', inventory);
-      cy.get(`[data-cy="checkbox-column-cell"] input`).click();
-      cy.contains('button', 'Confirm').click();
-    });
+    cy.singleSelectByDataCy('inventory', inventory);
+    // cy.getByDataCy('inventory').click();
+    // cy.contains('button', 'Browse').click();
+    // cy.getModal().within(() => {
+    //   cy.filterTableBySingleSelect('name', inventory);
+    //   cy.get(`[data-cy="checkbox-column-cell"] input`).click();
+    //   cy.contains('button', 'Confirm').click();
+    // });
   }
 
   // after creation - verify data is currect


### PR DESCRIPTION
There is a timing issue with browse dialogs that use dynamic filters.
It should not impact customers, but it does impact fast tests.
Long term we should look for a fix, but for now, replacing test selection of items to not use the browse dialogs.