### PR TITLE
XLAB Implement Automation dashboard collection for dashboard tab visibility

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.test.ts
@@ -1,0 +1,247 @@
+/* eslint-disable i18next/no-literal-string */
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('swr');
+vi.mock('../../../../../platform/main/PlatformActiveUserProvider');
+vi.mock('../../../common/api/metrics-utils', () => ({
+  metricsAPI: (strings: TemplateStringsArray, ...values: string[]) =>
+    strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), ''),
+}));
+vi.mock('../../../../common/crud/Data');
+
+import useSWR from 'swr';
+import { usePlatformActiveUser } from '../../../../../platform/main/PlatformActiveUserProvider';
+import { useFetcher } from '../../../../common/crud/Data';
+import { useAutomationDashboardCollectionStatus } from './useAutomationDashboardCollectionStatus';
+import { IAutomationDashboardCollectionStatus } from '../types';
+
+const DEFAULT_STATUS: IAutomationDashboardCollectionStatus = {
+  enabled: null,
+  next_run: null,
+  initial_collection_status: null,
+};
+
+function setupActiveUser({
+  is_superuser = false,
+  is_platform_auditor = false,
+}: {
+  is_superuser?: boolean;
+  is_platform_auditor?: boolean;
+} = {}) {
+  vi.mocked(usePlatformActiveUser).mockReturnValue({
+    activePlatformUser: { is_superuser, is_platform_auditor } as never,
+    refreshActivePlatformUser: vi.fn(),
+  });
+}
+
+function setupActiveUserUndefined() {
+  vi.mocked(usePlatformActiveUser).mockReturnValue({
+    activePlatformUser: undefined,
+    refreshActivePlatformUser: vi.fn(),
+  });
+}
+
+function setupActiveUserNull() {
+  vi.mocked(usePlatformActiveUser).mockReturnValue({
+    activePlatformUser: null as never,
+    refreshActivePlatformUser: vi.fn(),
+  });
+}
+
+function setupSWR(data?: IAutomationDashboardCollectionStatus, error?: Error) {
+  vi.mocked(useSWR).mockReturnValue({
+    data,
+    error,
+    mutate: vi.fn(),
+    isValidating: false,
+    isLoading: !data && !error,
+  } as never);
+}
+
+describe('useAutomationDashboardCollectionStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFetcher).mockReturnValue(vi.fn() as never);
+  });
+
+  describe('when user is not superuser or auditor', () => {
+    test('should return default status and not fetch', () => {
+      setupActiveUser({ is_superuser: false, is_platform_auditor: false });
+      setupSWR();
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+      // SWR should be called with null key (no fetch)
+      expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
+    });
+  });
+
+  describe('when activePlatformUser is undefined (still loading)', () => {
+    test('should return default status and not fetch', () => {
+      setupActiveUserUndefined();
+      setupSWR();
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
+    });
+  });
+
+  describe('when activePlatformUser is null (not logged in)', () => {
+    test('should return default status and not fetch', () => {
+      setupActiveUserNull();
+      setupSWR();
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
+    });
+  });
+
+  describe('when user is superuser', () => {
+    test('should return default status when data is undefined', () => {
+      setupActiveUser({ is_superuser: true });
+      setupSWR();
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+    });
+
+    test('should return data from API when available', () => {
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: new Date('2026-05-01T00:00:00Z'),
+        initial_collection_status: 'completed',
+      };
+      setupActiveUser({ is_superuser: true });
+      setupSWR(apiData);
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(apiData);
+    });
+
+    test('should return default status on error', () => {
+      setupActiveUser({ is_superuser: true });
+      setupSWR(undefined, new Error('Network error'));
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+    });
+
+    test('should fetch using the metrics API URL', () => {
+      setupActiveUser({ is_superuser: true });
+      setupSWR();
+
+      renderHook(() => useAutomationDashboardCollectionStatus());
+
+      const swrKey = vi.mocked(useSWR).mock.calls[0][0];
+      expect(typeof swrKey).toBe('string');
+      expect(swrKey as string).toContain('dashboard_reports/collection_status');
+    });
+
+    test('should pass the fetcher function as second argument to SWR', () => {
+      const mockFetcherFn = vi.fn();
+      vi.mocked(useFetcher).mockReturnValue(mockFetcherFn as never);
+      setupActiveUser({ is_superuser: true });
+      setupSWR();
+
+      renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(vi.mocked(useSWR).mock.calls[0][1]).toBe(mockFetcherFn);
+    });
+
+    test('should pass dedupingInterval and refreshInterval options to SWR', () => {
+      setupActiveUser({ is_superuser: true });
+      setupSWR();
+
+      renderHook(() => useAutomationDashboardCollectionStatus());
+
+      const options = vi.mocked(useSWR).mock.calls[0][2] as Record<string, unknown>;
+      expect(options).toMatchObject({ dedupingInterval: 0, refreshInterval: 10 * 1000 });
+    });
+
+    test('should return default status during initial loading (no data and no error)', () => {
+      setupActiveUser({ is_superuser: true });
+      vi.mocked(useSWR).mockReturnValue({
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: true,
+        isLoading: true,
+      } as never);
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+    });
+  });
+
+  describe('when user is platform auditor', () => {
+    test('should fetch and return data', () => {
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: false,
+        next_run: null,
+        initial_collection_status: 'pending',
+      };
+      setupActiveUser({ is_superuser: false, is_platform_auditor: true });
+      setupSWR(apiData);
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current).toEqual(apiData);
+      const swrKey = vi.mocked(useSWR).mock.calls[0][0];
+      expect(swrKey).not.toBeNull();
+    });
+  });
+
+  describe('status updates', () => {
+    test('should update status when data changes', () => {
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: null,
+        initial_collection_status: 'running',
+      };
+      setupActiveUser({ is_superuser: true });
+      setupSWR();
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      expect(result.current).toEqual(DEFAULT_STATUS);
+
+      // Simulate data arriving
+      setupSWR(apiData);
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current).toEqual(apiData);
+    });
+
+    test('should revert to default status when error occurs after data was loaded', () => {
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: null,
+        initial_collection_status: 'completed',
+      };
+      setupActiveUser({ is_superuser: true });
+      setupSWR(apiData);
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      expect(result.current).toEqual(apiData);
+
+      // Simulate error
+      setupSWR(undefined, new Error('Server error'));
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current).toEqual(DEFAULT_STATUS);
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.tsx
@@ -1,0 +1,45 @@
+import { IAutomationDashboardCollectionStatus } from '../types';
+import { useEffect, useMemo, useState } from 'react';
+import { usePlatformActiveUser } from '../../../../../platform/main/PlatformActiveUserProvider';
+import { metricsAPI } from '../../../common/api/metrics-utils';
+import { useFetcher } from '../../../../common/crud/Data';
+import useSWR from 'swr';
+
+const DEFAULT_STATUS: IAutomationDashboardCollectionStatus = {
+  enabled: null,
+  next_run: null,
+  initial_collection_status: null,
+};
+
+export function useAutomationDashboardCollectionStatus(): IAutomationDashboardCollectionStatus {
+  const { activePlatformUser } = usePlatformActiveUser();
+  const isSuperuserOrAuditor =
+    activePlatformUser?.is_superuser || activePlatformUser?.is_platform_auditor;
+
+  const url = metricsAPI`/dashboard_reports/collection_status/`;
+  const fetcher = useFetcher();
+  const { data, error } = useSWR<IAutomationDashboardCollectionStatus, Error>(
+    isSuperuserOrAuditor ? url : null,
+    fetcher,
+    { dedupingInterval: 0, refreshInterval: 10 * 1000 }
+  );
+
+  const [collectionStatus, setCollectionStatus] =
+    useState<IAutomationDashboardCollectionStatus>(DEFAULT_STATUS);
+
+  useEffect(() => {
+    setCollectionStatus(() => {
+      if (error) {
+        return DEFAULT_STATUS;
+      }
+
+      if (data) {
+        return data;
+      }
+
+      return DEFAULT_STATUS;
+    });
+  }, [data, error]);
+
+  return useMemo<IAutomationDashboardCollectionStatus>(() => collectionStatus, [collectionStatus]);
+}

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -64,6 +64,12 @@ export interface IDashboardFilterSet {
   is_default: boolean;
 }
 
