### PR TITLE
Hub EE Create - hide description

### DIFF
--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -254,12 +254,13 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
             </>
           )}
 
-          <PageFormTextArea<ExecutionEnvironmentFormProps>
-            name="description"
-            label={t('Description')}
-            placeholder={t('Enter a description')}
-            isDisabled={mode === 'add'}
-          />
+          {!isNew && (
+            <PageFormTextArea<ExecutionEnvironmentFormProps>
+              name="description"
+              label={t('Description')}
+              placeholder={t('Enter a description')}
+            />
+          )}
         </HubPageForm>
       )}
     </PageLayout>

--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
   PageFormSubmitHandler,
-  PageFormTextArea,
   PageFormTextInput,
   PageHeader,
   PageLayout,
@@ -228,7 +227,7 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
           )}
 
           {!isNew && (
-            <PageFormTextArea<ExecutionEnvironmentFormProps>
+            <PageFormTextInput<ExecutionEnvironmentFormProps>
               name="description"
               label={t('Description')}
               placeholder={t('Enter a description')}

--- a/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentForm.tsx
@@ -227,6 +227,14 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
             />
           )}
 
+          {!isNew && (
+            <PageFormTextArea<ExecutionEnvironmentFormProps>
+              name="description"
+              label={t('Description')}
+              placeholder={t('Enter a description')}
+            />
+          )}
+
           {isRemote && (
             <>
               <PageFormTextInput<ExecutionEnvironmentFormProps>
@@ -252,14 +260,6 @@ function ExecutionEnvironmentForm(props: { mode: 'add' | 'edit' }) {
               <TagsSelector tags={tagsToInclude} setTags={setTagsToInclude} mode={'include'} />
               <TagsSelector tags={tagsToExclude} setTags={setTagsToExclude} mode={'exclude'} />
             </>
-          )}
-
-          {!isNew && (
-            <PageFormTextArea<ExecutionEnvironmentFormProps>
-              name="description"
-              label={t('Description')}
-              placeholder={t('Enter a description')}
-            />
           )}
         </HubPageForm>
       )}


### PR DESCRIPTION
editing EE description is only available when editing, hide when creating a new EE
and move description under name(s)

create
![20240822133933](https://github.com/user-attachments/assets/7dce90c5-c41a-4a08-9021-e32626ec717a)

edit remote
![20240822135213](https://github.com/user-attachments/assets/77bd1851-e1f3-402e-9752-44cd5ea63b60)

edit local
![20240822135345](https://github.com/user-attachments/assets/956571c4-a5ae-4732-b2e2-e49a5a488600)

Cc @tiyiprh 