### PR TITLE
[AAP-70430] Shift platform help menu checks to Vitest and trim Playwright

### DIFF
--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -48,6 +48,10 @@ function mountAbout(settings: IPageSettings) {
   );
 }
 
+async function expectAboutDialogAbsent() {
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+}
+
 describe('PlatformAbout', () => {
   const server = setupServer(
     http.get(awxAPI`/ping/`, () => HttpResponse.json({ version: '4.5.0' })),
@@ -59,53 +63,41 @@ describe('PlatformAbout', () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
-  it('should display brand logo with alt text and default logo src', async () => {
-    mountAbout({ activeTheme: 'light' });
-
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
-      'src',
-      '/assets/platform-logo.svg'
-    );
-  });
-
-  it('should use white logo when active theme is dark', async () => {
-    mountAbout({ activeTheme: 'dark' });
-
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
-      'src',
-      '/assets/platform-logo-white.svg'
-    );
-  });
-
-  it('should use standard logo when active theme is light', async () => {
-    mountAbout({ activeTheme: 'light' });
-
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
-      'src',
-      '/assets/platform-logo.svg'
-    );
-  });
+  it.each([
+    {
+      activeTheme: 'light' as const,
+      expectedSrc: '/assets/platform-logo.svg',
+    },
+    {
+      activeTheme: 'dark' as const,
+      expectedSrc: '/assets/platform-logo-white.svg',
+    },
+  ])(
+    'should set brand image src to $expectedSrc when theme is $activeTheme',
+    async ({ activeTheme, expectedSrc }) => {
+      mountAbout({ activeTheme });
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
+        'src',
+        expectedSrc
+      );
+    }
+  );
 
   it('should close when the close button is activated', async () => {
     const user = userEvent.setup();
     mountAbout({ activeTheme: 'light' });
-
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    await screen.findByRole('dialog');
     await user.click(screen.getByRole('button', { name: /close/i }));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await expectAboutDialogAbsent();
   });
 
   it('should close when Escape is pressed', async () => {
     const user = userEvent.setup();
     mountAbout({ activeTheme: 'light' });
-
     const dialog = await screen.findByRole('dialog');
-    expect(dialog).toBeInTheDocument();
     dialog.focus();
     await user.keyboard('{Escape}');
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await expectAboutDialogAbsent();
   });
 });

