### PR TITLE
[wip] EE Push - add podman push instructions

### DIFF
--- a/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
+++ b/frontend/hub/execution-environments/hooks/useExecutionEnvironmentsActions.tsx
@@ -51,7 +51,42 @@ export function useExecutionEnvironmentsActions(callback?: (ees: ExecutionEnviro
         icon: ExternalLinkAltIcon,
         label: t('Push container images'),
         onClick: () => {
-          window.open(AAPDocsURL, '_blank');
+          const host = window.location.host;
+          const tlsVerify = window.location.protocol == 'https:';
+          const name = 'example';
+          const containerURL = `${host}/${name}:latest`;
+
+          console.log(`podman login --tls-verify=${tlsVerify.toString()} ${host}`);
+          console.log(`podman image tag ${name} ${containerURL}`);
+          console.log(`podman push --tls-verify=${tlsVerify.toString()} ${containerURL}`);
+          /*
+          const instructions = (
+            <ClipboardCopy isCode isReadOnly isExpanded variant='expansion'>
+              podman login --tls-verify={tlsVerify.toString()} {host}
+              {'\n'}
+              podman image tag {name} {containerURL}
+              {'\n'}
+              podman push --tls-verify={tlsVerify.toString()} {containerURL}
+              {'\n'}
+            </ClipboardCopy>
+          );
+
+          const pushImagesButton = (
+            <HelpButton
+              content={
+                <>
+                  {instructions}
+                  <ExternalLink href={AAPDocsURL}>{t`Documentation`}</ExternalLink>
+                </>
+              }
+              hasAutoWidth
+              header={t`Push container images`}
+              prefix={
+                <span data-cy='push-images-button'>{t`Push container images`}</span>
+              }
+            />
+          );
+          */
         },
       },
       {


### PR DESCRIPTION
Issue: AAP-29769

on Hub Execution Environments list, there's a Push images button, currently linking straight to docs.

Replacing with a popup showing how to push images locally, and a documentation link.

TODO - work in progress - the output is right, just console.log -> modal

Old UI:

![20240822170408](https://github.com/user-attachments/assets/584a6551-39e7-4e68-82cc-f7ec80e2b4cf)

Mock:
![Screenshot 2024-08-27 at 10 40 42 AM](https://github.com/user-attachments/assets/6bce1d4e-b38a-481d-aa40-89b4609a2ad6)




the value of `--tls-verify` depends on https vs http now .. but https with self-signed certificates needs tls-verify=false too .. maybe add a switch? (AAP-29647)

