### PR TITLE
Upgrade SonarQube scan action from v5 to v6

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -222,7 +222,7 @@ jobs:
         continue-on-error: true
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
         with:

--- a/.github/workflows/sonar_coverage.yml
+++ b/.github/workflows/sonar_coverage.yml
@@ -161,7 +161,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
         with:


### PR DESCRIPTION
[AAP-72074](https://redhat.atlassian.net/browse/AAP-72074)
## Summary
- Upgrades `SonarSource/sonarqube-scan-action` from v5 to v6 in both `platform-pull-request.yml` and `sonar_coverage.yml`
- v5 is deprecated and contains a high-severity command injection vulnerability ([GHSA-5xq9-5g24-4g6f](https://github.com/SonarSource/sonarqube-scan-action/security/advisories/GHSA-5xq9-5g24-4g6f))
- v6 rewrites the action from Bash to JavaScript to prevent injection attacks

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
## Test plan
- [ ] Verify SonarQube scan passes on a PR after merge