### PR TITLE
Fix About modal brand logo broken in builds

### DIFF
--- a/platform/main/PlatformAbout.tsx
+++ b/platform/main/PlatformAbout.tsx
@@ -6,6 +6,8 @@ import { hubAPI } from '@ansible/hub-ui/common/api/formatPath';
 import { AboutModal, Content } from '@patternfly/react-core';
 import { t } from 'i18next';
 import React, { useContext } from 'react';
+import platformLogo from '../assets/platform-logo.svg?url';
+import platformLogoWhite from '../assets/platform-logo-white.svg?url';
 
 export const PlatformAbout: React.FunctionComponent<{
   platformVersion?: string;
@@ -29,11 +31,7 @@ export const PlatformAbout: React.FunctionComponent<{
       productName={t('Ansible Automation Platform {{version}}', { version: platformVersion })}
       trademark="Copyright 2025 Red Hat, Inc."
       brandImageAlt={t('Brand Logo')}
-      brandImageSrc={
-        settings?.activeTheme === 'dark'
-          ? '/assets/platform-logo-white.svg'
-          : '/assets/platform-logo.svg'
-      }
+      brandImageSrc={settings?.activeTheme === 'dark' ? platformLogoWhite : platformLogo}
     >
       <Content>
         <Content component="dl">

--- a/playwright/tests/integration/platform/help-menu.spec.ts
+++ b/playwright/tests/integration/platform/help-menu.spec.ts
@@ -175,19 +175,24 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
   });
 
   test.describe('About Modal: Brand Logo', () => {
-    test('should display brand logo with alt text', { tag: ['@not_mock'] }, async ({ page }) => {
-      await page.locator('#help-menu-menu-toggle').click();
-      await page.locator('[data-testid="masthead-about"]').click();
+    test(
+      'should display brand logo that loads successfully',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        await page.locator('#help-menu-menu-toggle').click();
+        await page.locator('[data-testid="masthead-about"]').click();
 
-      const modal = page.getByRole('dialog');
-      const brandLogo = modal.locator('img[alt="Brand Logo"]');
+        const modal = page.getByRole('dialog');
+        const brandLogo = modal.locator('img[alt="Brand Logo"]');
 
-      await expect(brandLogo).toBeVisible();
-      await expect(brandLogo).toHaveAttribute('alt', 'Brand Logo');
-      await expect(brandLogo).toHaveAttribute('src', /platform-logo.*\.svg$/);
-    });
+        await expect(brandLogo).toBeVisible();
+        await expect(brandLogo).toHaveAttribute('alt', 'Brand Logo');
+        const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
+        expect(naturalWidth).toBeGreaterThan(0);
+      }
+    );
 
-    test('should use white logo for dark theme', { tag: ['@not_mock'] }, async ({ page }) => {
+    test('should load white logo for dark theme', { tag: ['@not_mock'] }, async ({ page }) => {
       const themeButton = page.locator('[data-cy="theme-icon"]');
       await expect(themeButton).toBeVisible();
       await themeButton.click();
@@ -198,17 +203,21 @@ test.describe('Platform Header Toolbar - Help Menu', () => {
       const modal = page.getByRole('dialog');
       const brandLogo = modal.locator('img[alt="Brand Logo"]');
 
-      await expect(brandLogo).toHaveAttribute('src', '/assets/platform-logo-white.svg');
+      await expect(brandLogo).toBeVisible();
+      const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
+      expect(naturalWidth).toBeGreaterThan(0);
     });
 
-    test('should use standard logo for light theme', { tag: ['@not_mock'] }, async ({ page }) => {
+    test('should load standard logo for light theme', { tag: ['@not_mock'] }, async ({ page }) => {
       await page.locator('#help-menu-menu-toggle').click();
       await page.locator('[data-testid="masthead-about"]').click();
 
       const modal = page.getByRole('dialog');
       const brandLogo = modal.locator('img[alt="Brand Logo"]');
 
-      await expect(brandLogo).toHaveAttribute('src', '/assets/platform-logo.svg');
+      await expect(brandLogo).toBeVisible();
+      const naturalWidth = await brandLogo.evaluate((img: HTMLImageElement) => img.naturalWidth);
+      expect(naturalWidth).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary

  - Replace hardcoded `/assets/*.svg` path strings in the About modal with Vite `?url` imports, which ensure the SVGs are included in build output
  - Update Playwright brand logo tests to assert `naturalWidth > 0` (image actually loaded) instead of checking exact `src` path strings


## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
