### PR TITLE
[AAP-72016] Fix image.yml packaging-ref default from devel to main

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -36,7 +36,7 @@ on:
       packaging-ref:
         description: 'Git ref to checkout for packaging repo'
         type: string
-        default: devel
+        default: main
     secrets:
       QUAY_USERNAME:
         required: false


### PR DESCRIPTION
## Summary

Jira: https://redhat.atlassian.net/browse/AAP-72016<!-- AAP-XXXXX -->

<!-- What changed and why? For backports, link the original PR. -->
Change `packaging-ref` default in `image.yml` from `devel` to `main`.

The packaging repo only has a `main` branch. The `devel` default was causing the packaging repo checkout to fail during the image build step since no `devel` ref exists.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify) - workflow update

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

Trigger `Run Playwright with Currents` workflow and confirm the image build step passes

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
