### PR TITLE
[AAP-73139] Removes RUNTIME_FEATURE_FLAGS_UI

### DIFF
--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
@@ -23,7 +23,6 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
       http.get('/api/gateway/v1/settings/feature_flags/', () =>
         HttpResponse.json({
           RUNTIME_FEATURE_FLAGS: true,
-          RUNTIME_FEATURE_FLAGS_UI: false,
         })
       )
     );
@@ -41,7 +40,6 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
       http.get('/api/gateway/v1/settings/feature_flags/', () =>
         HttpResponse.json({
           RUNTIME_FEATURE_FLAGS: false,
-          RUNTIME_FEATURE_FLAGS_UI: false,
         })
       )
     );

--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.ts
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.ts
@@ -4,7 +4,6 @@ import { gatewayAPI } from '../../utils/gateway-api-utils';
 
 interface FeatureFlagsSettings {
   RUNTIME_FEATURE_FLAGS: boolean;
-  RUNTIME_FEATURE_FLAGS_UI: boolean;
 }
 
 export function useRuntimeFeatureFlagsEnabled() {

--- a/playwright/utils/settingsFeatureFlags.ts
+++ b/playwright/utils/settingsFeatureFlags.ts
@@ -15,7 +15,6 @@ export const SettingsFeatureFlags = {
             contentType: 'application/json',
             body: JSON.stringify({
               RUNTIME_FEATURE_FLAGS: options.runtimeFeatureFlags,
-              RUNTIME_FEATURE_FLAGS_UI: false,
             }),
           })
       );


### PR DESCRIPTION
## Summary

As the RUNTIME_FEATURE_FLAGS_UI field is no longer used, and is being removed from Gateway, we should remove  the RUNTIME_FEATURE_FLAGS_UI references here as well.

Refer to https://github.com/ansible/jewel/pull/5 .

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

Depends on https://github.com/ansible/jewel/pull/5 .

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
