### PR TITLE
Hub RBAC updates

### DIFF
--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
@@ -7,6 +7,7 @@ import { useHubRoleFilters } from '../hooks/useHubRoleFilters';
 import { HubRbacRole } from '../../../interfaces/expanded/HubRbacRole';
 import { useHubMultiSelectListView } from '../../../common/useHubMultiSelectListView';
 import { hubAPI } from '../../../common/api/formatPath';
+import { useManagedRolesWithDescription } from '../../roles/hooks/useManagedRolesWithDescription';
 
 export function HubSelectRolesStep(props: {
   contentType?: string;
@@ -19,6 +20,7 @@ export function HubSelectRolesStep(props: {
   const { wizardData } = usePageWizard();
   const { resourceType } = wizardData as { [key: string]: unknown };
   const { fieldNameForPreviousStep, title } = props;
+  const managedRolesWithDescription = useManagedRolesWithDescription();
 
   const contentType = useMemo(() => {
     return props.contentType ? props.contentType : (resourceType as string)?.split('.').pop() ?? '';
@@ -53,7 +55,9 @@ export function HubSelectRolesStep(props: {
       },
       {
         header: t('Description'),
-        cell: (role) => role.description && <TextCell text={role.description} />,
+        cell: (role) => (
+          <TextCell text={managedRolesWithDescription[role.name] ?? role.description} />
+        ),
         card: 'description',
         list: 'description',
       },

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectRolesStep.tsx
@@ -62,7 +62,7 @@ export function HubSelectRolesStep(props: {
         list: 'description',
       },
     ];
-  }, [t]);
+  }, [managedRolesWithDescription, t]);
 
   const view = useHubMultiSelectListView<HubRbacRole>(
     {

--- a/frontend/hub/access/roles/RolePage/HubRoleForm.tsx
+++ b/frontend/hub/access/roles/RolePage/HubRoleForm.tsx
@@ -157,12 +157,13 @@ function HubRoleInputs(props: { disableContentType?: boolean }) {
         name={'content_type'}
         label={t('Content Type')}
         placeholderText={t('Select a content type')}
-        options={Object.entries(hubRoleMetadata.content_types)
-          .filter(([option]) => !['shared.team'].includes(option))
-          .map(([key, value]) => ({
-            label: value?.displayName,
-            value: key,
-          }))}
+        options={[
+          { value: 'galaxy.ansiblerepository', label: t('Repository') },
+          { value: 'galaxy.collectionremote', label: t('Remote') },
+          { value: 'galaxy.containernamespace', label: t('Execution Environment') },
+          { value: 'galaxy.namespace', label: t('Namespace') },
+          { value: 'null', label: t('System') },
+        ]}
         isDisabled={disableContentType}
         isRequired
       />

--- a/frontend/hub/access/roles/hooks/useHubRoleMetadata.tsx
+++ b/frontend/hub/access/roles/hooks/useHubRoleMetadata.tsx
@@ -81,6 +81,21 @@ export function useHubRoleMetadata(): HubRoleMetadata {
             'galaxy.change_containernamespace': t('Change container namespace'),
             'galaxy.delete_containernamespace': t('Delete container namespace'),
             'galaxy.view_containernamespace': t('View container namespace'),
+            'galaxy.namespace_add_containerdistribution': t('Push new containers'),
+            'galaxy.namespace_delete_containerdistribution':
+              'galaxy.namespace_delete_containerdistribution',
+            'galaxy.namespace_view_containerdistribution':
+              'galaxy.namespace_view_containerdistribution',
+            'galaxy.namespace_pull_containerdistribution':
+              'galaxy.namespace_pull_containerdistribution',
+            'galaxy.namespace_push_containerdistribution': t('Push to existing containers'),
+            'galaxy.namespace_change_containerdistribution': t('Change containers'),
+            'galaxy.namespace_view_containerpushrepository':
+              'galaxy.namespace_view_containerpushrepository',
+            'galaxy.namespace_modify_content_containerpushrepository': t('Change image tags'),
+            'galaxy.namespace_change_containerpushrepository':
+              'galaxy.namespace_change_containerpushrepository',
+            'galaxy.manage_roles_containernamespace': t('Manage container namespace roles'),
           },
         },
         'galaxy.containerregistryremote': {
@@ -133,22 +148,18 @@ export function useHubRoleMetadata(): HubRoleMetadata {
             'galaxy.change_collectionremote': t('Change collection remote'),
             'galaxy.delete_collectionremote': t('Delete collection remote'),
             'galaxy.view_collectionremote': t('View collection remote'),
-            'galaxy.namespace_add_containerdistribution':
-              'galaxy.namespace_add_containerdistribution',
+            'galaxy.namespace_add_containerdistribution': t('Push new containers'),
             'galaxy.namespace_delete_containerdistribution':
               'galaxy.namespace_delete_containerdistribution',
             'galaxy.namespace_view_containerdistribution':
               'galaxy.namespace_view_containerdistribution',
             'galaxy.namespace_pull_containerdistribution':
               'galaxy.namespace_pull_containerdistribution',
-            'galaxy.namespace_push_containerdistribution':
-              'galaxy.namespace_push_containerdistribution',
-            'galaxy.namespace_change_containerdistribution':
-              'galaxy.namespace_change_containerdistribution',
+            'galaxy.namespace_push_containerdistribution': t('Push to existing containers'),
+            'galaxy.namespace_change_containerdistribution': t('Change containers'),
             'galaxy.namespace_view_containerpushrepository':
               'galaxy.namespace_view_containerpushrepository',
-            'galaxy.namespace_modify_content_containerpushrepository':
-              'galaxy.namespace_modify_content_containerpushrepository',
+            'galaxy.namespace_modify_content_containerpushrepository': t('Change image tags'),
             'galaxy.namespace_change_containerpushrepository':
               'galaxy.namespace_change_containerpushrepository',
             'galaxy.manage_roles_containernamespace': t('Manage container namespace roles'),


### PR DESCRIPTION
- Updated permissions in `useHubRoleMetadata` to match updated response from `/api/galaxy/_ui/v2/role_metadata`
   - Additional permission options added under the Execution Environment content type
- Updated role description column in the roles wizard, so that readable descriptions display alongside roles (if available)
   - Before
      ![image](https://github.com/user-attachments/assets/0afdc47b-e98d-4d7b-9ac2-d803ff4ca435)
   - After
      ![image](https://github.com/user-attachments/assets/1ad1ae76-cdcf-43be-98dd-7eb3f113cf57)
- Updated implementation of the Edit Execution Environment form to correctly capture and display 403 Forbidden error 
    ![image](https://github.com/user-attachments/assets/ad1bf62c-8a4a-4ee6-8003-a82edde75b72)

