### PR TITLE
Update eda error adapter to handle generic detail errors from the api

### DIFF
--- a/frontend/eda/common/edaErrorAdapter.cy.tsx
+++ b/frontend/eda/common/edaErrorAdapter.cy.tsx
@@ -50,6 +50,14 @@ describe('edaErrorAdapter', () => {
     ]);
   });
 
+  it('should handle "detail" errors as generic errors', () => {
+    const error = new RequestError('Validation failed', undefined, 400, {}, { detail: 'Error' });
+    const result = edaErrorAdapter(error);
+    expect(result.genericErrors.length).equal(1);
+    expect(result.fieldErrors.length).equal(0);
+    expect(result.genericErrors).to.deep.equal([{ message: 'Error' }]);
+  });
+
   it('should deal with "errors" errors as generic errors', () => {
     const error = new RequestError(
       'Errors',

--- a/frontend/eda/common/edaErrorAdapter.tsx
+++ b/frontend/eda/common/edaErrorAdapter.tsx
@@ -13,8 +13,15 @@ export const edaErrorAdapter = (error: unknown): ErrorOutput => {
     const data = error.json;
     for (const key in data) {
       const value = (data as Record<string, unknown>)[key];
+      if (key === 'detail') {
+        if (Array.isArray(value)) {
+          genericErrors.push({ message: value[0] as string });
+        } else {
+          genericErrors.push({ message: value as string });
+        }
+      }
       // Check for non-field errors
-      if (key === 'non_field_errors' && Array.isArray(value)) {
+      else if (key === 'non_field_errors' && Array.isArray(value)) {
         value.forEach((message) => {
           if (typeof message === 'string') {
             genericErrors.push({ message });


### PR DESCRIPTION
In some instances, the API responds with an error structure that looks like:

```
{
    "detail": "Some error message"
}
```

EDA's error adapter currently interprets this as a "field" error.  This is a common generic error pattern though and it is also observed in AWX.  See https://github.com/ansible/ansible-ui/blob/main/frontend/awx/common/adapters/awxErrorAdapter.tsx#L15-L21 for a similar chunk of code in AWX's error handler.