### PR TITLE
[AAP-28420][AAP-AAP-29675][AAP-29676] Add user and teams access tabs to the Event Streams page

### DIFF
--- a/cypress/fixtures/edaEventStream.json
+++ b/cypress/fixtures/edaEventStream.json
@@ -1,0 +1,36 @@
+{
+  "name": "ev7",
+  "test_mode": true,
+  "additional_data_headers": "",
+  "organization": {
+    "id": 1,
+    "name": "Default",
+    "description": "The default organization"
+  },
+  "eda_credential": {
+    "id": 1,
+    "name": "basic es1",
+    "description": "",
+    "inputs": {
+      "username": "a",
+      "password": "$encrypted$",
+      "auth_type": "basic",
+      "http_header_key": "Authorization"
+    },
+    "managed": false,
+    "credential_type_id": 7,
+    "organization_id": 1
+  },
+  "event_stream_type": "basic",
+  "id": 8,
+  "owner": "admin",
+  "url": "https://localhost:8443/api/eda/v1/external_event_stream/87731dc0-cc3a-440a-af06-cdc24b52cfa7/post/",
+  "created_at": "2024-08-26T02:34:59.981077Z",
+  "modified_at": "2024-08-26T19:41:03.296883Z",
+  "test_content_type": "",
+  "test_content": "",
+  "test_error_message": "",
+  "test_headers": "",
+  "events_received": 0,
+  "last_event_received_at": null
+}

--- a/cypress/fixtures/edaEventStreamOptions.json
+++ b/cypress/fixtures/edaEventStreamOptions.json
@@ -1,0 +1,333 @@
+{
+  "name": "Event Stream Instance",
+  "description": "",
+  "renders": [
+    "application/json",
+    "text/html"
+  ],
+  "parses": [
+    "application/json",
+    "application/x-www-form-urlencoded",
+    "multipart/form-data"
+  ],
+  "actions": {
+    "PATCH": {
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name",
+        "help_text": "The name of the webhook"
+      },
+      "test_mode": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Test mode",
+        "help_text": "Enable test mode"
+      },
+      "additional_data_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Additional data headers",
+        "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+      },
+      "organization": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization"
+      },
+      "eda_credential": {
+        "type": "nested object",
+        "required": true,
+        "read_only": false,
+        "label": "Eda credential",
+        "children": {
+          "id": {
+            "type": "integer",
+            "required": false,
+            "read_only": true,
+            "label": "ID"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "read_only": false,
+            "label": "Name"
+          },
+          "description": {
+            "type": "string",
+            "required": false,
+            "read_only": false,
+            "label": "Description"
+          },
+          "inputs": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Inputs"
+          },
+          "managed": {
+            "type": "boolean",
+            "required": false,
+            "read_only": false,
+            "label": "Managed"
+          },
+          "credential_type_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Credential type id"
+          },
+          "organization_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Organization id"
+          }
+        }
+      },
+      "event_stream_type": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Event stream type",
+        "help_text": "The type of the event stream based on credential type"
+      },
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "owner": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Owner"
+      },
+      "url": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Url",
+        "help_text": "The URL which will be used to post to the event stream"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "test_content_type": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content type",
+        "help_text": "The content type of test data, when in test mode"
+      },
+      "test_content": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content",
+        "help_text": "The content recieved, when in test mode, stored as a yaml string"
+      },
+      "test_error_message": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test error message",
+        "help_text": "The error message,  when in test mode"
+      },
+      "test_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test headers",
+        "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+      },
+      "events_received": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "Events received",
+        "help_text": "The total number of events received by event stream"
+      },
+      "last_event_received_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Last event received at",
+        "help_text": "The date/time when the last event was received"
+      }
+    },
+    "GET": {
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name",
+        "help_text": "The name of the webhook"
+      },
+      "test_mode": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Test mode",
+        "help_text": "Enable test mode"
+      },
+      "additional_data_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Additional data headers",
+        "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+      },
+      "organization": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization"
+      },
+      "eda_credential": {
+        "type": "nested object",
+        "required": true,
+        "read_only": false,
+        "label": "Eda credential",
+        "children": {
+          "id": {
+            "type": "integer",
+            "required": false,
+            "read_only": true,
+            "label": "ID"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "read_only": false,
+            "label": "Name"
+          },
+          "description": {
+            "type": "string",
+            "required": false,
+            "read_only": false,
+            "label": "Description"
+          },
+          "inputs": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Inputs"
+          },
+          "managed": {
+            "type": "boolean",
+            "required": false,
+            "read_only": false,
+            "label": "Managed"
+          },
+          "credential_type_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Credential type id"
+          },
+          "organization_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Organization id"
+          }
+        }
+      },
+      "event_stream_type": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Event stream type",
+        "help_text": "The type of the event stream based on credential type"
+      },
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "owner": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Owner"
+      },
+      "url": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Url",
+        "help_text": "The URL which will be used to post to the event stream"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "test_content_type": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content type",
+        "help_text": "The content type of test data, when in test mode"
+      },
+      "test_content": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content",
+        "help_text": "The content recieved, when in test mode, stored as a yaml string"
+      },
+      "test_error_message": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test error message",
+        "help_text": "The error message,  when in test mode"
+      },
+      "test_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test headers",
+        "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+      },
+      "events_received": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "Events received",
+        "help_text": "The total number of events received by event stream"
+      },
+      "last_event_received_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Last event received at",
+        "help_text": "The date/time when the last event was received"
+      }
+    }
+  }
+}

