### PR TITLE
Remove subscription wizard analytics step

### DIFF
--- a/platform/settings/SubscriptionWizard.test.tsx
+++ b/platform/settings/SubscriptionWizard.test.tsx
@@ -34,7 +34,6 @@ describe('SubscriptionWizard Component', () => {
       // Check that all three steps are present in navigation
       const navigation = screen.getByRole('navigation', { name: 'Steps' });
       expect(navigation).toHaveTextContent('Ansible Automation Platform Subscription');
-      expect(navigation).toHaveTextContent('Optional: Automation Analytics');
       expect(navigation).toHaveTextContent('End User License Agreement');
       expect(navigation).toHaveTextContent('Review');
 
@@ -45,11 +44,9 @@ describe('SubscriptionWizard Component', () => {
       expect(currentStep).toHaveClass('pf-m-current');
 
       // Other steps should be disabled
-      const analyticsStep = screen.getByRole('button', { name: 'Optional: Automation Analytics' });
       const licenseStep = screen.getByRole('button', { name: 'End User License Agreement' });
       const reviewStep = screen.getByRole('button', { name: 'Review' });
 
-      expect(analyticsStep).toBeDisabled();
       expect(licenseStep).toBeDisabled();
       expect(reviewStep).toBeDisabled();
 
@@ -245,95 +242,5 @@ describe('SubscriptionWizard Component', () => {
         expect(subscriptionSelect).toBeEnabled();
       });
     }, 10000);
-  });
-
-  describe('Automation Analytics Step', () => {
-    const navigateToAnalyticsStep = async () => {
-      const user = userEvent.setup();
-      renderWithRouter();
-      await user.click(screen.getByRole('button', { name: 'Subscription manifest' }));
-      const file = new File(['mock manifest content'], 'manifest.zip', {
-        type: 'application/zip',
-      });
-      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
-      await user.upload(fileInput, file);
-      const nextButton = screen.getByRole('button', { name: /next/i });
-      await user.click(nextButton);
-
-      return user;
-    };
-
-    it('renders automation analytics step with correct content', async () => {
-      await navigateToAnalyticsStep();
-
-      await waitFor(
-        () => {
-          expect(
-            screen.getByRole('heading', { name: /Optional: Automation Analytics/i })
-          ).toBeInTheDocument();
-        },
-        { timeout: 10000 }
-      );
-
-      expect(
-        screen.getByText(/Enter client ID and client secret to enable Analytics/i)
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText(/Client ID/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Client secret/i)).toBeInTheDocument();
-      expect(screen.getByAltText(/Automation Analytics/i)).toBeInTheDocument();
-    }, 15000);
-
-    it('allows proceeding to next step with filled analytics fields', async () => {
-      const user = await navigateToAnalyticsStep();
-
-      await waitFor(
-        () => {
-          expect(screen.getByLabelText(/Client ID/i)).toBeInTheDocument();
-        },
-        { timeout: 10000 }
-      );
-
-      const clientIdField = screen.getByLabelText(/Client ID/i);
-      const clientSecretField = screen.getByLabelText(/Client secret/i);
-      await user.type(clientIdField, 'test-client-id');
-      await user.type(clientSecretField, 'test-client-secret');
-      // Should be able to proceed to next step
-      const nextButton = screen.getByRole('button', { name: /next/i });
-      expect(nextButton).toBeEnabled();
-      await user.click(nextButton);
-
-      await waitFor(
-        () => {
-          expect(
-            screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
-          ).toBeInTheDocument();
-        },
-        { timeout: 10000 }
-      );
-    }, 15000);
-
-    it('allows proceeding to next step with empty analytics fields (optional)', async () => {
-      const user = await navigateToAnalyticsStep();
-
-      await waitFor(
-        () => {
-          expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
-        },
-        { timeout: 10000 }
-      );
-
-      const nextButton = screen.getByRole('button', { name: /next/i });
-      expect(nextButton).toBeEnabled();
-      await user.click(nextButton);
-
-      await waitFor(
-        () => {
-          expect(
-            screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
-          ).toBeInTheDocument();
-        },
-        { timeout: 10000 }
-      );
-    }, 15000);
   });
 });

--- a/platform/settings/SubscriptionWizard.test.tsx
+++ b/platform/settings/SubscriptionWizard.test.tsx
@@ -1,9 +1,22 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SubscriptionWizard } from './SubscriptionWizard';
+
+vi.mock('@ansible/awx-ui/common/useAwxConfig', () => ({
+  useAwxConfig: () => ({ eula: 'End User License Agreement text for testing.' }),
+  useAwxConfigState: () => ({ refreshAwxConfig: vi.fn() }),
+}));
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 const mockOnSuccess = vi.fn();
 
