### PR TITLE
feat(platform): hide subscription banners for non-admin users

### DIFF
--- a/platform/main/PlatformApp.test.tsx
+++ b/platform/main/PlatformApp.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 import { beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import * as GatewayUIAuth from './GatewayUIAuth';
+import * as PlatformActiveUserModule from './PlatformActiveUserProvider';
 import { PlatformApp } from './PlatformApp';
 
 // Mock fetch globally
@@ -42,6 +43,7 @@ interface ManagedCloudStub {
 
 describe('Platform Subscription and Session Validation Tests', () => {
   let useIsManagedCloudStub: MockInstance & ManagedCloudStub;
+  let usePlatformActiveUserStub: MockInstance;
   let fetchMock: MockInstance;
 
   beforeAll(async () => {
@@ -72,6 +74,11 @@ describe('Platform Subscription and Session Validation Tests', () => {
       useIsManagedCloudStub.mockReturnValue(value);
       return useIsManagedCloudStub;
     };
+
+    // Default to superuser so existing tests see banners (AAPRFE-2823)
+    usePlatformActiveUserStub = vi
+      .spyOn(PlatformActiveUserModule, 'usePlatformActiveUser')
+      .mockReturnValue({ activePlatformUser: { is_superuser: true } as never });
 
     // Default intercepts matching the original Cypress test
     fetchMock.mockImplementation((url: string | URL) => {
@@ -276,6 +283,145 @@ describe('Platform Subscription and Session Validation Tests', () => {
       // Check that no subscription banners are displayed when managed cloud is enabled
       await waitFor(() => {
         expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not display compliance banners for non-admin users (AAPRFE-2823)', async () => {
+      // Arrange: Set user as non-superuser
+      usePlatformActiveUserStub.mockReturnValue({
+        activePlatformUser: { is_superuser: false },
+      });
+
+      // Override the config intercept to return non-compliant license
+      fetchMock.mockImplementation((url: string | URL) => {
+        const urlString = url.toString();
+
+        if (
+          urlString.includes('/config/') &&
+          (urlString.includes('/api/controller/v2/') || urlString.includes('/api/v2/'))
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                license_info: {
+                  compliant: false,
+                  grace_period_remaining: 2 * 24 * 60 * 60,
+                },
+              }),
+          } as Response);
+        }
+
+        if (urlString.includes('/api/gateway/v1/session/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ expires_in_seconds: 3600 }),
+          } as Response);
+        }
+
+        return Promise.reject(new Error(`Unmocked URL: ${urlString}`));
+      });
+
+      // Act
+      mountPlatformApp(<PlatformApp />);
+
+      // Assert: No compliance banner should be shown to non-admin users
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/Your subscription is out of compliance/)
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('should display compliance banners only for admin users (AAPRFE-2823)', async () => {
+      // Arrange: Set user as superuser
+      usePlatformActiveUserStub.mockReturnValue({
+        activePlatformUser: { is_superuser: true },
+      });
+
+      // Override the config intercept to return non-compliant license
+      fetchMock.mockImplementation((url: string | URL) => {
+        const urlString = url.toString();
+
+        if (
+          urlString.includes('/config/') &&
+          (urlString.includes('/api/controller/v2/') || urlString.includes('/api/v2/'))
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                license_info: {
+                  compliant: false,
+                  grace_period_remaining: 2 * 24 * 60 * 60,
+                },
+              }),
+          } as Response);
+        }
+
+        if (urlString.includes('/api/gateway/v1/session/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ expires_in_seconds: 3600 }),
+          } as Response);
+        }
+
+        return Promise.reject(new Error(`Unmocked URL: ${urlString}`));
+      });
+
+      // Act
+      mountPlatformApp(<PlatformApp />);
+
+      // Assert: Compliance banner should be shown to admin users
+      await waitFor(() => {
+        expect(
+          screen.getByText('Your subscription is out of compliance. 2 days grace period remaining.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not display subscription expiry banners for non-admin users (AAPRFE-2823)', async () => {
+      // Arrange: Set user as non-superuser
+      usePlatformActiveUserStub.mockReturnValue({
+        activePlatformUser: { is_superuser: false },
+      });
+
+      // Override the config intercept to return expiring subscription
+      fetchMock.mockImplementation((url: string | URL) => {
+        const urlString = url.toString();
+
+        if (
+          urlString.includes('/config/') &&
+          (urlString.includes('/api/controller/v2/') || urlString.includes('/api/v2/'))
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                license_info: {
+                  compliant: true,
+                  time_remaining: 14 * 24 * 60 * 60,
+                },
+              }),
+          } as Response);
+        }
+
+        if (urlString.includes('/api/gateway/v1/session/')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ expires_in_seconds: 3600 }),
+          } as Response);
+        }
+
+        return Promise.reject(new Error(`Unmocked URL: ${urlString}`));
+      });
+
+      // Act
+      mountPlatformApp(<PlatformApp />);
+
+      // Assert: No expiry banner should be shown to non-admin users
+      await waitFor(() => {
+        expect(screen.queryByText(/Your subscription will expire/)).not.toBeInTheDocument();
       });
     });
   });

--- a/platform/main/PlatformApp.test.tsx
+++ b/platform/main/PlatformApp.test.tsx
@@ -75,7 +75,7 @@ describe('Platform Subscription and Session Validation Tests', () => {
       return useIsManagedCloudStub;
     };
 
-    // Default to superuser so existing tests see banners (AAPRFE-2823)
+    // Default to superuser so existing tests see banners
     usePlatformActiveUserStub = vi
       .spyOn(PlatformActiveUserModule, 'usePlatformActiveUser')
       .mockReturnValue({ activePlatformUser: { is_superuser: true } as never });
@@ -286,7 +286,7 @@ describe('Platform Subscription and Session Validation Tests', () => {
       });
     });
 
