### PR TITLE
Fix collection documentation tab crash caused due to missing docs_blob field

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionContents.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionContents.tsx
@@ -32,7 +32,7 @@ export function CollectionContents() {
       collection.collection_version?.name || ''
     }&namespace=${collection.collection_version?.namespace || ''}&version=${
       collection.collection_version?.version || ''
-    }`
+    }&exclude_fields=files,manifest,docs_blob`
   );
 
   const tableColumns = useTableColumns(collection);

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
@@ -123,6 +123,39 @@ describe('CollectionDocumentation', () => {
   afterAll(() => server.close());
   afterEach(() => server.resetHandlers());
 
+  test('should request docs_blob by including exclude_fields in API URL', async () => {
+    let capturedUrl = '';
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockDocumentationResponse);
+        }
+      )
+    );
+
+    render(
+      <TestWrapper>
+        <CollectionDocumentation />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(capturedUrl).toContain('exclude_fields=');
+    });
+
+    const url = new URL(capturedUrl);
+    const excludeFields = url.searchParams.get('exclude_fields');
+    expect(excludeFields).toBeTruthy();
+    expect(excludeFields).toContain('files');
+    expect(excludeFields).toContain('manifest');
+    expect(excludeFields).toContain('contents');
+    expect(excludeFields).not.toContain('docs_blob');
+  });
+
   test('should render documentation tab with readme content', async () => {
     render(
       <TestWrapper>

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
@@ -45,7 +45,7 @@ export function CollectionDocumentation() {
       collection?.collection_version?.namespace || ''
     }&name=${collection?.collection_version?.name || ''}&version=${
       collection?.collection_version?.version || ''
-    }&offset=0&limit=1`
+    }&offset=0&limit=1&exclude_fields=files,manifest,contents`
   );
 
   // create groups for left tab of contents menu

--- a/frontend/hub/collections/CollectionPage/CollectionInstall.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionInstall.test.tsx
@@ -126,6 +126,70 @@ describe('CollectionInstall', () => {
   afterAll(() => server.close());
   afterEach(() => server.resetHandlers());
 
+  test('should request docs_blob by including exclude_fields in API URL', async () => {
+    let capturedUrl = '';
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockContentResponse);
+        }
+      )
+    );
+
+    render(
+      <TestWrapper>
+        <CollectionInstall />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(capturedUrl).toContain('exclude_fields=');
+    });
+
+    const url = new URL(capturedUrl);
+    const excludeFields = url.searchParams.get('exclude_fields');
+    expect(excludeFields).toBeTruthy();
+    expect(excludeFields).toContain('files');
+    expect(excludeFields).toContain('manifest');
+    expect(excludeFields).toContain('contents');
+    expect(excludeFields).not.toContain('docs_blob');
+  });
+
+  test('should handle missing docs_blob gracefully', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('/content/ansible/collection_versions/'),
+        () =>
+          HttpResponse.json({
+            count: 1,
+            next: '',
+            previous: '',
+            results: [
+              {
+                license: ['MIT'],
+              },
+            ],
+          })
+      )
+    );
+
+    render(
+      <TestWrapper>
+        <CollectionInstall />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Install' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: /go to documentation/i })).not.toBeInTheDocument();
+  });
+
   test('should render install information with license', async () => {
     render(
       <TestWrapper>

--- a/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionInstall.tsx
@@ -41,7 +41,7 @@ export function CollectionInstall() {
       collection?.collection_version?.namespace || ''
     }&name=${collection?.collection_version?.name || ''}&version=${
       collection?.collection_version?.version || ''
-    }&offset=0&limit=1`
+    }&offset=0&limit=1&exclude_fields=files,manifest,contents`
   );
 
   const content = contentResults?.results[0];

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -68,7 +68,7 @@ export function CollectionPage() {
           collection?.collection_version?.namespace || ''
         }&name=${collection?.collection_version?.name || ''}&version=${
           collection?.collection_version?.version || ''
-        }&offset=0&limit=1`
+        }&offset=0&limit=1&exclude_fields=files,manifest,docs_blob,contents`
       : ''
   );
   const content = contentResults?.results?.[0];

--- a/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
+++ b/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
@@ -673,6 +673,46 @@ test.describe('Hub Collections - Details Page', () => {
     );
   });
 
+  test.describe('Documentation Tab', () => {
+    test(
+      'should render documentation content without error',
+      { tag: ['@not_mock'] },
+      async ({ page, collection }) => {
+        const namespace = 'e2edocs';
+        const name = 'docstab';
+
+        await collection.createNamespace({ name: namespace });
+        const uploaded = await collection.uploadVersion({
+          namespace,
+          name,
+          version: '1.0.0',
+          repository: 'staging',
+        });
+
+        await collection.approveCollection({
+          namespace: uploaded.namespace,
+          name: uploaded.name,
+          version: uploaded.version,
+        });
+
+        await navigateToCollectionDetails(page, uploaded);
+
+        // Click on the Documentation tab
+        await page.getByRole('tab', { name: 'Documentation' }).click();
+
+        // Verify documentation content renders (not an error state)
+        await expect(page.getByRole('heading', { name: 'Page not found' })).not.toBeVisible();
+
+        // Verify the page does not show a generic error boundary
+        const mainContent = page.locator('main');
+        await expect(mainContent).not.toContainText('Error', { timeout: 10000 });
+
+        // Verify documentation structure rendered (drawer with navigation panel)
+        await expect(page.getByPlaceholder('Find content')).toBeVisible({ timeout: 10000 });
+      }
+    );
+  });
+
   test.describe('Deprecation', () => {
     test(
       'should deprecate and undeprecate a collection from detail page',


### PR DESCRIPTION
## Summary

  - The pulp_ansible 0.25.5 `CollectionVersionSerializer` strips `docs_blob`, `files`, `manifest`, and `contents` from API responses by default unless the request includes a `fields` or `exclude_fields` query parameter. The UI was calling `/pulp/api/v3/content/ansible/collection_versions/` without either parameter, so `docs_blob` was always absent from the response. The Documentation tab then crashed with a `TypeError` accessing `docs_blob.contents` on `undefined`, which the React error boundary rendered as a generic "Error".
  - Add `&exclude_fields=files,manifest,contents` (or the appropriate subset) to all four `collection_versions` API calls so the serializer returns the fields each page needs while still excluding the large fields it doesn't.
  - Add vitest regression tests verifying the `exclude_fields` parameter is present in the request URL, and a Playwright e2e test confirming the Documentation tab renders content against a live backend.
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots
<img width="1512" height="821" alt="Screenshot 2026-04-22 at 2 29 39 PM" src="https://github.com/user-attachments/assets/6d343e58-e17f-4e5d-8839-7f391166cfa9" />
