### PR TITLE
AWX: Fix unable to start Workflow with one or more prompts enabled

### DIFF
--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -279,6 +279,11 @@ export function LaunchWizard({
       inputs: <TemplateLaunchPromptStep defaultValues={initialValues} />,
       hidden: () => shouldHideOtherStep(config),
       validate: async (formData) => {
+        if (jobType === 'workflow_job_templates') {
+          // Skip validation for workflows — they don't have credentials
+          return;
+        }
+
         const missingCredentialTypes: string[] = [];
         await requestGet<AwxItemsResponse<Credential>>(
           awxAPI`/job_templates/${template.id?.toString()}/credentials/`

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -100,8 +100,8 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
     error: getLaunchError,
     refresh: getLaunchRefresh,
   } = useGet<LaunchConfiguration>(awxAPI`/${jobType}/${resourceId}/launch/`);
-  const error = getTemplateError || getLaunchError;
-  const refresh = getTemplateRefresh || getLaunchRefresh;
+  const error = getTemplateError ?? getLaunchError;
+  const refresh = getTemplateRefresh ?? getLaunchRefresh;
   const getJobOutputUrl = useGetJobOutputUrl();
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;


### PR DESCRIPTION
Fixes #3081 issue.
This PR resolves the issue by skipping validation for `WorkflowJobTemplateLaunch`, as workflows do not require credentials.

I believe this bug may have been introduced with the changes in [this PR](https://github.com/ansible/ansible-ui/pull/2738).