### PR TITLE
Fix eda project delete in tests

### DIFF
--- a/playwright/tests/integration/automation-decisions/projects/projects-crud.spec.ts
+++ b/playwright/tests/integration/automation-decisions/projects/projects-crud.spec.ts
@@ -71,6 +71,8 @@ test.describe('EDA Projects CRUD', () => {
           await expect(page.getByTestId('name')).toHaveText(editedName);
         });
       } finally {
+        // Ensure sync is idle before DELETE; the API may return 409 while sync is pending/running.
+        await EdaProject.api.waitForSync(page, edaProject.id);
         await EdaProject.api.delete(page, edaProject.id);
       }
     }

--- a/playwright/tests/integration/automation-decisions/projects/projects-list.spec.ts
+++ b/playwright/tests/integration/automation-decisions/projects/projects-list.spec.ts
@@ -93,6 +93,8 @@ test.describe('EDA Projects List', () => {
     await expect(page.getByTestId('page-title')).toHaveText(editedName);
     await expect(page.getByTestId('name')).toHaveText(editedName);
 
+    // Ensure sync is idle before DELETE; the API may return 409 while sync is pending/running.
+    await EdaProject.api.waitForSync(page, edaProject.id);
     await EdaProject.api.delete(page, edaProject.id);
   });
 


### PR DESCRIPTION
## Summary

Fixes two broken tests; deleting an EDA project during cleanup resulted in a 409, because the project was in the middle of a sync. Waiting for the sync to complete allows deletion to succeed.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
