### PR TITLE
Restore Launch and Edit button permissions for non-superadmin users

### DIFF
--- a/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceActions.tsx
@@ -70,11 +70,11 @@ export function useInventorySourceActions({
       return '';
     };
     const cannotEditInventorySource = (inventorySource: InventorySource): string =>
-      inventorySource?.summary_fields?.user_capabilities?.edit && activeAwxUser?.is_superuser
+      inventorySource?.summary_fields?.user_capabilities?.edit || activeAwxUser?.is_superuser
         ? ''
         : t(`The inventory source cannot be edited due to insufficient permission`);
     const cannotLaunchInventorySourceUpdate = (inventorySource: InventorySource): string => {
-      return inventorySource.summary_fields.user_capabilities.start && activeAwxUser?.is_superuser
+      return inventorySource.summary_fields.user_capabilities.start || activeAwxUser?.is_superuser
         ? ''
         : t(`The inventory source cannot be updated due to insufficient permission`);
     };


### PR DESCRIPTION
## Summary

  Fixes #3089

  Restores correct RBAC-based permission checks for the **Launch inventory update** (rocket)
  and **Edit inventory source** row actions on the Inventory Sources page.
  Non-superadmin users with valid roles (`Update`, `Admin`) were incorrectly blocked
  from using these buttons regardless of their `user_capabilities`.

  ## Root Cause

  This is a regression introduced in #2472.

  That PR replaced the original `&& !is_system_auditor` guard with `&& is_superuser`,
  which accidentally changed the semantics from "allow if user has permission"
  to "allow only if superuser".

  **State 1 — before PR #2472 (correct):**
  ```typescript
  // row action was enabled if user has start permission AND is not a read-only auditor
  inventorySource.summary_fields.user_capabilities.start && !activeAwxUser?.is_system_auditor

  State 2 — after PR #2472 (broken, this is what issue #3089 describes):
  // && means BOTH conditions must be true → blocked everyone except superadmins
  inventorySource.summary_fields.user_capabilities.start && activeAwxUser?.is_superuser

  State 3 — this PR (fixed):
  // || means: allow if user has the capability OR is a superuser
  inventorySource.summary_fields.user_capabilities.start || activeAwxUser?.is_superuser