### PR TITLE
Add bitbucket cloud webhook support

### DIFF
--- a/cypress/fixtures/credentialTypes.json
+++ b/cypress/fixtures/credentialTypes.json
@@ -1,5 +1,5 @@
 {
-  "count": 32,
+  "count": 33,
   "next": null,
   "previous": null,
   "results": [

--- a/cypress/fixtures/credentialTypes.json
+++ b/cypress/fixtures/credentialTypes.json
@@ -1935,6 +1935,41 @@
       "injectors": {}
     },
     {
+      "id": 33,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/33/",
+      "related": {
+        "credentials": "/api/v2/credential_types/33/credentials/",
+        "activity_stream": "/api/v2/credential_types/33/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-12-06T16:06:16.570665Z",
+      "modified": "2024-12-06T16:06:16.570665Z",
+      "name": "Bitbucket Cloud HTTP Access Token",
+      "description": "",
+      "kind": "token",
+      "namespace": "bitbucket_cloud_token",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "This token needs to come from your user settings in Bitbucket Cloud"
+          }
+        ],
+        "required": ["token"]
+      },
+      "injectors": {}
+    },
+    {
       "id": 13,
       "type": "credential_type",
       "url": "/api/v2/credential_types/13/",

--- a/cypress/fixtures/credential_types.json
+++ b/cypress/fixtures/credential_types.json
@@ -1,5 +1,5 @@
 {
-  "count": 32,
+  "count": 33,
   "next": null,
   "previous": null,
   "results": [

--- a/cypress/fixtures/credential_types.json
+++ b/cypress/fixtures/credential_types.json
@@ -1859,6 +1859,41 @@
       "injectors": {}
     },
     {
+      "id": 33,
+      "type": "credential_type",
+      "url": "/api/v2/credential_types/33/",
+      "related": {
+        "credentials": "/api/v2/credential_types/33/credentials/",
+        "activity_stream": "/api/v2/credential_types/33/activity_stream/"
+      },
+      "summary_fields": {
+        "user_capabilities": {
+          "edit": true,
+          "delete": true
+        }
+      },
+      "created": "2024-12-06T16:06:16.570665Z",
+      "modified": "2024-12-06T16:06:16.570665Z",
+      "name": "Bitbucket Cloud HTTP Access Token",
+      "description": "",
+      "kind": "token",
+      "namespace": "bitbucket_cloud_token",
+      "managed": true,
+      "inputs": {
+        "fields": [
+          {
+            "id": "token",
+            "label": "Token",
+            "type": "string",
+            "secret": true,
+            "help_text": "This token needs to come from your user settings in Bitbucket Cloud"
+          }
+        ],
+        "required": ["token"]
+      },
+      "injectors": {}
+    },
+    {
       "id": 13,
       "type": "credential_type",
       "url": "/api/v2/credential_types/13/",

--- a/frontend/awx/interfaces/JobTemplate.ts
+++ b/frontend/awx/interfaces/JobTemplate.ts
@@ -215,6 +215,6 @@ export interface JobTemplate
   webhook_credential: number;
   webhook_url: string;
   webhook_key: string;
-  webhook_service: 'github' | 'gitlab' | 'bitbucket_dc';
+  webhook_service: 'github' | 'gitlab' | 'bitbucket_dc' | 'bitbucket_cloud';
   project: number | null;
 }

--- a/frontend/awx/resources/templates/components/WebhookService.tsx
+++ b/frontend/awx/resources/templates/components/WebhookService.tsx
@@ -8,6 +8,7 @@ export function useWebhookServiceOptions() {
       { label: t`GitHub`, value: 'github' },
       { label: t`GitLab`, value: 'gitlab' },
       { label: t`Bitbucket Data Center`, value: 'bitbucket_dc' },
+      { label: t`Bitbucket Cloud`, value: 'bitbucket_cloud' },
     ],
     [t]
   );


### PR DESCRIPTION
To accommodate this change in AWX: https://github.com/ansible/awx/pull/15699

Which will add support to Bitbucket Cloud webhooks and tokens.