### PR TITLE
[AAP-42092] Use case-insensitive filters for all toolbar text searches

### DIFF
--- a/frontend/awx/access/common/AwxRolesWizardSteps/AwxSelectResourcesStep.tsx
+++ b/frontend/awx/access/common/AwxRolesWizardSteps/AwxSelectResourcesStep.tsx
@@ -76,7 +76,7 @@ export function AwxSelectResourcesStep(props: { userOrTeamName: string }) {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],

--- a/frontend/awx/access/roles/hooks/useAwxRolesFilters.tsx
+++ b/frontend/awx/access/roles/hooks/useAwxRolesFilters.tsx
@@ -10,7 +10,7 @@ export function useAwxRolesFilters() {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],

--- a/frontend/common/access/components/Access.tsx
+++ b/frontend/common/access/components/Access.tsx
@@ -152,7 +152,7 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
         key: 'role_definition__name',
         label: t('Role name'),
         type: ToolbarFilterType.SingleText,
-        query: 'role_definition__name__contains',
+        query: 'role_definition__name__icontains',
         comparison: 'contains',
       },
       ...(props.additionalTableFilters ? props.additionalTableFilters : []),

--- a/frontend/common/access/components/AccessList.tsx
+++ b/frontend/common/access/components/AccessList.tsx
@@ -98,7 +98,7 @@ export function AccessList<T extends UserRoleAccess>(props: AccessProps<T>) {
         key: 'role_definition__name',
         label: t('Role name'),
         type: ToolbarFilterType.SingleText,
-        query: 'role_definition__name__contains',
+        query: 'role_definition__name__icontains',
         comparison: 'contains',
       },
       ...(props.additionalTableFilters ?? []),

--- a/frontend/common/access/components/PlatformAccess.tsx
+++ b/frontend/common/access/components/PlatformAccess.tsx
@@ -149,7 +149,7 @@ export function PlatformAccess<T extends Assignment>(props: PlatformAccessProps<
         key: 'role_definition__name',
         label: t('Role name'),
         type: ToolbarFilterType.SingleText,
-        query: 'role_definition__name__contains',
+        query: 'role_definition__name__icontains',
         comparison: 'contains',
       },
       ...(props.additionalTableFilters ?? []),

--- a/frontend/eda/access/roles/hooks/useEdaRolesFilters.tsx
+++ b/frontend/eda/access/roles/hooks/useEdaRolesFilters.tsx
@@ -10,7 +10,7 @@ export function useEdaRolesFilters() {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],

--- a/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
+++ b/frontend/hub/access/common/HubRoleWizardSteps/HubSelectResourcesStep.tsx
@@ -67,7 +67,7 @@ export function HubSelectResourcesStep(props: { userOrTeamName: string }) {
               key: 'name',
               label: t('Name'),
               type: ToolbarFilterType.MultiText,
-              query: 'name__contains',
+              query: 'name__icontains',
               comparison: 'contains',
             },
           ],

--- a/frontend/hub/access/common/hooks/useHubRoleFilters.tsx
+++ b/frontend/hub/access/common/hooks/useHubRoleFilters.tsx
@@ -10,7 +10,7 @@ export function useHubRoleFilters() {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],

--- a/frontend/hub/access/common/hooks/useHubUserFilters.tsx
+++ b/frontend/hub/access/common/hooks/useHubUserFilters.tsx
@@ -10,7 +10,7 @@ export function useHubUserFilters() {
         key: 'username',
         label: t('Username'),
         type: ToolbarFilterType.MultiText,
-        query: 'username__contains',
+        query: 'username__icontains',
         comparison: 'contains',
       },
     ],

--- a/frontend/hub/administration/tasks/hooks/useTasksFilters.tsx
+++ b/frontend/hub/administration/tasks/hooks/useTasksFilters.tsx
@@ -10,7 +10,7 @@ export function useTasksFilters() {
         key: 'name',
         label: t('Task name'),
         type: ToolbarFilterType.SingleText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
       {

--- a/platform/access/authenticators/hooks/useMappingFilters.tsx
+++ b/platform/access/authenticators/hooks/useMappingFilters.tsx
@@ -11,7 +11,7 @@ export function useMappingFilters() {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name__contains',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],

--- a/platform/access/users/hooks/useOrganizationUsersFilters.tsx
+++ b/platform/access/users/hooks/useOrganizationUsersFilters.tsx
@@ -9,7 +9,7 @@ export function useUsernameToolbarFilter() {
       key: 'username',
       label: t('Username'),
       type: ToolbarFilterType.MultiText,
-      query: 'username__contains',
+      query: 'username__icontains',
       comparison: 'contains',
     }),
     [t]
@@ -23,7 +23,7 @@ export function useFirstNameToolbarFilter() {
       key: 'firstname',
       label: t('First name'),
       type: ToolbarFilterType.MultiText,
-      query: 'first_name__contains',
+      query: 'first_name__icontains',
       comparison: 'contains',
     }),
     [t]
@@ -37,7 +37,7 @@ export function useLastNameToolbarFilter() {
       key: 'lastname',
       label: t('Last name'),
       type: ToolbarFilterType.MultiText,
-      query: 'last_name__contains',
+      query: 'last_name__icontains',
       comparison: 'contains',
     }),
     [t]

--- a/platform/access/users/hooks/useUsersFilters.tsx
+++ b/platform/access/users/hooks/useUsersFilters.tsx
@@ -9,7 +9,7 @@ export function useUsernameToolbarFilter() {
       key: 'username',
       label: t('Username'),
       type: ToolbarFilterType.MultiText,
-      query: 'username__contains',
+      query: 'username__icontains',
       comparison: 'contains',
     }),
     [t]
@@ -23,7 +23,7 @@ export function useFirstNameToolbarFilter() {
       key: 'firstname',
       label: t('First name'),
       type: ToolbarFilterType.MultiText,
-      query: 'first_name__contains',
+      query: 'first_name__icontains',
       comparison: 'contains',
     }),
     [t]
@@ -37,7 +37,7 @@ export function useLastNameToolbarFilter() {
       key: 'lastname',
       label: t('Last name'),
       type: ToolbarFilterType.MultiText,
-      query: 'last_name__contains',
+      query: 'last_name__icontains',
       comparison: 'contains',
     }),
     [t]
@@ -51,7 +51,7 @@ export function useEmailToolbarFilter() {
       key: 'email',
       label: t('Email'),
       type: ToolbarFilterType.MultiText,
-      query: 'email__contains',
+      query: 'email__icontains',
       comparison: 'contains',
     }),
     [t]


### PR DESCRIPTION
## Summary

- Switch all user-typed toolbar text filter lookups from `__contains` to `__icontains` across 13 files
- Fixes case-sensitive search on the Users page (username, first name, last name, email) and all other toolbar text filters (role names, task names, authenticator mapping names)
- Restores case-insensitive search behaviour matching AAP 2.4

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Navigate to Access > Users, search for a username in different case (e.g. uppercase when stored as lowercase). Verify the user is found.
- Repeat for email, first name, and last name filters on the Users page.
- Navigate to roles lists (AWX, EDA, Hub) and search for a role name in different case. Verify the role is found.
- Navigate to Hub > Tasks and search for a task name in different case.

Closes #3121