@@ -242,5 +255,126 @@ describe('SubscriptionWizard Component', () => {
         expect(subscriptionSelect).toBeEnabled();
       });
     }, 10000);
+  });
+
+  describe('Auto-enabling Insights Tracking', () => {
+    it('should enable INSIGHTS_TRACKING_STATE when submitting service account subscription', async () => {
+      let patchedSettings: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post('*/config/subscriptions/', () =>
+          HttpResponse.json([
+            {
+              subscription_name: 'Test Subscription',
+              subscription_id: 'sub-123',
+              instance_count: 100,
+              license_date: Math.floor(Date.now() / 1000) + 86400,
+            },
+          ])
+        ),
+        http.post('*/config/attach/', () => HttpResponse.json({})),
+        http.patch('*/settings/all/', async ({ request }) => {
+          patchedSettings = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({});
+        })
+      );
+
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      await user.click(screen.getByRole('button', { name: 'Service Account' }));
+
+      const clientIdField = await screen.findByRole('textbox', { name: 'Client ID' });
+      const clientSecretField = document.querySelector(
+        'input[type="password"]'
+      ) as HTMLInputElement;
+      await user.type(clientIdField, 'test-client-id');
+      await user.type(clientSecretField, 'test-client-secret');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Subscription' })).toBeEnabled();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Subscription' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: /Test Subscription/ })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('option', { name: /Test Subscription/ }));
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
+      );
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Finish' }));
+
+      await waitFor(() => {
+        expect(mockOnSuccess).toHaveBeenCalled();
+      });
+
+      expect(patchedSettings).toEqual({ INSIGHTS_TRACKING_STATE: true });
+    }, 30000);
+
+    it('should not enable INSIGHTS_TRACKING_STATE when submitting manifest subscription', async () => {
+      let patchCalled = false;
+
+      server.use(
+        http.post('*/config/', () => HttpResponse.json({})),
+        http.patch('*/settings/all/', () => {
+          patchCalled = true;
+          return HttpResponse.json({});
+        })
+      );
+
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      await user.click(screen.getByRole('button', { name: 'Subscription manifest' }));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const file = new File(['mock manifest content'], 'manifest.zip', {
+        type: 'application/zip',
+      });
+      await user.upload(fileInput, file);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
+      );
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Finish' }));
+
+      await waitFor(() => {
+        expect(mockOnSuccess).toHaveBeenCalled();
+      });
+
+      expect(patchCalled).toBe(false);
+    }, 30000);
   });
 });

--- a/platform/settings/SubscriptionWizard.tsx
+++ b/platform/settings/SubscriptionWizard.tsx
@@ -11,9 +11,8 @@ import { PageFormHidden } from '@ansible/ansible-ui-framework/PageForm/Utils/Pag
 import { awxErrorAdapter } from '@ansible/awx-ui/common/adapters/awxErrorAdapter';
 import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { useAwxConfig, useAwxConfigState } from '@ansible/awx-ui/common/useAwxConfig';
-import { postRequest, requestPatch } from '@ansible/common-ui/crud/Data';
+import { postRequest } from '@ansible/common-ui/crud/Data';
 import { ILicenseInfo } from '@ansible/common-ui/interfaces/Config';
