### PR TITLE
XLAB Implementing report functionalities

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -36,19 +36,24 @@ vi.mock('./views/useAutomationDashboardView', () => ({
   useAutomationDashboardView: vi.fn(() => mockView),
 }));
 
-vi.mock('@ansible/ansible-ui-framework', () => ({
-  PageAlertToasterProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PageDashboard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  PageToolbar: () => null,
-  PageHeader: ({ title, controls }: { title: string; controls?: React.ReactNode }) => (
-    <div>
-      <h1>{title}</h1>
-      <div>{controls}</div>
-    </div>
-  ),
-  useGetPageUrl: vi.fn(() => (route: string) => `/mock/${route}`),
-}));
+vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ansible/ansible-ui-framework')>();
+  return {
+    ...actual,
+    PageLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    PageDashboard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    PageToolbar: () => null,
+    PageHeader: ({ title, controls }: { title: string; controls?: React.ReactNode }) => (
+      <div>
+        <h1>{title}</h1>
+        <div>{controls}</div>
+      </div>
+    ),
+    useGetPageUrl: vi.fn(() => (route: string) => `/mock/${route}`),
+    usePageDialog: vi.fn(() => [undefined, vi.fn()]),
+    usePageAlertToaster: vi.fn(() => ({ addAlert: vi.fn() })),
+  };
+});
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -3,7 +3,6 @@ import {
   PageDashboard,
   PageHeader,
   PageLayout,
-  PageToolbar,
   useGetPageUrl,
 } from '@ansible/ansible-ui-framework';
 import { Button } from '@patternfly/react-core';
