### PR TITLE
Fix flaky vitest

### DIFF
--- a/frontend/hub/common/components/InsightsSelectUser.test.tsx
+++ b/frontend/hub/common/components/InsightsSelectUser.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InsightsSelectUser } from './InsightsSelectUser';
 
@@ -48,9 +49,12 @@ describe('InsightsSelectUser', () => {
 
   const renderComponent = (props = {}) => {
     return render(
-      <MemoryRouter>
-        <InsightsSelectUser {...defaultProps} {...props} />
-      </MemoryRouter>
+      // Fresh SWR cache per render avoids stale /users data from earlier tests in this file
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <MemoryRouter>
+          <InsightsSelectUser {...defaultProps} {...props} />
+        </MemoryRouter>
+      </SWRConfig>
     );
   };
 


### PR DESCRIPTION
## Summary

Isolate swr cache across InsightsSelectUser tests to prevent cache conflicts. This is the same fix we've applied in other test files.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