--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -1,0 +1,111 @@
+import {
+  PageDialogProvider,
+  PageSettingsContext,
+  usePageDialog,
+  type IPageSettings,
+} from '@ansible/ansible-ui-framework';
+import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { edaAPI } from '@ansible/eda-ui/common/eda-utils';
+import { hubAPI } from '@ansible/hub-ui/common/api/formatPath';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import type { ComponentProps } from 'react';
+import { useEffect } from 'react';
+import { SWRConfig } from 'swr';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { PlatformAbout } from './PlatformAbout';
+
+vi.mock('@patternfly/react-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@patternfly/react-core')>();
+  const PfAboutModal = actual.AboutModal;
+  return {
+    ...actual,
+    AboutModal: (props: ComponentProps<typeof PfAboutModal>) => (
+      <PfAboutModal {...props} disableFocusTrap />
+    ),
+  };
+});
+
+function OpenPlatformAboutDialog() {
+  const [, setDialog] = usePageDialog();
+  useEffect(() => {
+    setDialog(<PlatformAbout platformVersion="2.5" />);
+  }, [setDialog]);
+  return null;
+}
+
+function mountAbout(settings: IPageSettings) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <PageSettingsContext.Provider value={[settings, vi.fn()]}>
+        <PageDialogProvider>
+          <OpenPlatformAboutDialog />
+        </PageDialogProvider>
+      </PageSettingsContext.Provider>
+    </SWRConfig>
+  );
+}
+
+describe('PlatformAbout', () => {
+  const server = setupServer(
+    http.get(awxAPI`/ping/`, () => HttpResponse.json({ version: '4.5.0' })),
+    http.get(hubAPI`/`, () => HttpResponse.json({ galaxy_ng_version: '4.9.0' })),
+    http.get(edaAPI`/config/`, () => HttpResponse.json({ version: '1.2.0' }))
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it('should display brand logo with alt text and default logo src', async () => {
+    mountAbout({ activeTheme: 'light' });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
+      'src',
+      '/assets/platform-logo.svg'
+    );
+  });
+
+  it('should use white logo when active theme is dark', async () => {
+    mountAbout({ activeTheme: 'dark' });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
+      'src',
+      '/assets/platform-logo-white.svg'
+    );
+  });
+
+  it('should use standard logo when active theme is light', async () => {
+    mountAbout({ activeTheme: 'light' });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
+      'src',
+      '/assets/platform-logo.svg'
+    );
+  });
+
+  it('should close when the close button is activated', async () => {
+    const user = userEvent.setup();
+    mountAbout({ activeTheme: 'light' });
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('should close when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    mountAbout({ activeTheme: 'light' });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    dialog.focus();
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+});

--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -72,6 +72,27 @@ describe('PlatformAbout', () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
+  it('should display complete content with versions from APIs', async () => {
+    mountAbout({ activeTheme: 'light' });
+    const dialog = await screen.findByRole('dialog');
+
+    expect(within(dialog).getByText(/Ansible Automation Platform/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/Copyright.*Red Hat/)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('Automation Controller Version')).toBeInTheDocument();
+      expect(within(dialog).getByText('4.5.0')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(within(dialog).getByText('Event-Driven Ansible Version')).toBeInTheDocument();
+      expect(within(dialog).getByText('1.2.0')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(within(dialog).getByText('Automation Hub Version')).toBeInTheDocument();
+      expect(within(dialog).getByText('4.9.0')).toBeInTheDocument();
+    });
+  });
+
   it.each([
     {
       label: 'light',

--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -52,6 +52,13 @@ async function expectAboutDialogAbsent() {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 }
 
+async function setupLightAboutDialog() {
+  const user = userEvent.setup();
+  mountAbout({ activeTheme: 'light' });
+  const dialog = await screen.findByRole('dialog');
+  return { user, dialog };
+}
+
 describe('PlatformAbout', () => {
   const server = setupServer(
     http.get(awxAPI`/ping/`, () => HttpResponse.json({ version: '4.5.0' })),
@@ -65,37 +72,32 @@ describe('PlatformAbout', () => {
 
   it.each([
     {
+      label: 'light',
       activeTheme: 'light' as const,
       expectedSrc: '/assets/platform-logo.svg',
     },
     {
+      label: 'dark',
       activeTheme: 'dark' as const,
       expectedSrc: '/assets/platform-logo-white.svg',
     },
-  ])(
-    'should set brand image src to $expectedSrc when theme is $activeTheme',
-    async ({ activeTheme, expectedSrc }) => {
-      mountAbout({ activeTheme });
-      const dialog = await screen.findByRole('dialog');
-      expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
-        'src',
-        expectedSrc
-      );
-    }
-  );
+  ])('should set brand image src for %# $label theme', async ({ activeTheme, expectedSrc }) => {
+    mountAbout({ activeTheme });
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('img', { name: 'Brand Logo' })).toHaveAttribute(
+      'src',
+      expectedSrc
+    );
+  });
 
   it('should close when the close button is activated', async () => {
-    const user = userEvent.setup();
-    mountAbout({ activeTheme: 'light' });
-    await screen.findByRole('dialog');
+    const { user } = await setupLightAboutDialog();
     await user.click(screen.getByRole('button', { name: /close/i }));
     await expectAboutDialogAbsent();
   });
 
   it('should close when Escape is pressed', async () => {
-    const user = userEvent.setup();
-    mountAbout({ activeTheme: 'light' });
-    const dialog = await screen.findByRole('dialog');
+    const { user, dialog } = await setupLightAboutDialog();
     dialog.focus();
     await user.keyboard('{Escape}');
     await expectAboutDialogAbsent();

--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -15,6 +15,8 @@ import type { ComponentProps } from 'react';
 import { useEffect } from 'react';
 import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import platformLogo from '../assets/platform-logo.svg?url';
+import platformLogoWhite from '../assets/platform-logo-white.svg?url';
 import { PlatformAbout } from './PlatformAbout';
 
 vi.mock('@patternfly/react-core', async (importOriginal) => {
@@ -74,12 +76,12 @@ describe('PlatformAbout', () => {
     {
       label: 'light',
       activeTheme: 'light' as const,
-      expectedSrc: '/assets/platform-logo.svg',
+      expectedSrc: platformLogo,
     },
     {
       label: 'dark',
       activeTheme: 'dark' as const,
-      expectedSrc: '/assets/platform-logo-white.svg',
+      expectedSrc: platformLogoWhite,
     },
   ])('should set brand image src for %# $label theme', async ({ activeTheme, expectedSrc }) => {
     mountAbout({ activeTheme });

--- a/platform/main/PlatformAbout.tsx
+++ b/platform/main/PlatformAbout.tsx
@@ -4,12 +4,13 @@ import { useGet } from '@ansible/common-ui/crud/useGet';
 import { edaAPI } from '@ansible/eda-ui/common/eda-utils';
 import { hubAPI } from '@ansible/hub-ui/common/api/formatPath';
 import { AboutModal, Content } from '@patternfly/react-core';
-import { t } from 'i18next';
 import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export const PlatformAbout: React.FunctionComponent<{
   platformVersion?: string;
 }> = ({ platformVersion }) => {
+  const { t } = useTranslation();
   const awxInfo = useGet<{ version: string }>(awxAPI`/ping/`);
   const hubInfo = useGet<{ galaxy_ng_version: string }>(hubAPI`/`);
   const edaInfo = useGet<{ version: string }>(edaAPI`/config/`);

--- a/platform/main/PlatformMasthead.test.tsx
+++ b/platform/main/PlatformMasthead.test.tsx
@@ -99,6 +99,14 @@ function mountMasthead(settings?: IPageSettings) {
   );
 }
 
+function getHelpMenuToggle(): HTMLElement {
+  const el = document.getElementById('help-menu-menu-toggle');
+  if (!el) {
+    throw new Error('Expected #help-menu-menu-toggle to be in the document');
+  }
+  return el;
+}
+
 describe('PlatformMasthead help menu', () => {
   beforeEach(() => {
     mockPageNavigate.mockClear();
@@ -113,16 +121,15 @@ describe('PlatformMasthead help menu', () => {
     const user = userEvent.setup();
     mountMasthead();
 
-    const helpToggle = document.getElementById('help-menu-menu-toggle');
-    expect(helpToggle).toBeTruthy();
+    const helpToggle = getHelpMenuToggle();
     expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
 
-    await user.click(helpToggle!);
+    await user.click(helpToggle);
     expect(helpToggle).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByTestId('masthead-documentation')).toBeVisible();
     expect(screen.getByTestId('masthead-about')).toBeVisible();
 
-    await user.click(helpToggle!);
+    await user.click(helpToggle);
     expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByTestId('masthead-documentation')).not.toBeInTheDocument();
   });
@@ -131,7 +138,7 @@ describe('PlatformMasthead help menu', () => {
     const user = userEvent.setup();
     mountMasthead();
 
-    await user.click(document.getElementById('help-menu-menu-toggle')!);
+    await user.click(getHelpMenuToggle());
     const docItem = screen.getByTestId('masthead-documentation');
     expect(within(docItem).getByRole('menuitem', { name: 'Documentation' })).toHaveAttribute(
       'href',
@@ -143,7 +150,7 @@ describe('PlatformMasthead help menu', () => {
     const user = userEvent.setup();
     mountMasthead();
 
-    await user.click(document.getElementById('help-menu-menu-toggle')!);
+    await user.click(getHelpMenuToggle());
     await user.click(screen.getByRole('menuitem', { name: 'Quick starts' }));
     expect(mockPageNavigate).toHaveBeenCalledWith(PlatformRoute.QuickStarts);
   });
@@ -152,7 +159,7 @@ describe('PlatformMasthead help menu', () => {
     const user = userEvent.setup();
     mountMasthead();
 
-    const helpToggle = document.getElementById('help-menu-menu-toggle')!;
+    const helpToggle = getHelpMenuToggle();
     helpToggle.focus();
     expect(helpToggle).toHaveFocus();
 
@@ -176,7 +183,7 @@ describe('PlatformMasthead help menu', () => {
     mockUseBreakpoint.mockImplementation((size: WindowSize) => size === 'sm');
     mountMasthead();
 
-    const helpToggle = document.getElementById('help-menu-menu-toggle')!;
+    const helpToggle = getHelpMenuToggle();
     expect(helpToggle).toBeVisible();
     await user.click(helpToggle);
     expect(screen.getByTestId('masthead-documentation')).toBeVisible();

--- a/platform/main/PlatformMasthead.test.tsx
+++ b/platform/main/PlatformMasthead.test.tsx
@@ -1,0 +1,185 @@
+import {
+  PageDialogProvider,
+  PageNavSideBarProvider,
+  PageSettingsContext,
+  type IPageSettings,
+  type WindowSize,
+} from '@ansible/ansible-ui-framework';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { QuickStart } from '@patternfly/quickstarts';
+import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlatformMasthead } from './PlatformMasthead';
+import { PlatformRoute } from './PlatformRoutes';
+
+const { mockPageNavigate, mockUseBreakpoint } = vi.hoisted(() => ({
+  mockPageNavigate: vi.fn(),
+  mockUseBreakpoint: vi.fn((_size: WindowSize) => true),
+}));
+
+vi.mock('@ansible/ansible-ui-framework', async () => {
+  const actual = await vi.importActual<typeof import('@ansible/ansible-ui-framework')>(
+    '@ansible/ansible-ui-framework'
+  );
+  return {
+    ...actual,
+    usePageNavigate: () => mockPageNavigate,
+    PageNotificationsIcon: () => <span data-testid="notifications-stub" />,
+    useBreakpoint: (size: WindowSize) => mockUseBreakpoint(size),
+  };
+});
+
+vi.mock('@ansible/awx-ui/main/AwxMasthead', () => ({
+  useAwxNotifications: () => undefined,
+}));
+
+vi.mock('@ansible/hub-ui/main/HubMasthead', () => ({
+  useHubNotifications: () => undefined,
+}));
+
+vi.mock('../notifications/useRssNotifications', () => ({
+  useRssNotifications: () => undefined,
+}));
+
+vi.mock('@ansible/awx-ui/common/useAwxActiveUser', () => ({
+  useAwxActiveUser: () => ({ refreshActiveAwxUser: vi.fn() }),
+}));
+
+vi.mock('@ansible/eda-ui/common/useEdaActiveUser', () => ({
+  useEdaActiveUser: () => ({ refreshActiveEdaUser: vi.fn() }),
+}));
+
+vi.mock('@ansible/hub-ui/common/useHubActiveUser', () => ({
+  useHubActiveUser: () => ({ refreshActiveHubUser: vi.fn() }),
+}));
+
+vi.mock('@ansible/common-ui/utils/useDocsVersion', () => ({
+  useDocsVersion: () => ({ version: '2.5' }),
+}));
+
+vi.mock('@ansible/common-ui/PageRefreshIcon', () => ({
+  PageRefreshIcon: () => null,
+}));
+
+vi.mock('@ansible/chatbot/ChatbotToolbarItem', () => ({
+  ChatbotToolbarItem: () => null,
+}));
+
+vi.mock('../overview/quickstarts/useQuickStarts', () => ({
+  useQuickStarts: vi.fn(() => [{ metadata: { name: 'qs-1' } } as QuickStart]),
+}));
+
+vi.mock('./PlatformActiveUserProvider', () => ({
+  usePlatformActiveUser: () => ({
+    activePlatformUser: { id: 1, username: 'admin' },
+    refreshActivePlatformUser: vi.fn(),
+  }),
+}));
+
+vi.mock('./GatewayUIAuth', () => ({
+  useIsManagedCloudInstall: () => false,
+}));
+
+function mountMasthead(settings?: IPageSettings) {
+  const pageSettings: IPageSettings = settings ?? { activeTheme: 'light', theme: 'light' };
+  return render(
+    <MemoryRouter>
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <PageSettingsContext.Provider value={[pageSettings, vi.fn()]}>
+          <PageNavSideBarProvider>
+            <PageDialogProvider>
+              <PlatformMasthead />
+            </PageDialogProvider>
+          </PageNavSideBarProvider>
+        </PageSettingsContext.Provider>
+      </SWRConfig>
+    </MemoryRouter>
+  );
+}
+
+describe('PlatformMasthead help menu', () => {
+  beforeEach(() => {
+    mockPageNavigate.mockClear();
+    mockUseBreakpoint.mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display help toggle with correct initial state and toggle open/closed', async () => {
+    const user = userEvent.setup();
+    mountMasthead();
+
+    const helpToggle = document.getElementById('help-menu-menu-toggle');
+    expect(helpToggle).toBeTruthy();
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(helpToggle!);
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('masthead-documentation')).toBeVisible();
+    expect(screen.getByTestId('masthead-about')).toBeVisible();
+
+    await user.click(helpToggle!);
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('masthead-documentation')).not.toBeInTheDocument();
+  });
+
+  it('should display documentation link with correct href', async () => {
+    const user = userEvent.setup();
+    mountMasthead();
+
+    await user.click(document.getElementById('help-menu-menu-toggle')!);
+    const docItem = screen.getByTestId('masthead-documentation');
+    expect(within(docItem).getByRole('menuitem', { name: 'Documentation' })).toHaveAttribute(
+      'href',
+      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform'
+    );
+  });
+
+  it('should call pageNavigate for Quick starts when the entry is shown', async () => {
+    const user = userEvent.setup();
+    mountMasthead();
+
+    await user.click(document.getElementById('help-menu-menu-toggle')!);
+    await user.click(screen.getByRole('menuitem', { name: 'Quick starts' }));
+    expect(mockPageNavigate).toHaveBeenCalledWith(PlatformRoute.QuickStarts);
+  });
+
+  it('should be keyboard navigable on the help menu toggle', async () => {
+    const user = userEvent.setup();
+    mountMasthead();
+
+    const helpToggle = document.getElementById('help-menu-menu-toggle')!;
+    helpToggle.focus();
+    expect(helpToggle).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('masthead-documentation')).toBeVisible();
+
+    await user.keyboard('{Escape}');
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
+
+    helpToggle.focus();
+    await user.keyboard('{Enter}');
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{Escape}');
+    expect(helpToggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should keep help menu usable when only small breakpoints resolve', async () => {
+    const user = userEvent.setup();
+    mockUseBreakpoint.mockImplementation((size: WindowSize) => size === 'sm');
+    mountMasthead();
+
+    const helpToggle = document.getElementById('help-menu-menu-toggle')!;
+    expect(helpToggle).toBeVisible();
+    await user.click(helpToggle);
+    expect(screen.getByTestId('masthead-documentation')).toBeVisible();
+    expect(screen.getByTestId('masthead-about')).toBeVisible();
+  });
+});

--- a/platform/main/PlatformMasthead.tsx
+++ b/platform/main/PlatformMasthead.tsx
@@ -107,7 +107,7 @@ export function PlatformMasthead() {
             </DropdownItem>
             {!managedCloudInstall && quickStarts.length > 0 ? (
               <DropdownItem
-                id="about"
+                id="quickstarts"
                 onClick={() => pageNavigate(PlatformRoute.QuickStarts)}
                 data-cy="masthead-quickstarts"
                 data-testid="masthead-quickstarts"

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -12,7 +12,7 @@ test.afterEach(setupAfter);
 test.describe('Platform Header Toolbar - Help Menu', () => {
   test(
     'should conditionally display based on topology type',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const awxConfigPromise = page.waitForResponse(
         (response) =>

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -10,69 +10,62 @@ test.beforeEach(setupBefore({ path: '/' }));
 test.afterEach(setupAfter);
 
 test.describe('Platform Header Toolbar - Help Menu', () => {
-  test.describe('Quick Starts', () => {
-    test(
-      'should conditionally display based on topology type',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        await page.locator('#help-menu-menu-toggle').click();
-        if (isTopology(TOPOLOGY_SAAS, TOPOLOGY_AZURE)) {
-          await expect(page.locator('[data-testid="masthead-quickstarts"]')).not.toBeVisible();
-        } else {
-          const quickStartsItem = page.locator('[data-testid="masthead-quickstarts"]');
-          await expect(quickStartsItem).toBeVisible();
-          await expect(quickStartsItem).toContainText('Quick starts');
-        }
-      }
-    );
-  });
-
-  test.describe('About Modal: Content Display', () => {
-    test(
-      'should display complete content with versions from APIs',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        const awxConfigPromise = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/controller/v2/ping/') &&
-            response.request().method() === 'GET'
-        );
-        const hubConfigPromise = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/galaxy/') && response.request().method() === 'GET'
-        );
-        await page.locator('#help-menu-menu-toggle').click();
-        await page.locator('[data-testid="masthead-about"]').click();
-        const awxResponse = await awxConfigPromise;
-        const hubResponse = await hubConfigPromise;
-        const awxConfig = (await awxResponse.json()) as ServiceVersionJson;
-        const hubConfig = (await hubResponse.json()) as HubRootJson;
-        const modal = page.getByRole('dialog');
-        await expect(modal).toBeVisible();
-        await expect(modal.getByText(/Ansible Automation Platform/)).toBeVisible();
-        await expect(modal.getByText(/Copyright.*Red Hat/)).toBeVisible();
-        await expect(modal.getByText('Automation Controller Version')).toBeVisible();
-        if (awxConfig.version) {
-          await expect(modal.getByText(awxConfig.version, { exact: true })).toBeVisible();
-        }
-        await expect(modal.getByText('Automation Hub Version')).toBeVisible();
-        if (hubConfig.galaxy_ng_version) {
-          await expect(modal.getByText(hubConfig.galaxy_ng_version, { exact: true })).toBeVisible();
-        }
-        if (!isSaaS()) {
-          const edaConfigPromise = page.waitForResponse(
+  test(
+    'should conditionally display based on topology type',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      const awxConfigPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/controller/v2/ping/') &&
+          response.request().method() === 'GET'
+      );
+      const hubConfigPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/galaxy/') && response.request().method() === 'GET'
+      );
+      const edaConfigPromise = !isSaaS()
+        ? page.waitForResponse(
             (response) =>
               response.url().includes('/api/eda/v1/config/') &&
               response.request().method() === 'GET'
-          );
-          const edaResponse = await edaConfigPromise;
-          const edaConfig = (await edaResponse.json()) as ServiceVersionJson;
-          await expect(modal.getByText('Event-Driven Ansible Version')).toBeVisible();
-          if (edaConfig.version) {
-            await expect(modal.getByText(edaConfig.version, { exact: true })).toBeVisible();
-          }
+          )
+        : null;
+
+      await page.locator('#help-menu-menu-toggle').click();
+
+      if (isTopology(TOPOLOGY_SAAS, TOPOLOGY_AZURE)) {
+        await expect(page.locator('[data-testid="masthead-quickstarts"]')).not.toBeVisible();
+      } else {
+        const quickStartsItem = page.locator('[data-testid="masthead-quickstarts"]');
+        await expect(quickStartsItem).toBeVisible();
+        await expect(quickStartsItem).toContainText('Quick starts');
+      }
+
+      await page.locator('[data-testid="masthead-about"]').click();
+      const awxResponse = await awxConfigPromise;
+      const hubResponse = await hubConfigPromise;
+      const awxConfig = (await awxResponse.json()) as ServiceVersionJson;
+      const hubConfig = (await hubResponse.json()) as HubRootJson;
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible();
+      await expect(modal.getByText(/Ansible Automation Platform/)).toBeVisible();
+      await expect(modal.getByText(/Copyright.*Red Hat/)).toBeVisible();
+      await expect(modal.getByText('Automation Controller Version')).toBeVisible();
+      if (awxConfig.version) {
+        await expect(modal.getByText(awxConfig.version, { exact: true })).toBeVisible();
+      }
+      await expect(modal.getByText('Automation Hub Version')).toBeVisible();
+      if (hubConfig.galaxy_ng_version) {
+        await expect(modal.getByText(hubConfig.galaxy_ng_version, { exact: true })).toBeVisible();
+      }
+      if (!isSaaS() && edaConfigPromise) {
+        const edaResponse = await edaConfigPromise;
+        const edaConfig = (await edaResponse.json()) as ServiceVersionJson;
+        await expect(modal.getByText('Event-Driven Ansible Version')).toBeVisible();
+        if (edaConfig.version) {
+          await expect(modal.getByText(edaConfig.version, { exact: true })).toBeVisible();
         }
       }
-    );
-  });
+    }
+  );
 });

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -23,13 +23,13 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
         (response) =>
           response.url().includes('/api/galaxy/') && response.request().method() === 'GET'
       );
-      const edaConfigPromise = !isSaaS()
-        ? page.waitForResponse(
+      const edaConfigPromise = isSaaS()
+        ? null
+        : page.waitForResponse(
             (response) =>
               response.url().includes('/api/eda/v1/config/') &&
               response.request().method() === 'GET'
-          )
-        : null;
+          );
 
       await page.locator('#help-menu-menu-toggle').click();
 
@@ -58,7 +58,7 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
       if (hubConfig.galaxy_ng_version) {
         await expect(modal.getByText(hubConfig.galaxy_ng_version, { exact: true })).toBeVisible();
       }
-      if (!isSaaS() && edaConfigPromise) {
+      if (edaConfigPromise) {
         const edaResponse = await edaConfigPromise;
         const edaConfig = (await edaResponse.json()) as ServiceVersionJson;
         await expect(modal.getByText('Event-Driven Ansible Version')).toBeVisible();

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -12,7 +12,7 @@ test.afterEach(setupAfter);
 test.describe('Platform Header Toolbar - Help Menu', () => {
   test(
     'should conditionally display based on topology type',
-    { tag: ['@not_mock', '@tier1'] },
+    { tag: ['@not_mock'] },
     async ({ page }) => {
       const awxConfigPromise = page.waitForResponse(
         (response) =>
@@ -68,99 +68,4 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
       }
     }
   );
-
-  test.describe('About Modal: Brand Logo', () => {
-    test(
-      'should display brand logo that loads successfully',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        await page.locator('#help-menu-menu-toggle').click();
-        await page.locator('[data-testid="masthead-about"]').click();
-
-        const modal = page.getByRole('dialog');
-        const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-        await expect(brandLogo).toBeVisible();
-        await expect(brandLogo).toHaveAttribute('alt', 'Brand Logo');
-        const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
-        expect(naturalWidth).toBeGreaterThan(0);
-      }
-    );
-
-    test('should load white logo for dark theme', { tag: ['@not_mock'] }, async ({ page }) => {
-      const themeButton = page.locator('[data-cy="theme-icon"]');
-      await expect(themeButton).toBeVisible();
-      await themeButton.click();
-
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-      await expect(brandLogo).toBeVisible();
-      const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
-      expect(naturalWidth).toBeGreaterThan(0);
-    });
-
-    test('should load standard logo for light theme', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-      await expect(brandLogo).toBeVisible();
-      const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
-      expect(naturalWidth).toBeGreaterThan(0);
-    });
-  });
-
-  test.describe('About Modal: User Interactions', () => {
-    test('should close using X button', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-      const modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-      await modal.locator('button[aria-label*="Close"]').first().click();
-      await expect(modal).not.toBeVisible();
-    });
-
-    test('should close using ESC key', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-      const modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-      await page.keyboard.press('Escape');
-      await expect(modal).not.toBeVisible();
-    });
-  });
-
-  test.describe('Accessibility', () => {
-    test('should be keyboard navigable', { tag: ['@not_mock'] }, async ({ page }) => {
-      const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-      await helpMenuToggle.focus();
-      await expect(helpMenuToggle).toBeFocused();
-      await page.keyboard.press('Enter');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'true');
-      await expect(page.locator('[data-testid="masthead-documentation"]')).toBeVisible();
-      await page.keyboard.press('Escape');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'false');
-      await helpMenuToggle.focus();
-      await page.keyboard.press('Space');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'true');
-      await page.keyboard.press('Escape');
-    });
-  });
-
-  test.describe('Responsive Design', () => {
-    test('should work on tablet viewport', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.setViewportSize({ width: 768, height: 1024 });
-      const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-      await expect(helpMenuToggle).toBeVisible();
-      await helpMenuToggle.click();
-      await expect(page.locator('[data-testid="masthead-documentation"]')).toBeVisible();
-      await expect(page.locator('[data-testid="masthead-about"]')).toBeVisible();
-    });
-  });
 });

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -13,7 +13,7 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
   test.describe('Quick Starts', () => {
     test(
       'should conditionally display based on topology type',
-      { tag: ['@not_mock', '@pre_merge'] },
+      { tag: ['@not_mock'] },
       async ({ page }) => {
         await page.locator('#help-menu-menu-toggle').click();
         if (isTopology(TOPOLOGY_SAAS, TOPOLOGY_AZURE)) {
@@ -30,7 +30,7 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
   test.describe('About Modal: Content Display', () => {
     test(
       'should display complete content with versions from APIs',
-      { tag: ['@not_mock', '@tier1'] },
+      { tag: ['@not_mock'] },
       async ({ page }) => {
         const awxConfigPromise = page.waitForResponse(
           (response) =>

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -1,117 +1,28 @@
 import { TOPOLOGY_AZURE, TOPOLOGY_SAAS } from '@ansible/playwright/commands/constants';
-import { isTopology, isSaaS } from '@ansible/playwright/commands/getTopologyType';
+import { isSaaS, isTopology } from '@ansible/playwright/commands/getTopologyType';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
 import { expect, test } from '@playwright/test';
 
-// Type definitions for API responses
-interface AwxConfig {
-  version: string;
-  [key: string]: unknown;
-}
-
-interface HubConfig {
-  galaxy_ng_version: string;
-  [key: string]: unknown;
-}
-
-interface EdaConfig {
-  version: string;
-  [key: string]: unknown;
-}
+type ServiceVersionJson = { version: string };
+type HubRootJson = { galaxy_ng_version: string };
 
 test.beforeEach(setupBefore({ path: '/' }));
 test.afterEach(setupAfter);
 
 test.describe('Platform Header Toolbar - Help Menu', () => {
-  test.describe('Help Menu Toggle and Display', () => {
-    test(
-      'should display button with correct initial state and toggle open/closed',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        // Initial state - button should be visible and closed
-        const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-        await expect(helpMenuToggle).toBeVisible();
-        await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'false');
-        // Open menu
-        await helpMenuToggle.click();
-        await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'true');
-        // Verify menu items are visible
-        await expect(page.locator('[data-testid="masthead-documentation"]')).toBeVisible();
-        await expect(page.locator('[data-testid="masthead-about"]')).toBeVisible();
-        // Close menu by clicking toggle again
-        await helpMenuToggle.click();
-        await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'false');
-        // Verify menu is closed
-        await expect(page.locator('[data-testid="masthead-documentation"]')).not.toBeVisible();
-      }
-    );
-  });
-
-  test.describe('Menu Items', () => {
-    test(
-      'menu should display documentation link with correct attributes',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        // Open help menu
-        await page.locator('#help-menu-menu-toggle').click();
-        // Verify documentation item
-        const docItem = page.locator('[data-testid="masthead-documentation"]');
-        await expect(docItem).toBeVisible();
-        await expect(docItem).toContainText('Documentation');
-        // Verify link attributes
-        const docLink = docItem.locator('a');
-        await expect(docLink).toHaveAttribute(
-          'href',
-          'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform'
-        );
-      }
-    );
-  });
-
   test.describe('Quick Starts', () => {
     test(
       'should conditionally display based on topology type',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@pre_merge'] },
       async ({ page }) => {
-        // Open help menu
         await page.locator('#help-menu-menu-toggle').click();
         if (isTopology(TOPOLOGY_SAAS, TOPOLOGY_AZURE)) {
-          // Quick starts should NOT exist in SaaS/Azure deployments
           await expect(page.locator('[data-testid="masthead-quickstarts"]')).not.toBeVisible();
         } else {
-          // Quick starts should exist in other deployments
           const quickStartsItem = page.locator('[data-testid="masthead-quickstarts"]');
           await expect(quickStartsItem).toBeVisible();
           await expect(quickStartsItem).toContainText('Quick starts');
         }
-      }
-    );
-
-    test(
-      'should navigate to quick starts page and close menu',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        // Skip for SaaS/Azure
-        if (isTopology(TOPOLOGY_SAAS, TOPOLOGY_AZURE)) {
-          test.skip();
-          return;
-        }
-        // Open help menu
-        const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-        await helpMenuToggle.click();
-        // Click quick starts
-        await page.locator('[data-testid="masthead-quickstarts"]').click();
-        // Verify navigation occurred
-        await expect(page).toHaveURL(/\/quickstarts/);
-        // Verify menu closed after navigation
-        await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'false');
-        // Verify quick starts page loaded
-        await expect(
-          page.getByRole('heading', { name: 'Quick Starts', exact: true })
-        ).toBeVisible();
-        await expect(
-          page.getByText('Learn Ansible automation with hands-on quickstarts.')
-        ).toBeVisible();
       }
     );
   });
@@ -119,9 +30,8 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
   test.describe('About Modal: Content Display', () => {
     test(
       'should display complete content with versions from APIs',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
-        // Set up API intercepts
         const awxConfigPromise = page.waitForResponse(
           (response) =>
             response.url().includes('/api/controller/v2/ping/') &&
@@ -131,32 +41,24 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
           (response) =>
             response.url().includes('/api/galaxy/') && response.request().method() === 'GET'
         );
-        // Open help menu and click About
         await page.locator('#help-menu-menu-toggle').click();
         await page.locator('[data-testid="masthead-about"]').click();
-        // Wait for API responses
         const awxResponse = await awxConfigPromise;
         const hubResponse = await hubConfigPromise;
-        const awxConfig = (await awxResponse.json()) as AwxConfig;
-        const hubConfig = (await hubResponse.json()) as HubConfig;
-        // Verify modal is visible
+        const awxConfig = (await awxResponse.json()) as ServiceVersionJson;
+        const hubConfig = (await hubResponse.json()) as HubRootJson;
         const modal = page.getByRole('dialog');
         await expect(modal).toBeVisible();
-        // Verify modal title/branding
         await expect(modal.getByText(/Ansible Automation Platform/)).toBeVisible();
-        // Verify trademark/copyright
         await expect(modal.getByText(/Copyright.*Red Hat/)).toBeVisible();
-        // Verify Automation Controller Version
         await expect(modal.getByText('Automation Controller Version')).toBeVisible();
         if (awxConfig.version) {
           await expect(modal.getByText(awxConfig.version, { exact: true })).toBeVisible();
         }
-        // Verify Automation Hub Version
         await expect(modal.getByText('Automation Hub Version')).toBeVisible();
         if (hubConfig.galaxy_ng_version) {
           await expect(modal.getByText(hubConfig.galaxy_ng_version, { exact: true })).toBeVisible();
         }
-        // For non-SaaS deployments, verify EDA version
         if (!isSaaS()) {
           const edaConfigPromise = page.waitForResponse(
             (response) =>
@@ -164,7 +66,7 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
               response.request().method() === 'GET'
           );
           const edaResponse = await edaConfigPromise;
-          const edaConfig = (await edaResponse.json()) as EdaConfig;
+          const edaConfig = (await edaResponse.json()) as ServiceVersionJson;
           await expect(modal.getByText('Event-Driven Ansible Version')).toBeVisible();
           if (edaConfig.version) {
             await expect(modal.getByText(edaConfig.version, { exact: true })).toBeVisible();
@@ -172,101 +74,5 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
         }
       }
     );
-  });
-
-  test.describe('About Modal: Brand Logo', () => {
-    test('should display brand logo with alt text', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-      await expect(brandLogo).toBeVisible();
-      await expect(brandLogo).toHaveAttribute('alt', 'Brand Logo');
-      await expect(brandLogo).toHaveAttribute('src', /platform-logo.*\.svg$/);
-    });
-
-    test('should use white logo for dark theme', { tag: ['@not_mock'] }, async ({ page }) => {
-      const themeButton = page.locator('[data-cy="theme-icon"]');
-      await expect(themeButton).toBeVisible();
-      await themeButton.click();
-
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-      await expect(brandLogo).toHaveAttribute('src', '/assets/platform-logo-white.svg');
-    });
-
-    test('should use standard logo for light theme', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
-
-      await expect(brandLogo).toHaveAttribute('src', '/assets/platform-logo.svg');
-    });
-  });
-
-  test.describe('About Modal: User Interactions', () => {
-    test('should close using X button', { tag: ['@not_mock'] }, async ({ page }) => {
-      // Open about modal
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-      const modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-      // Click close button
-      await modal.locator('button[aria-label*="Close"]').first().click();
-      await expect(modal).not.toBeVisible();
-    });
-
-    test('should close using ESC key', { tag: ['@not_mock'] }, async ({ page }) => {
-      // Open about modal
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
-      const modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-      // Press ESC
-      await page.keyboard.press('Escape');
-      await expect(modal).not.toBeVisible();
-    });
-  });
-
-  test.describe('Accessibility', () => {
-    test('should be keyboard navigable', { tag: ['@not_mock'] }, async ({ page }) => {
-      // Focus help menu button
-      const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-      await helpMenuToggle.focus();
-      await expect(helpMenuToggle).toBeFocused();
-      // Open with Enter key
-      await page.keyboard.press('Enter');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'true');
-      await expect(page.locator('[data-testid="masthead-documentation"]')).toBeVisible();
-      // Close with Escape key
-      await page.keyboard.press('Escape');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'false');
-      // Open with Space key
-      await helpMenuToggle.focus();
-      await page.keyboard.press('Space');
-      await expect(helpMenuToggle).toHaveAttribute('aria-expanded', 'true');
-      // Close again
-      await page.keyboard.press('Escape');
-    });
-  });
-
-  test.describe('Responsive Design', () => {
-    test('should work on tablet viewport', { tag: ['@not_mock'] }, async ({ page }) => {
-      // Set tablet viewport
-      await page.setViewportSize({ width: 768, height: 1024 });
-      const helpMenuToggle = page.locator('#help-menu-menu-toggle');
-      await expect(helpMenuToggle).toBeVisible();
-      await helpMenuToggle.click();
-      await expect(page.locator('[data-testid="masthead-documentation"]')).toBeVisible();
-      await expect(page.locator('[data-testid="masthead-about"]')).toBeVisible();
-    });
   });
 });


### PR DESCRIPTION
## Summary

- Add Vitest coverage for the masthead help menu and About dialog, including MSW for the AWX ping, Hub root, and EDA config endpoints used by About.
- Trim Playwright `help-menu.spec.ts` to the cases that still need a live stack: Quick Starts visibility vs topology and About modal version lines from real APIs.
- In **About Vitest only**, mock `@patternfly/react-core` so `AboutModal` is rendered with `disableFocusTrap`. PatternFly’s focus trap expects full browser focus behavior; jsdom throws (“tabbable node”) otherwise. Production `AboutModal` is unchanged.

### Why `PlatformAbout.tsx` uses `useTranslation`

`PlatformAbout` previously called `import { t } from 'i18next'`. Platform Vitest uses `mockI18n()` from the framework, which **mocks `react-i18next` only** (stable `t` for `useTranslation`). The standalone `i18next` `t` used in tests is not wired the same way, which led to empty or wrong strings for `AboutModal` props (e.g. `brandImageAlt`, `productName`) and failing assertions. Switching the component to `useTranslation()` aligns it with the test mock and with the repo’s i18n guidance; runtime behavior stays the same given the normal app bootstrap.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

## Testing

### Ephemeral E2E Tests

Trigger tests by posting a comment `/run-aap-ui-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

### Manual Testing

### Screenshots

