### PR TITLE
[AAP-29013][AAP-29014] Event stream form updates

### DIFF
--- a/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
+++ b/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
@@ -67,7 +67,12 @@ export function PageFormSingleSelectEdaResource<
           options:
             response.results?.map((resource) => ({
               value: resource.id as PathValue<FormData, Name>,
-              description: resource.description,
+              description: resource?.description
+                ? resource.description.slice(
+                    0,
+                    resource.description.indexOf('.') || resource.description.length
+                  )
+                : '',
               label: resource.name,
             })) ?? [],
           next: response.count,

--- a/frontend/eda/event-streams/EventStreamForm.tsx
+++ b/frontend/eda/event-streams/EventStreamForm.tsx
@@ -81,11 +81,13 @@ function EventStreamInputs() {
           label={t('Event stream type')}
         />
       </PageFormHidden>
-      <PageFormSelectEventStreamCredential<IEdaEventStreamCreate>
-        isRequired
-        name="eda_credential_id"
-        type={eventStreamType?.kind || ''}
-      />
+      {eventStreamType && (
+        <PageFormSelectEventStreamCredential<IEdaEventStreamCreate>
+          isRequired
+          name="eda_credential_id"
+          type={eventStreamType?.kind || ''}
+        />
+      )}
       <PageFormTextInput<IEdaEventStreamCreate>
         name="additional_data_headers"
         data-cy="additional_data_headers-form-field"


### PR DESCRIPTION
- Only display the description for the event stream types up to the first '.'
- Only display the credential select after a credential type was selected.

![Screenshot from 2024-08-26 19-42-16](https://github.com/user-attachments/assets/367a3718-05e6-4640-ae6a-5fea132be060)
![Screenshot from 2024-08-26 19-46-01](https://github.com/user-attachments/assets/113e84f1-3b9c-4418-a31f-23c68f741d42)