@@ -18,6 +17,7 @@ import {
 } from './components';
 
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
+import { DashboardToolbar } from './components/DashboardToolbar';
 
 export function AutomationDashboard() {
   const { t } = useTranslation();
@@ -30,28 +30,6 @@ export function AutomationDashboard() {
 
   const view = useAutomationDashboardView({ toolbarFilters });
   const { details, exportPdf, loading } = view;
-  const {
-    filterState,
-    setFilterState,
-    clearAllFilters,
-    page,
-    perPage,
-    setPage,
-    setPerPage,
-    sort,
-    setSort,
-    sortDirection,
-    setSortDirection,
-    itemCount,
-    selectedItems,
-    selectItem,
-    selectItems,
-    unselectItem,
-    unselectAll,
-    isSelected,
-    keyFn,
-    limitFiltersToOneOrOperation,
-  } = view.mainTableView;
   const [exporting, setExporting] = useState(false);
 
   const handleExportPdf = async () => {
@@ -84,33 +62,7 @@ export function AutomationDashboard() {
           </Button>
         }
       />
-      <PageToolbar
-        toolbarFilters={toolbarFilters}
-        disableCardView
-        disableListView
-        disableTableView
-        viewType={'table'}
-        keyFn={keyFn}
-        itemCount={itemCount}
-        filterState={filterState}
-        setFilterState={setFilterState}
-        clearAllFilters={clearAllFilters}
-        page={page}
-        perPage={perPage}
-        setPage={setPage}
-        setPerPage={setPerPage}
-        sort={sort}
-        setSort={setSort}
-        sortDirection={sortDirection}
-        setSortDirection={setSortDirection}
-        selectedItems={selectedItems}
-        selectItem={selectItem}
-        selectItems={selectItems}
-        unselectItem={unselectItem}
-        unselectAll={unselectAll}
-        isSelected={isSelected}
-        limitFiltersToOneOrOperation={limitFiltersToOneOrOperation}
-      />
+      <DashboardToolbar toolbarFilters={toolbarFilters} {...view.mainTableView} />
       <PageDashboard>
         <DashboardValueCard
           id="successful-jobs-card"

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
@@ -57,8 +57,7 @@ const filterSet: IDashboardFilterSet = {
 };
 
 const mockOnDelete = vi.fn();
-const mockOnCreate = vi.fn();
-const mockOnUpdate = vi.fn();
+const mockOnSave = vi.fn();
 
 function renderActions(
   filterState: IFilterState | undefined,
@@ -69,10 +68,18 @@ function renderActions(
       filterState,
       selectedFilterSet,
       onDelete: mockOnDelete,
-      onCreate: mockOnCreate,
-      onUpdate: mockOnUpdate,
+      onSave: mockOnSave,
     })
   ).result.current;
+}
+
+function getDropdownSubAction(action: Dropdown, label: string): IPageActionButton {
+  expect(action.type).toBe(PageActionType.Dropdown);
+  const sub = action.actions.find(
+    (a): a is IPageActionButton => a.type !== PageActionType.Seperator && a.label === label
+  );
+  expect(sub).toBeDefined();
+  return sub!;
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -160,166 +167,91 @@ describe('useAutomationDashboardToolbarActions', () => {
 
     test('should disable "Create new report" when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Create new report'
-        );
-        expect(sub?.isDisabled).toBeTruthy();
-      }
+      const subAction = getDropdownSubAction(action, 'Create new report');
+      expect(subAction?.isDisabled).toBeTruthy();
     });
 
     test('should disable "Edit current report" when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
-        );
-        expect(sub?.isDisabled).toBeTruthy();
-      }
+      const subAction = getDropdownSubAction(action, 'Edit current report');
+      expect(subAction?.isDisabled).toBeTruthy();
     });
 
     test('should enable "Create new report" when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Create new report'
-        );
-        expect(sub?.isDisabled).toBeFalsy();
-      }
+      const subAction = getDropdownSubAction(action, 'Create new report');
+      expect(subAction?.isDisabled).toBeFalsy();
     });
 
     test('should enable "Edit current report" when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
-        );
-        expect(sub?.isDisabled).toBeFalsy();
-      }
+      const subAction = getDropdownSubAction(action, 'Edit current report');
+      expect(subAction?.isDisabled).toBeFalsy();
     });
 
     test('should disable "Delete current report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
-
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
-        );
-        expect(sub?.isDisabled).toBe('Only administrators can delete reports');
-      }
+      const subAction = getDropdownSubAction(action, 'Delete current report');
+      expect(subAction?.isDisabled).toBe('Only administrators can delete reports');
     });
 
     test('should enable "Delete current report" for superusers', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
-        );
-        expect(sub?.isDisabled).toBeFalsy();
-      }
+      const subAction = getDropdownSubAction(action, 'Delete current report');
+      expect(subAction?.isDisabled).toBeFalsy();
     });
 
     test('should disable "Create new report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
-
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Create new report'
-        );
-        expect(sub?.isDisabled).toBe('Only administrators can save reports');
-      }
+      const subAction = getDropdownSubAction(action, 'Create new report');
+      expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
     test('should disable "Edit current report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
-
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
-        );
-        expect(sub?.isDisabled).toBe('Only administrators can save reports');
-      }
+      const subAction = getDropdownSubAction(action, 'Edit current report');
+      expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
     test('should contain exactly 3 sub-actions', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        expect(action.actions).toHaveLength(3);
-      }
+      expect(action.type).toBe(PageActionType.Dropdown);
+      expect(action.actions).toHaveLength(3);
     });
 
     test('should include "Create new report", "Edit current report", "Delete current report" sub-actions', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+      expect(action.type).toBe(PageActionType.Dropdown);
 
-      if (action.type === PageActionType.Dropdown) {
-        const labels = action.actions.flatMap((a) =>
-          a.type === PageActionType.Seperator ? [] : [a.label]
-        );
-        expect(labels).toContain('Create new report');
-        expect(labels).toContain('Edit current report');
-        expect(labels).toContain('Delete current report');
-      }
+      const labels = action.actions.flatMap((a) =>
+        a.type === PageActionType.Seperator ? [] : [a.label]
+      );
+      expect(labels).toContain('Create new report');
+      expect(labels).toContain('Edit current report');
+      expect(labels).toContain('Delete current report');
     });
 
     test('should call createToolbarFilterSet when "Create new report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Create new report'
-        );
-        sub?.onClick();
-      }
-
+      const subAction = getDropdownSubAction(action, 'Create new report');
+      subAction?.onClick();
       expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
     });
 
     test('should call updateToolbarFilterSet when "Edit current report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
-        );
-        sub?.onClick();
-      }
-
+      const subAction = getDropdownSubAction(action, 'Edit current report');
+      subAction?.onClick();
       expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, nonDefaultFilterState);
     });
 
     test('should call removeToolbarFilterSet when "Delete current report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-
-      if (action.type === PageActionType.Dropdown) {
-        const sub = action.actions.find(
-          (a): a is IPageActionButton =>
-            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
-        );
-        sub?.onClick();
-      }
-
+      const subAction = getDropdownSubAction(action, 'Delete current report');
+      subAction?.onClick();
       expect(mockRemoveFn).toHaveBeenCalledWith(filterSet);
     });
   });

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
@@ -1,0 +1,326 @@
+/* eslint-disable i18next/no-literal-string */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  IPageActionButton,
+  IPageActionDropdown,
+  PageActionSelection,
+  PageActionType,
+} from '@ansible/ansible-ui-framework';
+import type { IFilterState } from '@ansible/ansible-ui-framework';
+import { AutomationDashboardDateRangeFilterPresets } from '../constants';
+import type { IDashboardFilterSet, IJobTemplate } from '../types';
+import { useAutomationDashboardToolbarActions } from './useAutomationDashboardToolbarActions';
+
+type Dropdown = IPageActionDropdown<IJobTemplate>;
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockCreateFn, mockUpdateFn, mockRemoveFn, mockActiveAwxUser } = vi.hoisted(() => ({
+  mockCreateFn: vi.fn(),
+  mockUpdateFn: vi.fn(),
+  mockRemoveFn: vi.fn(),
+  mockActiveAwxUser: { is_superuser: true },
+}));
+
+vi.mock('./useCreateToolbarFilterSet', () => ({
+  useCreateToolbarFilterSet: vi.fn(() => mockCreateFn),
+}));
+
+vi.mock('./useUpdateToolbarFilterSet', () => ({
+  useUpdateToolbarFilterSet: vi.fn(() => mockUpdateFn),
+}));
+
+vi.mock('./useRemoveToolbarFilterSet', () => ({
+  useRemoveToolbarFilterSet: vi.fn(() => mockRemoveFn),
+}));
+
+vi.mock('../../../common/useAwxActiveUser', () => ({
+  useAwxActiveUser: vi.fn(() => ({ activeAwxUser: mockActiveAwxUser })),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const defaultFilterState: IFilterState = {
+  period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
+};
+
+const nonDefaultFilterState: IFilterState = {
+  period: [AutomationDashboardDateRangeFilterPresets.last_30_days],
+};
+
+const filterSet: IDashboardFilterSet = {
+  id: 1,
+  name: 'Report A',
+  filters: '{}',
+  is_default: false,
+};
+
+const mockOnDelete = vi.fn();
+const mockOnCreate = vi.fn();
+const mockOnUpdate = vi.fn();
+
+function renderActions(
+  filterState: IFilterState | undefined,
+  selectedFilterSet: IDashboardFilterSet | undefined
+) {
+  return renderHook(() =>
+    useAutomationDashboardToolbarActions({
+      filterState,
+      selectedFilterSet,
+      onDelete: mockOnDelete,
+      onCreate: mockOnCreate,
+      onUpdate: mockOnUpdate,
+    })
+  ).result.current;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useAutomationDashboardToolbarActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveAwxUser.is_superuser = true;
+  });
+
+  describe('when no selectedFilterSet', () => {
+    test('should return a single Button action', () => {
+      const actions = renderActions(defaultFilterState, undefined);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].type).toBe(PageActionType.Button);
+    });
+
+    test('should label the button "Save as report"', () => {
+      const action = renderActions(defaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.label).toBe('Save as report');
+    });
+
+    test('should have None selection', () => {
+      const action = renderActions(defaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.selection).toBe(PageActionSelection.None);
+    });
+
+    test('should disable the button when filter state equals the default', () => {
+      const action = renderActions(defaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.isDisabled).toBeTruthy();
+    });
+
+    test('should enable the button when filter state differs from the default', () => {
+      const action = renderActions(nonDefaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.isDisabled).toBeFalsy();
+    });
+
+    test('should disable the button with admin-only message when user is not a superuser', () => {
+      mockActiveAwxUser.is_superuser = false;
+
+      const action = renderActions(nonDefaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.isDisabled).toBe('Only administrators can save reports');
+    });
+
+    test('should disable the button even on non-default filter state when user is not a superuser', () => {
+      mockActiveAwxUser.is_superuser = false;
+
+      const action = renderActions(nonDefaultFilterState, undefined)[0] as IPageActionButton;
+
+      expect(action.isDisabled).toBeTruthy();
+    });
+
+    test('should call createToolbarFilterSet on click', () => {
+      const action = renderActions(nonDefaultFilterState, undefined)[0] as IPageActionButton;
+      action.onClick();
+      expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
+    });
+  });
+
+  describe('when selectedFilterSet is defined', () => {
+    test('should return a single Dropdown action', () => {
+      const actions = renderActions(defaultFilterState, filterSet);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].type).toBe(PageActionType.Dropdown);
+    });
+
+    test('should label the dropdown "Save as report"', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      expect(action.label).toBe('Save as report');
+    });
+
+    test('should never disable the dropdown itself', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      expect(action.isDisabled).toBeFalsy();
+    });
+
+    test('should disable "Create new report" when filter state equals the default', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Create new report'
+        );
+        expect(sub?.isDisabled).toBeTruthy();
+      }
+    });
+
+    test('should disable "Edit current report" when filter state equals the default', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
+        );
+        expect(sub?.isDisabled).toBeTruthy();
+      }
+    });
+
+    test('should enable "Create new report" when filter state differs from the default', () => {
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Create new report'
+        );
+        expect(sub?.isDisabled).toBeFalsy();
+      }
+    });
+
+    test('should enable "Edit current report" when filter state differs from the default', () => {
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
+        );
+        expect(sub?.isDisabled).toBeFalsy();
+      }
+    });
+
+    test('should disable "Delete current report" with admin-only message when user is not a superuser', () => {
+      mockActiveAwxUser.is_superuser = false;
+
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
+        );
+        expect(sub?.isDisabled).toBe('Only administrators can delete reports');
+      }
+    });
+
+    test('should enable "Delete current report" for superusers', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
+        );
+        expect(sub?.isDisabled).toBeFalsy();
+      }
+    });
+
+    test('should disable "Create new report" with admin-only message when user is not a superuser', () => {
+      mockActiveAwxUser.is_superuser = false;
+
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Create new report'
+        );
+        expect(sub?.isDisabled).toBe('Only administrators can save reports');
+      }
+    });
+
+    test('should disable "Edit current report" with admin-only message when user is not a superuser', () => {
+      mockActiveAwxUser.is_superuser = false;
+
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
+        );
+        expect(sub?.isDisabled).toBe('Only administrators can save reports');
+      }
+    });
+
+    test('should contain exactly 3 sub-actions', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        expect(action.actions).toHaveLength(3);
+      }
+    });
+
+    test('should include "Create new report", "Edit current report", "Delete current report" sub-actions', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const labels = action.actions.flatMap((a) =>
+          a.type === PageActionType.Seperator ? [] : [a.label]
+        );
+        expect(labels).toContain('Create new report');
+        expect(labels).toContain('Edit current report');
+        expect(labels).toContain('Delete current report');
+      }
+    });
+
+    test('should call createToolbarFilterSet when "Create new report" is clicked', () => {
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Create new report'
+        );
+        sub?.onClick();
+      }
+
+      expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
+    });
+
+    test('should call updateToolbarFilterSet when "Edit current report" is clicked', () => {
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Edit current report'
+        );
+        sub?.onClick();
+      }
+
+      expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, nonDefaultFilterState);
+    });
+
+    test('should call removeToolbarFilterSet when "Delete current report" is clicked', () => {
+      const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
+
+      if (action.type === PageActionType.Dropdown) {
+        const sub = action.actions.find(
+          (a): a is IPageActionButton =>
+            a.type !== PageActionType.Seperator && a.label === 'Delete current report'
+        );
+        sub?.onClick();
+      }
+
+      expect(mockRemoveFn).toHaveBeenCalledWith(filterSet);
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -1,0 +1,126 @@
+import {
+  IFilterState,
+  IPageAction,
+  PageActionSelection,
+  PageActionType,
+} from '@ansible/ansible-ui-framework';
+import { ButtonVariant } from '@patternfly/react-core';
+import { PencilAltIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AutomationDashboardDateRangeFilterPresets } from '../constants';
+import { IDashboardFilterSet, IJobTemplate } from '../types';
+import { useCreateToolbarFilterSet } from './useCreateToolbarFilterSet';
+import { useRemoveToolbarFilterSet } from './useRemoveToolbarFilterSet';
+import { useUpdateToolbarFilterSet } from './useUpdateToolbarFilterSet';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+
+/** Returns true when filterState is empty or equals the default (period = last 7 days only). */
+function isDefaultFilterState(filterState: IFilterState | undefined): boolean {
+  if (!filterState) return true;
+  const activeEntries = Object.entries(filterState).filter(([, v]) => v && v.length > 0);
+  if (activeEntries.length === 0) return true;
+  return (
+    activeEntries.length === 1 &&
+    activeEntries[0][0] === 'period' &&
+    activeEntries[0][1]?.length === 1 &&
+    (activeEntries[0][1][0] as AutomationDashboardDateRangeFilterPresets) ===
+      AutomationDashboardDateRangeFilterPresets.last_7_days
+  );
+}
+
+export function useAutomationDashboardToolbarActions(props: {
+  filterState?: IFilterState;
+  selectedFilterSet?: IDashboardFilterSet;
+  onDelete: (deletedFilterSet: IDashboardFilterSet) => void;
+  onCreate: (newFilterSet: IDashboardFilterSet) => void;
+  onUpdate: (filterSet: IDashboardFilterSet) => void;
+}) {
+  const { t } = useTranslation();
+  const { activeAwxUser } = useAwxActiveUser();
+  const { filterState, selectedFilterSet, onDelete, onCreate, onUpdate } = props;
+  const createToolbarFilterSet = useCreateToolbarFilterSet(onCreate);
+  const updateToolbarFilterSet = useUpdateToolbarFilterSet(onUpdate);
+  const removeToolbarFilterSet = useRemoveToolbarFilterSet((deleted) => {
+    if (deleted.length > 0) onDelete(deleted[0]);
+  });
+
+  const superuserDisabledReason = activeAwxUser?.is_superuser
+    ? undefined
+    : t('Only administrators can save reports');
+
+  const superuserDeleteDisabledReason = activeAwxUser?.is_superuser
+    ? undefined
+    : t('Only administrators can delete reports');
+
+  const saveDisabledReason =
+    superuserDisabledReason ??
+    (isDefaultFilterState(filterState) ? t('Modify filters before saving as a report') : undefined);
+
+  return useMemo<IPageAction<IJobTemplate>[]>(
+    () =>
+      selectedFilterSet
+        ? [
+            {
+              type: PageActionType.Dropdown,
+              icon: PlusCircleIcon,
+              variant: ButtonVariant.primary,
+              isPinned: true,
+              selection: PageActionSelection.None,
+              label: t('Save as report'),
+              actions: [
+                {
+                  type: PageActionType.Button,
+                  icon: PlusCircleIcon,
+                  selection: PageActionSelection.None,
+                  label: t('Create new report'),
+                  isDisabled: saveDisabledReason,
+                  onClick: () => (filterState ? createToolbarFilterSet(filterState) : {}),
+                },
+                {
+                  type: PageActionType.Button,
+                  icon: PencilAltIcon,
+                  selection: PageActionSelection.None,
+                  label: t('Edit current report'),
+                  isDisabled: saveDisabledReason,
+                  onClick: () =>
+                    filterState && selectedFilterSet
+                      ? updateToolbarFilterSet(selectedFilterSet, filterState)
+                      : {},
+                },
+                {
+                  type: PageActionType.Button,
+                  selection: PageActionSelection.None,
+                  label: t('Delete current report'),
+                  onClick: () => removeToolbarFilterSet(selectedFilterSet),
+                  icon: TrashIcon,
+                  isDisabled: superuserDeleteDisabledReason,
+                  variant: ButtonVariant.danger,
+                },
+              ],
+            },
+          ]
+        : [
+            {
+              type: PageActionType.Button,
+              icon: PlusCircleIcon,
+              variant: ButtonVariant.primary,
+              isPinned: true,
+              selection: PageActionSelection.None,
+              label: t('Save as report'),
+              isDisabled: saveDisabledReason,
+              onClick: () => (filterState ? createToolbarFilterSet(filterState) : {}),
+            },
+          ],
+    [
+      selectedFilterSet,
+      t,
+      saveDisabledReason,
+      superuserDeleteDisabledReason,
+      filterState,
+      createToolbarFilterSet,
+      updateToolbarFilterSet,
+      removeToolbarFilterSet,
+    ]
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -33,14 +33,13 @@ export function useAutomationDashboardToolbarActions(props: {
   filterState?: IFilterState;
   selectedFilterSet?: IDashboardFilterSet;
   onDelete: (deletedFilterSet: IDashboardFilterSet) => void;
-  onCreate: (newFilterSet: IDashboardFilterSet) => void;
-  onUpdate: (filterSet: IDashboardFilterSet) => void;
+  onSave: (filterSet: IDashboardFilterSet) => void;
 }) {
   const { t } = useTranslation();
   const { activeAwxUser } = useAwxActiveUser();
-  const { filterState, selectedFilterSet, onDelete, onCreate, onUpdate } = props;
-  const createToolbarFilterSet = useCreateToolbarFilterSet(onCreate);
-  const updateToolbarFilterSet = useUpdateToolbarFilterSet(onUpdate);
+  const { filterState, selectedFilterSet, onDelete, onSave } = props;
+  const createToolbarFilterSet = useCreateToolbarFilterSet(onSave);
+  const updateToolbarFilterSet = useUpdateToolbarFilterSet(onSave);
   const removeToolbarFilterSet = useRemoveToolbarFilterSet((deleted) => {
     if (deleted.length > 0) onDelete(deleted[0]);
   });

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -1,0 +1,280 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { PageAlertToasterProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import type { IDashboardFilterSet } from '../types';
+import { useCreateEditToolbarFilterSetDialog } from './useCreateEditToolbarFilterSetDialog';
+
+// ─── MSW server ───────────────────────────────────────────────────────────────
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const newFilterSet: IDashboardFilterSet = {
+  id: 0,
+  name: '',
+  filters: '{"period":["last_30_days"]}',
+  is_default: false,
+};
+
+const existingFilterSet: IDashboardFilterSet = {
+  id: 5,
+  name: 'Existing Report',
+  filters: '{"period":["last_7_days"]}',
+  is_default: false,
+};
+
+const createdFilterSet: IDashboardFilterSet = {
+  id: 42,
+  name: 'New Report',
+  filters: '{"period":["last_30_days"]}',
+  is_default: false,
+};
+
+const filterState = { period: ['last_30_days'] };
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
+
+// Mirrors the real PageFramework hierarchy:
+//   PageDialogProvider > PageAlertToasterProvider > children
+// The hook lives inside PageAlertToasterProvider, the dialog is rendered by
+// PageDialogProvider (outside PageAlertToasterProvider — which is why the hook
+// must own the alert call, not the dialog component).
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <PageDialogProvider>
+      <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
+    </PageDialogProvider>
+  );
+}
+
+// Component that calls the hook and exposes a button to open the dialog
+function OpenDialogButton({
+  filterSet,
+  onComplete,
+}: {
+  filterSet: IDashboardFilterSet;
+  onComplete: (fs: IDashboardFilterSet) => void;
+}) {
+  const openDialog = useCreateEditToolbarFilterSetDialog(onComplete);
+  return <button onClick={() => openDialog(filterState, filterSet)}>Open dialog</button>;
+}
+
+/** Opens the dialog, fills the name field, and clicks Save. */
+async function openAndSubmit(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+  await user.clear(screen.getByRole('textbox', { name: /name/i }));
+  await user.type(screen.getByRole('textbox', { name: /name/i }), name);
+  await user.click(screen.getByRole('button', { name: /save/i }));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useCreateEditToolbarFilterSetDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('dialog rendering', () => {
+    test('should open the dialog when invoked for a new filter set', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Create report')).toBeInTheDocument();
+    });
+
+    test('should show "Edit report" title when editing an existing filter set', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={existingFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(screen.getByText('Edit report')).toBeInTheDocument();
+    });
+
+    test('should render the Name input', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(screen.getByRole('textbox', { name: /name/i })).toBeInTheDocument();
+    });
+
+    test('should close the dialog when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('creating a new filter set (POST)', () => {
+    test('should POST to the filter sets endpoint on submit', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(metricsAPI`/dashboard_reports/filter_sets/`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(createdFilterSet, { status: 201 });
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await openAndSubmit(user, 'New Report');
+
+      await waitFor(() => {
+        expect(capturedBody).toMatchObject({ name: 'New Report' });
+      });
+    });
+
+    test('should call onComplete with the created filter set', async () => {
+      server.use(
+        http.post(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(createdFilterSet, { status: 201 })
+        )
+      );
+
+      const onComplete = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={onComplete} />
+        </Wrapper>
+      );
+
+      await openAndSubmit(user, 'New Report');
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(createdFilterSet);
+      });
+    });
+
+    test('should close the dialog after successful submit', async () => {
+      server.use(
+        http.post(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(createdFilterSet, { status: 201 })
+        )
+      );
+
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={newFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await openAndSubmit(user, 'New Report');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('editing an existing filter set (PUT)', () => {
+    test('should PUT to the filter set endpoint on submit', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put(
+          metricsAPI`/dashboard_reports/filter_sets/${existingFilterSet.id}/`,
+          async ({ request }) => {
+            capturedBody = await request.json();
+            return HttpResponse.json({ ...existingFilterSet, name: 'Updated' });
+          }
+        )
+      );
+
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={existingFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await openAndSubmit(user, 'Updated');
+
+      await waitFor(() => {
+        expect(capturedBody).toMatchObject({ name: 'Updated' });
+      });
+    });
+
+    test('should call onComplete after a successful PUT', async () => {
+      const updated = { ...existingFilterSet, name: 'Updated' };
+      server.use(
+        http.put(metricsAPI`/dashboard_reports/filter_sets/${existingFilterSet.id}/`, () =>
+          HttpResponse.json(updated)
+        )
+      );
+
+      const onComplete = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={existingFilterSet} onComplete={onComplete} />
+        </Wrapper>
+      );
+
+      await openAndSubmit(user, 'Updated');
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ name: 'Updated' }));
+      });
+    });
+  });
+
+  describe('hook return value', () => {
+    test('should return a stable function reference when dependencies do not change', () => {
+      const stableOnComplete = vi.fn();
+      const { result, rerender } = renderHook(
+        () => useCreateEditToolbarFilterSetDialog(stableOnComplete),
+        { wrapper: Wrapper }
+      );
+
+      const first = result.current;
+      rerender();
+      expect(result.current).toBe(first);
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -20,12 +20,12 @@ afterAll(() => server.close());
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-const newFilterSet: IDashboardFilterSet = {
-  id: 0,
+const newFilterSet = {
+  id: undefined,
   name: '',
   filters: '{"period":["last_30_days"]}',
   is_default: false,
-};
+} as IDashboardFilterSet & { id: undefined };
 
 const existingFilterSet: IDashboardFilterSet = {
   id: 5,
@@ -216,14 +216,12 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
   describe('editing an existing filter set (PUT)', () => {
     test('should PUT to the filter set endpoint on submit', async () => {
       let capturedBody: unknown;
+      const id = existingFilterSet.id;
       server.use(
-        http.put(
-          metricsAPI`/dashboard_reports/filter_sets/${existingFilterSet.id}/`,
-          async ({ request }) => {
-            capturedBody = await request.json();
-            return HttpResponse.json({ ...existingFilterSet, name: 'Updated' });
-          }
-        )
+        http.put(metricsAPI`/dashboard_reports/filter_sets/${id}/`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ ...existingFilterSet, name: 'Updated' });
+        })
       );
 
       const user = userEvent.setup();
@@ -242,8 +240,9 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
 
     test('should call onComplete after a successful PUT', async () => {
       const updated = { ...existingFilterSet, name: 'Updated' };
+      const id = existingFilterSet.id;
       server.use(
-        http.put(metricsAPI`/dashboard_reports/filter_sets/${existingFilterSet.id}/`, () =>
+        http.put(metricsAPI`/dashboard_reports/filter_sets/${id}/`, () =>
           HttpResponse.json(updated)
         )
       );

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -42,15 +42,15 @@ function CreateEditToolbarFilterSetDialog(props: {
     let response: IDashboardFilterSet;
     let successMessage: string;
 
-    if (filterSet.id) {
+    if (filterSet.id === undefined) {
+      const url = metricsAPI`/dashboard_reports/filter_sets/`;
+      successMessage = t('Report {{name}} successfully created.', { name: data.name });
+      response = await postRequest(url, payload);
+    } else {
       const url = metricsAPI`/dashboard_reports/filter_sets/${filterSet.id}/`;
       successMessage = t('Report {{name}} updated successfully.', { name: data.name });
       const putResponse = await putRequest(url, payload);
       response = putResponse ?? { ...filterSet, ...payload };
-    } else {
-      const url = metricsAPI`/dashboard_reports/filter_sets/`;
-      successMessage = t('Report {{name}} successfully created.', { name: data.name });
-      response = await postRequest(url, payload);
     }
 
     onComplete(response);
@@ -102,9 +102,8 @@ export function useCreateEditToolbarFilterSetDialog(
 
   return useCallback(
     (filterState: IFilterState, filterSet: IDashboardFilterSet) => {
-      if (!filterState) return;
       const newFilterSet = { ...filterSet, filters: JSON.stringify(filterState) };
-      const title = filterSet.id ? t('Edit report') : t('Create report');
+      const title = filterSet.id === undefined ? t('Create report') : t('Edit report');
       setDialog(
         <CreateEditToolbarFilterSetDialog
           title={title}

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -1,0 +1,121 @@
+import {
+  IFilterState,
+  PageForm,
+  PageFormSubmitHandler,
+  PageFormTextInput,
+  usePageAlertToaster,
+  usePageDialog,
+} from '@ansible/ansible-ui-framework';
+import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
+import { usePutRequest } from '@ansible/common-ui/crud/usePutRequest';
+import { Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import { IDashboardFilterSet } from '../types';
+
+type DashboardFilterSetFormValues = {
+  name: string;
+};
+
+function CreateEditToolbarFilterSetDialog(props: {
+  title: string;
+  description?: string;
+  filterSet: IDashboardFilterSet;
+  onComplete: (filterSet: IDashboardFilterSet) => void;
+  onSuccess: (message: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [_, setDialog] = usePageDialog();
+  const { title, description, filterSet, onComplete, onSuccess } = props;
+  const postRequest = usePostRequest<Omit<IDashboardFilterSet, 'id'>, IDashboardFilterSet>();
+  const putRequest = usePutRequest<Omit<IDashboardFilterSet, 'id'>, IDashboardFilterSet>();
+  const onClose = useCallback(() => setDialog(undefined), [setDialog]);
+
+  const onSubmit: PageFormSubmitHandler<DashboardFilterSetFormValues> = async (data) => {
+    const payload: Omit<IDashboardFilterSet, 'id'> = {
+      name: data.name,
+      filters: filterSet.filters,
+      is_default: filterSet.is_default ?? false,
+    };
+
+    let response: IDashboardFilterSet;
+    let successMessage: string;
+
+    if (filterSet.id) {
+      const url = metricsAPI`/dashboard_reports/filter_sets/${filterSet.id}/`;
+      successMessage = t('Report {{name}} updated successfully.', { name: data.name });
+      const putResponse = await putRequest(url, payload);
+      response = putResponse ?? { ...filterSet, ...payload };
+    } else {
+      const url = metricsAPI`/dashboard_reports/filter_sets/`;
+      successMessage = t('Report {{name}} successfully created.', { name: data.name });
+      response = await postRequest(url, payload);
+    }
+
+    onComplete(response);
+    onSuccess(successMessage);
+    onClose();
+  };
+
+  return (
+    <Modal
+      ouiaId={title}
+      isOpen
+      onClose={onClose}
+      variant={ModalVariant.small}
+      tabIndex={0}
+      aria-label={title}
+      position={'top'}
+    >
+      <ModalHeader title={title} description={description} />
+      <ModalBody>
+        <PageForm<DashboardFilterSetFormValues>
+          singleColumn
+          disableSubmitOnEnter
+          submitText={t('Save')}
+          onSubmit={onSubmit}
+          cancelText={t('Cancel')}
+          onCancel={onClose}
+          defaultValue={{ name: filterSet.name }}
+        >
+          <PageFormTextInput
+            name={'name'}
+            id={'name'}
+            label={t('Name')}
+            placeholder={t('Enter report name')}
+            isRequired
+            maxLength={255}
+          />
+        </PageForm>
+      </ModalBody>
+    </Modal>
+  );
+}
+
+export function useCreateEditToolbarFilterSetDialog(
+  onComplete: (filterSet: IDashboardFilterSet) => void
+) {
+  const [_, setDialog] = usePageDialog();
+  const { t } = useTranslation();
+  const alertToaster = usePageAlertToaster();
+
+  return useCallback(
+    (filterState: IFilterState, filterSet: IDashboardFilterSet) => {
+      if (!filterState) return;
+      const newFilterSet = { ...filterSet, filters: JSON.stringify(filterState) };
+      const title = filterSet.id ? t('Edit report') : t('Create report');
+      setDialog(
+        <CreateEditToolbarFilterSetDialog
+          title={title}
+          filterSet={newFilterSet}
+          onComplete={onComplete}
+          onSuccess={(message) =>
+            alertToaster.addAlert({ variant: 'success', title: message, timeout: 2000 })
+          }
+        />
+      );
+    },
+    [setDialog, t, onComplete, alertToaster]
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.tsx
@@ -8,11 +8,11 @@ export function useCreateToolbarFilterSet(onComplete: (filterSet: IDashboardFilt
   return useCallback(
     (filterState: IFilterState) => {
       const filterSet = {
-        id: 0,
+        id: undefined,
         name: '',
         is_default: false,
         filters: '{}',
-      } as IDashboardFilterSet;
+      } as IDashboardFilterSet & { id: undefined };
       createFilters(filterState, filterSet);
     },
     [createFilters]

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.tsx
@@ -1,0 +1,20 @@
+import { IFilterState } from '@ansible/ansible-ui-framework';
+import { useCallback } from 'react';
+import { IDashboardFilterSet } from '../types';
+import { useCreateEditToolbarFilterSetDialog } from './useCreateEditToolbarFilterSetDialog';
+
+export function useCreateToolbarFilterSet(onComplete: (filterSet: IDashboardFilterSet) => void) {
+  const createFilters = useCreateEditToolbarFilterSetDialog(onComplete);
+  return useCallback(
+    (filterState: IFilterState) => {
+      const filterSet = {
+        id: 0,
+        name: '',
+        is_default: false,
+        filters: '{}',
+      } as IDashboardFilterSet;
+      createFilters(filterState, filterSet);
+    },
+    [createFilters]
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable i18next/no-literal-string */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
+import type { IDashboardFilterSet } from '../types';
+import { useRemoveToolbarFilterSet } from './useRemoveToolbarFilterSet';
+
+vi.mock('../../../common/useAwxBulkConfirmation');
+vi.mock('@ansible/common-ui/crud/Data');
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const filterSet: IDashboardFilterSet = {
+  id: 7,
+  name: 'My Report',
+  filters: '{}',
+  is_default: false,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useRemoveToolbarFilterSet', () => {
+  const mockBulkAction = vi.fn();
+  const mockOnComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAwxBulkConfirmation).mockReturnValue(mockBulkAction);
+  });
+
+  test('should return a function', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    expect(result.current).toBeTypeOf('function');
+  });
+
+  test('should call bulkAction when invoked with a filter set', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    expect(mockBulkAction).toHaveBeenCalledOnce();
+  });
+
+  test('should pass the filter set as a single-item array to bulkAction', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { items: IDashboardFilterSet[] };
+    expect(args.items).toEqual([filterSet]);
+  });
+
+  test('should set isDanger to true', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { isDanger: boolean };
+    expect(args.isDanger).toBe(true);
+  });
+
+  test('should use filter set id as the key function result', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as {
+      keyFn: (item: IDashboardFilterSet) => number;
+    };
+    expect(args.keyFn(filterSet)).toBe(filterSet.id);
+  });
+
+  test('should include a DELETE actionFn targeting the filter set endpoint', async () => {
+    const { requestDelete } = vi.mocked(await import('@ansible/common-ui/crud/Data'));
+    requestDelete.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as {
+      actionFn: (item: IDashboardFilterSet, signal: AbortSignal) => Promise<void>;
+    };
+
+    const signal = new AbortController().signal;
+    void args.actionFn(filterSet, signal);
+
+    expect(requestDelete).toHaveBeenCalledWith(
+      expect.stringContaining(`/dashboard_reports/filter_sets/${filterSet.id}/`),
+      signal
+    );
+  });
+
+  test('should forward the onComplete callback to bulkAction', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as {
+      onComplete: (items: IDashboardFilterSet[]) => void;
+    };
+    args.onComplete([filterSet]);
+
+    expect(mockOnComplete).toHaveBeenCalledWith([filterSet]);
+  });
+
+  test('should include a confirmation column with a Name header', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as {
+      confirmationColumns: { header: string }[];
+    };
+    expect(args.confirmationColumns[0]?.header).toBe('Name');
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
@@ -1,0 +1,47 @@
+import { ITableColumn, TextCell } from '@ansible/ansible-ui-framework';
+import { requestDelete } from '@ansible/common-ui/crud/Data';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import { useAwxBulkConfirmation } from '../../../common/useAwxBulkConfirmation';
+import { IDashboardFilterSet } from '../types';
+
+export function useRemoveToolbarFilterSet(onComplete: (filterSets: IDashboardFilterSet[]) => void) {
+  const { t } = useTranslation();
+  const bulkAction = useAwxBulkConfirmation<IDashboardFilterSet>();
+
+  const reportNameColumn = useMemo<ITableColumn<IDashboardFilterSet>>(
+    () => ({
+      header: t('Name'),
+      cell: (item: IDashboardFilterSet) => {
+        const name = item.name;
+        return <TextCell text={name} iconSize="sm" />;
+      },
+    }),
+    [t]
+  );
+
+  const confirmationColumns = useMemo<ITableColumn<IDashboardFilterSet>[]>(
+    () => [reportNameColumn],
+    [reportNameColumn]
+  );
+
+  return useCallback(
+    (filterSet: IDashboardFilterSet) => {
+      bulkAction({
+        actionFn: (item: IDashboardFilterSet, signal: AbortSignal) =>
+          requestDelete(metricsAPI`/dashboard_reports/filter_sets/${item.id.toString()}/`, signal),
+        actionButtonText: t('Delete report'),
+        actionColumns: [],
+        confirmationColumns: confirmationColumns,
+        title: t('Permanently delete report?'),
+        confirmText: t('Yes, delete 1 report.'),
+        items: [filterSet],
+        keyFn: (item) => item.id,
+        isDanger: true,
+        onComplete,
+      });
+    },
+    [bulkAction, t, confirmationColumns, onComplete]
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/common/useUpdateToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useUpdateToolbarFilterSet.tsx
@@ -1,0 +1,14 @@
+import { IFilterState } from '@ansible/ansible-ui-framework';
+import { useCallback } from 'react';
+import { IDashboardFilterSet } from '../types';
+import { useCreateEditToolbarFilterSetDialog } from './useCreateEditToolbarFilterSetDialog';
+
+export function useUpdateToolbarFilterSet(onComplete: (filterSet: IDashboardFilterSet) => void) {
+  const updateFilters = useCreateEditToolbarFilterSetDialog(onComplete);
+  return useCallback(
+    (filterSet: IDashboardFilterSet, filterState: IFilterState) => {
+      updateFilters(filterState, filterSet);
+    },
+    [updateFilters]
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
@@ -1,0 +1,221 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PageAlertToasterProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
+import type { PageToolbarProps } from '@ansible/ansible-ui-framework';
+import type { IDashboardFilterSet, IJobTemplate } from '../types';
+import { DashboardToolbar } from './DashboardToolbar';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock the async select: render a simple <select> so we can interact with it
+vi.mock('@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect', () => ({
+  PageAsyncSingleSelect: ({
+    onSelect,
+    placeholder,
+    id,
+  }: {
+    onSelect: (value: string | null) => void;
+    placeholder: string;
+    id: string;
+  }) => (
+    <select
+      data-testid={id}
+      aria-label={placeholder}
+      onChange={(e) => onSelect(e.target.value || null)}
+    >
+      <option value="">-- select --</option>
+      <option value="1">Report A</option>
+      <option value="2">Report B</option>
+    </select>
+  ),
+}));
+
+// Mock PageToolbar to render a minimal stub (we test it is given toolbarActions below)
+const capturedToolbarProps: Record<string, unknown>[] = [];
+vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ansible/ansible-ui-framework')>();
+  return {
+    ...actual,
+    PageToolbar: (props: PageToolbarProps<IJobTemplate>) => {
+      capturedToolbarProps.push(props as unknown as Record<string, unknown>);
+      return <div data-testid="page-toolbar" />;
+    },
+  };
+});
+
+// Mock useAutomationDashboardToolbarActions to keep action tests separate
+const mockToolbarActions = [{ type: 'button', label: 'Test Action' }];
+vi.mock('../common/useAutomationDashboardToolbarActions', () => ({
+  useAutomationDashboardToolbarActions: vi.fn(() => mockToolbarActions),
+}));
+
+// Mock useFilterSetView so we control the filter set state
+const mockSetFilterState = vi.fn();
+const mockSetSelectedFilterSet = vi.fn();
+
+const filterSetA: IDashboardFilterSet = {
+  id: 1,
+  name: 'Report A',
+  filters: '{"period":["last_30_days"]}',
+  is_default: false,
+};
+
+const filterSetB: IDashboardFilterSet = {
+  id: 2,
+  name: 'Report B',
+  filters: 'INVALID_JSON',
+  is_default: false,
+};
+
+const { mockUseFilterSetView } = vi.hoisted(() => ({
+  mockUseFilterSetView: vi.fn(),
+}));
+
+vi.mock('../views/useFilterSetView', () => ({
+  useFilterSetView: mockUseFilterSetView,
+}));
+
+function makeFilterSetViewReturn(overrides = {}) {
+  return {
+    value: undefined as string | undefined,
+    version: 0,
+    setValue: vi.fn(),
+    queryOptions: vi.fn().mockResolvedValue({ options: [], remaining: 0, next: '' }),
+    filterSets: [filterSetA, filterSetB],
+    selectedFilterSet: undefined as IDashboardFilterSet | undefined,
+    setSelectedFilterSet: mockSetSelectedFilterSet,
+    removeFilterSet: vi.fn(),
+    upsertFilterSet: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <PageDialogProvider>
+      <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
+    </PageDialogProvider>
+  );
+}
+
+function buildProps(
+  overrides: Partial<PageToolbarProps<IJobTemplate>> = {}
+): PageToolbarProps<IJobTemplate> {
+  return {
+    toolbarFilters: [],
+    filterState: { period: ['last_7_days'] },
+    setFilterState: mockSetFilterState,
+    clearAllFilters: vi.fn(),
+    viewType: 'table',
+    keyFn: (item: IJobTemplate) => item.id,
+    disableCardView: true,
+    disableListView: true,
+    disableTableView: true,
+    ...overrides,
+  } as unknown as PageToolbarProps<IJobTemplate>;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DashboardToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedToolbarProps.length = 0;
+    mockUseFilterSetView.mockReturnValue(makeFilterSetViewReturn());
+  });
+
+  describe('rendering', () => {
+    test('should render the filter set select', () => {
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('filterset-select')).toBeInTheDocument();
+    });
+
+    test('should render the PageToolbar', () => {
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      expect(screen.getByTestId('page-toolbar')).toBeInTheDocument();
+    });
+
+    test('should pass toolbarActions from useAutomationDashboardToolbarActions to PageToolbar', () => {
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      const lastProps: Record<string, unknown> | undefined = capturedToolbarProps.at(-1);
+      expect(lastProps?.['toolbarActions']).toBe(mockToolbarActions);
+    });
+  });
+
+  describe('filter set selection', () => {
+    test('should call setFilterState with parsed filters when a valid filter set is selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      await user.selectOptions(screen.getByTestId('filterset-select'), '1');
+
+      expect(mockSetFilterState).toHaveBeenCalledWith({ period: ['last_30_days'] });
+    });
+
+    test('should call setSelectedFilterSet with the matching filter set on selection', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      await user.selectOptions(screen.getByTestId('filterset-select'), '1');
+
+      expect(mockSetSelectedFilterSet).toHaveBeenCalledWith(filterSetA);
+    });
+
+    test('should fall back to default filter state when selected filter set has invalid JSON', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      await user.selectOptions(screen.getByTestId('filterset-select'), '2');
+
+      expect(mockSetFilterState).toHaveBeenCalledWith({ period: ['last_7_days'] });
+    });
+
+    test('should reset to default filter state when selection is cleared', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} />
+        </Wrapper>
+      );
+
+      // Select then deselect
+      await user.selectOptions(screen.getByTestId('filterset-select'), '1');
+      await user.selectOptions(screen.getByTestId('filterset-select'), '');
+
+      // Last call should be with default filter state
+      expect(mockSetFilterState).toHaveBeenLastCalledWith({ period: ['last_7_days'] });
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
@@ -54,18 +54,10 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     [setSelectedFilterSet, setFilterState]
   );
 
-  const onCreate = useCallback(
+  const onSave = useCallback(
     (newFilterSet: IDashboardFilterSet) => {
       upsertFilterSet(newFilterSet);
       applyFilterSet(newFilterSet);
-    },
-    [upsertFilterSet, applyFilterSet]
-  );
-
-  const onUpdate = useCallback(
-    (filterSet: IDashboardFilterSet) => {
-      upsertFilterSet(filterSet);
-      applyFilterSet(filterSet);
     },
     [upsertFilterSet, applyFilterSet]
   );
@@ -82,8 +74,7 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     filterState,
     selectedFilterSet,
     onDelete: onFilterSetDelete,
-    onUpdate,
-    onCreate,
+    onSave,
   });
 
   const onSelect = useCallback(
@@ -107,8 +98,16 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
   );
 
   return (
-    <Flex alignItems={{ default: 'alignItemsFlexStart' }} style={{ marginLeft: '1.5rem' }}>
-      <FlexItem style={{ marginRight: '-1rem', paddingBottom: '1rem', minWidth: '180px' }}>
+    <Flex
+      alignItems={{ default: 'alignItemsFlexStart' }}
+      gap={{ default: 'gapSm' }}
+      style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+    >
+      <FlexItem
+        style={{
+          minWidth: '180px',
+        }}
+      >
         <PageAsyncSingleSelect
           key={String(version)}
           id={'filterset-select'}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
@@ -1,0 +1,128 @@
+import { IFilterState, PageToolbar, PageToolbarProps } from '@ansible/ansible-ui-framework';
+import { PageAsyncSingleSelect } from '@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAutomationDashboardToolbarActions } from '../common/useAutomationDashboardToolbarActions';
+import { AutomationDashboardDateRangeFilterPresets } from '../constants';
+import { IDashboardFilterSet, IJobTemplate } from '../types';
+import { useFilterSetView } from '../views/useFilterSetView';
+
+const DEFAULT_FILTER_STATE: IFilterState = {
+  period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
+};
+
+function parseFilterState(raw: string): IFilterState {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      Object.values(parsed as Record<string, unknown>).every(
+        (v) => Array.isArray(v) && v.every((entry) => typeof entry === 'string')
+      )
+    ) {
+      return parsed as IFilterState;
+    }
+  } catch {
+    return DEFAULT_FILTER_STATE;
+  }
+  return DEFAULT_FILTER_STATE;
+}
+
+export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
+  const { t } = useTranslation();
+  const {
+    value,
+    version,
+    setValue,
+    queryOptions,
+    filterSets,
+    setSelectedFilterSet,
+    selectedFilterSet,
+    removeFilterSet,
+    upsertFilterSet,
+  } = useFilterSetView();
+  const { setFilterState, filterState } = props;
+
+  const applyFilterSet = useCallback(
+    (filterSet: IDashboardFilterSet) => {
+      setSelectedFilterSet(filterSet);
+      setFilterState?.(parseFilterState(filterSet.filters));
+    },
+    [setSelectedFilterSet, setFilterState]
+  );
+
+  const onCreate = useCallback(
+    (newFilterSet: IDashboardFilterSet) => {
+      upsertFilterSet(newFilterSet);
+      applyFilterSet(newFilterSet);
+    },
+    [upsertFilterSet, applyFilterSet]
+  );
+
+  const onUpdate = useCallback(
+    (filterSet: IDashboardFilterSet) => {
+      upsertFilterSet(filterSet);
+      applyFilterSet(filterSet);
+    },
+    [upsertFilterSet, applyFilterSet]
+  );
+
+  const onFilterSetDelete = useCallback(
+    (deletedFilterSet: IDashboardFilterSet) => {
+      removeFilterSet(deletedFilterSet);
+      setFilterState?.(DEFAULT_FILTER_STATE);
+    },
+    [removeFilterSet, setFilterState]
+  );
+
+  const toolbarActions = useAutomationDashboardToolbarActions({
+    filterState,
+    selectedFilterSet,
+    onDelete: onFilterSetDelete,
+    onUpdate,
+    onCreate,
+  });
+
+  const onSelect = useCallback(
+    (selectedValue: string | null) => {
+      setValue(selectedValue ?? undefined);
+      const filterset = filterSets.find((fs) => String(fs.id) === selectedValue);
+      setSelectedFilterSet(filterset);
+      setFilterState?.(
+        filterset?.filters ? parseFilterState(filterset.filters) : DEFAULT_FILTER_STATE
+      );
+    },
+    [setValue, filterSets, setSelectedFilterSet, setFilterState]
+  );
+
+  const queryLabel = useCallback(
+    (val: string) => {
+      const fs = filterSets.find((f) => String(f.id) === val);
+      return <>{fs?.name ?? val}</>;
+    },
+    [filterSets]
+  );
+
+  return (
+    <Flex alignItems={{ default: 'alignItemsFlexStart' }} style={{ marginLeft: '1.5rem' }}>
+      <FlexItem style={{ marginRight: '-1rem', paddingBottom: '1rem', minWidth: '180px' }}>
+        <PageAsyncSingleSelect
+          key={String(version)}
+          id={'filterset-select'}
+          placeholder={t('Select report')}
+          value={value}
+          queryLabel={queryLabel}
+          queryOptions={queryOptions}
+          onSelect={onSelect}
+          queryErrorText={t('Error loading report options')}
+        />
+      </FlexItem>
+      <FlexItem>
+        <PageToolbar {...props} toolbarActions={toolbarActions} />
+      </FlexItem>
+    </Flex>
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -57,6 +57,13 @@ export interface IDashboardDetails {
   host_chart: IDashboardChart;
 }
 
+export interface IDashboardFilterSet {
+  id: number;
+  name: string;
+  filters: string;
+  is_default: boolean;
+}
+
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
 
 export interface AutomationDashboardToolbarFiltersProps {

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
@@ -1,0 +1,279 @@
+/* eslint-disable i18next/no-literal-string */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import type { IDashboardFilterSet } from '../types';
+import { useFilterSetView } from './useFilterSetView';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const filterSetA: IDashboardFilterSet = {
+  id: 1,
+  name: 'Report A',
+  filters: '{"period":["last_7_days"]}',
+  is_default: false,
+};
+
+const filterSetB: IDashboardFilterSet = {
+  id: 2,
+  name: 'Report B',
+  filters: '{"period":["last_30_days"]}',
+  is_default: true,
+};
+
+const pageResponse = (results: IDashboardFilterSet[], next: string | null = null) => ({
+  count: results.length,
+  next,
+  previous: null,
+  results,
+});
+
+// ─── MSW server ───────────────────────────────────────────────────────────────
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+function queryOpts(
+  search = ''
+): Parameters<ReturnType<typeof useFilterSetView>['queryOptions']>[0] {
+  return { signal: new AbortController().signal, next: undefined, search };
+}
+
+describe('useFilterSetView', () => {
+  describe('initial state', () => {
+    test('should start with undefined value and empty filterSets', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      expect(result.current.value).toBeUndefined();
+      expect(result.current.version).toBe(0);
+      expect(result.current.filterSets).toEqual([]);
+      expect(result.current.selectedFilterSet).toBeUndefined();
+    });
+
+    test('should expose required functions', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      expect(result.current.setValue).toBeTypeOf('function');
+      expect(result.current.queryOptions).toBeTypeOf('function');
+      expect(result.current.setSelectedFilterSet).toBeTypeOf('function');
+      expect(result.current.removeFilterSet).toBeTypeOf('function');
+      expect(result.current.upsertFilterSet).toBeTypeOf('function');
+    });
+  });
+
+  describe('setSelectedFilterSet', () => {
+    test('should update selectedFilterSet', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.setSelectedFilterSet(filterSetA);
+      });
+
+      expect(result.current.selectedFilterSet).toEqual(filterSetA);
+    });
+
+    test('should clear selectedFilterSet when set to undefined', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.setSelectedFilterSet(filterSetA);
+      });
+      act(() => {
+        result.current.setSelectedFilterSet(undefined);
+      });
+
+      expect(result.current.selectedFilterSet).toBeUndefined();
+    });
+  });
+
+  describe('upsertFilterSet', () => {
+    test('should add a new filter set and set value to its id', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+      });
+
+      expect(result.current.filterSets).toContainEqual(filterSetA);
+      expect(result.current.value).toBe('1');
+    });
+
+    test('should increment version on every upsert to force remount', () => {
+      const { result } = renderHook(() => useFilterSetView());
+      const initialVersion = result.current.version;
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+      });
+
+      expect(result.current.version).toBe(initialVersion + 1);
+    });
+
+    test('should update an existing filter set by id', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+      });
+
+      const updated: IDashboardFilterSet = { ...filterSetA, name: 'Report A – Updated' };
+      act(() => {
+        result.current.upsertFilterSet(updated);
+      });
+
+      expect(result.current.filterSets).toHaveLength(1);
+      expect(result.current.filterSets[0].name).toBe('Report A – Updated');
+    });
+
+    test('should accumulate multiple distinct filter sets', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+      });
+      act(() => {
+        result.current.upsertFilterSet(filterSetB);
+      });
+
+      expect(result.current.filterSets).toHaveLength(2);
+    });
+  });
+
+  describe('removeFilterSet', () => {
+    test('should remove the filter set and reset value and selectedFilterSet', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+        result.current.setSelectedFilterSet(filterSetA);
+      });
+
+      act(() => {
+        result.current.removeFilterSet(filterSetA);
+      });
+
+      expect(result.current.filterSets).not.toContainEqual(filterSetA);
+      expect(result.current.value).toBeUndefined();
+      expect(result.current.selectedFilterSet).toBeUndefined();
+    });
+
+    test('should not affect other filter sets when removing one', () => {
+      const { result } = renderHook(() => useFilterSetView());
+
+      act(() => {
+        result.current.upsertFilterSet(filterSetA);
+        result.current.upsertFilterSet(filterSetB);
+      });
+      act(() => {
+        result.current.removeFilterSet(filterSetA);
+      });
+
+      expect(result.current.filterSets).toHaveLength(1);
+      expect(result.current.filterSets[0]).toEqual(filterSetB);
+    });
+  });
+
+  describe('queryOptions', () => {
+    test('should fetch options from the API and return them', async () => {
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(pageResponse([filterSetA, filterSetB]))
+        )
+      );
+
+      const { result } = renderHook(() => useFilterSetView());
+
+      let options: Awaited<ReturnType<typeof result.current.queryOptions>>;
+      await act(async () => {
+        options = await result.current.queryOptions(queryOpts());
+      });
+
+      expect(options!.options).toEqual([
+        { label: 'Report A', value: '1' },
+        { label: 'Report B', value: '2' },
+      ]);
+      expect(options!.remaining).toBe(0);
+    });
+
+    test('should merge fetched results into filterSets cache', async () => {
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(pageResponse([filterSetA]))
+        )
+      );
+
+      const { result } = renderHook(() => useFilterSetView());
+
+      await act(async () => {
+        await result.current.queryOptions(queryOpts());
+      });
+
+      await waitFor(() => {
+        expect(result.current.filterSets).toContainEqual(filterSetA);
+      });
+    });
+
+    test('should not add duplicate entries to the filterSets cache', async () => {
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(pageResponse([filterSetA]))
+        )
+      );
+
+      const { result } = renderHook(() => useFilterSetView());
+
+      // Two sequential calls — React must flush state between them
+      await act(async () => {
+        await result.current.queryOptions(queryOpts());
+      });
+      await act(async () => {
+        await result.current.queryOptions(queryOpts());
+      });
+
+      expect(result.current.filterSets.filter((f) => f.id === filterSetA.id)).toHaveLength(1);
+    });
+
+    test('should include next page token when more pages exist', async () => {
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json({ ...pageResponse([filterSetA], 'page2'), count: 15 })
+        )
+      );
+
+      const { result } = renderHook(() => useFilterSetView());
+
+      let options: Awaited<ReturnType<typeof result.current.queryOptions>>;
+      await act(async () => {
+        options = await result.current.queryOptions(queryOpts());
+      });
+
+      expect(options!.next).toBe('2');
+      expect(options!.remaining).toBeGreaterThan(0);
+    });
+
+    test('should pass the search parameter to the API', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(pageResponse([]));
+        })
+      );
+
+      const { result } = renderHook(() => useFilterSetView());
+
+      await act(async () => {
+        await result.current.queryOptions(queryOpts('my report'));
+      });
+
+      expect(new URL(capturedUrl).searchParams.get('search')).toBe('my report');
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
@@ -15,9 +15,6 @@ export function useFilterSetView() {
     undefined
   );
 