+export interface IAutomationDashboardCollectionStatus {
+  enabled: boolean | null;
+  next_run: Date | null;
+  initial_collection_status: string | null;
+}
+
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
 
 export interface AutomationDashboardToolbarFiltersProps {

--- a/frontend/awx/main/useAwxNavigation.tsx
+++ b/frontend/awx/main/useAwxNavigation.tsx
@@ -38,9 +38,6 @@ import { useAwxTeamsRoutes } from './routes/useAwxTeamsRoutes';
 import { useAwxTemplateRoutes } from './routes/useAwxTemplateRoutes';
 import { useAwxUsersRoutes } from './routes/useAwxUsersRoutes';
 import { useAwxWorkflowApprovalRoutes } from './routes/useAwxWorkflowApprovalRoutes';
-
-import { UIFlag } from '@ansible/platform-ui/settings/ui-flags/IUIFlag';
-import { useUIFlag } from '@ansible/platform-ui/settings/ui-flags/useUIFlag';
 import { AutomationDashboard } from '../analytics/automation-dashboard/AutomationDashboard';
 
 export function useAwxNavigation() {
@@ -64,7 +61,6 @@ export function useAwxNavigation() {
   const awxExecutionEnvironmentsRoutes = useAwxExecutionEnvironmentRoutes();
   const awxCredentialTypesRoutes = useAwxCredentialTypesRoutes();
   const { activeAwxUser } = useAwxActiveUser();
-  const automationDashboardFlag = useUIFlag(UIFlag.AutomationDashboard);
 
   const overview: PageNavigationItem[] = [
     {
@@ -103,24 +99,18 @@ export function useAwxNavigation() {
     },
   ];
 
-  const automationDashboardItem: PageNavigationItem[] = automationDashboardFlag?.enabled
-    ? [
-        {
-          id: AwxRoute.AutomationDashboard,
-          label: t('Automation Dashboard'),
-          path: 'automation-dashboard',
-          element: <AutomationDashboard />,
-        },
-      ]
-    : [];
-
   const analyticsItems: PageNavigationItem[] = [
     {
       id: AwxRoute.Analytics,
       label: t('Analytics'),
       path: 'analytics',
       children: [
-        ...automationDashboardItem,
+        {
+          id: AwxRoute.AutomationDashboard,
+          label: t('Automation Dashboard'),
+          path: 'automation-dashboard',
+          element: <AutomationDashboard />,
+        },
         {
           id: AwxRoute.AutomationCalculator,
           label: t('Automation Calculator'),

--- a/platform/main/useAutomationAnalytics.test.tsx
+++ b/platform/main/useAutomationAnalytics.test.tsx
@@ -12,11 +12,13 @@ const {
   mockUseHasAwxService,
   mockUseIsManagedCloudInstall,
   mockUsePlatformActiveUser,
+  mockUseAutomationDashboardCollectionStatus,
 } = vi.hoisted(() => ({
   mockUseAwxNavigation: vi.fn(),
   mockUseHasAwxService: vi.fn(),
   mockUseIsManagedCloudInstall: vi.fn(),
   mockUsePlatformActiveUser: vi.fn(),
+  mockUseAutomationDashboardCollectionStatus: vi.fn(),
 }));
 
 vi.mock('@ansible/awx-ui/main/useAwxNavigation', () => ({
@@ -37,6 +39,13 @@ vi.mock('./GatewayUIAuth', () => ({
 vi.mock('./PlatformActiveUserProvider', () => ({
   usePlatformActiveUser: mockUsePlatformActiveUser,
 }));
+
+vi.mock(
+  '../../frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus',
+  () => ({
+    useAutomationDashboardCollectionStatus: mockUseAutomationDashboardCollectionStatus,
+  })
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -89,6 +98,8 @@ describe('useAutomationAnalytics', () => {
     mockUsePlatformActiveUser.mockReturnValue({
       activePlatformUser: { is_superuser: true, is_platform_auditor: false },
     });
+    // Dashboard feature enabled by default
+    mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: true });
   });
 
   // --- Label ---
@@ -107,9 +118,6 @@ describe('useAutomationAnalytics', () => {
   });
 
   test('should be visible for superuser with AWX service', () => {
-    mockUsePlatformActiveUser.mockReturnValue({
-      activePlatformUser: { is_superuser: true, is_platform_auditor: false },
-    });
     const { result } = renderHook(() => useAutomationAnalytics());
     expect(result.current.hidden).toBe(false);
   });
@@ -132,9 +140,12 @@ describe('useAutomationAnalytics', () => {
 
   test('should be hidden when AWX service is unavailable even for superuser', () => {
     mockUseHasAwxService.mockReturnValue(false);
-    mockUsePlatformActiveUser.mockReturnValue({
-      activePlatformUser: { is_superuser: true, is_platform_auditor: false },
-    });
+    const { result } = renderHook(() => useAutomationAnalytics());
+    expect(result.current.hidden).toBe(true);
+  });
+
+  test('should be hidden when activePlatformUser is null', () => {
+    mockUsePlatformActiveUser.mockReturnValue({ activePlatformUser: null });
     const { result } = renderHook(() => useAutomationAnalytics());
     expect(result.current.hidden).toBe(true);
   });
@@ -149,58 +160,114 @@ describe('useAutomationAnalytics', () => {
   });
 
   test('should keep SubscriptionUsage in children when not managed cloud install', () => {
-    mockUseIsManagedCloudInstall.mockReturnValue(false);
     const { result } = renderHook(() => useAutomationAnalytics());
     const { children } = asGroup(result.current);
     expect(children.find((c) => c.id === AwxRoute.SubscriptionUsage)).toBeDefined();
   });
 
-  // --- non-superuser children filtering ---
+  // --- automationDashboardEnabled = true ---
 
-  test('should preserve all children for superuser', () => {
-    // Arrange: 3 children (dashboard + subscription-usage + calculator), is_superuser = true
-    const { result } = renderHook(() => useAutomationAnalytics());
-    const { children } = asGroup(result.current);
-    expect(children).toHaveLength(3);
-    expect(children.map((c) => c.id)).toContain(AwxRoute.AutomationDashboard);
-    expect(children.map((c) => c.id)).toContain(AwxRoute.SubscriptionUsage);
-    expect(children.map((c) => c.id)).toContain(AwxRoute.AutomationCalculator);
-  });
-
-  test('should keep only automation dashboard for non-superuser', () => {
-    mockUsePlatformActiveUser.mockReturnValue({
-      activePlatformUser: { is_superuser: false, is_platform_auditor: true },
+  describe('when automationDashboardEnabled is true', () => {
+    test('should preserve all children for superuser', () => {
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children).toHaveLength(3);
+      expect(children.map((c) => c.id)).toContain(AwxRoute.AutomationDashboard);
+      expect(children.map((c) => c.id)).toContain(AwxRoute.SubscriptionUsage);
+      expect(children.map((c) => c.id)).toContain(AwxRoute.AutomationCalculator);
     });
-    const { result } = renderHook(() => useAutomationAnalytics());
-    const { children } = asGroup(result.current);
-    expect(children).toHaveLength(1);
-    expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
-  });
 
-  test('should keep only automation dashboard for non-superuser non-auditor', () => {
-    mockUsePlatformActiveUser.mockReturnValue({
-      activePlatformUser: { is_superuser: false, is_platform_auditor: false },
+    test('should keep only automation dashboard for non-superuser auditor', () => {
+      mockUsePlatformActiveUser.mockReturnValue({
+        activePlatformUser: { is_superuser: false, is_platform_auditor: true },
+      });
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children).toHaveLength(1);
+      expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
     });
-    const { result } = renderHook(() => useAutomationAnalytics());
-    const { children } = asGroup(result.current);
-    expect(children).toHaveLength(1);
-    expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
-  });
 
-  test('should keep only automation dashboard for non-superuser even when managed cloud removes subscription usage first', () => {
-    mockUseIsManagedCloudInstall.mockReturnValue(true);
-    mockUsePlatformActiveUser.mockReturnValue({
-      activePlatformUser: { is_superuser: false, is_platform_auditor: true },
+    test('should keep only automation dashboard for non-superuser non-auditor', () => {
+      mockUsePlatformActiveUser.mockReturnValue({
+        activePlatformUser: { is_superuser: false, is_platform_auditor: false },
+      });
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children).toHaveLength(1);
+      expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
     });
-    // Arrange: managed cloud removes subscription-usage first (2 children left),
-    // then non-superuser filter removes everything except the dashboard (1 child).
-    const { result } = renderHook(() => useAutomationAnalytics());
-    const { children } = asGroup(result.current);
-    expect(children).toHaveLength(1);
-    expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
+
+    test('should keep only automation dashboard when activePlatformUser is null', () => {
+      mockUsePlatformActiveUser.mockReturnValue({ activePlatformUser: null });
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children).toHaveLength(1);
+      expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
+    });
+
+    test('should keep only automation dashboard for non-superuser when managed cloud removes subscription usage first', () => {
+      mockUseIsManagedCloudInstall.mockReturnValue(true);
+      mockUsePlatformActiveUser.mockReturnValue({
+        activePlatformUser: { is_superuser: false, is_platform_auditor: true },
+      });
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children).toHaveLength(1);
+      expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
+    });
   });
 
-  // --- !analytics.children.length condition ---
+  // --- automationDashboardEnabled = false ---
+
+  describe('when automationDashboardEnabled is false', () => {
+    beforeEach(() => {
+      mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: false });
+    });
+
+    test('should remove automation dashboard from children for superuser', () => {
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeUndefined();
+    });
+
+    test('should keep other children for superuser when dashboard is disabled', () => {
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children.map((c) => c.id)).toContain(AwxRoute.SubscriptionUsage);
+      expect(children.map((c) => c.id)).toContain(AwxRoute.AutomationCalculator);
+    });
+
+    test('should be hidden when dashboard disabled and no other children remain', () => {
+      // Only automation dashboard in the nav → after removal children.length = 0
+      mockUseAwxNavigation.mockImplementation(() => [
+        {
+          id: AwxRoute.Analytics,
+          label: 'Analytics',
+          path: 'analytics',
+          children: [
+            {
+              id: AwxRoute.AutomationDashboard,
+              label: 'Automation Dashboard',
+              path: 'automation-dashboard',
+              element: <></>,
+            },
+          ],
+        },
+      ]);
+      const { result } = renderHook(() => useAutomationAnalytics());
+      expect(result.current.hidden).toBe(true);
+    });
+
+    test('should not remove automation dashboard from children for superuser when dashboard is enabled', () => {
+      // Sanity: switching back to enabled keeps the dashboard
+      mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: true });
+      const { result } = renderHook(() => useAutomationAnalytics());
+      const { children } = asGroup(result.current);
+      expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeDefined();
+    });
+  });
+
+  // --- empty children guard ---
 
   test('should be hidden when analytics group has no children even for superuser', () => {
     mockUseAwxNavigation.mockImplementation(() => [
@@ -211,31 +278,94 @@ describe('useAutomationAnalytics', () => {
         children: [],
       },
     ]);
-    // superuser + awxService pass the first two hidden guards,
-    // but !analytics.children.length must still hide the item
     const { result } = renderHook(() => useAutomationAnalytics());
     expect(result.current.hidden).toBe(true);
   });
 
-  test('should not be hidden when analytics group has children for superuser', () => {
-    // Sanity-check: a non-empty children list does not trigger the length guard
+  // --- analytics item not present in nav ---
+
+  test('should return undefined when analytics item is not found in nav', () => {
+    // Nav has no AwxRoute.Analytics node → removeNavigationItemById returns undefined
+    mockUseAwxNavigation.mockImplementation(() => [
+      { id: 'some-other-id', label: 'Other', path: 'other', element: <></> },
+    ]);
     const { result } = renderHook(() => useAutomationAnalytics());
-    expect(result.current.hidden).toBe(false);
+    // The if-block is skipped, the raw (undefined) value is returned
+    expect(result.current).toBeUndefined();
   });
 
-  // --- activePlatformUser null / undefined ---
+  // --- analytics is a leaf item (no children) ---
 
-  test('should be hidden when activePlatformUser is null', () => {
-    mockUsePlatformActiveUser.mockReturnValue({ activePlatformUser: null });
+  test('should return item unchanged when analytics node has no children property', () => {
+    const leafItem: PageNavigationItem = {
+      id: AwxRoute.Analytics,
+      label: 'Analytics',
+      path: 'analytics',
+      element: <></>,
+    };
+    mockUseAwxNavigation.mockImplementation(() => [leafItem]);
     const { result } = renderHook(() => useAutomationAnalytics());
-    expect(result.current.hidden).toBe(true);
+    // if-block is skipped, no label/hidden mutation
+    expect(result.current.label).toBe('Analytics');
+    expect((result.current as { hidden?: boolean }).hidden).toBeUndefined();
   });
 
-  test('should keep only automation dashboard when activePlatformUser is null', () => {
-    mockUsePlatformActiveUser.mockReturnValue({ activePlatformUser: null });
+  // --- child without id in the filtering loop ---
+
+  test('should skip children without id when enabled and user is non-superuser', () => {
+    mockUsePlatformActiveUser.mockReturnValue({
+      activePlatformUser: { is_superuser: false, is_platform_auditor: true },
+    });
+    mockUseAwxNavigation.mockImplementation(() => [
+      {
+        id: AwxRoute.Analytics,
+        label: 'Analytics',
+        path: 'analytics',
+        children: [
+          {
+            id: AwxRoute.AutomationDashboard,
+            label: 'Automation Dashboard',
+            path: 'automation-dashboard',
+            element: <></>,
+          },
+          {
+            // No id — the `if (item.id)` guard should protect against this
+            label: 'No-id item',
+            path: 'no-id',
+            element: <></>,
+          },
+          {
+            id: AwxRoute.AutomationCalculator,
+            label: 'Automation Calculator',
+            path: 'automation-calculator',
+            element: <></>,
+          },
+        ],
+      },
+    ]);
     const { result } = renderHook(() => useAutomationAnalytics());
     const { children } = asGroup(result.current);
-    expect(children).toHaveLength(1);
-    expect(children[0].id).toBe(AwxRoute.AutomationDashboard);
+    // AutomationDashboard kept; AutomationCalculator removed; no-id item stays (not removed)
+    expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeDefined();
+    expect(children.find((c) => c.id === AwxRoute.AutomationCalculator)).toBeUndefined();
+    expect(children.find((c) => !c.id)).toBeDefined();
+  });
+
+  // --- useIsManagedCloudInstall returns null (coalesces to false) ---
+
+  test('should treat null managed cloud install as false and keep SubscriptionUsage', () => {
+    mockUseIsManagedCloudInstall.mockReturnValue(null);
+    const { result } = renderHook(() => useAutomationAnalytics());
+    const { children } = asGroup(result.current);
+    expect(children.find((c) => c.id === AwxRoute.SubscriptionUsage)).toBeDefined();
+  });
+
+  // --- automationDashboardEnabled = null (falsy, same branch as false) ---
+
+  test('should remove automation dashboard when enabled is null', () => {
+    mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: null });
+    const { result } = renderHook(() => useAutomationAnalytics());
+    const { children } = asGroup(result.current);
+    expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeUndefined();
   });
 });

--- a/platform/main/usePlatformNavigation.tsx
+++ b/platform/main/usePlatformNavigation.tsx
@@ -51,6 +51,7 @@ import { usePlatformActiveUser } from './PlatformActiveUserProvider';
 import { PlatformRoute } from './PlatformRoutes';
 import { Redirect } from './Redirect';
 import { usePersonaView } from './persona-view/usePersonaView';
+import { useAutomationDashboardCollectionStatus } from '../../frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus';
 
 export function usePlatformNavigation() {
   const { t } = useTranslation();
@@ -286,19 +287,24 @@ export function useAutomationAnalytics(): PageNavigationItem {
   const managedCloudInstall = useIsManagedCloudInstall() ?? false;
   const analytics = removeNavigationItemById(awxNav, AwxRoute.Analytics)!;
   const { activePlatformUser } = usePlatformActiveUser();
+  const { enabled: automationDashboardEnabled } = useAutomationDashboardCollectionStatus();
+
   if (analytics && 'children' in analytics) {
     analytics.label = t('Automation Analytics');
     if (managedCloudInstall) {
       removeNavigationItemById(analytics.children, AwxRoute.SubscriptionUsage);
     }
-
-    if (!activePlatformUser?.is_superuser) {
-      const automationDashboardId = 'awx-automation-dashboard';
-      analytics.children
-        .filter((c) => c.id !== automationDashboardId)
-        .forEach((item) => {
-          if (item.id) removeNavigationItemById(analytics.children, item.id);
-        });
+    const automationDashboardId = 'awx-automation-dashboard';
+    if (automationDashboardEnabled) {
+      if (!activePlatformUser?.is_superuser) {
+        analytics.children
+          .filter((c) => c.id !== automationDashboardId)
+          .forEach((item) => {
+            if (item.id) removeNavigationItemById(analytics.children, item.id);
+          });
+      }
+    } else {
+      removeNavigationItemById(analytics.children, automationDashboardId);
     }
 
     analytics.hidden =

--- a/platform/settings/ui-flags/IUIFlag.ts
+++ b/platform/settings/ui-flags/IUIFlag.ts
@@ -1,6 +1,5 @@
 export enum UIFlag {
   PersonaViewSwitcher = 'persona-view-switcher',
-  AutomationDashboard = 'automation-dashboard',
 }
 
 export interface IUIFlag {

--- a/platform/settings/ui-flags/useUIFlags.tsx
+++ b/platform/settings/ui-flags/useUIFlags.tsx
@@ -20,15 +20,6 @@ export const getTranslatedUIFlags = (): IUIFlag[] => {
       enabled: false,
       status: 'beta',
     },
-    {
-      id: UIFlag.AutomationDashboard,
-      name: t('Automation Dashboard'),
-      description: t(
-        'Discover the significant cost and time savings achieved by automating Ansible jobs with the Ansible Automation Platform. Explore how automation reduces manual effort, enhances efficiency, and optimizes IT operations across your organization.'
-      ),
-      enabled: false,
-      status: 'alpha',
-    },
   ];
 };
 

--- a/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
+++ b/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
-import { platformUI } from '@ansible/playwright/commands/login';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
-
-const platformUIWithoutSlash = platformUI.endsWith('/') ? platformUI.slice(0, -1) : platformUI;
 
 async function mockReportRoute(
   page: import('playwright').Page,
@@ -131,22 +128,16 @@ async function mockReportDetailRoute(
 }
 
 test.beforeEach(async ({ page }) => {
-  // The feature flag for Automation Dashboard is off by default and
-  // needs to be turned on for the tests
-  await setupBefore({ path: '/settings/dev/flags' })({ page });
-  const row = page.getByRole('row').filter({ hasText: 'Automation Dashboard' });
-  await row.getByRole('gridcell', { name: 'Disabled' }).locator('span').click();
-  await expect(row.locator('input[type="checkbox"]')).toHaveAttribute('aria-label', 'Enabled');
-  await page.getByRole('button', { name: 'Automation Analytics' }).click();
-  await page.getByTestId('awx-automation-dashboard').isVisible();
+  await setupBefore()({ page });
+  // Mock the collection status API to enable the Automation Dashboard
+  await page.route(`**/api/metrics/v1/dashboard_reports/collection_status/`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabled: true, next_run: null, initial_collection_status: null }),
+    });
+  });
   await navigateTo(page, 'Automation Analytics', 'Automation Dashboard');
-});
-
-test.afterEach(async ({ page }) => {
-  await page.goto(platformUIWithoutSlash + '/settings/dev/flags');
-  const row = page.getByRole('row').filter({ hasText: 'Automation Dashboard' });
-  await row.getByRole('gridcell', { name: 'Enabled' }).locator('span').click();
-  await expect(row.locator('input[type="checkbox"]')).toHaveAttribute('aria-label', 'Disabled');
 });
 
 test.afterEach(setupAfter);


### PR DESCRIPTION
## Summary

<!-- What changed and why? For backports, link the original PR. -->
This pull request introduces the new `useAutomationDashboardCollectionStatus` hook to manage the feature flag for the Automation Dashboard, and refactors related navigation and analytics logic to use this dynamic flag instead of the previous static UI flag. It also adds comprehensive tests for the new hook and updates related analytics tests to reflect the new behavior. The changes ensure that the Automation Dashboard's visibility is determined by backend status rather than a static config, making the feature more robust and user-aware.

**Key changes:**

**1. Feature flag implementation for Automation Dashboard**
- Introduced the `useAutomationDashboardCollectionStatus` hook, which fetches and tracks the Automation Dashboard's enabled status and collection state from the backend, using SWR for data fetching and caching (`frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.tsx`, `frontend/awx/analytics/automation-dashboard/types/index.ts`) [[1]](diffhunk://#diff-4853801456815b2fe49367fd78474e5f2544a29324bc93f677df41dbdc6d9468R1-R45) [[2]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbR67-R72).

**2. Navigation refactor to use dynamic feature flag**
- Refactored the AWX navigation logic to always include the Automation Dashboard navigation item, but its actual visibility is now controlled by the backend-driven status from the new hook, rather than the old static UI flag (`frontend/awx/main/useAwxNavigation.tsx`) [[1]](diffhunk://#diff-93e3c8035263b2a9b0ef760afcbcd6fe37c680995bf2f25fc6a2e27d46978a75L41-L43) [[2]](diffhunk://#diff-93e3c8035263b2a9b0ef760afcbcd6fe37c680995bf2f25fc6a2e27d46978a75L67) [[3]](diffhunk://#diff-93e3c8035263b2a9b0ef760afcbcd6fe37c680995bf2f25fc6a2e27d46978a75L106-R113).

**3. Analytics logic and tests updated**
- Updated the analytics navigation logic and tests to use `useAutomationDashboardCollectionStatus` for determining the Automation Dashboard's presence and visibility, including handling edge cases such as non-superuser/auditor users and when the dashboard is disabled (`platform/main/useAutomationAnalytics.test.tsx`) [[1]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878R15-R21) [[2]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878R43-R49) [[3]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878R101-R102) [[4]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878L110-L112) [[5]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878L135-R148) [[6]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878L152-L161) [[7]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878L170-R180) [[8]](diffhunk://#diff-741245ec534c06e331393dfa44346bb389fb7e90cd496ae81c042d4279d16878L190-R270).

**4. Comprehensive tests for new hook**
- Added a full test suite for `useAutomationDashboardCollectionStatus`, covering all user roles, loading/error states, and status updates (`frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.test.ts`).

These changes make the Automation Dashboard feature flag more dynamic and reliable, improving both user experience and maintainability.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Trigger tests by posting a comment `/run-aap-ui-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
