### PR TITLE
[AAP-29664] Navigation after collection deletion

### DIFF
--- a/cypress/e2e/hub/collections-detail.cy.ts
+++ b/cypress/e2e/hub/collections-detail.cy.ts
@@ -89,9 +89,7 @@ describe('Collections Details', () => {
       `/collections/validated/${namespace.name}/${collectionName}/details?version=1.0.0`
     );
     cy.selectDetailsPageKebabAction('delete-version-from-system');
-    cy.clickButton(/^Close$/);
     //Verify the version has been deleted
-    cy.navigateTo('hub', Collections.url);
     cy.getByDataCy('table-view').click();
     cy.filterTableBySingleText(collectionName, true);
     cy.clickLink(collectionName);
@@ -227,30 +225,24 @@ describe('Collections Details', () => {
       cy.clickButton(/^Close$/);
       cy.getModal().should('not.exist');
       // Verify collection has been deprecated
-      cy.contains('span', 'Deprecated');
+      cy.contains('span', 'Deprecated').should('exist');
       // Undeprecate collection
       cy.selectDetailsPageKebabAction('undeprecate-collection');
       cy.clickButton(/^Close$/);
-      cy.getModal().should('not.exist');
       // Verify collection has been undeprecated
       cy.contains('span', 'Deprecated').should('not.exist');
 
       // deprecate collection again
       cy.selectDetailsPageKebabAction('deprecate-collection');
       cy.clickButton(/^Close$/);
-      cy.getModal().should('not.exist');
       // Verify collection has been deprecated
       cy.contains('span', 'Deprecated');
 
       cy.contains('a', namespace.name).click();
       cy.contains(`[role="tab"]`, 'Collections').click();
-      cy.filterTableBySingleText(collectionName, true);
-      cy.get(`[aria-label="Simple table"]`).within(() => {
-        cy.contains('td', collectionName).click();
-        cy.contains('span', 'Deprecated');
-      });
-
       cy.getByDataCy('table-view').click();
+      cy.selectTableRowByCheckbox('name', collectionName, true);
+
       cy.get(`[aria-label="Simple table"]`).within(() => {
         cy.getByDataCy('actions-dropdown').click();
       });
@@ -265,7 +257,6 @@ describe('Collections Details', () => {
       cy.getModal().should('not.exist');
 
       cy.get(`[aria-label="Simple table"]`).within(() => {
-        cy.contains('td', collectionName).click();
         cy.contains('span', 'Deprecated').should('not.exist');
       });
       cy.deleteHubCollectionByName(collectionName);

--- a/cypress/e2e/hub/collections-list.cy.ts
+++ b/cypress/e2e/hub/collections-list.cy.ts
@@ -132,11 +132,10 @@ describe('Collections List', () => {
         cy.get('[data-ouia-component-id="Permanently delete collections versions"]').within(() => {
           cy.get('[data-ouia-component-id="confirm"]').click();
           cy.get('[data-ouia-component-id="submit"]').click();
-          cy.clickButton(/^Close$/);
         });
+        cy.deleteHubCollectionByName(collectionName);
       }
     );
-    cy.deleteHubCollectionByName(collectionName);
   });
 
   it('can copy a version to repository and then delete it from repository', () => {

--- a/frontend/hub/collections/hooks/useDeleteCollections.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollections.tsx
@@ -8,7 +8,7 @@ import { useHubBulkConfirmation } from '../../common/useHubBulkConfirmation';
 import { PulpItemsResponse } from '../../common/useHubView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionColumns } from './useCollectionColumns';
-import { navigateAfterDelete } from './useDeleteCollectionsFromRepository';
+import { HubRoute } from '../../main/HubRoutes';
 
 export function useDeleteCollections(
   onComplete?: (collections: CollectionVersionSearch[]) => void,
@@ -33,7 +33,7 @@ export function useDeleteCollections(
 
       confirmText +=
         ' ' +
-        t(`Note that if you selected one collection in multiple repositories, it will be 
+        t(`Note that if you selected one collection in multiple repositories, it will be
       deleted only once from all repositories.`);
 
       const title = version
@@ -69,7 +69,7 @@ export function useDeleteCollections(
         actionFn: (collection: CollectionVersionSearch, signal) => {
           return deleteCollection(collection, version, signal).then(() => {
             if (detail) {
-              return navigateAfterDelete(collection, version || false, navigate);
+              navigate(HubRoute.Collections);
             }
           });
         },

--- a/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
+++ b/frontend/hub/collections/hooks/useDeleteCollectionsFromRepository.tsx
@@ -86,7 +86,7 @@ export function useDeleteCollectionsFromRepository(
           return deleteCollectionFromRepository(newRepository, [collection], version, t).then(
             () => {
               if (detail) {
-                return navigateAfterDelete(collection, version || false, navigate);
+                navigate(HubRoute.Collections);
               }
             }
           );
@@ -172,24 +172,5 @@ export async function deleteCollectionFromRepository(
         'Not all collections versions were removed. This operation can remove only 300 versions. Try to repeat this operation.'
       )
     );
-  }
-}
-
-export function navigateAfterDelete(
-  collection: CollectionVersionSearch,
-  version: boolean,
-  navigate: ReturnType<typeof usePageNavigate>
-) {
-  if (version) {
-    navigate(HubRoute.CollectionPage, {
-      query: {
-        repository: collection.repository?.name || '',
-        name: collection.collection_version?.name || '',
-        namespace: collection.collection_version?.namespace || '',
-        redirectIfEmpty: 'true',
-      },
-    });
-  } else {
-    navigate(HubRoute.Collections);
   }
 }


### PR DESCRIPTION
This addresses AAP-29664.  After deleting a collection the user will be navigated to the collections list every time.  

We did see a case where if deleting only a version of a collection the user might want to remain on the details view for that collection, but decided that since the details will would likely be exactly the same after deleting a version the user could become confused as they'd expect to see different information.

Additionally the approach of deleting an items results in the user being navigated to a list view is an established pattern in the new UI so this bring in consistency.