--- a/cypress/fixtures/edaEventStreamOptions.json
+++ b/cypress/fixtures/edaEventStreamOptions.json
@@ -1,15 +1,8 @@
 {
   "name": "Event Stream Instance",
   "description": "",
-  "renders": [
-    "application/json",
-    "text/html"
-  ],
-  "parses": [
-    "application/json",
-    "application/x-www-form-urlencoded",
-    "multipart/form-data"
-  ],
+  "renders": ["application/json", "text/html"],
+  "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
   "actions": {
     "PATCH": {
       "name": {

--- a/cypress/fixtures/edaEventStreamRoles.json
+++ b/cypress/fixtures/edaEventStreamRoles.json
@@ -1,0 +1,119 @@
+{
+  "count": 4,
+  "next": null,
+  "previous": null,
+  "page_size": 50,
+  "page": 1,
+  "results": [
+    {
+      "id": 22,
+      "url": "/api/eda/v1/role_definitions/22/",
+      "related": {
+        "team_assignments": "/api/eda/v1/role_definitions/22/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/22/user_assignments/"
+      },
+      "summary_fields": {},
+      "permissions": ["eda.change_eventstream", "eda.delete_eventstream", "eda.view_eventstream"],
+      "content_type": "eda.eventstream",
+      "modified": "2024-08-25T06:17:24.364224Z",
+      "created": "2024-08-21T22:20:59.657360Z",
+      "name": "Event Stream Admin",
+      "description": "Has all permissions to a single event stream",
+      "managed": true,
+      "modified_by": null,
+      "created_by": null
+    },
+    {
+      "id": 23,
+      "url": "/api/eda/v1/role_definitions/23/",
+      "related": {
+        "team_assignments": "/api/eda/v1/role_definitions/23/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/23/user_assignments/"
+      },
+      "summary_fields": {},
+      "permissions": ["eda.change_eventstream", "eda.view_eventstream"],
+      "content_type": "eda.eventstream",
+      "modified": "2024-08-25T06:17:24.367576Z",
+      "created": "2024-08-21T22:20:59.661014Z",
+      "name": "Event Stream Use",
+      "description": "Has use permissions to a single event stream",
+      "managed": true,
+      "modified_by": null,
+      "created_by": null
+    },
+    {
+      "id": 27,
+      "url": "/api/eda/v1/role_definitions/27/",
+      "related": {
+        "created_by": "/api/eda/v1/users/1/",
+        "modified_by": "/api/eda/v1/users/1/",
+        "team_assignments": "/api/eda/v1/role_definitions/27/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/27/user_assignments/"
+      },
+      "summary_fields": {
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "admin@test.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        },
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "admin@test.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        }
+      },
+      "permissions": ["eda.view_eventstream"],
+      "content_type": "eda.eventstream",
+      "modified": "2024-08-26T20:16:26.148302Z",
+      "created": "2024-08-26T20:16:26.148326Z",
+      "name": "LGView",
+      "description": "",
+      "managed": false,
+      "modified_by": 1,
+      "created_by": 1
+    },
+    {
+      "id": 25,
+      "url": "/api/eda/v1/role_definitions/25/",
+      "related": {
+        "created_by": "/api/eda/v1/users/1/",
+        "modified_by": "/api/eda/v1/users/1/",
+        "team_assignments": "/api/eda/v1/role_definitions/25/team_assignments/",
+        "user_assignments": "/api/eda/v1/role_definitions/25/user_assignments/"
+      },
+      "summary_fields": {
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "admin@test.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        },
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "email": "admin@test.com",
+          "first_name": "",
+          "last_name": "",
+          "is_superuser": true
+        }
+      },
+      "permissions": ["eda.view_eventstream"],
+      "content_type": "eda.eventstream",
+      "modified": "2024-08-26T18:20:07.813852Z",
+      "created": "2024-08-22T17:06:59.107929Z",
+      "name": "test",
+      "description": "",
+      "managed": false,
+      "modified_by": 1,
+      "created_by": 1
+    }
+  ]
+}

--- a/cypress/fixtures/edaEventStreamsOptions.json
+++ b/cypress/fixtures/edaEventStreamsOptions.json
@@ -1,0 +1,326 @@
+{
+  "name": "Event Stream List",
+  "description": "",
+  "renders": ["application/json", "text/html"],
+  "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
+  "actions": {
+    "POST": {
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name",
+        "help_text": "The name of the webhook"
+      },
+      "test_mode": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Test mode",
+        "help_text": "Enable test mode"
+      },
+      "additional_data_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Additional data headers",
+        "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+      },
+      "organization": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization"
+      },
+      "eda_credential": {
+        "type": "nested object",
+        "required": true,
+        "read_only": false,
+        "label": "Eda credential",
+        "children": {
+          "id": {
+            "type": "integer",
+            "required": false,
+            "read_only": true,
+            "label": "ID"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "read_only": false,
+            "label": "Name"
+          },
+          "description": {
+            "type": "string",
+            "required": false,
+            "read_only": false,
+            "label": "Description"
+          },
+          "inputs": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Inputs"
+          },
+          "managed": {
+            "type": "boolean",
+            "required": false,
+            "read_only": false,
+            "label": "Managed"
+          },
+          "credential_type_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Credential type id"
+          },
+          "organization_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Organization id"
+          }
+        }
+      },
+      "event_stream_type": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Event stream type",
+        "help_text": "The type of the event stream based on credential type"
+      },
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "owner": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Owner"
+      },
+      "url": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Url",
+        "help_text": "The URL which will be used to post to the event stream"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "test_content_type": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content type",
+        "help_text": "The content type of test data, when in test mode"
+      },
+      "test_content": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content",
+        "help_text": "The content recieved, when in test mode, stored as a yaml string"
+      },
+      "test_error_message": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test error message",
+        "help_text": "The error message,  when in test mode"
+      },
+      "test_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test headers",
+        "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+      },
+      "events_received": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "Events received",
+        "help_text": "The total number of events received by event stream"
+      },
+      "last_event_received_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Last event received at",
+        "help_text": "The date/time when the last event was received"
+      }
+    },
+    "GET": {
+      "name": {
+        "type": "string",
+        "required": true,
+        "read_only": false,
+        "label": "Name",
+        "help_text": "The name of the webhook"
+      },
+      "test_mode": {
+        "type": "boolean",
+        "required": false,
+        "read_only": false,
+        "label": "Test mode",
+        "help_text": "Enable test mode"
+      },
+      "additional_data_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Additional data headers",
+        "help_text": "The additional http headers which will be added to the event data. The headers are comma delimited"
+      },
+      "organization": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Organization"
+      },
+      "eda_credential": {
+        "type": "nested object",
+        "required": true,
+        "read_only": false,
+        "label": "Eda credential",
+        "children": {
+          "id": {
+            "type": "integer",
+            "required": false,
+            "read_only": true,
+            "label": "ID"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "read_only": false,
+            "label": "Name"
+          },
+          "description": {
+            "type": "string",
+            "required": false,
+            "read_only": false,
+            "label": "Description"
+          },
+          "inputs": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Inputs"
+          },
+          "managed": {
+            "type": "boolean",
+            "required": false,
+            "read_only": false,
+            "label": "Managed"
+          },
+          "credential_type_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Credential type id"
+          },
+          "organization_id": {
+            "type": "field",
+            "required": false,
+            "read_only": true,
+            "label": "Organization id"
+          }
+        }
+      },
+      "event_stream_type": {
+        "type": "string",
+        "required": false,
+        "read_only": false,
+        "label": "Event stream type",
+        "help_text": "The type of the event stream based on credential type"
+      },
+      "id": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "ID"
+      },
+      "owner": {
+        "type": "field",
+        "required": false,
+        "read_only": true,
+        "label": "Owner"
+      },
+      "url": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Url",
+        "help_text": "The URL which will be used to post to the event stream"
+      },
+      "created_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Created at"
+      },
+      "modified_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Modified at"
+      },
+      "test_content_type": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content type",
+        "help_text": "The content type of test data, when in test mode"
+      },
+      "test_content": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test content",
+        "help_text": "The content recieved, when in test mode, stored as a yaml string"
+      },
+      "test_error_message": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test error message",
+        "help_text": "The error message,  when in test mode"
+      },
+      "test_headers": {
+        "type": "string",
+        "required": false,
+        "read_only": true,
+        "label": "Test headers",
+        "help_text": "The headers recieved, when in test mode, stored as a yaml string"
+      },
+      "events_received": {
+        "type": "integer",
+        "required": false,
+        "read_only": true,
+        "label": "Events received",
+        "help_text": "The total number of events received by event stream"
+      },
+      "last_event_received_at": {
+        "type": "datetime",
+        "required": false,
+        "read_only": true,
+        "label": "Last event received at",
+        "help_text": "The date/time when the last event was received"
+      }
+    }
+  }
+}

