### PR TITLE
AWX: Add an option to override the job type at the workflow level

### DIFF
--- a/frontend/awx/interfaces/LaunchConfiguration.ts
+++ b/frontend/awx/interfaces/LaunchConfiguration.ts
@@ -4,6 +4,7 @@ export interface LaunchConfiguration {
   can_start_without_user_input: boolean;
   passwords_needed_to_start: string[];
   ask_scm_branch_on_launch: boolean;
+  ask_nodes_job_type_on_launch: boolean;
   ask_variables_on_launch: boolean;
   ask_tags_on_launch: boolean;
   ask_diff_mode_on_launch: boolean;
@@ -39,6 +40,7 @@ export interface LaunchConfiguration {
     limit: string;
     labels: { id: number; name: string }[];
     scm_branch: string;
+    nodes_job_type: 'run' | 'check';
     job_tags: string;
     skip_tags: string;
     extra_vars: string;

--- a/frontend/awx/interfaces/WorkflowJobLaunch.ts
+++ b/frontend/awx/interfaces/WorkflowJobLaunch.ts
@@ -9,6 +9,7 @@ export interface WorkflowJobLaunch {
   ask_limit_on_launch: boolean;
   ask_scm_branch_on_launch: boolean;
   ask_skip_tags_on_launch: boolean;
+  ask_nodes_job_type_on_launch: boolean;
   ask_tags_on_launch: boolean;
   ask_variables_on_launch: boolean;
   ask_verbosity_on_launch: boolean;
@@ -41,6 +42,7 @@ export interface WorkflowJobLaunch {
     }[];
     limit: string;
     scm_branch: string;
+    nodes_job_type: string;
     skip_tags: string;
     job_type: string;
     verbosity: number;

--- a/frontend/awx/interfaces/WorkflowJobTemplate.ts
+++ b/frontend/awx/interfaces/WorkflowJobTemplate.ts
@@ -27,6 +27,7 @@ export interface WorkflowJobTemplate
   type: 'workflow_job_template';
   created: string;
   allow_simultaneous: boolean;
+  ask_nodes_job_type_on_launch: boolean;
   modified: string;
   webhook_service: string;
   skip_tags: string;
@@ -120,6 +121,7 @@ export interface WorkflowJobTemplateForm
     | 'webhook_credential'
     | 'skip_tags'
     | 'job_tags'
+    | 'nodes_job_type'
     | 'type'
     | 'execution_environment'
     | 'id'
@@ -159,6 +161,7 @@ export interface WorkflowJobTemplateCreate
     | 'summary_fields'
     | 'related'
     | 'job_type'
+    | 'nodes_job_type'
     | 'type'
     | 'created'
     | 'modified'
@@ -183,4 +186,5 @@ export interface WorkflowJobTemplateCreate
   webhook_credential: number | null;
   extra_vars: string;
   organization?: number;
+  ask_nodes_job_type_on_launch: boolean;
 }

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -49,6 +49,7 @@ export const formFieldToLaunchConfig = {
   timeout: 'ask_timeout_on_launch',
   extra_vars: 'ask_variables_on_launch',
   verbosity: 'ask_verbosity_on_launch',
+  nodes_job_type: 'ask_nodes_job_type_on_launch',
 };
 
 export interface TemplateLaunch {
@@ -77,6 +78,7 @@ interface LaunchPayload {
   skip_tags: string;
   timeout: number;
   verbosity: number;
+  nodes_job_type: string;
 }
 type LaunchPayloadProperty = keyof LaunchPayload;
 
@@ -156,6 +158,7 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
           setValue('skip_tags', prompt.skip_tags?.map((tag) => tag.name).join(','));
           setValue('timeout', prompt.timeout);
           setValue('verbosity', prompt.verbosity);
+          setValue('nodes_job_type', prompt.nodes_job_type);
         }
         if (labelPayload.length > 0) {
           setValue('labels', labelPayload);
@@ -244,6 +247,7 @@ export function LaunchWizard({
       skip_tags: parseStringToTagArray(defaults.skip_tags),
       timeout: defaults.timeout,
       verbosity: defaults.verbosity,
+      nodes_job_type: defaults.nodes_job_type,
     },
     launch_config: config,
     survey: {},

--- a/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
@@ -197,6 +197,7 @@ export function TemplateLaunchReviewStep(props: { template: JobTemplate }) {
           {prompt?.skip_tags?.map(({ name }) => <Label key={name}>{name}</Label>)}
         </LabelGroup>
       </PageDetail>
+      <PageDetail label={t('Nodes job type')}>{prompt?.nodes_job_type}</PageDetail>
       <PageDetailCodeEditor label={t('Extra vars')} value={extraVarDetails} />
     </PageDetails>
   );

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
@@ -74,6 +74,7 @@ export function EditWorkflowJobTemplate() {
       ask_skip_tags_on_launch: workflowJobTemplate.ask_skip_tags_on_launch || false,
       ask_tags_on_launch: workflowJobTemplate.ask_tags_on_launch || false,
       ask_variables_on_launch: workflowJobTemplate.ask_variables_on_launch || false,
+      ask_nodes_job_type_on_launch: workflowJobTemplate.ask_nodes_job_type_on_launch || false,
       description: workflowJobTemplate.description || '',
       extra_vars: workflowJobTemplate.extra_vars || '---',
       inventory: workflowJobTemplate.summary_fields.inventory || null,

--- a/frontend/awx/resources/templates/WorkflowJobTemplateInputs.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateInputs.tsx
@@ -125,6 +125,14 @@ export function WorkflowJobTemplateInputs(props: {
           label={t('Enable concurrent jobs')}
           name="allow_simultaneous"
         />
+        <PageFormCheckbox<WorkflowJobTemplateForm>
+          labelHelpTitle={t('Nodes job type')}
+          labelHelp={t(
+            'If enabled, a prompt will appear during workflow launch, allowing you to set the job type for each node. This feature prevents the creation of identical workflows with only different job types. NOTE: If your workflow contains nodes with mixed job_type values, enabling this feature will override all of them with a single job_type at execution time.'
+          )}
+          label={t('Enable prompt on launch for nodes job type')}
+          name="ask_nodes_job_type_on_launch"
+        />
       </PageFormSection>
 
       {isWebhookEnabled ? <WebhookSubForm templateType="workflow_job_templates" /> : null}

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.tsx
@@ -39,7 +39,10 @@ export function WorkflowJobTemplateDetails(props: {
 
   const { summary_fields: summaryFields } = template;
 
-  const showOptionsField = template.allow_simultaneous || template.webhook_service;
+  const showOptionsField =
+    template.allow_simultaneous ||
+    template.webhook_service ||
+    template.ask_nodes_job_type_on_launch;
 
   const inventoryUrlPaths: { [key: string]: string } = {
     '': 'inventory',
@@ -136,6 +139,11 @@ export function WorkflowJobTemplateDetails(props: {
           )}
           {template.webhook_service && (
             <TextListItem component={TextListItemVariants.li}>{t`Webhooks`}</TextListItem>
+          )}
+          {template.ask_nodes_job_type_on_launch && (
+            <TextListItem component={TextListItemVariants.li}>
+              {t`Prompt on launch for nodes job type`}
+            </TextListItem>
           )}
         </TextList>
       </PageDetail>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
@@ -136,6 +136,7 @@ export interface PromptFormValues {
   labels: { name: string; id: number }[];
   limit: string;
   scm_branch: string;
+  nodes_job_type: string;
   skip_tags: { name: string }[];
   timeout: number;
   verbosity: 0 | 1 | 2 | 3 | 4 | 5;

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
@@ -66,6 +66,7 @@ export function NodePromptsStep() {
       limit: prompt?.limit ?? defaults.limit,
       organization: prompt?.organization ?? organizationId,
       scm_branch: prompt?.scm_branch ?? defaults.scm_branch,
+      nodes_job_type: prompt?.nodes_job_type ?? defaults.nodes_job_type,
       skip_tags: prompt?.skip_tags ?? parseStringToTagArray(defaults.skip_tags),
       timeout: prompt?.timeout ?? defaults.timeout,
       verbosity: prompt?.verbosity ?? defaults.verbosity,
@@ -261,6 +262,23 @@ export function NodePromptsStep() {
           label={t('Variables')}
           name="prompt.extra_vars"
           format="yaml"
+        />
+      </ConditionalField>
+      <ConditionalField isHidden={!config.ask_nodes_job_type_on_launch}>
+        <PageFormSelect<WizardFormValues>
+          isRequired
+          id="nodes_job_type"
+          label={t('Nodes job type')}
+          labelHelpTitle={t('Nodes job type')}
+          labelHelp={t(
+            'Set the job type for each node. This feature prevents the creation of identical workflows with only different job types.'
+          )}
+          name="prompt.nodes_job_type"
+          options={[
+            { label: t('Check'), value: 'check' },
+            { label: t('Run'), value: 'run' },
+          ]}
+          placeholderText={t('Select nodes job type')}
         />
       </ConditionalField>
     </PageFormGrid>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.ts
@@ -59,6 +59,7 @@ export function shouldHideOtherStep(launchData: LaunchConfiguration) {
     launchData.ask_tags_on_launch ||
     launchData.ask_timeout_on_launch ||
     launchData.ask_variables_on_launch ||
-    launchData.ask_verbosity_on_launch
+    launchData.ask_verbosity_on_launch ||
+    launchData.ask_nodes_job_type_on_launch
   );
 }

--- a/frontend/awx/resources/templates/hooks/useLaunchTemplate.tsx
+++ b/frontend/awx/resources/templates/hooks/useLaunchTemplate.tsx
@@ -77,7 +77,8 @@ export function canLaunchWithoutPrompt(launchData: TemplateLaunch) {
     launchData.can_start_without_user_input &&
     !launchData.survey_enabled &&
     (!launchData.passwords_needed_to_start || launchData.passwords_needed_to_start.length === 0) &&
-    (!launchData.variables_needed_to_start || launchData.variables_needed_to_start.length === 0)
+    (!launchData.variables_needed_to_start || launchData.variables_needed_to_start.length === 0) &&
+    !launchData.ask_nodes_job_type_on_launch
   );
 }
 


### PR DESCRIPTION
This PR adds a feature that allows overriding the job type of each workflow node at launch time.

To enable this, the `Enable prompt on launch for nodes job type` option must be selected when creating or editing the workflow template.

The corresponding API changes are available in this [PR](https://github.com/ansible/awx/pull/15932).

**NOTE:**
Due to an [existing bug](https://github.com/ansible/ansible-ui/issues/3081) that prevents workflow launches, this PR cannot be fully tested until the issue is resolved.