-  // Refs allow queryOptions (stable useCallback) to always read the latest values
-  const filterSetsRef = useRef(filterSets);
-  filterSetsRef.current = filterSets;
   const getRequest = useGetRequest<AwxItemsResponse<IDashboardFilterSet>>();
   const getRequestRef = useRef(getRequest);
   getRequestRef.current = getRequest;
@@ -30,7 +27,7 @@ export function useFilterSetView() {
     const data = await getRequestRef.current(metricsAPI`/dashboard_reports/filter_sets/`, query);
 
     const hasMore = data.results.length > 0 && !!data.next;
-    const remaining = hasMore ? data.count - page * PAGE_SIZE : 0;
+    const remaining = hasMore ? Math.max(0, data.count - page * PAGE_SIZE) : 0;
     const nextPage = hasMore ? String(page + 1) : '';
 
     const validResults = data.results.filter(

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useRef, useState } from 'react';
+import { useGetRequest } from '@ansible/common-ui/crud/useGet';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { PageAsyncSelectOptionsFn } from '@ansible/ansible-ui-framework/PageInputs/PageAsyncSelectOptions';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import { IDashboardFilterSet } from '../types';
+
+const PAGE_SIZE = 10;
+
+export function useFilterSetView() {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  const [version, setVersion] = useState(0);
+  const [filterSets, setFilterSets] = useState<IDashboardFilterSet[]>([]);
+  const [selectedFilterSet, setSelectedFilterSet] = useState<IDashboardFilterSet | undefined>(
+    undefined
+  );
+
+  // Refs allow queryOptions (stable useCallback) to always read the latest values
+  const filterSetsRef = useRef(filterSets);
+  filterSetsRef.current = filterSets;
+  const getRequest = useGetRequest<AwxItemsResponse<IDashboardFilterSet>>();
+  const getRequestRef = useRef(getRequest);
+  getRequestRef.current = getRequest;
+
+  const queryOptions = useCallback<PageAsyncSelectOptionsFn<string>>(async ({ next, search }) => {
+    const page = next ? Number(next) : 1;
+    const query: Record<string, string | number> = { page, page_size: PAGE_SIZE, order_by: 'name' };
+    if (search) query['search'] = search;
+
+    const data = await getRequestRef.current(metricsAPI`/dashboard_reports/filter_sets/`, query);
+
+    const hasMore = data.results.length > 0 && !!data.next;
+    const remaining = hasMore ? data.count - page * PAGE_SIZE : 0;
+    const nextPage = hasMore ? String(page + 1) : '';
+
+    const validResults = data.results.filter(
+      (r): r is IDashboardFilterSet & { name: string } => !!r.name && r.id !== undefined
+    );
+
+    // Merge fetched results into local cache, avoiding duplicates
+    setFilterSets((prev) => {
+      const existingIds = new Set(prev.map((r) => r.id));
+      const additions = validResults.filter((r) => !existingIds.has(r.id));
+      return additions.length > 0 ? [...prev, ...additions] : prev;
+    });
+
+    return {
+      remaining,
+      options: validResults.map((r) => ({ label: r.name, value: String(r.id) })),
+      next: nextPage,
+    };
+  }, []);
+
+  const removeFilterSet = useCallback((filterSet: IDashboardFilterSet) => {
+    setValue(undefined);
+    setSelectedFilterSet(undefined);
+    setFilterSets((prev) => prev.filter((fs) => fs.id !== filterSet.id));
+    setVersion((v) => v + 1);
+  }, []);
+
+  const upsertFilterSet = useCallback((filterSet: IDashboardFilterSet) => {
+    setFilterSets((prev) => {
+      const exists = prev.some((fs) => fs.id === filterSet.id);
+      return exists
+        ? prev.map((fs) => (fs.id === filterSet.id ? filterSet : fs))
+        : [...prev, filterSet];
+    });
+    setValue(String(filterSet.id));
+    // Increment version to force PageAsyncSingleSelect remount and clear stale options cache
+    setVersion((v) => v + 1);
+  }, []);
+
+  return {
+    value,
+    version,
+    setValue,
+    queryOptions,
+    filterSets,
+    selectedFilterSet,
+    setSelectedFilterSet,
+    removeFilterSet,
+    upsertFilterSet,
+  };
+}


### PR DESCRIPTION
## Summary

This pull request refactors the Automation Dashboard toolbar in AWX to add support for saving, editing, and deleting report filter sets, and introduces a new custom toolbar component. It also improves the mocking strategy in tests and adds comprehensive unit tests for the new toolbar actions hook.

**Toolbar refactor and feature enhancement:**

* Replaces the generic `PageToolbar` in `AutomationDashboard.tsx` with a new custom `DashboardToolbar` component, passing all relevant table view props and `toolbarFilters` for more flexible and feature-rich toolbar actions.

**Report filter set actions:**

* Adds a new hook `useAutomationDashboardToolbarActions` that enables creating, editing, and deleting report filter sets, with logic to enable/disable actions based on user permissions and filter state.
* The toolbar actions now render as a single button or a dropdown with sub-actions, depending on whether a report filter set is selected.

**Testing improvements:**

* Adds comprehensive unit tests for `useAutomationDashboardToolbarActions`, covering all action states, permission checks, and handler invocations.
* Updates test mocks for `@ansible/ansible-ui-framework` in `AutomationDashboard.test.tsx` to use the actual module as a base and override only the necessary components, improving test reliability. 

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="1600" height="804" alt="image" src="https://github.com/user-attachments/assets/0fd51cdf-d99d-4164-b019-82b71db48cf9" />

<img width="1600" height="804" alt="image" src="https://github.com/user-attachments/assets/c59d3ac7-c872-4a00-b6a6-34d43962e989" />

<img width="1600" height="586" alt="image" src="https://github.com/user-attachments/assets/58d3a596-98ef-440e-b3b9-bf8935f1a4e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Save current filter settings as reusable reports (create, edit, delete) via a modal with success toasts.
  - Added a dashboard toolbar and selector to manage/apply saved reports; integrates into the automation dashboard and falls back safely when saved data is invalid.
  - Report saving and deletion restricted to administrators, with explanatory disabled states/messages.

* **Tests**
  - Added comprehensive tests for toolbar actions, dialog flows, create/update/delete, selector behavior, async loading, and related integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->