### PR TITLE
[AAP-29918] Fixes timezone errors and improves timezone clarity 

### DIFF
--- a/cypress/e2e/awx/projects/project-details.cy.ts
+++ b/cypress/e2e/awx/projects/project-details.cy.ts
@@ -120,8 +120,10 @@ describe('Projects', () => {
       cy.get('[data-ouia-component-id="simple-table"]')
         .scrollIntoView()
         .within(() => {
-          cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-          cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+          cy.getByDataCy('next-occurrence-timestamps-column-header')
+            .should('be.visible')
+            .and('contain', 'Next occurrence timestamps');
+          cy.getByDataCy('next-occurrence-timestamps-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 1); //First, 1 rule is showing
         });
       cy.getByDataCy('edit-schedule').click();
@@ -142,8 +144,10 @@ describe('Projects', () => {
       cy.get('[data-ouia-component-id="simple-table"]')
         .scrollIntoView()
         .within(() => {
-          cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-          cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+          cy.getByDataCy('next-occurrence-timestamps-column-header')
+            .should('be.visible')
+            .and('contain', 'Next occurrence timestamps');
+          cy.getByDataCy('next-occurrence-timestamps-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 2); //Now, 2 rules are showing
         });
       cy.getByDataCy('edit-schedule').click();
@@ -164,8 +168,10 @@ describe('Projects', () => {
       cy.get('[data-ouia-component-id="simple-table"]')
         .scrollIntoView()
         .within(() => {
-          cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-          cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+          cy.getByDataCy('next-occurrence-timestamps-column-header')
+            .should('be.visible')
+            .and('contain', 'Next occurrence timestamps');
+          cy.getByDataCy('next-occurrence-timestamps-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 1); //1 Rule is showing again
         });
     });
@@ -190,9 +196,9 @@ describe('Projects', () => {
       cy.clickButton(/^Next$/);
       cy.wait('@preview');
       cy.getByDataCy('local-time-zone').should('contain', 'UTC');
-      cy.get('[data-cy="exceptions-column-header"]')
+      cy.get('[data-cy="next-exclusion-timestamps-column-header"]')
         .should('be.visible')
-        .and('contain', 'Exceptions');
+        .and('contain', 'Next exclusion timestamps');
       cy.intercept('PATCH', awxAPI`/schedules/${schedule.id.toString()}/`).as('edited');
       cy.getByDataCy('Submit').click();
       cy.intercept('GET', awxAPI`/projects/${project.id.toString()}/`).as('projectList');
@@ -219,7 +225,7 @@ describe('Projects', () => {
       cy.intercept('PATCH', awxAPI`/schedules/${schedule.id.toString()}/`).as('editedAgain');
       cy.getByDataCy('Submit').click();
       cy.wait('@editedAgain');
-      cy.get('[data-cy="exceptions-column-header"]').should('not.exist');
+      cy.get('[data-cy="next-exclusion-timestamps-column-header"]').should('not.exist');
     });
 
     it('can toggle a schedule', () => {

--- a/cypress/e2e/awx/schedules/schedules.cy.ts
+++ b/cypress/e2e/awx/schedules/schedules.cy.ts
@@ -417,7 +417,9 @@ describe('Schedules - Create and Delete', () => {
         );
       });
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
+        cy.getByDataCy('next-occurrence-timestamps-column-header')
+          .should('be.visible')
+          .and('contain', 'Rules');
         cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
         cy.get('tbody tr').should('have.length', 1);
       });
@@ -439,7 +441,7 @@ describe('Schedules - Create and Delete', () => {
         );
       });
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.getByDataCy('exceptions-column-header')
+        cy.getByDataCy('next-exclusion-timestamps-column-header')
           .should('be.visible')
           .and('contain', 'Exceptions');
         cy.getByDataCy('exceptions-column-cell').should('have.descendants', 'ul');
@@ -489,7 +491,9 @@ describe('Schedules - Create and Delete', () => {
         .first()
         .scrollIntoView()
         .within(() => {
-          cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
+          cy.getByDataCy('next-occurrence-timestamps-column-header')
+            .should('be.visible')
+            .and('contain', 'Rules');
           cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
           cy.get('tbody tr').should('have.length', 1);
         });
@@ -498,7 +502,7 @@ describe('Schedules - Create and Delete', () => {
         .last()
         .scrollIntoView()
         .within(() => {
-          cy.getByDataCy('exceptions-column-header')
+          cy.getByDataCy('next-exclusion-timestamps-column-header')
             .should('be.visible')
             .and('contain', 'Exceptions');
           cy.getByDataCy('exceptions-column-cell').should('have.descendants', 'ul');
@@ -677,8 +681,10 @@ describe('Schedules - Edit', () => {
       `RRULE:FREQ=MINUTELY;INTERVAL=1;WKST=SU;UNTIL=${date.replaceAll('-', '')}T`
     );
     cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-      cy.getByDataCy('rules-column-header').should('be.visible').and('contain', 'Rules');
-      cy.getByDataCy('rules-column-cell').should('have.descendants', 'ul');
+      cy.getByDataCy('next-occurrence-timestamps-column-header')
+        .should('be.visible')
+        .and('contain', 'Next occurrence timestamps');
+      cy.getByDataCy('next-occurrence-timestamps-column-cell').should('have.descendants', 'ul');
       cy.get('tbody tr').should('have.length', 3);
     });
     cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');
@@ -823,7 +829,7 @@ describe('Schedules - Edit', () => {
         'RRULE:FREQ=MONTHLY'
       );
       cy.get('[data-ouia-component-id="simple-table"]').within(() => {
-        cy.get('[data-cy="exceptions-column-header"]').should('not.exist');
+        cy.get("[data-cy='next-exclusion-timestamps-column-header']").should('not.exist');
         cy.get('tbody tr').should('have.length', 1);
       });
       cy.intercept('PATCH', awxAPI`/schedules/*`).as('editedSchedule');

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
@@ -15,25 +15,14 @@ import { UserDateDetail } from '../../../common/UserDateDetail';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Schedule } from '../../../interfaces/Schedule';
 import { AwxRoute } from '../../../main/AwxRoutes';
-import {
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
-  Divider,
-  Flex,
-  FlexItem,
-  Label,
-  LabelGroup,
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@patternfly/react-core';
+import { Divider, Label, LabelGroup } from '@patternfly/react-core';
 import { parseStringToTagArray } from '../../../resources/templates/JobTemplateFormHelpers';
 import { PageDetailCodeEditor } from '../../../../../framework/PageDetails/PageDetailCodeEditor';
-import { useEffect, useState } from 'react';
-import { postRequest } from '../../../../common/crud/Data';
-import { DateTime } from 'luxon';
 import { RRuleSet, rrulestr } from 'rrule';
 import { RulesList } from '../components/RulesList';
+import { ScheduleSummary } from '../components/ScheduleSummary';
+import { TimezoneToggle } from './TimezoneToggle';
+import { useState } from 'react';
 
 /**
  *
@@ -44,6 +33,8 @@ import { RulesList } from '../components/RulesList';
  */
 export function ScheduleDetails(props: { isSystemJobTemplateSchedule?: boolean }) {
   const { t } = useTranslation();
+  const [isLocal, setIsLocal] = useState(true);
+
   const params = useParams<{ id: string; schedule_id: string }>();
   const pageNavigate = usePageNavigate();
   const {
@@ -139,75 +130,28 @@ export function ScheduleDetails(props: { isSystemJobTemplateSchedule?: boolean }
               : schedule.extra_data.days?.toString()}
           </PageDetail>
         )}
-        {schedule && <ScheduleSummary rrule={schedule.rrule} />}
+
+        {schedule && (
+          <>
+            <PageDetail fullWidth label={t('Toggle timezone')}>
+              <TimezoneToggle
+                isLocal={isLocal}
+                setIsLocal={setIsLocal}
+                localTimezone={schedule.timezone}
+              />
+            </PageDetail>
+
+            <ScheduleSummary rrule={schedule.rrule} isLocal={isLocal} />
+          </>
+        )}
 
         <PageDetail fullWidth>
-          <RulesList ruleType="rules" rules={rules} />
-          {exceptions.length ? <RulesList ruleType="exceptions" rules={exceptions} /> : null}
+          <RulesList ruleType="rules" rules={rules} isLocalForDetails={isLocal} />
+          {exceptions.length ? (
+            <RulesList ruleType="exceptions" rules={exceptions} isLocalForDetails={isLocal} />
+          ) : null}
         </PageDetail>
       </PageDetails>
     </>
-  );
-}
-
-export function ScheduleSummary(props: { rrule: string }) {
-  const { t } = useTranslation();
-  const [mode, setMode] = useState('local');
-  const [preview, setPreview] = useState<{ local: string[]; utc: string[] }>();
-  useEffect(() => {
-    async function fetchPreview() {
-      const { local, utc } = await postRequest<{ local: string[]; utc: string[] }>(
-        awxAPI`/schedules/preview/`,
-        {
-          rrule: props.rrule,
-        }
-      );
-      setPreview({ local, utc });
-    }
-    if (props.rrule) {
-      void fetchPreview();
-    }
-  }, [props.rrule]);
-  const timesArray = mode === 'utc' ? preview?.utc : preview?.local;
-
-  return (
-    <DescriptionListGroup>
-      <DescriptionListTerm>
-        <Flex>
-          <FlexItem>{t('Schedule summary')}</FlexItem>
-          <FlexItem align={{ default: 'alignRight' }}>
-            <ToggleGroup isCompact>
-              <ToggleGroupItem
-                id="toggle-local"
-                data-cy="toggle-local"
-                aria-label={t('Toggle to local')}
-                isSelected={mode === 'local'}
-                text="Local"
-                type="button"
-                onChange={() => setMode('local')}
-              />
-              <ToggleGroupItem
-                id="toggle-utc"
-                data-cy="toggle-utc"
-                aria-label={t('Toggle to UTC')}
-                isSelected={mode === 'utc'}
-                text="UTC"
-                type="button"
-                onChange={() => setMode('utc')}
-              />
-            </ToggleGroup>
-          </FlexItem>
-        </Flex>
-      </DescriptionListTerm>
-      {timesArray?.map((value, i) => {
-        return (
-          <DescriptionListDescription key={i}>
-            {DateTime.fromISO(value, { setZone: true }).toLocaleString(
-              DateTime.DATETIME_SHORT_WITH_SECONDS
-            )}
-          </DescriptionListDescription>
-        );
-      })}
-    </DescriptionListGroup>
   );
 }

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
@@ -146,9 +146,19 @@ export function ScheduleDetails(props: { isSystemJobTemplateSchedule?: boolean }
         )}
 
         <PageDetail fullWidth>
-          <RulesList ruleType="rules" rules={rules} isLocalForDetails={isLocal} />
+          <RulesList
+            ruleType="rules"
+            timezone={schedule.timezone}
+            rules={rules}
+            isLocalForDetails={isLocal}
+          />
           {exceptions.length ? (
-            <RulesList ruleType="exceptions" rules={exceptions} isLocalForDetails={isLocal} />
+            <RulesList
+              ruleType="exceptions"
+              timezone={schedule.timezone}
+              rules={exceptions}
+              isLocalForDetails={isLocal}
+            />
           ) : null}
         </PageDetail>
       </PageDetails>

--- a/frontend/awx/views/schedules/SchedulePage/TimezoneToggle.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/TimezoneToggle.tsx
@@ -1,0 +1,34 @@
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+
+export function TimezoneToggle(props: {
+  isLocal: boolean;
+  setIsLocal: (b: boolean) => void;
+  localTimezone: string;
+}) {
+  const { isLocal, setIsLocal } = props;
+  const { t } = useTranslation();
+
+  return (
+    <ToggleGroup isCompact>
+      <ToggleGroupItem
+        id="toggle-local"
+        data-cy="toggle-local"
+        aria-label={t('Toggle to {{localTimezone}}', { timezone: props.localTimezone })}
+        isSelected={props.isLocal}
+        text={props.localTimezone}
+        type="button"
+        onChange={() => setIsLocal(true)}
+      />
+      <ToggleGroupItem
+        id="toggle-utc"
+        data-cy="toggle-utc"
+        aria-label={t('Toggle to UTC')}
+        isSelected={!isLocal}
+        text="UTC"
+        type="button"
+        onChange={() => setIsLocal(false)}
+      />
+    </ToggleGroup>
+  );
+}

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -62,16 +62,16 @@ export function RuleForm(
     const values = getValues() as RuleFields;
     delete values.endType;
     delete values.id;
-    const { rules = [], exceptions = [], until = null, ...rest } = values;
+    const { rules = [], exceptions = [], endType, until = null, ...rest } = values;
     const start = DateTime.fromISO(`${date}`).set(get24Hour(time));
     const { year, month, day, hour, minute } = start;
     const dateString = `${year}${pad(month)}${pad(day)}T${pad(hour)}${pad(minute)}00`;
     const rrulestring = `DTSTART;TZID=${timezone}:${dateString}`;
     const ruleStart = RRule.fromString(rrulestring);
     const rule = new RRule({ ...ruleStart.options, ...rest });
-    if (until !== null) {
-      const { time: untilTime, date: untilDate } = until;
-
+    if (endType === 'until') {
+      const untilTime = until?.time;
+      const untilDate = until?.date;
       if (untilDate && untilTime) {
         const utcDate = DateTime.fromISO(`${untilDate}`).set(get24Hour(untilTime)).toUTC();
         const { year, month, day, hour, minute } = utcDate;

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -69,7 +69,7 @@ export function RuleForm(
     const rrulestring = `DTSTART;TZID=${timezone}:${dateString}`;
     const ruleStart = RRule.fromString(rrulestring);
     const rule = new RRule({ ...ruleStart.options, ...rest });
-    if (endType === 'until') {
+    if (until !== null) {
       const untilTime = until?.time;
       const untilDate = until?.date;
       if (untilDate && untilTime) {

--- a/frontend/awx/views/schedules/components/ScheduleSummary.tsx
+++ b/frontend/awx/views/schedules/components/ScheduleSummary.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { postRequest } from '../../../../common/crud/Data';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { Flex, FlexItem, Label } from '@patternfly/react-core';
+import { DateTime } from 'luxon';
+import { LabelGroupWrapper } from '../../../../common/label-group-wrapper';
+
+/**
+ *
+ * @param {string} rrule - RRule, or exrule as a string
+ * @param {boolean}[hideColumnTitle] - A boolean used to determine whether we should the text
+ * `Summary schedule` as this component is used by the RuleList.tsx, and by ScheduleDetails.tsx
+ *
+ */
+export function ScheduleSummary(props: {
+  rrule: string;
+  isLocal: boolean;
+  hideColumnTitle?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [preview, setPreview] = useState<{ local: string[]; utc: string[] }>();
+  useEffect(() => {
+    async function fetchPreview() {
+      const { local, utc } = await postRequest<{ local: string[]; utc: string[] }>(
+        awxAPI`/schedules/preview/`,
+        {
+          rrule: props.rrule,
+        }
+      );
+      setPreview({ local, utc });
+    }
+    if (props.rrule) {
+      void fetchPreview();
+    }
+  }, [props.rrule]);
+  const timesArray = !props.isLocal ? preview?.utc : preview?.local;
+
+  return (
+    <Flex>
+      {!props.hideColumnTitle && <FlexItem>{t('Schedule summary')}</FlexItem>}
+      <FlexItem>
+        <LabelGroupWrapper numLabels={5}>
+          {timesArray?.map((value, i) => {
+            return (
+              <Label key={i}>
+                {DateTime.fromISO(value, { setZone: true }).toLocaleString(
+                  DateTime.DATETIME_SHORT_WITH_SECONDS
+                )}
+              </Label>
+            );
+          })}
+        </LabelGroupWrapper>
+      </FlexItem>
+    </Flex>
+  );
+}

--- a/frontend/awx/views/schedules/hooks/ruleHelpers.tsx
+++ b/frontend/awx/views/schedules/hooks/ruleHelpers.tsx
@@ -10,7 +10,6 @@ export function useGetFrequencyOptions() {
     { label: t('Daily'), value: Frequency.DAILY },
     { label: t('Hourly'), value: Frequency.HOURLY },
     { label: t('Minutely'), value: Frequency.MINUTELY },
-    { label: t('Secondly'), value: Frequency.SECONDLY },
   ];
 }
 

--- a/frontend/awx/views/schedules/wizard/ExceptionsStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ExceptionsStep.tsx
@@ -18,12 +18,11 @@ export function ExceptionsStep() {
   const exceptions = getValues('exceptions') as RuleListItemType[];
   const hasExceptions = exceptions?.length > 0;
   const { setStepData, wizardData } = usePageWizard();
-  const { rules } = wizardData as ScheduleFormWizard;
+  const { rules, timezone } = wizardData as ScheduleFormWizard;
 
   useEffect(() => {
     setValue('rules', rules);
     const {
-      timezone,
       startDateTime: { date, time },
     } = wizardData as ScheduleFormWizard;
 
@@ -44,7 +43,7 @@ export function ExceptionsStep() {
     });
 
     setValue('exceptions', updatedExceptions);
-  }, [setStepData, setValue, exceptions, rules, wizardData]);
+  }, [setStepData, setValue, exceptions, timezone, rules, wizardData]);
 
   return (
     <PageFormSection singleColumn>
@@ -62,7 +61,13 @@ export function ExceptionsStep() {
       {isOpen && <RuleForm isOpen={isOpen} title={t('Define exceptions')} setIsOpen={setIsOpen} />}
 
       {(hasExceptions || (!isOpen && !hasExceptions)) && (
-        <RulesList rules={exceptions} needsHeader ruleType="exception" setIsOpen={setIsOpen} />
+        <RulesList
+          rules={exceptions}
+          timezone={timezone}
+          needsHeader
+          ruleType="exception"
+          setIsOpen={setIsOpen}
+        />
       )}
     </PageFormSection>
   );

--- a/frontend/awx/views/schedules/wizard/ExceptionsStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ExceptionsStep.tsx
@@ -29,12 +29,10 @@ export function ExceptionsStep() {
 
     const [startHour, startMinute] = time.split(':');
     const isStartPM = time.includes('PM');
-    const start = DateTime.fromISO(`${date}`)
-      .set({
-        hour: isStartPM ? parseInt(startHour, 10) + 12 : parseInt(`${startHour}`, 10),
-        minute: parseInt(startMinute, 10),
-      })
-      .toUTC();
+    const start = DateTime.fromISO(`${date}`).set({
+      hour: isStartPM ? parseInt(startHour, 10) + 12 : parseInt(`${startHour}`, 10),
+      minute: parseInt(startMinute, 10),
+    });
     const { year, month, day, hour, minute } = start;
     const updatedExceptions = (exceptions || []).map(({ rule, id }) => {
       const newRule = new RRule({

--- a/frontend/awx/views/schedules/wizard/RulesStep.tsx
+++ b/frontend/awx/views/schedules/wizard/RulesStep.tsx
@@ -17,6 +17,7 @@ export function RulesStep() {
   const { setValue, getValues } = useFormContext();
   const { wizardData } = usePageWizard();
 
+  const { timezone } = wizardData as ScheduleFormWizard;
   const rules = getValues('rules') as RuleListItemType[];
   const hasRules = rules?.length > 0;
   useEffect(() => {
@@ -60,7 +61,15 @@ export function RulesStep() {
         <RuleForm title={t('Define rules')} isOpen={isOpen} setIsOpen={setIsOpen} />
       )}
 
-      {hasRules && <RulesList needsHeader rules={rules} ruleType="rules" setIsOpen={setIsOpen} />}
+      {hasRules && (
+        <RulesList
+          needsHeader
+          timezone={timezone}
+          rules={rules}
+          ruleType="rules"
+          setIsOpen={setIsOpen}
+        />
+      )}
     </PageFormSection>
   );
 }

--- a/frontend/awx/views/schedules/wizard/RulesStep.tsx
+++ b/frontend/awx/views/schedules/wizard/RulesStep.tsx
@@ -27,12 +27,10 @@ export function RulesStep() {
 
     const [startHour, startMinute] = time.split(':');
     const isStartPM = time.includes('PM');
-    const start = DateTime.fromISO(`${date}`)
-      .set({
-        hour: isStartPM ? parseInt(startHour, 10) + 12 : parseInt(`${startHour}`, 10),
-        minute: parseInt(startMinute, 10),
-      })
-      .toUTC();
+    const start = DateTime.fromISO(`${date}`).set({
+      hour: isStartPM ? parseInt(startHour, 10) + 12 : parseInt(`${startHour}`, 10),
+      minute: parseInt(startMinute, 10),
+    });
     const { year, month, day, hour, minute } = start;
     const updatedRules = (rules || []).map(({ rule, id }) => {
       const newRule = new RRule({

--- a/frontend/awx/views/schedules/wizard/ScheduleAddWizard.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleAddWizard.tsx
@@ -191,7 +191,7 @@ export function ScheduleAddWizard(props: {
       schedule_type: '',
       resource: '',
       startDateTime: { date: currentDate, time: time },
-      timezone: 'America/New_York',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     },
     rules: { ...RULES_DEFAULT_VALUES, rules: [] },
     exceptions: { ...RULES_DEFAULT_VALUES, exceptions: [] },

--- a/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
@@ -8,6 +8,8 @@ import { ScheduleFormWizard } from '../types';
 import { PageFormSection } from '../../../../../framework/PageForm/Utils/PageFormSection';
 import { RRule, RRuleSet } from 'rrule';
 import { RulesList } from '../components/RulesList';
+import { TimezoneToggle } from '../SchedulePage/TimezoneToggle';
+import { useState } from 'react';
 
 const ResourceLink: { [key: string]: string } = {
   inventory_update: AwxRoute.InventorySourceDetail,
@@ -21,6 +23,7 @@ const ResourceLink: { [key: string]: string } = {
 export function ScheduleReviewStep() {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
+  const [isLocal, setIsLocal] = useState(true);
 
   const { wizardData, visibleSteps } = usePageWizard() as {
     wizardData: ScheduleFormWizard;
@@ -99,8 +102,18 @@ export function ScheduleReviewStep() {
           <PageDetail label={t('Days of data to keep')}>{schedule_days_to_keep}</PageDetail>
           {hasPromptDetails ? <PromptReviewDetails /> : null}
         </PageDetails>
-        <RulesList ruleType="rules" rules={rules} />
-        {exceptions.length ? <RulesList ruleType="exceptions" rules={exceptions} /> : null}
+        <PageDetail fullWidth label={t('Toggle timezone')}>
+          <TimezoneToggle isLocal={isLocal} setIsLocal={setIsLocal} localTimezone={timezone} />
+        </PageDetail>
+        <RulesList ruleType="rules" rules={rules} timezone={timezone} isLocalForDetails={isLocal} />
+        {exceptions.length ? (
+          <RulesList
+            ruleType="exceptions"
+            rules={exceptions}
+            timezone={timezone}
+            isLocalForDetails={isLocal}
+          />
+        ) : null}
       </PageFormSection>
     </>
   );


### PR DESCRIPTION
This addresses AAP-29918.  Thats the first commit.  It also improves user clarity when toggling between `local` and `utc` times when looking at the occurrence and exceptions labels.  Now, instead of showing `local` in the toggle we show the timezone to which the schedule is set.  Also, in places where we show occurrence labels for individual rrules, and for the whole schedule (ie. schedule details view) when the user toggles between `local` and `utc` all of the timestamps on the screen change to accurately represent that is selected in the toggle.
![Screenshot 2024-08-27 at 5 38 41 PM](https://github.com/user-attachments/assets/9ca74c22-862c-4d86-87a6-4ccfb4cab833)
![Screenshot 2024-08-27 at 5 38 32 PM](https://github.com/user-attachments/assets/ca10b242-8877-4915-8424-374ba32aaeeb)