-import { useGetDocsUrl } from '@ansible/common-ui/utils/useGetDocsUrl';
 import { ExternalLink } from '@ansible/hub-ui//common/ExternalLink';
 import {
   Content,
@@ -26,7 +25,6 @@ import {
 import { useCallback, useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import AnalyticsGraphic from '../assets/AAGraphic 1.svg?url';
 
 interface SubscriptionWizardData {
   subscriptionSelection: 'manifest' | 'service_account' | 'username' | 'satellite';
@@ -38,8 +36,6 @@ interface SubscriptionWizardData {
   satellite_username: string;
   satellite_password: string;
   subscription_id?: string;
-  analytics_client_id: string;
-  analytics_client_secret: string;
   agree: boolean;
 }
 
@@ -53,11 +49,6 @@ export function SubscriptionWizard(props: { onSuccess: () => void }) {
         id: 'subscription',
         label: t('Ansible Automation Platform Subscription'),
         inputs: <SubscriptionStep />,
-      },
-      {
-        id: 'analytics',
-        label: t('Optional: Automation Analytics'),
-        inputs: <AutomationAnalyticsStep />,
       },
       {
         id: 'license-agreement',
@@ -98,15 +89,6 @@ export function SubscriptionWizard(props: { onSuccess: () => void }) {
           break;
       }
       refreshAwxConfig?.();
-
-      // Set up analytics if client credentials are provided in automation analytics step
-      if (data.analytics_client_id && data.analytics_client_secret) {
-        await requestPatch(awxAPI`/settings/all/`, {
-          REDHAT_USERNAME: data.analytics_client_id,
-          REDHAT_PASSWORD: data.analytics_client_secret,
-          INSIGHTS_TRACKING_STATE: true,
-        });
-      }
       props.onSuccess();
     },
     [props, refreshAwxConfig]
@@ -334,52 +316,6 @@ function SubscriptionStep() {
           }
         />
       </PageFormHidden>
-    </>
-  );
-}
-
-function AutomationAnalyticsStep() {
-  const { t } = useTranslation();
-  const config = useAwxConfig();
-  const docsUrl = useGetDocsUrl(config, 'configureAnalytics');
-
-  return (
-    <>
-      <Content>
-        <Content component="h1">{t('Optional: Automation Analytics')}</Content>
-        <Content>
-          {t(
-            'Enter client ID and client secret to enable Analytics. This collects and transmits analytics on the service usage to Red Hat. For more information, see '
-          )}
-          <ExternalLink href={docsUrl}>{t('documentation')}</ExternalLink>
-          {t('.')}
-        </Content>
-        <Content>
-          <div
-            style={{
-              marginTop: 'var(--pf-t--global--spacer--xl)',
-              marginBottom: 'var(--pf-t--global--spacer--lg)',
-            }}
-          >
-            <img
-              src={AnalyticsGraphic}
-              alt={t('Automation Analytics')}
-              style={{ width: '100%', height: 'auto' }}
-            />
-          </div>
-        </Content>
-      </Content>
-      <PageFormTextInput<SubscriptionWizardData>
-        name="analytics_client_id"
-        label={t`Client ID`}
-        labelHelp={t('Client ID used to send data to Automation Analytics')}
-      />
-      <PageFormTextInput<SubscriptionWizardData>
-        name="analytics_client_secret"
-        label={t`Client secret`}
-        type="password"
-        labelHelp={t('Client secret used to send data to Automation Analytics')}
-      />
     </>
   );
 }

--- a/platform/settings/SubscriptionWizard.tsx
+++ b/platform/settings/SubscriptionWizard.tsx
@@ -11,7 +11,7 @@ import { PageFormHidden } from '@ansible/ansible-ui-framework/PageForm/Utils/Pag
 import { awxErrorAdapter } from '@ansible/awx-ui/common/adapters/awxErrorAdapter';
 import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { useAwxConfig, useAwxConfigState } from '@ansible/awx-ui/common/useAwxConfig';
-import { postRequest } from '@ansible/common-ui/crud/Data';
+import { postRequest, requestPatch } from '@ansible/common-ui/crud/Data';
 import { ILicenseInfo } from '@ansible/common-ui/interfaces/Config';
 import { ExternalLink } from '@ansible/hub-ui//common/ExternalLink';
 import {
@@ -85,6 +85,9 @@ export function SubscriptionWizard(props: { onSuccess: () => void }) {
         case 'satellite':
           await postRequest(awxAPI`/config/attach/`, {
             subscription_id: data.subscription_id,
+          });
+          await requestPatch(awxAPI`/settings/all/`, {
+            INSIGHTS_TRACKING_STATE: true,
           });
           break;
       }


### PR DESCRIPTION
## Summary

This PR removes the optional analytics step from the subscription wizard and also auto-enables analytics for subscriptions retrieved using service account, basic auth and satellite credentials.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->
Dependent backend PR: https://github.com/ansible/awx/pull/16388

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->
Set up an aap-dev server and ensure the awx component is using latest devel
Verify the optional analytics step in the subscription wizard is not there
Use basic auth using Red Hat credentials to retrieve a subscription
Navigate to `/settings/automation-execution/system` and verify `Gather data for Automation Analytics` is enabled

### Screenshots

<img width="1276" height="559" alt="Screenshot 2026-04-24 at 3 36 56 PM" src="https://github.com/user-attachments/assets/b6193311-9d1a-4016-ad60-35e38b1f2cea" />

<img width="1328" height="756" alt="Screenshot 2026-05-20 at 1 02 16 PM" src="https://github.com/user-attachments/assets/502a951e-509b-4b23-b5d6-07a5d12af366" />