-    it('should not display compliance banners for non-admin users (AAPRFE-2823)', async () => {
+    it('should not display compliance banners for non-admin users', async () => {
       // Arrange: Set user as non-superuser
       usePlatformActiveUserStub.mockReturnValue({
         activePlatformUser: { is_superuser: false },
@@ -333,7 +333,7 @@ describe('Platform Subscription and Session Validation Tests', () => {
       });
     });
 
-    it('should display compliance banners only for admin users (AAPRFE-2823)', async () => {
+    it('should display compliance banners only for admin users', async () => {
       // Arrange: Set user as superuser
       usePlatformActiveUserStub.mockReturnValue({
         activePlatformUser: { is_superuser: true },
@@ -380,7 +380,7 @@ describe('Platform Subscription and Session Validation Tests', () => {
       });
     });
 
-    it('should not display subscription expiry banners for non-admin users (AAPRFE-2823)', async () => {
+    it('should not display subscription expiry banners for non-admin users', async () => {
       // Arrange: Set user as non-superuser
       usePlatformActiveUserStub.mockReturnValue({
         activePlatformUser: { is_superuser: false },

--- a/platform/main/PlatformApp.tsx
+++ b/platform/main/PlatformApp.tsx
@@ -72,7 +72,6 @@ export function PlatformApp() {
   const { activePlatformUser } = usePlatformActiveUser();
   const subscriptionBanner = useMemo(() => {
     // Hide compliance banners for non-admin users - they cannot act on compliance issues
-    // See AAPRFE-2823: https://issues.redhat.com/browse/AAPRFE-2823
     if (!activePlatformUser?.is_superuser) return null;
     if (!awxConfig?.license_info || managedCloudInstall) return null;
     if (!awxConfig.license_info.compliant) {

--- a/platform/main/PlatformApp.tsx
+++ b/platform/main/PlatformApp.tsx
@@ -11,6 +11,7 @@ import { useUIFlag } from '../settings/ui-flags/useUIFlag';
 import { gatewayAPI } from '../utils/gateway-api-utils';
 import { useIsManagedCloudInstall } from './GatewayUIAuth';
 import { PersonaViewSwitcher } from './persona-view/PersonaViewSwitcher';
+import { usePlatformActiveUser } from './PlatformActiveUserProvider';
 import { PlatformMasthead } from './PlatformMasthead';
 import { usePlatformNavigation } from './usePlatformNavigation';
 import { PageTitleProvider } from '@ansible/ansible-ui-framework/PageTitle/PageTitle';
@@ -68,7 +69,11 @@ export function PlatformApp() {
 
   const { awxConfig, serviceDown, serviceDownStatusCode } = useAwxConfigState();
   const managedCloudInstall = useIsManagedCloudInstall() ?? false;
+  const { activePlatformUser } = usePlatformActiveUser();
   const subscriptionBanner = useMemo(() => {
+    // Hide compliance banners for non-admin users - they cannot act on compliance issues
+    // See AAPRFE-2823: https://issues.redhat.com/browse/AAPRFE-2823
+    if (!activePlatformUser?.is_superuser) return null;
     if (!awxConfig?.license_info || managedCloudInstall) return null;
     if (!awxConfig.license_info.compliant) {
       if (awxConfig.license_info.grace_period_remaining) {
@@ -109,7 +114,7 @@ export function PlatformApp() {
       );
     }
     return null;
-  }, [awxConfig, managedCloudInstall]);
+  }, [activePlatformUser?.is_superuser, awxConfig, managedCloudInstall]);
 
   const controllerDownBanner = useMemo(() => {
     if (!serviceDown) return null;


### PR DESCRIPTION
## Summary

Hide the "out of compliance" banner for non-admin users.

Non-admin users cannot act on subscription compliance issues, so displaying the banner to them:
- Causes confusion ("should I stop using the platform?")
- Creates unnecessary support burden

This change hides all subscription-related banners (compliance, grace period, expiry warnings) for non-superuser accounts.

## Risk Analysis - REQUIRED

- [ ] **High**
- [ ] **Medium**
- [x] **Low**

**Justification:**
- Change is isolated to banner visibility logic only
- No API changes, no backend changes
- Uses existing `usePlatformActiveUser` hook (already in use elsewhere)
- All existing tests pass; 3 new tests added
- Easy to revert if needed

## Changes Made

- `platform/main/PlatformApp.tsx`: Add `is_superuser` check to `subscriptionBanner` useMemo
- `platform/main/PlatformApp.test.tsx`: Add 3 new test cases covering admin/non-admin scenarios

## Implementation Details

Uses existing pattern from `SubscriptionDetails.tsx`:
```tsx
const { activePlatformUser } = usePlatformActiveUser();
// ...
if (!activePlatformUser?.is_superuser) return null;
```

## Test Plan

- [x] All 14 existing tests pass
- [x] New tests verify:
  - Non-admin users do NOT see compliance banners
  - Admin users DO see compliance banners
  - Non-admin users do NOT see subscription expiry banners
- [x] TypeScript compilation passes
- [x] ESLint passes

### Manual Testing Steps

1. Log in as a non-superuser account
2. Ensure subscription is out of compliance (or will expire soon)
3. Verify: No red/yellow subscription banner appears
4. Log in as superuser account
5. Verify: Subscription banner appears as expected

## Screenshots

N/A - Banner visibility change only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)