--- a/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
+++ b/frontend/common/access/hooks/useMapContentTypeToDisplayName.tsx
@@ -22,6 +22,7 @@ export function useMapContentTypeToDisplayName() {
         decisionenvironment: options?.isTitleCase
           ? t('Decision Environment')
           : t('decision environment'),
+        eventstream: options?.isTitleCase ? t('Event Stream') : t('event stream'),
         auditrule: options?.isTitleCase ? t('Rule Audit') : t('rule audit'),
         team: options?.isTitleCase ? t('Team') : t('team'),
         organization: options?.isTitleCase ? t('Organization') : t('organization'),

--- a/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourcesStep.tsx
+++ b/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourcesStep.tsx
@@ -15,6 +15,7 @@ import { EdaCredentialType } from '../../../interfaces/EdaCredentialType';
 import { useEdaMultiSelectListView } from '../../../common/useEdaMultiSelectListView';
 import { edaAPI } from '../../../common/eda-utils';
 import styled from 'styled-components';
+import { EdaEventStream } from '../../../interfaces/EdaEventStream';
 
 export type EdaResourceType =
   | EdaActivationInstance
@@ -24,7 +25,8 @@ export type EdaResourceType =
   | EdaRulebookActivation
   | EdaRuleAudit
   | EdaProject
-  | EdaCredentialType;
+  | EdaCredentialType
+  | EdaEventStream;
 
 const resourceToEndpointMapping: { [key: string]: string } = {
   'eda.edacredential': edaAPI`/eda-credentials/`,
@@ -35,6 +37,7 @@ const resourceToEndpointMapping: { [key: string]: string } = {
   'eda.credentialtype': edaAPI`/credential-types/`,
   'eda.decisionenvironment': edaAPI`/decision-environments/`,
   'eda.auditrule': edaAPI`/audit-rules/`,
+  'eda.eventstream': edaAPI`/event-streams/`,
 };
 
 const StyledTitle = styled(Title)`
@@ -57,6 +60,7 @@ export function EdaSelectResourcesStep() {
       'eda.credentialtype': t('Select credential types'),
       'eda.decisionenvironment': t('Select decision environments'),
       'eda.auditrule': t('Select audit rules'),
+      'eda.eventstream': t('Select event stream'),
     };
   }, [t]);
   const tableColumns = useMemo<ITableColumn<EdaResourceType>[]>(

--- a/frontend/eda/access/roles/hooks/useEdaRoleMetadata.tsx
+++ b/frontend/eda/access/roles/hooks/useEdaRoleMetadata.tsx
@@ -130,6 +130,10 @@ export function useEdaRoleMetadata(): EdaRoleMetadata {
             'shared.change_team': t('Change team'),
             'shared.delete_team': t('Delete team'),
             'shared.view_team': t('View team'),
+            'eda.add_eventstream': t('Add event stream'),
+            'eda.change_eventstream': t('Change event stream'),
+            'eda.delete_eventstream': t('Delete event stream'),
+            'eda.view_eventstream': t('View event stream'),
           },
         },
         'eda.project': {

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -160,6 +160,8 @@ export function EventStreamPage() {
         tabs={[
           { label: t('Details'), page: EdaRoute.EventStreamDetails },
           { label: t('Activations'), page: EdaRoute.EventStreamActivations },
+          { label: t('Team Access'), page: EdaRoute.EventStreamTeamAccess },
+          { label: t('User Access'), page: EdaRoute.EventStreamUserAccess },
         ]}
         params={{ id: eventStream?.id }}
       />

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -105,7 +105,7 @@ export function EventStreamPage() {
               isDisabled: () =>
                 canEditEventStream
                   ? ''
-                  : t(`The event stream cannot be edited due to insufficient permission`),
+                  : t(`The event stream cannot be updated due to insufficient permission`),
             },
             {
               type: PageActionType.Button,

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamPage.tsx
@@ -24,15 +24,21 @@ import { useDeleteEventStreams } from '../hooks/useDeleteEventStreams';
 import { usePatchRequest } from '../../../common/crud/usePatchRequest';
 import { useDisableEventStreams } from '../hooks/useDisableEventStreams';
 import { EdaResult } from '../../interfaces/EdaResult';
+import { useOptions } from '../../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
 
 export function EventStreamPage() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const pageNavigate = usePageNavigate();
-  const getPageUrl = useGetPageUrl();
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(
+    edaAPI`/event-streams/${params.id ?? ''}/`
+  );
+  const canEditEventStream = Boolean(data && data.actions && data.actions['PATCH']);
   const { data: eventStream, refresh } = useGet<EdaEventStream>(
     edaAPI`/event-streams/${params.id ?? ''}/`
   );
+  const getPageUrl = useGetPageUrl();
   const patchRequest = usePatchRequest();
   const alertToaster = usePageAlertToaster();
   const disableEventStreams = useDisableEventStreams((disabled) => {
@@ -96,6 +102,10 @@ export function EventStreamPage() {
                 else void disableEventStreams([eventStream]);
               },
               isSwitchOn: (eventStream: EdaEventStream) => !eventStream.test_mode,
+              isDisabled: () =>
+                canEditEventStream
+                  ? ''
+                  : t(`The event stream cannot be edited due to insufficient permission`),
             },
             {
               type: PageActionType.Button,
@@ -104,6 +114,10 @@ export function EventStreamPage() {
               icon: PencilAltIcon,
               isPinned: true,
               label: t('Edit event stream'),
+              isDisabled: () =>
+                canEditEventStream
+                  ? ''
+                  : t(`The event stream cannot be edited due to insufficient permission`),
               onClick: (eventStream: EdaEventStream) =>
                 pageNavigate(EdaRoute.EditEventStream, { params: { id: eventStream.id } }),
             },
@@ -115,16 +129,22 @@ export function EventStreamPage() {
               selection: PageActionSelection.Single,
               icon: TrashIcon,
               label: t('Delete event stream'),
-              isDisabled: () =>
-                esActivations?.results && esActivations.results.length > 0
-                  ? t('To delete this event stream, disconnect it from all rulebook activations')
-                  : undefined,
+              isDisabled: () => {
+                if (canEditEventStream) {
+                  return esActivations?.results && esActivations.results.length > 0
+                    ? t('To delete this event stream, disconnect it from all rulebook activations')
+                    : '';
+                } else {
+                  return t(`The event stream cannot be deleted due to insufficient permission`);
+                }
+              },
               onClick: (eventStream: EdaEventStream) => deleteEventStreams([eventStream]),
               isDanger: true,
             },
           ]
         : [],
     [
+      canEditEventStream,
       deleteEventStreams,
       disableEventStreams,
       enableEventStream,

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamTeamAccess.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamTeamAccess.tsx
@@ -1,0 +1,15 @@
+import { useParams } from 'react-router-dom';
+import { EdaRoute } from '../../main/EdaRoutes';
+import { TeamAccess } from '../../../common/access/components/TeamAccess';
+
+export function EventStreamTeamAccess() {
+  const params = useParams<{ id: string }>();
+  return (
+    <TeamAccess
+      service="eda"
+      id={params.id || ''}
+      type={'eventstream'}
+      addRolesRoute={EdaRoute.EventStreamAddTeams}
+    />
+  );
+}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamUserAccess.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamUserAccess.tsx
@@ -1,0 +1,15 @@
+import { useParams } from 'react-router-dom';
+import { EdaRoute } from '../../main/EdaRoutes';
+import { UserAccess } from '../../../common/access/components/UserAccess';
+
+export function EventStreamUserAccess() {
+  const params = useParams<{ id: string }>();
+  return (
+    <UserAccess
+      service="eda"
+      id={params.id || ''}
+      type={'project'}
+      addRolesRoute={EdaRoute.EventStreamAddUsers}
+    />
+  );
+}

--- a/frontend/eda/event-streams/EventStreamPage/EventStreamUserAccess.tsx
+++ b/frontend/eda/event-streams/EventStreamPage/EventStreamUserAccess.tsx
@@ -8,7 +8,7 @@ export function EventStreamUserAccess() {
     <UserAccess
       service="eda"
       id={params.id || ''}
-      type={'project'}
+      type={'eventstream'}
       addRolesRoute={EdaRoute.EventStreamAddUsers}
     />
   );

--- a/frontend/eda/event-streams/EventStreams.cy.tsx
+++ b/frontend/eda/event-streams/EventStreams.cy.tsx
@@ -9,7 +9,12 @@ describe('EventStreams.cy.ts', () => {
         fixture: 'edaEventStreams.json',
       }
     );
-
+    cy.intercept(
+      { method: 'OPTIONS', url: edaAPI`/event-streams/*` },
+      {
+        fixture: 'edaEventStreamsOptions.json',
+      }
+    );
     cy.intercept(
       { method: 'GET', url: edaAPI`/event-streams/?page=2&page_size=10` },
       {
@@ -239,7 +244,16 @@ describe('EventStreams.cy.ts', () => {
 });
 
 describe('Empty list', () => {
-  beforeEach(() => {
+  before(() => {
+    cy.intercept(
+      {
+        method: 'OPTIONS',
+        url: edaAPI`/event-streams/`,
+      },
+      {
+        fixture: 'edaEventStreamsOptions.json',
+      }
+    ).as('getOptions');
     cy.intercept(
       {
         method: 'GET',

--- a/frontend/eda/event-streams/EventStreams.tsx
+++ b/frontend/eda/event-streams/EventStreams.tsx
@@ -8,7 +8,9 @@ import { useEventStreamActions } from './hooks/useEventStreamActions';
 import { useEventStreamColumns } from './hooks/useEventStreamColumns';
 import { useEventStreamFilters } from './hooks/useEventStreamFilters';
 import { useEventStreamsActions } from './hooks/useEventStreamsActions';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { useOptions } from '../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../interfaces/OptionsResponse';
 
 export function EventStreams() {
   const { t } = useTranslation();
@@ -21,6 +23,8 @@ export function EventStreams() {
     tableColumns,
   });
   const toolbarActions = useEventStreamsActions(view);
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(edaAPI`/event-streams/`);
+  const canCreateEventStream = Boolean(data && data.actions && data.actions['POST']);
   const rowActions = useEventStreamActions(view);
   return (
     <PageLayout>
@@ -38,11 +42,24 @@ export function EventStreams() {
         toolbarFilters={toolbarFilters}
         rowActions={rowActions}
         errorStateTitle={t('Error loading event streams')}
-        emptyStateTitle={t('There are currently no event streams created for your organization.')}
-        emptyStateDescription={t('Please create an event stream by using the button below.')}
+        emptyStateTitle={
+          canCreateEventStream
+            ? t('There are currently no event streams created for your organization.')
+            : t('You do not have permission to create an event stream.')
+        }
+        emptyStateDescription={
+          canCreateEventStream
+            ? t('Please create an event stream by using the button below.')
+            : t(
+                'Please contact your organization administrator if there is an issue with your access.'
+              )
+        }
+        emptyStateIcon={canCreateEventStream ? undefined : CubesIcon}
         emptyStateButtonIcon={<PlusCircleIcon />}
-        emptyStateButtonText={t('Create event stream')}
-        emptyStateButtonClick={() => pageNavigate(EdaRoute.CreateEventStream)}
+        emptyStateButtonText={canCreateEventStream ? t('Create event stream') : undefined}
+        emptyStateButtonClick={
+          canCreateEventStream ? () => pageNavigate(EdaRoute.CreateEventStream) : undefined
+        }
         {...view}
         defaultSubtitle={t('Event stream')}
       />

--- a/frontend/eda/event-streams/components/EdaEventStreamAddTeams.cy.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddTeams.cy.tsx
@@ -13,7 +13,7 @@ describe('EdaEventStreamAddTeams', () => {
   beforeEach(() => {
     cy.intercept('GET', edaAPI`/event-streams/*`, { fixture: 'edaEventStream.json' });
     cy.intercept('GET', edaAPI`/teams/?order_by=name*`, { fixture: 'edaTeams.json' });
-    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=event-stream*`, {
+    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=eventstream*`, {
       fixture: 'edaEventStreamRoles.json',
     });
     cy.mount(component, params);
@@ -46,7 +46,7 @@ describe('EdaEventStreamAddTeams', () => {
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
     cy.clickButton(/^Next$/);
     cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
@@ -54,7 +54,7 @@ describe('EdaEventStreamAddTeams', () => {
   it('should display selected team and role in the Review step', () => {
     cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
     cy.clickButton(/^Next$/);
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
     cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Teams');
@@ -62,10 +62,10 @@ describe('EdaEventStreamAddTeams', () => {
     cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Demo');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
-    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'EventStream Admin');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Event Stream Admin');
     cy.get('[data-cy="expandable-section-edaRoles"]').should(
       'contain.text',
-      'Has all permissions to a single event-stream and its child resources - rulebook'
+      'Has all permissions to a single event stream'
     );
   });
   it('should trigger bulk action dialog on submit', () => {
@@ -75,7 +75,7 @@ describe('EdaEventStreamAddTeams', () => {
     }).as('createRoleAssignment');
     cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
     cy.clickButton(/^Next$/);
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.clickButton(/^Finish$/);
     cy.wait('@createRoleAssignment');
@@ -83,7 +83,7 @@ describe('EdaEventStreamAddTeams', () => {
     cy.get('.pf-v5-c-modal-box').within(() => {
       cy.get('table tbody').find('tr').should('have.length', 1);
       cy.get('table tbody').should('contain.text', 'Demo');
-      cy.get('table tbody').should('contain.text', 'EventStream Admin');
+      cy.get('table tbody').should('contain.text', 'Event Stream Admin');
       cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
       cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');
     });

--- a/frontend/eda/event-streams/components/EdaEventStreamAddTeams.cy.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddTeams.cy.tsx
@@ -1,0 +1,91 @@
+import { edaAPI } from '../../common/eda-utils';
+import { EdaEventStreamAddTeams } from './EdaEventStreamAddTeams';
+
+describe('EdaEventStreamAddTeams', () => {
+  const component = <EdaEventStreamAddTeams />;
+  const path = '/event-streams/:id/team-access/add-teams';
+  const initialEntries = [`/event-streams/1/team-access/add-teams`];
+  const params = {
+    path,
+    initialEntries,
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', edaAPI`/event-streams/*`, { fixture: 'edaEventStream.json' });
+    cy.intercept('GET', edaAPI`/teams/?order_by=name*`, { fixture: 'edaTeams.json' });
+    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=event-stream*`, {
+      fixture: 'edaEventStreamRoles.json',
+    });
+    cy.mount(component, params);
+  });
+  it('should render with correct steps', () => {
+    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select team(s)');
+    cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select roles to apply');
+    cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Review');
+    cy.get('[data-cy="wizard-nav-item-teams"] button').should('have.class', 'pf-m-current');
+    cy.get('table tbody').find('tr').should('have.length', 4);
+  });
+  it('can filter teams by name', () => {
+    cy.intercept(edaAPI`/teams/?name=Gal*`, { fixtures: 'edaTeams.json' }).as('nameFilterRequest');
+    cy.filterTableByText('Gal');
+    cy.wait('@nameFilterRequest');
+    cy.clearAllFilters();
+  });
+  it('should validate that at least one team is selected for moving to next step', () => {
+    cy.get('table tbody').find('tr').should('have.length', 4);
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one team.');
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-teams"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+  });
+  it('should validate that at least one role is selected for moving to Review step', () => {
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+  });
+  it('should display selected team and role in the Review step', () => {
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Teams');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-teams"]').should('contain.text', 'Demo');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'EventStream Admin');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should(
+      'contain.text',
+      'Has all permissions to a single event-stream and its child resources - rulebook'
+    );
+  });
+  it('should trigger bulk action dialog on submit', () => {
+    cy.intercept('POST', edaAPI`/role_team_assignments/`, {
+      statusCode: 201,
+      body: { team: 3, role_definition: 14, content_type: 'eda.event-stream', object_id: 1 },
+    }).as('createRoleAssignment');
+    cy.selectTableRowByCheckbox('name', 'Demo', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.clickButton(/^Finish$/);
+    cy.wait('@createRoleAssignment');
+    // Bulk action modal is displayed with success
+    cy.get('.pf-v5-c-modal-box').within(() => {
+      cy.get('table tbody').find('tr').should('have.length', 1);
+      cy.get('table tbody').should('contain.text', 'Demo');
+      cy.get('table tbody').should('contain.text', 'EventStream Admin');
+      cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
+      cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');
+    });
+  });
+});

--- a/frontend/eda/event-streams/components/EdaEventStreamAddTeams.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddTeams.tsx
@@ -1,0 +1,158 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  LoadingPage,
+  PageHeader,
+  PageLayout,
+  PageWizard,
+  PageWizardStep,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../framework';
+import { RoleAssignmentsReviewStep } from '../../../common/access/RolesWizard/steps/RoleAssignmentsReviewStep';
+import { postRequest } from '../../../common/crud/Data';
+import { useGet } from '../../../common/crud/useGet';
+import { EdaSelectRolesStep } from '../../access/common/EdaRolesWizardSteps/EdaSelectRolesStep';
+import { EdaSelectTeamsStep } from '../../access/common/EdaRolesWizardSteps/EdaSelectTeamsStep';
+import { edaAPI } from '../../common/eda-utils';
+import { edaErrorAdapter } from '../../common/edaErrorAdapter';
+import { useEdaBulkActionDialog } from '../../common/useEdaBulkActionDialog';
+import { EdaEventStream } from '../../interfaces/EdaEventStream';
+import { EdaRbacRole } from '../../interfaces/EdaRbacRole';
+import { EdaTeam } from '../../interfaces/EdaTeam';
+import { EdaRoute } from '../../main/EdaRoutes';
+
+interface WizardFormValues {
+  teams: EdaTeam[];
+  edaRoles: EdaRbacRole[];
+}
+
+interface TeamRolePair {
+  team: EdaTeam;
+  role: EdaRbacRole;
+}
+
+export function EdaEventStreamAddTeams() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const params = useParams<{ id: string }>();
+  const pageNavigate = usePageNavigate();
+  const { data: eventstream, isLoading } = useGet<EdaEventStream>(
+    edaAPI`/event-streams/${params.id ?? ''}/`
+  );
+  const teamRoleProgressDialog = useEdaBulkActionDialog<TeamRolePair>();
+
+  if (isLoading || !eventstream) return <LoadingPage />;
+
+  const steps: PageWizardStep[] = [
+    {
+      id: 'teams',
+      label: t('Select team(s)'),
+      inputs: (
+        <EdaSelectTeamsStep
+          descriptionForTeamsSelection={t(
+            'Select the team(s) that you want to give access to {{eventstreamName}}.',
+            {
+              eventstreamName: eventstream?.name,
+            }
+          )}
+        />
+      ),
+      validate: (formData, _) => {
+        const { teams } = formData as { teams: EdaTeam[] };
+        if (!teams?.length) {
+          throw new Error(t('Select at least one team.'));
+        }
+      },
+    },
+    {
+      id: 'roles',
+      label: t('Select roles to apply'),
+      inputs: (
+        <EdaSelectRolesStep
+          contentType="eventstream"
+          fieldNameForPreviousStep="teams"
+          descriptionForRoleSelection={t('Choose roles to apply to {{eventstreamName}}.', {
+            eventstreamName: eventstream?.name,
+          })}
+        />
+      ),
+      validate: (formData, _) => {
+        const { edaRoles } = formData as { edaRoles: EdaRbacRole[] };
+        if (!edaRoles?.length) {
+          throw new Error(t('Select at least one role.'));
+        }
+      },
+    },
+    {
+      id: 'review',
+      label: t('Review'),
+      inputs: <RoleAssignmentsReviewStep />,
+    },
+  ];
+
+  const onSubmit = async (data: WizardFormValues) => {
+    const { teams, edaRoles } = data;
+    const items: TeamRolePair[] = [];
+    for (const team of teams) {
+      for (const role of edaRoles) {
+        items.push({ team, role });
+      }
+    }
+    return new Promise<void>((resolve) => {
+      teamRoleProgressDialog({
+        title: t('Add roles'),
+        keyFn: ({ team, role }) => `${team.id}_${role.id}`,
+        items,
+        actionColumns: [
+          { header: t('Team'), cell: ({ team }) => team.name },
+          { header: t('Role'), cell: ({ role }) => role.name },
+        ],
+        actionFn: ({ team, role }) =>
+          postRequest(edaAPI`/role_team_assignments/`, {
+            team: team.id,
+            role_definition: role.id,
+            content_type: 'eda.eventstream',
+            object_id: eventstream.id,
+          }),
+        onComplete: () => {
+          resolve();
+        },
+        onClose: () => {
+          pageNavigate(EdaRoute.EventStreamTeamAccess, {
+            params: { id: eventstream.id.toString() },
+          });
+        },
+      });
+    });
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Add roles')}
+        breadcrumbs={[
+          { label: t('EventStreams'), to: getPageUrl(EdaRoute.EventStreams) },
+          {
+            label: eventstream?.name,
+            to: getPageUrl(EdaRoute.EventStreamDetails, { params: { id: eventstream?.id } }),
+          },
+          {
+            label: t('Team Access'),
+            to: getPageUrl(EdaRoute.EventStreamTeamAccess, { params: { id: eventstream?.id } }),
+          },
+          { label: t('Add roles') },
+        ]}
+      />
+      <PageWizard<WizardFormValues>
+        errorAdapter={edaErrorAdapter}
+        steps={steps}
+        onSubmit={onSubmit}
+        disableGrid
+        onCancel={() => {
+          pageNavigate(EdaRoute.EventStreamTeamAccess, { params: { id: eventstream?.id } });
+        }}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/eda/event-streams/components/EdaEventStreamAddUsers.cy.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddUsers.cy.tsx
@@ -1,0 +1,93 @@
+import { edaAPI } from '../../common/eda-utils';
+import { EdaEventStreamAddUsers } from './EdaEventStreamAddUsers';
+
+describe('EdaEventStreamAddUsers', () => {
+  const component = <EdaEventStreamAddUsers />;
+  const path = '/event-streams/:id/user-access/add-users';
+  const initialEntries = [`/event-streams/1/user-access/add-users`];
+  const params = {
+    path,
+    initialEntries,
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', edaAPI`/event-streams/*`, { fixture: 'edaEventStream.json' });
+    cy.intercept('GET', edaAPI`/users/*`, { fixture: 'edaNormalUsers.json' });
+    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=event-stream*`, {
+      fixture: 'edaEventStreamRoles.json',
+    });
+    cy.mount(component, params);
+  });
+  it('should render with correct steps', () => {
+    cy.get('[data-cy="wizard-nav"] li').eq(0).should('contain.text', 'Select user(s)');
+    cy.get('[data-cy="wizard-nav"] li').eq(1).should('contain.text', 'Select roles to apply');
+    cy.get('[data-cy="wizard-nav"] li').eq(2).should('contain.text', 'Review');
+    cy.get('[data-cy="wizard-nav-item-users"] button').should('have.class', 'pf-m-current');
+    cy.get('table tbody').find('tr').should('have.length', 2);
+  });
+  it('can filter users by username', () => {
+    cy.intercept(edaAPI`/users/?is_superuser=false&name=demo*`, {
+      fixture: 'edaNormalUsers.json',
+    }).as('nameFilterRequest');
+    cy.filterTableByText('demo');
+    cy.wait('@nameFilterRequest');
+    cy.clearAllFilters();
+  });
+  it('should validate that at least one user is selected for moving to next step', () => {
+    cy.get('table tbody').find('tr').should('have.length', 2);
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one user.');
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-users"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+  });
+  it('should validate that at least one role is selected for moving to Review step', () => {
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
+    cy.clickButton(/^Next$/);
+    cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+  });
+  it('should display selected user and role in the Review step', () => {
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'Users');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'demo-user');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'EventStream Admin');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should(
+      'contain.text',
+      'Has all permissions to a single event-stream and its child resources - rulebook'
+    );
+  });
+  it('should trigger bulk action dialog on submit', () => {
+    cy.intercept('POST', edaAPI`/role_user_assignments/`, {
+      statusCode: 201,
+      body: { user: 5, role_definition: 14, content_type: 'eda.event-stream', object_id: 1 },
+    }).as('createRoleAssignment');
+    cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.clickButton(/^Next$/);
+    cy.clickButton(/^Finish$/);
+    cy.wait('@createRoleAssignment');
+    // Bulk action modal is displayed with success
+    cy.get('.pf-v5-c-modal-box').within(() => {
+      cy.get('table tbody').find('tr').should('have.length', 1);
+      cy.get('table tbody').should('contain.text', 'demo-user');
+      cy.get('table tbody').should('contain.text', 'EventStream Admin');
+      cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
+      cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');
+    });
+  });
+});

--- a/frontend/eda/event-streams/components/EdaEventStreamAddUsers.cy.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddUsers.cy.tsx
@@ -13,7 +13,7 @@ describe('EdaEventStreamAddUsers', () => {
   beforeEach(() => {
     cy.intercept('GET', edaAPI`/event-streams/*`, { fixture: 'edaEventStream.json' });
     cy.intercept('GET', edaAPI`/users/*`, { fixture: 'edaNormalUsers.json' });
-    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=event-stream*`, {
+    cy.intercept('GET', edaAPI`/role_definitions/?content_type__model=eventstream*`, {
       fixture: 'edaEventStreamRoles.json',
     });
     cy.mount(component, params);
@@ -48,7 +48,7 @@ describe('EdaEventStreamAddUsers', () => {
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('have.class', 'pf-m-current');
     cy.clickButton(/^Next$/);
     cy.get('.pf-v5-c-alert__title').should('contain.text', 'Select at least one role.');
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-roles"] button').should('not.have.class', 'pf-m-current');
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
@@ -56,7 +56,7 @@ describe('EdaEventStreamAddUsers', () => {
   it('should display selected user and role in the Review step', () => {
     cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.get('[data-cy="wizard-nav-item-review"] button').should('have.class', 'pf-m-current');
     cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'Users');
@@ -64,10 +64,10 @@ describe('EdaEventStreamAddUsers', () => {
     cy.get('[data-cy="expandable-section-users"]').should('contain.text', 'demo-user');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Roles');
     cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', '1');
-    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'EventStream Admin');
+    cy.get('[data-cy="expandable-section-edaRoles"]').should('contain.text', 'Event Stream Admin');
     cy.get('[data-cy="expandable-section-edaRoles"]').should(
       'contain.text',
-      'Has all permissions to a single event-stream and its child resources - rulebook'
+      'Has all permissions to a single event stream'
     );
   });
   it('should trigger bulk action dialog on submit', () => {
@@ -77,7 +77,7 @@ describe('EdaEventStreamAddUsers', () => {
     }).as('createRoleAssignment');
     cy.selectTableRowByCheckbox('username', 'demo-user', { disableFilter: true });
     cy.clickButton(/^Next$/);
-    cy.selectTableRowByCheckbox('name', 'EventStream Admin', { disableFilter: true });
+    cy.selectTableRowByCheckbox('name', 'Event Stream Admin', { disableFilter: true });
     cy.clickButton(/^Next$/);
     cy.clickButton(/^Finish$/);
     cy.wait('@createRoleAssignment');
@@ -85,7 +85,7 @@ describe('EdaEventStreamAddUsers', () => {
     cy.get('.pf-v5-c-modal-box').within(() => {
       cy.get('table tbody').find('tr').should('have.length', 1);
       cy.get('table tbody').should('contain.text', 'demo-user');
-      cy.get('table tbody').should('contain.text', 'EventStream Admin');
+      cy.get('table tbody').should('contain.text', 'Event Stream Admin');
       cy.get('div.pf-v5-c-progress__description').should('contain.text', 'Success');
       cy.get('div.pf-v5-c-progress__status').should('contain.text', '100%');
     });

--- a/frontend/eda/event-streams/components/EdaEventStreamAddUsers.tsx
+++ b/frontend/eda/event-streams/components/EdaEventStreamAddUsers.tsx
@@ -1,0 +1,159 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import {
+  LoadingPage,
+  PageHeader,
+  PageLayout,
+  PageWizard,
+  PageWizardStep,
+  useGetPageUrl,
+  usePageNavigate,
+} from '../../../../framework';
+import { RoleAssignmentsReviewStep } from '../../../common/access/RolesWizard/steps/RoleAssignmentsReviewStep';
+import { postRequest } from '../../../common/crud/Data';
+import { useGet } from '../../../common/crud/useGet';
+import { EdaSelectRolesStep } from '../../access/common/EdaRolesWizardSteps/EdaSelectRolesStep';
+import { EdaSelectUsersStep } from '../../access/common/EdaRolesWizardSteps/EdaSelectUsersStep';
+import { edaAPI } from '../../common/eda-utils';
+import { edaErrorAdapter } from '../../common/edaErrorAdapter';
+import { useEdaBulkActionDialog } from '../../common/useEdaBulkActionDialog';
+import { EdaEventStream } from '../../interfaces/EdaEventStream';
+import { EdaRbacRole } from '../../interfaces/EdaRbacRole';
+import { EdaUser } from '../../interfaces/EdaUser';
+import { EdaRoute } from '../../main/EdaRoutes';
+
+interface WizardFormValues {
+  users: EdaUser[];
+  edaRoles: EdaRbacRole[];
+}
+
+interface UserRolePair {
+  user: EdaUser;
+  role: EdaRbacRole;
+}
+
+export function EdaEventStreamAddUsers() {
+  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
+  const params = useParams<{ id: string }>();
+
+  const { data: eventstream, isLoading } = useGet<EdaEventStream>(
+    edaAPI`/event-streams/${params.id ?? ''}/`
+  );
+  const userProgressDialog = useEdaBulkActionDialog<UserRolePair>();
+  const pageNavigate = usePageNavigate();
+
+  if (isLoading || !eventstream) return <LoadingPage />;
+
+  const steps: PageWizardStep[] = [
+    {
+      id: 'users',
+      label: t('Select user(s)'),
+      inputs: (
+        <EdaSelectUsersStep
+          descriptionForUsersSelection={t(
+            'Select the user(s) that you want to give access to {{eventstreamName}}.',
+            {
+              eventstreamName: eventstream?.name,
+            }
+          )}
+        />
+      ),
+      validate: (formData, _) => {
+        const { users } = formData as { users: EdaUser[] };
+        if (!users?.length) {
+          throw new Error(t('Select at least one user.'));
+        }
+      },
+    },
+    {
+      id: 'roles',
+      label: t('Select roles to apply'),
+      inputs: (
+        <EdaSelectRolesStep
+          contentType="eventstream"
+          fieldNameForPreviousStep="users"
+          descriptionForRoleSelection={t('Choose roles to apply to {{eventstreamName}}.', {
+            eventstreamName: eventstream?.name,
+          })}
+        />
+      ),
+      validate: (formData, _) => {
+        const { edaRoles } = formData as { edaRoles: EdaRbacRole[] };
+        if (!edaRoles?.length) {
+          throw new Error(t('Select at least one role.'));
+        }
+      },
+    },
+    {
+      id: 'review',
+      label: t('Review'),
+      inputs: <RoleAssignmentsReviewStep />,
+    },
+  ];
+
+  const onSubmit = (data: WizardFormValues) => {
+    const { users, edaRoles } = data;
+    const items: UserRolePair[] = [];
+    for (const user of users) {
+      for (const role of edaRoles) {
+        items.push({ user, role });
+      }
+    }
+    return new Promise<void>((resolve) => {
+      userProgressDialog({
+        title: t('Add roles'),
+        keyFn: ({ user, role }) => `${user.id}_${role.id}`,
+        items,
+        actionColumns: [
+          { header: t('User'), cell: ({ user }) => user.username },
+          { header: t('Role'), cell: ({ role }) => role.name },
+        ],
+        actionFn: ({ user, role }) =>
+          postRequest(edaAPI`/role_user_assignments/`, {
+            user: user.id,
+            role_definition: role.id,
+            content_type: 'eda.eventstream',
+            object_id: eventstream.id,
+          }),
+        onComplete: () => {
+          resolve();
+        },
+        onClose: () => {
+          pageNavigate(EdaRoute.EventStreamUserAccess, {
+            params: { id: eventstream.id.toString() },
+          });
+        },
+      });
+    });
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader
+        title={t('Add roles')}
+        breadcrumbs={[
+          { label: t('EventStreams'), to: getPageUrl(EdaRoute.EventStreams) },
+          {
+            label: eventstream?.name,
+            to: getPageUrl(EdaRoute.EventStreamDetails, { params: { id: eventstream?.id } }),
+          },
+          {
+            label: t('User Access'),
+            to: getPageUrl(EdaRoute.EventStreamUserAccess, { params: { id: eventstream?.id } }),
+          },
+          { label: t('Add roles') },
+        ]}
+      />
+      <PageWizard<WizardFormValues>
+        errorAdapter={edaErrorAdapter}
+        steps={steps}
+        onSubmit={onSubmit}
+        disableGrid
+        onCancel={() => {
+          pageNavigate(EdaRoute.EventStreamUserAccess, { params: { id: eventstream?.id } });
+        }}
+      />
+    </PageLayout>
+  );
+}

--- a/frontend/eda/event-streams/hooks/useEventStreamsActions.tsx
+++ b/frontend/eda/event-streams/hooks/useEventStreamsActions.tsx
@@ -12,11 +12,16 @@ import { IEdaView } from '../../common/useEventDrivenView';
 import { EdaEventStream } from '../../interfaces/EdaEventStream';
 import { EdaRoute } from '../../main/EdaRoutes';
 import { useDeleteEventStreams } from './useDeleteEventStreams';
+import { useOptions } from '../../../common/crud/useOptions';
+import { ActionsResponse, OptionsResponse } from '../../interfaces/OptionsResponse';
+import { edaAPI } from '../../common/eda-utils';
 
 export function useEventStreamsActions(view: IEdaView<EdaEventStream>) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const deleteEventStreams = useDeleteEventStreams(view.unselectItemsAndRefresh);
+  const { data } = useOptions<OptionsResponse<ActionsResponse>>(edaAPI`/event-streams/`);
+  const canCreateEventStream = Boolean(data && data.actions && data.actions['POST']);
   return useMemo<IPageAction<EdaEventStream>[]>(
     () => [
       {
@@ -26,6 +31,11 @@ export function useEventStreamsActions(view: IEdaView<EdaEventStream>) {
         isPinned: true,
         icon: PlusCircleIcon,
         label: t('Create event stream'),
+        isDisabled: canCreateEventStream
+          ? undefined
+          : t(
+              'You do not have permission to create a project. Please contact your organization administrator if there is an issue with your access.'
+            ),
         onClick: () => pageNavigate(EdaRoute.CreateEventStream),
       },
       {
@@ -37,6 +47,6 @@ export function useEventStreamsActions(view: IEdaView<EdaEventStream>) {
         isDanger: true,
       },
     ],
-    [deleteEventStreams, pageNavigate, t]
+    [canCreateEventStream, deleteEventStreams, pageNavigate, t]
   );
 }

--- a/frontend/eda/main/EdaRoutes.tsx
+++ b/frontend/eda/main/EdaRoutes.tsx
@@ -92,6 +92,10 @@ export enum EdaRoute {
   EventStreamPage = 'eda-event-stream-page',
   EventStreamDetails = 'eda-event-stream-details',
   EventStreamActivations = 'eda-event-stream-activations',
+  EventStreamTeamAccess = 'eda-event-stream-team-access',
+  EventStreamUserAccess = 'eda-event-stream-user-access',
+  EventStreamAddTeams = 'eda-event-stream-add-teams',
+  EventStreamAddUsers = 'eda-event-stream-add-users',
 
   Settings = 'eda-settings',
   SettingsPreferences = 'eda-settings-preferences',

--- a/frontend/eda/main/useEdaNavigation.tsx
+++ b/frontend/eda/main/useEdaNavigation.tsx
@@ -82,6 +82,10 @@ import { EventStreams } from '../event-streams/EventStreams';
 import { EdaRoute } from './EdaRoutes';
 import { useEdaOrganizationRoutes } from './routes/useEdaOrganizationsRoutes';
 import { EventStreamActivations } from '../event-streams/EventStreamPage/EventStreamActivations';
+import { EdaEventStreamAddTeams } from '../event-streams/components/EdaEventStreamAddTeams';
+import { EdaEventStreamAddUsers } from '../event-streams/components/EdaEventStreamAddUsers';
+import { EventStreamUserAccess } from '../event-streams/EventStreamPage/EventStreamUserAccess';
+import { EventStreamTeamAccess } from '../event-streams/EventStreamPage/EventStreamTeamAccess';
 
 export function useEdaNavigation() {
   const { t } = useTranslation();
@@ -348,10 +352,30 @@ export function useEdaNavigation() {
               element: <EventStreamActivations />,
             },
             {
+              id: EdaRoute.EventStreamTeamAccess,
+              path: 'team-access',
+              element: <EventStreamTeamAccess />,
+            },
+            {
+              id: EdaRoute.EventStreamUserAccess,
+              path: 'user-access',
+              element: <EventStreamUserAccess />,
+            },
+            {
               path: '',
               element: <Navigate to="details" />,
             },
           ],
+        },
+        {
+          id: EdaRoute.EventStreamAddUsers,
+          path: ':id/user-access/add',
+          element: <EdaEventStreamAddUsers />,
+        },
+        {
+          id: EdaRoute.EventStreamAddTeams,
+          path: ':id/team-access/add',
+          element: <EdaEventStreamAddTeams />,
         },
         {
           path: '',


### PR DESCRIPTION
Add user and teams access tabs to the Event Streams page

![Screenshot from 2024-08-26 16-48-51](https://github.com/user-attachments/assets/6cde3729-258f-464b-9d54-bbb62c12151a)
![Screenshot from 2024-08-26 16-48-45](https://github.com/user-attachments/assets/cc329e46-9d38-4086-9239-591f8d058fc0)
![Screenshot from 2024-08-26 16-48-40](https://github.com/user-attachments/assets/e697dcc3-ca2f-4b82-a791-e97a5e3874d2)
![Screenshot from 2024-08-26 16-40-00](https://github.com/user-attachments/assets/9590fbf3-5ab9-4473-88d9-8c42b77c8162)

![Screenshot from 2024-08-26 14-27-48](https://github.com/user-attachments/assets/159ea118-c348-4c39-8cb6-321db1e6c619)
![Screenshot from 2024-08-26 14-19-21](https://github.com/user-attachments/assets/1df205a1-016a-4061-86b8-5748959a863e)

![Screenshot from 2024-08-22 16-58-51](https://github.com/user-attachments/assets/afa1aa9b-d67a-4aa8-b0aa-6766cb1cdbaf)
![Screenshot from 2024-08-22 16-55-57](https://github.com/user-attachments/assets/0605db6b-14e0-46f9-853e-f2972a9b0ac5)

![Screenshot from 2024-08-22 13-35-39](https://github.com/user-attachments/assets/e97cf9b7-8a4d-465d-936a-cd37b2765ad1)
