### PR TITLE
Onboard ansible-ui to Codecov with OIDC and add push-to-main coverage

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -1,6 +1,8 @@
 name: Platform PR
 
 on:
+  push:
+    branches: [main, devel]
   pull_request:
 
 env:
@@ -117,6 +119,8 @@ jobs:
     name: Vitest Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write
     needs:
       - vitest-awx
       - vitest
@@ -157,8 +161,18 @@ jobs:
           path: coverage/combined
           retention-days: 7
           if-no-files-found: error
-      - name: Upload unit test coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload unit test coverage to Codecov (OIDC)
+        if: ${{ !vars.CODECOV_URL }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./coverage/combined/lcov.info
+          flags: unit-tests
+          disable_search: true
+          fail_ci_if_error: false
+      - name: Upload unit test coverage to Codecov (Token)
+        if: ${{ vars.CODECOV_URL }}
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           url: ${{ vars.CODECOV_URL }}
@@ -168,8 +182,10 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
       - name: Save off PR Number
+        if: github.event_name == 'pull_request'
         run: echo "PR ${{ github.event.number }}" > pr_number.txt
       - name: Upload PR Number
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pr_number
@@ -221,7 +237,8 @@ jobs:
           path: coverage/combined
         continue-on-error: true
 
-      - name: SonarQube Scan
+      - name: SonarQube Scan (PR)
+        if: github.event_name == 'pull_request'
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
@@ -233,6 +250,17 @@ jobs:
             -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
             -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
             -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
+
+      - name: SonarQube Scan (Branch)
+        if: github.event_name == 'push'
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
+        with:
+          args: >
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.branch.name=${{ github.ref_name }}
 
   success:
     name: Success


### PR DESCRIPTION
## Summary

- Upgrades `codecov/codecov-action` from v4 to v5 with OIDC auth for the public upstream repo (no token/secrets needed)
- Keeps token auth path for the private downstream repo (conditional on `vars.CODECOV_URL`)
- Adds `push` trigger on `main`/`devel` branches to establish coverage baselines for both Codecov and SonarQube
- Adds SonarQube branch analysis on push events for accurate "new code" detection on PRs
- Guards PR-only steps with event conditions so they don't run on push

## How it works

| | **ansible-ui (public upstream)** | **aap-ui (private downstream)** |
|---|---|---|
| `vars.CODECOV_URL` | Not set | Set to self-hosted instance URL |
| Auth | OIDC (`use_oidc: true`) | Token (`CODECOV_TOKEN` + `CODECOV_URL`) |
| Codecov instance | app.codecov.io | Self-hosted |

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Test plan

- [ ] PR triggers the Vitest Coverage job and the Codecov OIDC upload step runs
- [ ] Coverage data appears in the [Codecov dashboard](https://app.codecov.io/gh/ansible/ansible-ui)
- [ ] SonarQube PR analysis still works as before
- [ ] After merge to devel, push trigger runs and uploads baseline coverage