### PR TITLE
Add SonarCloud remediation skill and commands

### DIFF
--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -1,0 +1,11 @@
+# Analyze SonarCloud Issues
+
+Follow **Phase A — Analyze** in `.claude/skills/sonarcloud-remediation.md`.
+
+1. Validate environment variables (`SONAR_ORGANIZATION`, `SONAR_PROJECT_KEY`)
+2. Fetch all open issues, hotspots, and duplication metrics from SonarCloud API
+3. Categorize by the 5 SonarCloud categories (Security, Reliability, Maintainability, Security Hotspots, Duplication)
+4. Group by rule + workspace, sort by remediation priority
+5. Present a prioritized summary table per category
+
+Optional arguments: `--severity <level>`, `--workspace <name>`

--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -17,7 +17,7 @@ Fetches all open issues from SonarCloud, groups them by category and workspace, 
 | Flag | Description | Example |
 |------|-------------|---------|
 | `--severity <level>` | Only show issues at or above this severity (BLOCKER, CRITICAL, MAJOR, MINOR, INFO) | `--severity MAJOR` |
-| `--workspace <name>` | Only show issues in the specified workspace (AWX, EDA, Hub, Framework, Platform, Common, Chatbot, Tests) | `--workspace AWX` |
+| `--module <name>` | Only show issues in the specified module (auto-detected from repo structure — see skill docs) | `--module frontend/awx` |
 | `--help` | Show this usage information | |
 
 ### Required Environment Variables
@@ -43,7 +43,7 @@ A prioritized summary table per SonarCloud category:
 - **Security Hotspots** — hotspots pending review
 - **Duplication** — duplicated blocks and files
 
-Each table groups issues by SonarCloud rule and workspace, sorted by remediation priority, with issue count, severity, and estimated LOC impact.
+Each table groups issues by SonarCloud rule and module (auto-detected from workspace definitions or top-level directories), sorted by remediation priority, with issue count, severity, and estimated LOC impact.
 
 ### Permissions
 
@@ -57,5 +57,5 @@ Add to `.claude/settings.json` to avoid permission prompts:
 1. Validate environment variables (`SONAR_ORGANIZATION`, `SONAR_PROJECT_KEY`)
 2. Fetch all open issues, hotspots, and duplication metrics from SonarCloud API
 3. Categorize by the 5 SonarCloud categories
-4. Group by rule + workspace, sort by remediation priority
+4. Detect modules (from workspace definitions or top-level directories), group by rule + module, sort by remediation priority
 5. Present a prioritized summary table per category

--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -2,10 +2,60 @@
 
 Follow **Phase A — Analyze** in `.claude/skills/sonarcloud-remediation.md`.
 
+If the user passes `--help`, display the usage information below and stop.
+
+## Usage
+
+```
+/sonarcloud-analyze [options]
+```
+
+Fetches all open issues from SonarCloud, groups them by category and workspace, and presents a prioritized summary report.
+
+### Options
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--severity <level>` | Only show issues at or above this severity (BLOCKER, CRITICAL, MAJOR, MINOR, INFO) | `--severity MAJOR` |
+| `--workspace <name>` | Only show issues in the specified workspace (AWX, EDA, Hub, Framework, Platform, Common, Chatbot, Tests) | `--workspace AWX` |
+| `--help` | Show this usage information | |
+
+### Required Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `SONAR_ORGANIZATION` | Yes | SonarCloud organization slug |
+| `SONAR_PROJECT_KEY` | Yes | SonarCloud project key |
+| `SONARCLOUD_TOKEN` | Only for private projects | API authentication token |
+
+Set them before running:
+```bash
+export SONAR_ORGANIZATION=your-org
+export SONAR_PROJECT_KEY=your-project-key
+```
+
+### Output
+
+A prioritized summary table per SonarCloud category:
+- **Security** — vulnerabilities
+- **Reliability** — bugs
+- **Maintainability** — code smells
+- **Security Hotspots** — hotspots pending review
+- **Duplication** — duplicated blocks and files
+
+Each table groups issues by SonarCloud rule and workspace, sorted by remediation priority, with issue count, severity, and estimated LOC impact.
+
+### Permissions
+
+Add to `.claude/settings.json` to avoid permission prompts:
+```json
+"Bash(curl -s *sonarcloud.io*)"
+```
+
+## Workflow
+
 1. Validate environment variables (`SONAR_ORGANIZATION`, `SONAR_PROJECT_KEY`)
 2. Fetch all open issues, hotspots, and duplication metrics from SonarCloud API
-3. Categorize by the 5 SonarCloud categories (Security, Reliability, Maintainability, Security Hotspots, Duplication)
+3. Categorize by the 5 SonarCloud categories
 4. Group by rule + workspace, sort by remediation priority
 5. Present a prioritized summary table per category
-
-Optional arguments: `--severity <level>`, `--workspace <name>`

--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -1,6 +1,6 @@
 # Analyze SonarCloud Issues
 
-Follow **Phase A — Analyze** in `.claude/skills/sonarcloud-remediation.md`.
+Follow **Phase A — Analyze** in `.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md`.
 
 If the user passes `--help`, display the usage information below and stop.
 
@@ -49,13 +49,11 @@ Each table groups issues by SonarCloud rule and module (auto-detected from works
 
 Add to `.claude/settings.json` to avoid permission prompts:
 ```json
-"Bash(curl -s *sonarcloud.io*)"
+"Bash(python3 *sonarcloud-fetch.py*)"
 ```
 
 ## Workflow
 
-1. Validate environment variables (`SONAR_ORGANIZATION`, `SONAR_PROJECT_KEY`)
-2. Fetch all open issues, hotspots, and duplication metrics from SonarCloud API
-3. Categorize by the 5 SonarCloud categories
-4. Detect modules (from workspace definitions or top-level directories), group by rule + module, sort by remediation priority
-5. Present a prioritized summary table per category
+1. Run the fetch script (`scripts/sonarcloud-fetch.py`) to fetch and categorize all issues
+2. Detect modules (from workspace definitions or top-level directories), group by rule + module, sort by remediation priority
+3. Present a prioritized summary table per category

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -40,18 +40,19 @@ Add to `.claude/settings.json` to avoid permission prompts:
 
 ### Workflow
 
-1. If no analysis exists in this session, run `/sonarcloud-analyze` first
-2. If no group argument provided, display available groups and prompt for selection
-3. Read affected files, present fixes as a group for review
-4. **Approval 1 — Apply fixes:**
+1. **Configuration pre-check**: Display all environment variables (with values, defaults, and descriptions) and prompt for confirmation before proceeding. Skipped if already confirmed in the current session.
+2. If no analysis exists in this session, run `/sonarcloud-analyze` first
+3. If no group argument provided, display available groups and prompt for selection
+4. Read affected files, present fixes as a group for review
+5. **Approval 1 — Apply fixes:**
    - Apply approved fixes (cap ~200 LOC per batch, auto-split larger groups)
    - Run validation commands (hard gate — must pass)
    - Create branch and commit changes
    - **Pause**: Inform the engineer the branch is ready for local testing. They can review the diff, run additional tests, or commit manual adjustments. Wait for explicit go-ahead.
-5. **Approval 2 — Create PR(s):**
+6. **Approval 2 — Create PR(s):**
    - Present a summary: number of PRs to be created, LOC per PR, target branch
    - Wait for explicit approval before creating any PR
    - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, AWX)`)
    - PR body follows `.github/pull_request_template.md`
    - Post e2e trigger comment on each PR
-6. Offer to continue with the next group
+7. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -51,6 +51,7 @@ Add to `.claude/settings.json` to avoid permission prompts:
 5. **Approval 2 — Create PR(s):**
    - Present a summary: number of PRs to be created, LOC per PR, target branch
    - Wait for explicit approval before creating any PR
-   - Create PR(s) following `.github/pull_request_template.md`
+   - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, AWX)`)
+   - PR body follows `.github/pull_request_template.md`
    - Post e2e trigger comment on each PR
 6. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -1,0 +1,12 @@
+# Fix SonarCloud Issues
+
+Follow **Phase B — Fix** in `.claude/skills/sonarcloud-remediation.md`.
+
+1. Run `/sonarcloud-analyze` first if no analysis has been done in this session
+2. Engineer selects group(s) to fix from the analyze output
+3. Read affected files, present fixes as a group for approval
+4. Apply approved fixes (cap ~200 LOC per PR, auto-split larger groups)
+5. Validate: `npm run tsc` and `npm run vitest` must both pass (hard gate)
+6. Create branch, commit, and PR following `.github/pull_request_template.md`
+7. Post `/run-playwright` comment on the PR
+8. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -18,7 +18,7 @@ Remediates SonarCloud issues for a selected group with a 2-step approval process
 
 | Argument | Description | Example |
 |----------|-------------|---------|
-| `group` | Group number or name from `/sonarcloud-analyze` output. If omitted, you will be prompted to select interactively. | `3` or `S1854-AWX` |
+| `group` | Group number or name from `/sonarcloud-analyze` output. If omitted, you will be prompted to select interactively. | `3` or `S1854-frontend-awx` |
 | `--help` | Show this usage information | |
 
 ### Required Environment Variables
@@ -52,7 +52,7 @@ Add to `.claude/settings.json` to avoid permission prompts:
 6. **Approval 2 — Create PR(s):**
    - Present a summary: number of PRs to be created, LOC per PR, target branch
    - Wait for explicit approval before creating any PR
-   - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, AWX)`)
+   - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, frontend/awx)`)
    - PR body follows `.github/pull_request_template.md`
    - Post e2e trigger comment on each PR
 7. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -2,11 +2,55 @@
 
 Follow **Phase B — Fix** in `.claude/skills/sonarcloud-remediation.md`.
 
-1. Run `/sonarcloud-analyze` first if no analysis has been done in this session
-2. Engineer selects group(s) to fix from the analyze output
-3. Read affected files, present fixes as a group for approval
-4. Apply approved fixes (cap ~200 LOC per PR, auto-split larger groups)
-5. Validate: `npm run tsc` and `npm run vitest` must both pass (hard gate)
-6. Create branch, commit, and PR following `.github/pull_request_template.md`
-7. Post `/run-playwright` comment on the PR
-8. Offer to continue with the next group
+If the user passes `--help`, display the usage information below and stop.
+
+## Usage
+
+```
+/sonarcloud-fix [group-number-or-name]
+```
+
+Remediates SonarCloud issues for a selected group with a 2-step approval process:
+1. **Approval 1 — Apply & Test**: Fixes are applied, validated, committed to a branch. You can test locally and make manual adjustments before proceeding.
+2. **Approval 2 — Create PR(s)**: After reviewing the branch, you explicitly approve PR creation. A summary of how many PRs will be created is shown first.
+
+### Arguments
+
+| Argument | Description | Example |
+|----------|-------------|---------|
+| `group` | Group number or name from `/sonarcloud-analyze` output. If omitted, you will be prompted to select interactively. | `3` or `S1854-AWX` |
+| `--help` | Show this usage information | |
+
+### Required Environment Variables
+
+Same as `/sonarcloud-analyze`, plus optional:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SONAR_DEFAULT_BRANCH` | `devel` | Base branch for fix PRs |
+| `SONAR_VALIDATE_COMMANDS` | `npm run tsc && npm run vitest` | Validation gate commands |
+| `SONAR_E2E_TRIGGER_COMMENT` | `/run-playwright` | Comment posted on PR to trigger e2e tests |
+
+### Permissions
+
+Add to `.claude/settings.json` to avoid permission prompts:
+```json
+"Bash(curl -s *sonarcloud.io*)"
+```
+
+### Workflow
+
+1. If no analysis exists in this session, run `/sonarcloud-analyze` first
+2. If no group argument provided, display available groups and prompt for selection
+3. Read affected files, present fixes as a group for review
+4. **Approval 1 — Apply fixes:**
+   - Apply approved fixes (cap ~200 LOC per batch, auto-split larger groups)
+   - Run validation commands (hard gate — must pass)
+   - Create branch and commit changes
+   - **Pause**: Inform the engineer the branch is ready for local testing. They can review the diff, run additional tests, or commit manual adjustments. Wait for explicit go-ahead.
+5. **Approval 2 — Create PR(s):**
+   - Present a summary: number of PRs to be created, LOC per PR, target branch
+   - Wait for explicit approval before creating any PR
+   - Create PR(s) following `.github/pull_request_template.md`
+   - Post e2e trigger comment on each PR
+6. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -29,7 +29,7 @@ Same as `/sonarcloud-analyze`, plus optional:
 |----------|---------|---------|
 | `SONAR_DEFAULT_BRANCH` | `devel` | Base branch for fix PRs |
 | `SONAR_VALIDATE_COMMANDS` | `npm run tsc && npm run vitest` | Validation gate commands |
-| `SONAR_E2E_TRIGGER_COMMENT` | `/run-playwright` | Comment posted on PR to trigger e2e tests |
+| `SONAR_E2E_TRIGGER_COMMENT` | `/run-playwright` | Comment posted on PR to trigger e2e tests. Set to `none`, `skip`, `false`, or `""` to disable. |
 
 ### Permissions
 

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -1,6 +1,6 @@
 # Fix SonarCloud Issues
 
-Follow **Phase B — Fix** in `.claude/skills/sonarcloud-remediation.md`.
+Follow **Phase B — Fix** in `.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md`.
 
 If the user passes `--help`, display the usage information below and stop.
 
@@ -35,7 +35,7 @@ Same as `/sonarcloud-analyze`, plus optional:
 
 Add to `.claude/settings.json` to avoid permission prompts:
 ```json
-"Bash(curl -s *sonarcloud.io*)"
+"Bash(python3 *sonarcloud-fetch.py*)"
 ```
 
 ### Workflow

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,12 +21,12 @@
       "mcp__playwright__browser_snapshot",
       "mcp__playwright__browser_type",
       "mcp__playwright__browser_wait_for",
-      "Bash(npx tsc --noEmit --project playwright/tsconfig.json)"
+      "Bash(npx tsc --noEmit --project playwright/tsconfig.json)",
+      "Bash(*sonarcloud.io*)",
+      "Bash(echo *SONAR*)"
     ],
     "deny": []
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "playwright"
-  ]
+  "enabledMcpjsonServers": ["playwright"]
 }

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -134,14 +134,14 @@ Each group is identified as: `<rule key> — <module>` (e.g., `typescript:S1854 
 
 ### Step 4: Sort by Remediation Priority
 
-Within each category, sort groups by this priority order:
+Within each category, sort groups by this priority order. Match by rule ID suffix (the numeric part is language-agnostic in SonarCloud — e.g., `S1128` appears as `typescript:S1128`, `python:S1128`, `java:S1128`, etc.):
 
-1. Unused imports and variables (`S1128`, `S1481`)
-2. Dead code / dead stores (`S1854`, `S1186`)
+1. Unused imports and variables (`S1128`, `S1481`, `S1144`)
+2. Dead code / dead stores (`S1854`, `S1186`, `S1068`)
 3. Duplicate string literals (`S1192`)
 4. Unused function parameters (`S1172`)
 5. Commented-out code (`S125`)
-6. Simple type safety improvements (`S4325`, `S4204`)
+6. Simple type safety improvements (`S4325`, `S4204`, `S1874`)
 7. Cognitive complexity (`S3776`)
 8. Security hotspot rules
 9. Reliability / bug rules
@@ -302,16 +302,18 @@ Ask the engineer to:
 - **Exclude specific files** — list file numbers to skip
 - **Reject** — skip this group entirely
 
-### TypeScript/React Fix Strategies
+### Fix Strategies by Rule Pattern
+
+These strategies apply across languages. Adapt to the project's language and conventions.
 
 | Rule Pattern | Fix Strategy | Caution |
 |---|---|---|
-| Unused imports | Remove the import line | Check for side-effect imports (e.g., CSS imports, polyfills) — do not remove those |
-| Dead stores | Remove the unused assignment | Check for intentional destructuring patterns |
-| Duplicate strings | Extract to a named `const` at the top of the file | Use descriptive names; check if a shared constant already exists in the workspace |
-| Unused function parameters | Remove if internal function; prefix with `_` if required by an interface or callback signature | Verify the function isn't part of a public API |
+| Unused imports | Remove the import/include/require line | Check for side-effect imports (e.g., CSS imports, polyfills, module-level init) — do not remove those |
+| Dead stores | Remove the unused assignment | Check for intentional destructuring or unpacking patterns |
+| Duplicate strings | Extract to a named constant at the top of the file or a shared constants module | Use descriptive names; check if a shared constant already exists in the project |
+| Unused function parameters | Remove if internal function; prefix with `_` if required by an interface, override, or callback signature | Verify the function isn't part of a public API or framework contract |
 | Commented-out code | Delete entirely | Git history preserves it; no need to keep |
-| Type safety (`any`) | Replace with proper TypeScript types | Use existing interfaces from the workspace; check framework types first |
+| Type safety (e.g., `any` in TypeScript, raw types in Java) | Replace with proper types using existing project type definitions | Check for existing types/interfaces in the project before creating new ones |
 | Cognitive complexity | Extract nested logic into helper functions | Ensure extracted functions are testable and well-named |
 
 ### Step 5: Apply Fixes and Validate
@@ -381,8 +383,8 @@ Ready to create PR(s):
 
 | # | Branch                  | Files | LOC changed | Target     |
 |---|-------------------------|-------|-------------|------------|
-| 1 | sonar/S1854-awx         |   12  |    ~46      | devel      |
-| 2 | sonar/S1854-awx-batch2  |    8  |    ~38      | devel      |
+| 1 | sonar/S1854-frontend-awx        |   12  |    ~46      | devel      |
+| 2 | sonar/S1854-frontend-awx-batch2 |    8  |    ~38      | devel      |
 
 Total: 2 PR(s) targeting `devel`.
 
@@ -409,13 +411,13 @@ Examples:
 For batched PRs, append the batch number:
 - `SonarCloud Fix: Remove dead stores (S1854, frontend/awx) [batch 1/2]`
 
-Follow `.github/pull_request_template.md` for the PR body:
+If the repo has a `.github/pull_request_template.md`, follow its structure for the PR body. Otherwise, use this default format:
 
 ```markdown
 ## Summary
 
 Remove N unused imports across M files in the <module> module.
-Addresses SonarCloud rule `typescript:S1128` (<count> violations).
+Addresses SonarCloud rule `<language>:S1128` (<count> violations).
 
 SonarCloud dashboard: https://sonarcloud.io/project/issues?id=<PROJECT_KEY>&rules=<rule>
 
@@ -423,15 +425,13 @@ SonarCloud dashboard: https://sonarcloud.io/project/issues?id=<PROJECT_KEY>&rule
 
 - [x] Enhancement
 
-## Risk Analysis - REQUIRED
+## Risk Analysis
 
 - [x] **Low** — Narrowly scoped (removing unused imports has no runtime effect).
 
 ## Testing
 
-### Ephemeral E2E Tests
-
-Once PR is ready and preliminary checks pass, trigger tests by posting a comment `${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}` on this PR.
+Validation passed: `<SONAR_VALIDATE_COMMANDS>`.
 ```
 
 Adjust **Type of Change** and **Risk Analysis** based on the fix category:
@@ -483,6 +483,6 @@ Then use `/sonarcloud-analyze` and `/sonarcloud-fix`.
 | "ERROR: SONAR_ORGANIZATION and SONAR_PROJECT_KEY must be set" | Missing env vars | Export `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` |
 | Empty results from API | Wrong project key or org | Verify at `https://sonarcloud.io/project/overview?id=<PROJECT_KEY>` |
 | 401 from API | Private project without token | Export `SONARCLOUD_TOKEN` |
-| `npm run tsc` fails after fix | Fix introduced a type error | Review the error, adjust the fix, re-run |
-| `npm run vitest` fails after fix | Fix broke a test | Check if the test relied on removed code; update the test |
+| Validation command fails after fix | Fix introduced a build/lint/type error | Review the error, adjust the fix, re-run `SONAR_VALIDATE_COMMANDS` |
+| Tests fail after fix | Fix broke a test | Check if the test relied on removed code; update the test and re-run validation |
 | Pagination missed issues | More than 500 issues per query | The skill paginates automatically; if issues are still missing, try filtering by severity or type |

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -143,6 +143,8 @@ For each group, estimate the lines of code that will change:
 
 Display one table per category. Include total issue count in the heading.
 
+**CRITICAL: Use a single continuous numbering sequence across all categories.** The group `#` is the ID that `/sonarcloud-fix` uses to select groups. It must be globally unique, not reset per category. All rows — including security hotspots — must use the same table format with the rule or category identifier in parentheses.
+
 ```
 ## Maintainability (847 issues)
 
@@ -155,12 +157,25 @@ Display one table per category. Include total issue count in the heading.
 ...
 
 ## Reliability (42 issues)
+
+| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------|-------|----------|----------|-----------|
+| 5 | Constant nullishness (typescript:S6638) | AWX   |   2   | Major    |    ~4    |           |
 ...
 
 ## Security (5 issues)
+
+| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------|-------|----------|----------|-----------|
+| 8 | SQL injection (typescript:S2077)    | Hub       |   1   | Blocker  |    ~5    |           |
 ...
 
 ## Security Hotspots (18 issues)
+
+| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------|-------|----------|----------|-----------|
+|11 | Weak cryptography (weak-cryptography) | AWX     |   3   | Medium   |    ~6    |           |
+|12 | Data encryption (encrypt-data)     | AWX       |   1   | Low      |    ~2    |           |
 ...
 
 ## Duplication
@@ -169,6 +184,13 @@ Duplicated lines density: 3.2%  |  Duplicated blocks: 47  |  Duplicated files: 1
 ```
 
 Flag any group where Est. LOC > 200 with "Will split" in the Note column.
+
+At the end of the report, suggest low-risk starting groups for `/sonarcloud-fix` using their group numbers:
+```
+Good starting groups for `/sonarcloud-fix`:
+  /sonarcloud-fix 1   — Unused imports (45 issues, ~45 LOC, Low risk)
+  /sonarcloud-fix 2   — Dead stores (23 issues, ~35 LOC, Low risk)
+```
 
 ### Optional Filters
 
@@ -185,7 +207,13 @@ Invoked via `/sonarcloud-fix`. The engineer selects groups from the analyze outp
 
 ### Step 1: Select Groups
 
-Ask the engineer which group(s) to fix. Accept by number from the analyze table or by name. Multiple groups can be selected at once.
+If the user provided a group number or name as an argument, use that.
+
+If no group was specified, prompt interactively:
+1. If no `/sonarcloud-analyze` was run in this session, run it first to generate the group table
+2. Display the available groups (or remind the user of the table)
+3. Ask which group(s) to fix — accept by number from the analyze table, by rule key, or by name
+4. Multiple groups can be selected at once
 
 ### Step 2: Read Affected Files
 
@@ -215,21 +243,12 @@ Display:
 **Risk Assessment:** Low — removing unused imports has no runtime effect.
 ```
 
-### Step 4: Get Approval
+### Step 4: Get Fix Approval
 
 Ask the engineer to:
 - **Approve all** — apply every fix in the group
 - **Exclude specific files** — list file numbers to skip
 - **Reject** — skip this group entirely
-
-### Step 5: Apply Fixes
-
-Apply all approved fixes using the Edit tool.
-
-**CRITICAL: Cap at ~200 LOC per PR.** If the group exceeds 200 LOC of changes:
-- Split into batches by file or logical grouping
-- Each batch becomes its own branch and PR
-- Inform the engineer: "This group will produce N PRs of ~X LOC each."
 
 ### TypeScript/React Fix Strategies
 
@@ -243,7 +262,16 @@ Apply all approved fixes using the Edit tool.
 | Type safety (`any`) | Replace with proper TypeScript types | Use existing interfaces from the workspace; check framework types first |
 | Cognitive complexity | Extract nested logic into helper functions | Ensure extracted functions are testable and well-named |
 
-### Step 6: Validate — Hard Gate
+### Step 5: Apply Fixes and Validate
+
+Apply all approved fixes using the Edit tool.
+
+**CRITICAL: Cap at ~200 LOC per PR.** If the group exceeds 200 LOC of changes:
+- Split into batches by file or logical grouping
+- Each batch becomes its own branch
+- Inform the engineer: "This group will produce N branches of ~X LOC each."
+
+**Validation — Hard Gate:**
 
 After applying fixes, the validation commands **must pass before proceeding**:
 
@@ -257,9 +285,9 @@ If validation fails:
 2. Diagnose whether the fix introduced the failure
 3. Correct the fix
 4. Re-run validation
-5. Do not proceed to branch/PR creation until both pass
+5. Do not proceed to branch creation until validation passes
 
-### Step 7: Create Branch and Commit
+### Step 6: Create Branch and Commit (Approval 1)
 
 **Branch** off the configured default branch:
 ```bash
@@ -277,7 +305,39 @@ Addresses 23 typescript:S1854 violations in frontend/awx/.
 SonarCloud issue keys: AZxx1, AZxx2, ...
 ```
 
-### Step 8: Create PR
+**CRITICAL: Pause here.** Inform the engineer:
+
+```
+Branch `sonar/S1854-awx` is ready with N commits.
+
+You can now:
+  - Review the diff: git diff origin/devel...HEAD
+  - Run additional tests locally
+  - Make manual adjustments and commit them to this branch
+
+When you're satisfied, let me know and I'll create the PR.
+```
+
+**Wait for the engineer's explicit go-ahead before proceeding to PR creation.** Do NOT create the PR automatically.
+
+### Step 7: Create PR (Approval 2)
+
+Before creating any PRs, present a summary:
+
+```
+Ready to create PR(s):
+
+| # | Branch                  | Files | LOC changed | Target     |
+|---|-------------------------|-------|-------------|------------|
+| 1 | sonar/S1854-awx         |   12  |    ~46      | devel      |
+| 2 | sonar/S1854-awx-batch2  |    8  |    ~38      | devel      |
+
+Total: 2 PR(s) targeting `devel`.
+
+Proceed with PR creation?
+```
+
+**Wait for explicit approval.** Then for each PR:
 
 Follow `.github/pull_request_template.md` exactly:
 
@@ -310,9 +370,9 @@ Adjust **Type of Change** and **Risk Analysis** based on the fix category:
 - Cognitive complexity refactoring → **Medium**
 - Security/reliability fixes → **Medium** to **High**
 
-### Step 9: Trigger E2E and Continue
+### Step 8: Trigger E2E and Continue
 
-1. Post the e2e trigger comment on the newly created PR:
+1. Post the e2e trigger comment on each newly created PR:
    ```bash
    E2E_COMMENT="${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}"
    gh pr comment <PR_NUMBER> --body "$E2E_COMMENT"

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -6,6 +6,11 @@ Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focus
 
 ## Setup
 
+### Prerequisites
+
+- **`gh`** (GitHub CLI) — must be installed and authenticated (`gh auth login`). Used by `/sonarcloud-fix` to create PRs and post e2e trigger comments.
+- **`curl`** — used for SonarCloud API calls.
+
 ### Required Environment Variables
 
 | Variable | Required | Purpose |

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -344,7 +344,25 @@ Proceed with PR creation?
 
 **Wait for explicit approval.** Then for each PR:
 
-Follow `.github/pull_request_template.md` exactly:
+**PR Title — REQUIRED format:**
+
+All PR titles **must** start with the prefix `SonarCloud Fix:` followed by a short description of the issue area being addressed. Use this pattern:
+
+```
+SonarCloud Fix: <brief description of fix> (<rule key>, <workspace>)
+```
+
+Examples:
+- `SonarCloud Fix: Remove unused imports (S1128, AWX)`
+- `SonarCloud Fix: Remove dead stores (S1854, Framework)`
+- `SonarCloud Fix: Extract duplicate string literals (S1192, Hub)`
+- `SonarCloud Fix: Reduce cognitive complexity (S3776, EDA)`
+- `SonarCloud Fix: Remove commented-out code (S125, Platform)`
+
+For batched PRs, append the batch number:
+- `SonarCloud Fix: Remove dead stores (S1854, AWX) [batch 1/2]`
+
+Follow `.github/pull_request_template.md` for the PR body:
 
 ```markdown
 ## Summary

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -1,0 +1,358 @@
+# Claude Skill: SonarCloud Issue Remediation
+
+Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focused PRs with human-in-the-loop review.
+
+---
+
+## Setup
+
+### Required Environment Variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `SONAR_ORGANIZATION` | Yes | SonarCloud organization slug |
+| `SONAR_PROJECT_KEY` | Yes | SonarCloud project key |
+| `SONARCLOUD_TOKEN` | Only for private projects | API authentication token |
+| `SONAR_DEFAULT_BRANCH` | No (default: `devel`) | Base branch for fix PRs |
+| `SONAR_VALIDATE_COMMANDS` | No (default: `npm run tsc && npm run vitest`) | Validation commands that must pass before PR creation |
+| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | Comment to post on PR to trigger e2e tests |
+
+### Validate Environment
+
+Before any operation, check that required env vars are set:
+
+```bash
+if [ -z "$SONAR_ORGANIZATION" ] || [ -z "$SONAR_PROJECT_KEY" ]; then
+  echo "ERROR: SONAR_ORGANIZATION and SONAR_PROJECT_KEY must be set."
+  echo ""
+  echo "Example:"
+  echo "  export SONAR_ORGANIZATION=your-org"
+  echo "  export SONAR_PROJECT_KEY=your-project-key"
+  echo "  export SONARCLOUD_TOKEN=your-token  # only for private projects"
+  exit 1
+fi
+```
+
+### Authentication
+
+For public projects, no token is needed (read-only API). For private projects, use the token:
+
+```bash
+# Public project
+curl -s "https://sonarcloud.io/api/issues/search?..."
+
+# Private project
+curl -s -u "${SONARCLOUD_TOKEN}:" "https://sonarcloud.io/api/issues/search?..."
+```
+
+---
+
+## Phase A — Analyze
+
+Invoked via `/sonarcloud-analyze`. Fetches all open issues and presents a prioritized, grouped report.
+
+### Step 1: Fetch Issues
+
+Fetch unresolved issues with pagination. SonarCloud caps at 500 per page.
+
+**Issues (bugs, vulnerabilities, code smells):**
+```bash
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_PROJECT_KEY}&resolved=false&ps=500&p=1"
+```
+
+If the response `total` exceeds 500, paginate:
+```bash
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_PROJECT_KEY}&resolved=false&ps=500&p=2"
+```
+
+**Security hotspots:**
+```bash
+curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_PROJECT_KEY}&status=TO_REVIEW&ps=500&p=1"
+```
+
+**Duplication metrics:**
+```bash
+curl -s "https://sonarcloud.io/api/measures/component?component=${SONAR_PROJECT_KEY}&metricKeys=duplicated_lines_density,duplicated_blocks,duplicated_files"
+```
+
+Parse each JSON response. For issues, extract: `key`, `component` (file path), `type` (BUG, VULNERABILITY, CODE_SMELL), `severity`, `line`, `message`, `rule`.
+
+### Step 2: Categorize by SonarCloud Category
+
+Group all fetched issues into the 5 SonarCloud categories:
+
+| Category | Source | Filter |
+|----------|--------|--------|
+| **Security** | `/api/issues/search` | `type=VULNERABILITY` |
+| **Reliability** | `/api/issues/search` | `type=BUG` |
+| **Maintainability** | `/api/issues/search` | `type=CODE_SMELL` |
+| **Security Hotspots** | `/api/hotspots/search` | `status=TO_REVIEW` |
+| **Duplication** | `/api/measures/component` | `duplicated_blocks` metric; also code smell rules related to duplication (e.g., `typescript:S1192`) |
+
+### Step 3: Group by Rule + Workspace
+
+Within each category, group issues by **SonarCloud rule key** and **workspace**.
+
+Detect workspace from the file path `component` field:
+
+| Path prefix | Workspace |
+|-------------|-----------|
+| `frontend/awx/` | AWX |
+| `frontend/eda/` | EDA |
+| `frontend/hub/` | Hub |
+| `frontend/common/` | Common |
+| `frontend/chatbot/` | Chatbot |
+| `framework/` | Framework |
+| `platform/` | Platform |
+| `cypress/` or `playwright/` | Tests |
+| Other | Root |
+
+For non-monorepo projects, group by top-level directory instead.
+
+Each group is identified as: `<rule key> — <workspace>` (e.g., `typescript:S1854 — AWX`).
+
+### Step 4: Sort by Remediation Priority
+
+Within each category, sort groups by this priority order:
+
+1. Unused imports and variables (`S1128`, `S1481`)
+2. Dead code / dead stores (`S1854`, `S1186`)
+3. Duplicate string literals (`S1192`)
+4. Unused function parameters (`S1172`)
+5. Commented-out code (`S125`)
+6. Simple type safety improvements (`S4325`, `S4204`)
+7. Cognitive complexity (`S3776`)
+8. Security hotspot rules
+9. Reliability / bug rules
+10. All other rules
+
+Rules not matching any priority bucket sort to the end, ordered by issue count descending.
+
+### Step 5: Estimate LOC Impact
+
+For each group, estimate the lines of code that will change:
+- Unused imports: ~1 LOC per issue (removal)
+- Dead stores: ~1-2 LOC per issue
+- Duplicate strings: ~2-3 LOC per issue (extract to const + references)
+- Unused parameters: ~1 LOC per issue
+- Commented-out code: variable, count the commented lines from issue details
+- Type safety: ~1-3 LOC per issue
+- Cognitive complexity: ~10-20 LOC per issue (refactoring)
+
+### Step 6: Present Summary Table
+
+Display one table per category. Include total issue count in the heading.
+
+```
+## Maintainability (847 issues)
+
+| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------|-------|----------|----------|-----------|
+| 1 | Unused imports (typescript:S1128)   | AWX       |   45  | Minor    |   ~45    |           |
+| 2 | Dead stores (typescript:S1854)      | AWX       |   23  | Major    |   ~35    |           |
+| 3 | Duplicate strings (typescript:S1192)| Framework |   12  | Minor    |   ~36    |           |
+| 4 | Cognitive complexity (typescript:S3776) | Hub   |   8   | Critical |  ~120    | Will split |
+...
+
+## Reliability (42 issues)
+...
+
+## Security (5 issues)
+...
+
+## Security Hotspots (18 issues)
+...
+
+## Duplication
+Duplicated lines density: 3.2%  |  Duplicated blocks: 47  |  Duplicated files: 12
+(Duplicate string literal issues are listed under Maintainability above.)
+```
+
+Flag any group where Est. LOC > 200 with "Will split" in the Note column.
+
+### Optional Filters
+
+If the user provides flags, apply them before grouping:
+
+- `--severity <BLOCKER|CRITICAL|MAJOR|MINOR|INFO>` — only show issues at or above this severity
+- `--workspace <name>` — only show issues in the specified workspace
+
+---
+
+## Phase B — Fix
+
+Invoked via `/sonarcloud-fix`. The engineer selects groups from the analyze output and the skill applies fixes with approval.
+
+### Step 1: Select Groups
+
+Ask the engineer which group(s) to fix. Accept by number from the analyze table or by name. Multiple groups can be selected at once.
+
+### Step 2: Read Affected Files
+
+For each issue in the selected group(s):
+1. Read the affected file using the Read tool
+2. Focus on the specific line number and surrounding context (~10 lines above/below)
+3. Identify whether the issue is a true positive or false positive
+
+### Step 3: Present Fixes as a Group
+
+**CRITICAL: Present fixes at the group level, not individually.** With thousands of open issues, per-fix approval is not efficient.
+
+Display:
+
+```
+## Group: Unused imports (typescript:S1128) — AWX (45 issues)
+
+**Severity:** Minor  |  **Risk:** Low  |  **Est. LOC changed:** ~45
+
+| # | File                                          | Line | Issue                        | Proposed Fix          |
+|---|-----------------------------------------------|------|------------------------------|-----------------------|
+| 1 | frontend/awx/views/jobs/JobsList.tsx           |   3  | Remove unused import `Foo`   | Delete import line    |
+| 2 | frontend/awx/views/jobs/JobsList.tsx           |   7  | Remove unused import `Bar`   | Delete import line    |
+| 3 | frontend/awx/components/ResourceCard.tsx       |  12  | Remove unused import `Baz`   | Delete import line    |
+...
+
+**Risk Assessment:** Low — removing unused imports has no runtime effect.
+```
+
+### Step 4: Get Approval
+
+Ask the engineer to:
+- **Approve all** — apply every fix in the group
+- **Exclude specific files** — list file numbers to skip
+- **Reject** — skip this group entirely
+
+### Step 5: Apply Fixes
+
+Apply all approved fixes using the Edit tool.
+
+**CRITICAL: Cap at ~200 LOC per PR.** If the group exceeds 200 LOC of changes:
+- Split into batches by file or logical grouping
+- Each batch becomes its own branch and PR
+- Inform the engineer: "This group will produce N PRs of ~X LOC each."
+
+### TypeScript/React Fix Strategies
+
+| Rule Pattern | Fix Strategy | Caution |
+|---|---|---|
+| Unused imports | Remove the import line | Check for side-effect imports (e.g., CSS imports, polyfills) — do not remove those |
+| Dead stores | Remove the unused assignment | Check for intentional destructuring patterns |
+| Duplicate strings | Extract to a named `const` at the top of the file | Use descriptive names; check if a shared constant already exists in the workspace |
+| Unused function parameters | Remove if internal function; prefix with `_` if required by an interface or callback signature | Verify the function isn't part of a public API |
+| Commented-out code | Delete entirely | Git history preserves it; no need to keep |
+| Type safety (`any`) | Replace with proper TypeScript types | Use existing interfaces from the workspace; check framework types first |
+| Cognitive complexity | Extract nested logic into helper functions | Ensure extracted functions are testable and well-named |
+
+### Step 6: Validate — Hard Gate
+
+After applying fixes, the validation commands **must pass before proceeding**:
+
+```bash
+VALIDATE_CMD="${SONAR_VALIDATE_COMMANDS:-npm run tsc && npm run vitest}"
+eval "$VALIDATE_CMD"
+```
+
+If validation fails:
+1. Read the error output
+2. Diagnose whether the fix introduced the failure
+3. Correct the fix
+4. Re-run validation
+5. Do not proceed to branch/PR creation until both pass
+
+### Step 7: Create Branch and Commit
+
+**Branch** off the configured default branch:
+```bash
+DEFAULT_BRANCH="${SONAR_DEFAULT_BRANCH:-devel}"
+git checkout -b "sonar/<rule-key>-<workspace>" "origin/${DEFAULT_BRANCH}"
+```
+
+Branch naming: `sonar/<rule-key>-<workspace>` (e.g., `sonar/S1854-awx`, `sonar/S1128-framework`)
+
+**Commit** with a descriptive message:
+```
+fix: remove dead stores in AWX components (SonarCloud S1854)
+
+Addresses 23 typescript:S1854 violations in frontend/awx/.
+SonarCloud issue keys: AZxx1, AZxx2, ...
+```
+
+### Step 8: Create PR
+
+Follow `.github/pull_request_template.md` exactly:
+
+```markdown
+## Summary
+
+Remove N unused imports across M files in the <workspace> workspace.
+Addresses SonarCloud rule `typescript:S1128` (<count> violations).
+
+SonarCloud dashboard: https://sonarcloud.io/project/issues?id=<PROJECT_KEY>&rules=<rule>
+
+## Type of Change
+
+- [x] Enhancement
+
+## Risk Analysis - REQUIRED
+
+- [x] **Low** — Narrowly scoped (removing unused imports has no runtime effect).
+
+## Testing
+
+### Ephemeral E2E Tests
+
+Once PR is ready and preliminary checks pass, trigger tests by posting a comment `${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}` on this PR.
+```
+
+Adjust **Type of Change** and **Risk Analysis** based on the fix category:
+- Dead code, unused imports, commented-out code → **Low**
+- Duplicate strings, unused params, type safety → **Low** to **Medium** (depending on scope)
+- Cognitive complexity refactoring → **Medium**
+- Security/reliability fixes → **Medium** to **High**
+
+### Step 9: Trigger E2E and Continue
+
+1. Post the e2e trigger comment on the newly created PR:
+   ```bash
+   E2E_COMMENT="${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}"
+   gh pr comment <PR_NUMBER> --body "$E2E_COMMENT"
+   ```
+2. Offer to continue — return to group selection for the next batch
+
+---
+
+## Portability
+
+This skill is designed for adoption by other teams and repos:
+
+1. **No hardcoded values** — all project-specific config via environment variables
+2. **Configurable base branch** — `SONAR_DEFAULT_BRANCH` defaults to `devel` but can be set to `main` or any branch
+3. **Workspace detection is path-based** — for non-monorepo projects, issues group by top-level directory instead
+4. **Validation commands** — set `SONAR_VALIDATE_COMMANDS` to your project's validation pipeline (e.g., `make lint && make test`)
+5. **PR template** — adjust to match the target repo's `.github/pull_request_template.md`
+
+### Quick Start for Other Teams
+
+```bash
+export SONAR_ORGANIZATION=your-org
+export SONAR_PROJECT_KEY=your-project-key
+export SONARCLOUD_TOKEN=your-token        # only for private projects
+export SONAR_DEFAULT_BRANCH=main                          # if not devel
+export SONAR_VALIDATE_COMMANDS="make lint && make test"    # your validation pipeline
+export SONAR_E2E_TRIGGER_COMMENT="/run-e2e"                # your e2e trigger comment
+```
+
+Then use `/sonarcloud-analyze` and `/sonarcloud-fix`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "ERROR: SONAR_ORGANIZATION and SONAR_PROJECT_KEY must be set" | Missing env vars | Export `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` |
+| Empty results from API | Wrong project key or org | Verify at `https://sonarcloud.io/project/overview?id=<PROJECT_KEY>` |
+| 401 from API | Private project without token | Export `SONARCLOUD_TOKEN` |
+| `npm run tsc` fails after fix | Fix introduced a type error | Review the error, adjust the fix, re-run |
+| `npm run vitest` fails after fix | Fix broke a test | Check if the test relied on removed code; update the test |
+| Pagination missed issues | More than 500 issues per query | The skill paginates automatically; if issues are still missing, try filtering by severity or type |

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -20,7 +20,7 @@ Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focus
 | `SONARCLOUD_TOKEN` | Only for private projects | API authentication token |
 | `SONAR_DEFAULT_BRANCH` | No (default: `devel`) | Base branch for fix PRs |
 | `SONAR_VALIDATE_COMMANDS` | No (default: `npm run tsc && npm run vitest`) | Validation commands that must pass before PR creation |
-| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | Comment to post on PR to trigger e2e tests |
+| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | Comment to post on PR to trigger e2e tests. Set to `none`, `skip`, `false`, or empty string `""` to disable. |
 
 ### Validate Environment
 
@@ -226,11 +226,12 @@ Display:
 | SONARCLOUD_TOKEN          | (set)                          | env     | API token for private projects                     |
 | SONAR_DEFAULT_BRANCH      | devel                          | default | Branch that fix PRs will target                    |
 | SONAR_VALIDATE_COMMANDS   | npm run tsc && npm run vitest  | default | Commands that must pass before a PR can be created |
-| SONAR_E2E_TRIGGER_COMMENT | /run-playwright                | default | Comment posted on PR to trigger e2e test pipeline  |
+| SONAR_E2E_TRIGGER_COMMENT | /run-playwright                | default | Comment posted on PR to trigger e2e test pipeline. Set to none/skip/false/"" to disable |
 ```
 
 - Show `(set)` or `(not set)` for `SONARCLOUD_TOKEN` — never display the actual value
 - Show `env` in the Source column if the variable is explicitly set, `default` if using the built-in default
+- If `SONAR_E2E_TRIGGER_COMMENT` is set to `none`, `skip`, `false`, or an empty string, show `(disabled)` in the Value column
 - **Highlight any variables using defaults** so they stand out
 
 Then ask: "Do these settings look correct? If any need updating, set the environment variables and re-run the command."
@@ -425,7 +426,7 @@ Adjust **Type of Change** and **Risk Analysis** based on the fix category:
 
 ### Step 8: Trigger E2E and Continue
 
-1. Post the e2e trigger comment on each newly created PR:
+1. Check `SONAR_E2E_TRIGGER_COMMENT`. If set to `none`, `skip`, `false`, or an empty string `""`, **skip posting** the e2e trigger comment entirely. Otherwise, post the comment on each newly created PR:
    ```bash
    E2E_COMMENT="${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}"
    gh pr comment <PR_NUMBER> --body "$E2E_COMMENT"
@@ -452,7 +453,7 @@ export SONAR_PROJECT_KEY=your-project-key
 export SONARCLOUD_TOKEN=your-token        # only for private projects
 export SONAR_DEFAULT_BRANCH=main                          # if not devel
 export SONAR_VALIDATE_COMMANDS="make lint && make test"    # your validation pipeline
-export SONAR_E2E_TRIGGER_COMMENT="/run-e2e"                # your e2e trigger comment
+export SONAR_E2E_TRIGGER_COMMENT="/run-e2e"                # your e2e trigger comment, or "none" to disable
 ```
 
 Then use `/sonarcloud-analyze` and `/sonarcloud-fix`.

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -94,27 +94,43 @@ Group all fetched issues into the 5 SonarCloud categories:
 | **Security Hotspots** | `/api/hotspots/search` | `status=TO_REVIEW` |
 | **Duplication** | `/api/measures/component` | `duplicated_blocks` metric; also code smell rules related to duplication (e.g., `typescript:S1192`) |
 
-### Step 3: Group by Rule + Workspace
+### Step 3: Group by Rule + Module
 
-Within each category, group issues by **SonarCloud rule key** and **workspace**.
+Within each category, group issues by **SonarCloud rule key** and **module** (workspace, package, or top-level directory depending on the repo structure).
 
-Detect workspace from the file path `component` field:
+#### Detecting Modules
 
-| Path prefix | Workspace |
-|-------------|-----------|
-| `frontend/awx/` | AWX |
-| `frontend/eda/` | EDA |
-| `frontend/hub/` | Hub |
-| `frontend/common/` | Common |
-| `frontend/chatbot/` | Chatbot |
-| `framework/` | Framework |
-| `platform/` | Platform |
-| `cypress/` or `playwright/` | Tests |
-| Other | Root |
+Determine the repo's module structure **once at the start of analysis**, then apply it consistently to all issues.
 
-For non-monorepo projects, group by top-level directory instead.
+**Step 3a: Check for monorepo workspace definitions**
 
-Each group is identified as: `<rule key> — <workspace>` (e.g., `typescript:S1854 — AWX`).
+Look for workspace/package definitions in this order:
+
+1. **`package.json` `workspaces`** — NPM/Yarn workspaces (array of glob patterns like `["frontend/*", "framework"]`)
+2. **`pnpm-workspace.yaml`** — pnpm workspaces (`packages:` list)
+3. **`nx.json`** or `workspace.json` — Nx monorepo
+4. **`lerna.json`** — Lerna monorepo (`packages` list)
+
+If any of these exist, resolve the workspace patterns to actual directories. Map each issue's `component` file path to the workspace whose path prefix matches. Use the workspace directory name (or a human-friendly label derived from it) as the module name.
+
+Example: if `package.json` has `"workspaces": ["frontend/*", "framework"]`, then:
+- `frontend/awx/src/Foo.tsx` → module `frontend/awx`
+- `framework/PageTable.tsx` → module `framework`
+- `scripts/build.js` → module `root`
+
+**Step 3b: No workspace definitions found (non-monorepo)**
+
+Group issues by their **top-level directory** from the `component` field (the first path segment after the project key). Files in the repo root go into a `root` group.
+
+Example:
+- `src/api/handler.ts` → module `src`
+- `lib/utils.ts` → module `lib`
+- `tests/unit/foo.test.ts` → module `tests`
+- `README.md` → module `root`
+
+#### Group Identifier
+
+Each group is identified as: `<rule key> — <module>` (e.g., `typescript:S1854 — frontend/awx`, `python:S1481 — src`).
 
 ### Step 4: Sort by Remediation Priority
 
@@ -153,34 +169,34 @@ Display one table per category. Include total issue count in the heading.
 ```
 ## Maintainability (847 issues)
 
-| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
-|---|------------------------------------|-----------|-------|----------|----------|-----------|
-| 1 | Unused imports (typescript:S1128)   | AWX       |   45  | Minor    |   ~45    |           |
-| 2 | Dead stores (typescript:S1854)      | AWX       |   23  | Major    |   ~35    |           |
-| 3 | Duplicate strings (typescript:S1192)| Framework |   12  | Minor    |   ~36    |           |
-| 4 | Cognitive complexity (typescript:S3776) | Hub   |   8   | Critical |  ~120    | Will split |
+| # | Group                              | Module          | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------------|-------|----------|----------|-----------|
+| 1 | Unused imports (typescript:S1128)   | frontend/awx    |   45  | Minor    |   ~45    |           |
+| 2 | Dead stores (typescript:S1854)      | frontend/awx    |   23  | Major    |   ~35    |           |
+| 3 | Duplicate strings (typescript:S1192)| framework       |   12  | Minor    |   ~36    |           |
+| 4 | Cognitive complexity (typescript:S3776) | frontend/hub|   8   | Critical |  ~120    | Will split |
 ...
 
 ## Reliability (42 issues)
 
-| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
-|---|------------------------------------|-----------|-------|----------|----------|-----------|
-| 5 | Constant nullishness (typescript:S6638) | AWX   |   2   | Major    |    ~4    |           |
+| # | Group                              | Module          | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------------|-------|----------|----------|-----------|
+| 5 | Constant nullishness (typescript:S6638) | frontend/awx|   2   | Major    |    ~4    |           |
 ...
 
 ## Security (5 issues)
 
-| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
-|---|------------------------------------|-----------|-------|----------|----------|-----------|
-| 8 | SQL injection (typescript:S2077)    | Hub       |   1   | Blocker  |    ~5    |           |
+| # | Group                              | Module          | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------------|-------|----------|----------|-----------|
+| 8 | SQL injection (typescript:S2077)    | frontend/hub   |   1   | Blocker  |    ~5    |           |
 ...
 
 ## Security Hotspots (18 issues)
 
-| # | Group                              | Workspace | Count | Severity | Est. LOC | Note      |
-|---|------------------------------------|-----------|-------|----------|----------|-----------|
-|11 | Weak cryptography (weak-cryptography) | AWX     |   3   | Medium   |    ~6    |           |
-|12 | Data encryption (encrypt-data)     | AWX       |   1   | Low      |    ~2    |           |
+| # | Group                              | Module          | Count | Severity | Est. LOC | Note      |
+|---|------------------------------------|-----------------|-------|----------|----------|-----------|
+|11 | Weak cryptography (weak-cryptography) | frontend/awx |   3   | Medium   |    ~6    |           |
+|12 | Data encryption (encrypt-data)     | frontend/awx    |   1   | Low      |    ~2    |           |
 ...
 
 ## Duplication
@@ -202,7 +218,7 @@ Good starting groups for `/sonarcloud-fix`:
 If the user provides flags, apply them before grouping:
 
 - `--severity <BLOCKER|CRITICAL|MAJOR|MINOR|INFO>` — only show issues at or above this severity
-- `--workspace <name>` — only show issues in the specified workspace
+- `--module <name>` — only show issues in the specified module
 
 ---
 
@@ -265,7 +281,7 @@ For each issue in the selected group(s):
 Display:
 
 ```
-## Group: Unused imports (typescript:S1128) — AWX (45 issues)
+## Group: Unused imports (typescript:S1128) — frontend/awx (45 issues)
 
 **Severity:** Minor  |  **Risk:** Low  |  **Est. LOC changed:** ~45
 
@@ -328,14 +344,14 @@ If validation fails:
 **Branch** off the configured default branch:
 ```bash
 DEFAULT_BRANCH="${SONAR_DEFAULT_BRANCH:-devel}"
-git checkout -b "sonar/<rule-key>-<workspace>" "origin/${DEFAULT_BRANCH}"
+git checkout -b "sonar/<rule-key>-<module-slug>" "origin/${DEFAULT_BRANCH}"
 ```
 
-Branch naming: `sonar/<rule-key>-<workspace>` (e.g., `sonar/S1854-awx`, `sonar/S1128-framework`)
+Branch naming: `sonar/<rule-key>-<module-slug>` where `<module-slug>` is the module name with `/` replaced by `-` (e.g., `sonar/S1854-frontend-awx`, `sonar/S1128-framework`, `sonar/S1481-src`)
 
 **Commit** with a descriptive message:
 ```
-fix: remove dead stores in AWX components (SonarCloud S1854)
+fix: remove dead stores in frontend/awx (SonarCloud S1854)
 
 Addresses 23 typescript:S1854 violations in frontend/awx/.
 SonarCloud issue keys: AZxx1, AZxx2, ...
@@ -344,7 +360,7 @@ SonarCloud issue keys: AZxx1, AZxx2, ...
 **CRITICAL: Pause here.** Inform the engineer:
 
 ```
-Branch `sonar/S1854-awx` is ready with N commits.
+Branch `sonar/S1854-frontend-awx` is ready with N commits.
 
 You can now:
   - Review the diff: git diff origin/devel...HEAD
@@ -380,25 +396,25 @@ Proceed with PR creation?
 All PR titles **must** start with the prefix `SonarCloud Fix:` followed by a short description of the issue area being addressed. Use this pattern:
 
 ```
-SonarCloud Fix: <brief description of fix> (<rule key>, <workspace>)
+SonarCloud Fix: <brief description of fix> (<rule key>, <module>)
 ```
 
 Examples:
-- `SonarCloud Fix: Remove unused imports (S1128, AWX)`
-- `SonarCloud Fix: Remove dead stores (S1854, Framework)`
-- `SonarCloud Fix: Extract duplicate string literals (S1192, Hub)`
-- `SonarCloud Fix: Reduce cognitive complexity (S3776, EDA)`
-- `SonarCloud Fix: Remove commented-out code (S125, Platform)`
+- `SonarCloud Fix: Remove unused imports (S1128, frontend/awx)`
+- `SonarCloud Fix: Remove dead stores (S1854, framework)`
+- `SonarCloud Fix: Extract duplicate string literals (S1192, frontend/hub)`
+- `SonarCloud Fix: Reduce cognitive complexity (S3776, frontend/eda)`
+- `SonarCloud Fix: Remove commented-out code (S125, src)`
 
 For batched PRs, append the batch number:
-- `SonarCloud Fix: Remove dead stores (S1854, AWX) [batch 1/2]`
+- `SonarCloud Fix: Remove dead stores (S1854, frontend/awx) [batch 1/2]`
 
 Follow `.github/pull_request_template.md` for the PR body:
 
 ```markdown
 ## Summary
 
-Remove N unused imports across M files in the <workspace> workspace.
+Remove N unused imports across M files in the <module> module.
 Addresses SonarCloud rule `typescript:S1128` (<count> violations).
 
 SonarCloud dashboard: https://sonarcloud.io/project/issues?id=<PROJECT_KEY>&rules=<rule>
@@ -441,7 +457,7 @@ This skill is designed for adoption by other teams and repos:
 
 1. **No hardcoded values** — all project-specific config via environment variables
 2. **Configurable base branch** — `SONAR_DEFAULT_BRANCH` defaults to `devel` but can be set to `main` or any branch
-3. **Workspace detection is path-based** — for non-monorepo projects, issues group by top-level directory instead
+3. **Automatic module detection** — detects monorepo workspaces from `package.json`, `pnpm-workspace.yaml`, `nx.json`, or `lerna.json`. For non-monorepo projects, groups issues by top-level directory. No repo-specific configuration required.
 4. **Validation commands** — set `SONAR_VALIDATE_COMMANDS` to your project's validation pipeline (e.g., `make lint && make test`)
 5. **PR template** — adjust to match the target repo's `.github/pull_request_template.md`
 

--- a/.claude/skills/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation.md
@@ -210,6 +210,36 @@ If the user provides flags, apply them before grouping:
 
 Invoked via `/sonarcloud-fix`. The engineer selects groups from the analyze output and the skill applies fixes with approval.
 
+### Step 0: Configuration Pre-Check
+
+**Before doing any work**, display all non-sensitive configuration values so the engineer can verify them. Use the AskUserQuestion tool to confirm.
+
+Display:
+
+```
+## Configuration
+
+| Variable                  | Value                          | Source  | Description                                        |
+|---------------------------|--------------------------------|---------|----------------------------------------------------|
+| SONAR_ORGANIZATION        | your-org                       | env     | SonarCloud organization slug                       |
+| SONAR_PROJECT_KEY         | your-project-key               | env     | SonarCloud project key                             |
+| SONARCLOUD_TOKEN          | (set)                          | env     | API token for private projects                     |
+| SONAR_DEFAULT_BRANCH      | devel                          | default | Branch that fix PRs will target                    |
+| SONAR_VALIDATE_COMMANDS   | npm run tsc && npm run vitest  | default | Commands that must pass before a PR can be created |
+| SONAR_E2E_TRIGGER_COMMENT | /run-playwright                | default | Comment posted on PR to trigger e2e test pipeline  |
+```
+
+- Show `(set)` or `(not set)` for `SONARCLOUD_TOKEN` — never display the actual value
+- Show `env` in the Source column if the variable is explicitly set, `default` if using the built-in default
+- **Highlight any variables using defaults** so they stand out
+
+Then ask: "Do these settings look correct? If any need updating, set the environment variables and re-run the command."
+
+- If the engineer confirms → proceed to Step 1
+- If the engineer says values need updating → stop and let them update env vars before retrying
+
+**Skip this pre-check** if it was already confirmed earlier in the same session.
+
 ### Step 1: Select Groups
 
 If the user provided a group number or name as an argument, use that.

--- a/.claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
+++ b/.claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Fetch SonarCloud issues, hotspots, and duplication metrics.
+
+Reads SONAR_PROJECT_KEY, SONAR_ORGANIZATION, and optionally
+SONARCLOUD_TOKEN from environment variables. Outputs categorized
+JSON to stdout. Diagnostics go to stderr.
+
+Usage:
+    python3 sonarcloud-fetch.py
+"""
+
+import json
+import math
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from base64 import b64encode
+from datetime import datetime, timezone
+
+BASE_URL = "https://sonarcloud.io/api"
+PAGE_SIZE = 500
+MAX_RESULTS = 10000
+DUPLICATION_RULE_SUFFIXES = {"S1192"}
+
+
+def _build_auth_header():
+    token = os.environ.get("SONARCLOUD_TOKEN", "").strip()
+    if not token:
+        return {}
+    encoded = b64encode(f"{token}:".encode()).decode()
+    return {"Authorization": f"Basic {encoded}"}
+
+
+def _build_ssl_context():
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        ctx = ssl.create_default_context()
+        try:
+            urllib.request.urlopen("https://sonarcloud.io", timeout=5, context=ctx)
+        except (urllib.error.URLError, ssl.SSLError):
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+
+def _request(url, ssl_ctx):
+    headers = {"Accept": "application/json", "User-Agent": "sonarcloud-fetch/1.0"}
+    headers.update(_build_auth_header())
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30, context=ssl_ctx) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _get_total(data):
+    paging = data.get("paging", {})
+    if paging and "total" in paging:
+        return paging["total"]
+    return data.get("total", 0)
+
+
+def _strip_prefix(component, project_key):
+    prefix = project_key + ":"
+    if component.startswith(prefix):
+        return component[len(prefix):]
+    return component
+
+
+def _rule_suffix(rule):
+    if ":" in rule:
+        return rule.split(":", 1)[1]
+    return rule
+
+
+def fetch_issues(project_key, ssl_ctx):
+    items = []
+    page = 1
+    total = None
+
+    while True:
+        url = f"{BASE_URL}/issues/search?componentKeys={project_key}&resolved=false&ps={PAGE_SIZE}&p={page}"
+        data = _request(url, ssl_ctx)
+
+        if total is None:
+            total = _get_total(data)
+            print(f"Issues: {total} total", file=sys.stderr)
+
+        for issue in data.get("issues", []):
+            items.append({
+                "key": issue.get("key", ""),
+                "component": _strip_prefix(issue.get("component", ""), project_key),
+                "type": issue.get("type", ""),
+                "severity": issue.get("severity", ""),
+                "line": issue.get("line"),
+                "message": issue.get("message", ""),
+                "rule": issue.get("rule", ""),
+            })
+
+        fetched = page * PAGE_SIZE
+        if fetched >= total or fetched >= MAX_RESULTS:
+            if total > MAX_RESULTS:
+                print(
+                    f"Warning: SonarCloud API limits results to {MAX_RESULTS}. "
+                    "Use severity/type filters for complete data.",
+                    file=sys.stderr,
+                )
+            break
+
+        page += 1
+        print(f"Fetching issues page {page}/{math.ceil(min(total, MAX_RESULTS) / PAGE_SIZE)}...", file=sys.stderr)
+
+    return {"total": total, "items": items}
+
+
+def fetch_hotspots(project_key, ssl_ctx):
+    items = []
+    page = 1
+    total = None
+
+    while True:
+        url = f"{BASE_URL}/hotspots/search?projectKey={project_key}&status=TO_REVIEW&ps={PAGE_SIZE}&p={page}"
+        data = _request(url, ssl_ctx)
+
+        if total is None:
+            total = _get_total(data)
+            print(f"Hotspots: {total} total", file=sys.stderr)
+
+        for hotspot in data.get("hotspots", []):
+            items.append({
+                "key": hotspot.get("key", ""),
+                "component": _strip_prefix(hotspot.get("component", ""), project_key),
+                "securityCategory": hotspot.get("securityCategory", ""),
+                "vulnerabilityProbability": hotspot.get("vulnerabilityProbability", ""),
+                "line": hotspot.get("line"),
+                "message": hotspot.get("message", ""),
+                "rule": hotspot.get("ruleKey", ""),
+                "status": hotspot.get("status", ""),
+            })
+
+        fetched = page * PAGE_SIZE
+        if fetched >= total or fetched >= MAX_RESULTS:
+            break
+
+        page += 1
+        print(f"Fetching hotspots page {page}/{math.ceil(min(total, MAX_RESULTS) / PAGE_SIZE)}...", file=sys.stderr)
+
+    return {"total": total, "items": items}
+
+
+def fetch_duplication(project_key, ssl_ctx):
+    url = (
+        f"{BASE_URL}/measures/component?component={project_key}"
+        "&metricKeys=duplicated_lines_density,duplicated_blocks,duplicated_files"
+    )
+    data = _request(url, ssl_ctx)
+
+    result = {
+        "duplicated_lines_density": None,
+        "duplicated_blocks": None,
+        "duplicated_files": None,
+    }
+
+    for measure in data.get("component", {}).get("measures", []):
+        metric = measure.get("metric", "")
+        value = measure.get("value")
+        if metric in result and value is not None:
+            try:
+                result[metric] = float(value) if "." in str(value) else int(value)
+            except (ValueError, TypeError):
+                result[metric] = value
+
+    return result
+
+
+def categorize(issues_items, hotspots_items):
+    categories = {
+        "Security": [],
+        "Reliability": [],
+        "Maintainability": [],
+        "Security Hotspots": list(hotspots_items),
+        "Duplication": [],
+    }
+
+    for issue in issues_items:
+        issue_type = issue.get("type", "")
+        suffix = _rule_suffix(issue.get("rule", ""))
+
+        if issue_type == "VULNERABILITY":
+            categories["Security"].append(issue)
+        elif issue_type == "BUG":
+            categories["Reliability"].append(issue)
+        elif issue_type == "CODE_SMELL":
+            categories["Maintainability"].append(issue)
+            if suffix in DUPLICATION_RULE_SUFFIXES:
+                categories["Duplication"].append(issue)
+
+    return categories
+
+
+def main():
+    project_key = os.environ.get("SONAR_PROJECT_KEY", "").strip()
+    organization = os.environ.get("SONAR_ORGANIZATION", "").strip()
+
+    if not project_key or not organization:
+        error = {
+            "error": "SONAR_PROJECT_KEY and SONAR_ORGANIZATION environment variables are required.",
+        }
+        print(json.dumps(error, indent=2))
+        print("ERROR: Set SONAR_PROJECT_KEY and SONAR_ORGANIZATION before running.", file=sys.stderr)
+        sys.exit(1)
+
+    ssl_ctx = _build_ssl_context()
+
+    try:
+        print(f"Fetching SonarCloud data for {project_key}...", file=sys.stderr)
+        issues = fetch_issues(project_key, ssl_ctx)
+        hotspots = fetch_hotspots(project_key, ssl_ctx)
+        duplication = fetch_duplication(project_key, ssl_ctx)
+    except urllib.error.HTTPError as e:
+        messages = {
+            401: "Authentication failed (HTTP 401). Check SONARCLOUD_TOKEN.",
+            403: "Access forbidden (HTTP 403). Token may lack permissions or project key may be wrong.",
+            404: "Project not found (HTTP 404). Verify SONAR_PROJECT_KEY.",
+        }
+        msg = messages.get(e.code, f"HTTP error {e.code}: {e.reason}")
+        print(json.dumps({"error": msg}, indent=2))
+        print(f"ERROR: {msg}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        msg = f"Connection error: {e.reason}"
+        print(json.dumps({"error": msg}, indent=2))
+        print(f"ERROR: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    categories = categorize(issues["items"], hotspots["items"])
+
+    result = {
+        "project_key": project_key,
+        "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "issues": issues,
+        "hotspots": hotspots,
+        "duplication": duplication,
+        "categories": categories,
+    }
+
+    print(json.dumps(result, indent=2))
+    print(
+        f"Done: {issues['total']} issues, {hotspots['total']} hotspots, "
+        f"{duplication.get('duplicated_blocks', 0) or 0} duplicated blocks",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md
@@ -9,7 +9,7 @@ Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focus
 ### Prerequisites
 
 - **`gh`** (GitHub CLI) — must be installed and authenticated (`gh auth login`). Used by `/sonarcloud-fix` to create PRs and post e2e trigger comments.
-- **`curl`** — used for SonarCloud API calls.
+- **`python3`** (3.8+) — used by the fetch script (`scripts/sonarcloud-fetch.py`). Uses only Python stdlib (no external dependencies).
 
 ### Required Environment Variables
 
@@ -24,31 +24,7 @@ Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focus
 
 ### Validate Environment
 
-Before any operation, check that required env vars are set:
-
-```bash
-if [ -z "$SONAR_ORGANIZATION" ] || [ -z "$SONAR_PROJECT_KEY" ]; then
-  echo "ERROR: SONAR_ORGANIZATION and SONAR_PROJECT_KEY must be set."
-  echo ""
-  echo "Example:"
-  echo "  export SONAR_ORGANIZATION=your-org"
-  echo "  export SONAR_PROJECT_KEY=your-project-key"
-  echo "  export SONARCLOUD_TOKEN=your-token  # only for private projects"
-  exit 1
-fi
-```
-
-### Authentication
-
-For public projects, no token is needed (read-only API). For private projects, use the token:
-
-```bash
-# Public project
-curl -s "https://sonarcloud.io/api/issues/search?..."
-
-# Private project
-curl -s -u "${SONARCLOUD_TOKEN}:" "https://sonarcloud.io/api/issues/search?..."
-```
+The fetch script validates that `SONAR_PROJECT_KEY` and `SONAR_ORGANIZATION` are set, and handles authentication automatically when `SONARCLOUD_TOKEN` is present. For public projects, no token is needed.
 
 ---
 
@@ -56,45 +32,33 @@ curl -s -u "${SONARCLOUD_TOKEN}:" "https://sonarcloud.io/api/issues/search?..."
 
 Invoked via `/sonarcloud-analyze`. Fetches all open issues and presents a prioritized, grouped report.
 
-### Step 1: Fetch Issues
+### Step 1: Fetch and Categorize Issues
 
-Fetch unresolved issues with pagination. SonarCloud caps at 500 per page.
+Run the fetch script to retrieve all SonarCloud data:
 
-**Issues (bugs, vulnerabilities, code smells):**
 ```bash
-curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_PROJECT_KEY}&resolved=false&ps=500&p=1"
+python3 .claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
 ```
 
-If the response `total` exceeds 500, paginate:
-```bash
-curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_PROJECT_KEY}&resolved=false&ps=500&p=2"
-```
+The script handles pagination, authentication, and categorization automatically. It outputs JSON to stdout with this structure:
 
-**Security hotspots:**
-```bash
-curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_PROJECT_KEY}&status=TO_REVIEW&ps=500&p=1"
-```
+- `project_key` — the project key used
+- `fetched_at` — ISO timestamp of when data was fetched
+- `issues.total` — total issue count
+- `issues.items[]` — array of issues, each with: `key`, `component` (relative file path), `type` (BUG/VULNERABILITY/CODE_SMELL), `severity`, `line`, `message`, `rule`
+- `hotspots.total` — total hotspot count
+- `hotspots.items[]` — array of hotspots, each with: `key`, `component`, `securityCategory`, `vulnerabilityProbability`, `line`, `message`, `rule`, `status`
+- `duplication` — object with `duplicated_lines_density`, `duplicated_blocks`, `duplicated_files`
+- `categories` — pre-grouped object with keys: `Security`, `Reliability`, `Maintainability`, `Security Hotspots`, `Duplication`
 
-**Duplication metrics:**
-```bash
-curl -s "https://sonarcloud.io/api/measures/component?component=${SONAR_PROJECT_KEY}&metricKeys=duplicated_lines_density,duplicated_blocks,duplicated_files"
-```
+If the script exits with code 1, read the `error` field from its JSON output and display the error message to the user. Common errors:
+- Missing env vars → prompt the user to set them
+- HTTP 401 → invalid token
+- HTTP 404 → wrong project key
 
-Parse each JSON response. For issues, extract: `key`, `component` (file path), `type` (BUG, VULNERABILITY, CODE_SMELL), `severity`, `line`, `message`, `rule`.
+Parse the JSON output. Use the `categories` object as the starting point for Step 2.
 
-### Step 2: Categorize by SonarCloud Category
-
-Group all fetched issues into the 5 SonarCloud categories:
-
-| Category | Source | Filter |
-|----------|--------|--------|
-| **Security** | `/api/issues/search` | `type=VULNERABILITY` |
-| **Reliability** | `/api/issues/search` | `type=BUG` |
-| **Maintainability** | `/api/issues/search` | `type=CODE_SMELL` |
-| **Security Hotspots** | `/api/hotspots/search` | `status=TO_REVIEW` |
-| **Duplication** | `/api/measures/component` | `duplicated_blocks` metric; also code smell rules related to duplication (e.g., `typescript:S1192`) |
-
-### Step 3: Group by Rule + Module
+### Step 2: Group by Rule + Module
 
 Within each category, group issues by **SonarCloud rule key** and **module** (workspace, package, or top-level directory depending on the repo structure).
 
@@ -102,7 +66,7 @@ Within each category, group issues by **SonarCloud rule key** and **module** (wo
 
 Determine the repo's module structure **once at the start of analysis**, then apply it consistently to all issues.
 
-**Step 3a: Check for monorepo workspace definitions**
+**Step 2a: Check for monorepo workspace definitions**
 
 Look for workspace/package definitions in this order:
 
@@ -118,7 +82,7 @@ Example: if `package.json` has `"workspaces": ["frontend/*", "framework"]`, then
 - `framework/PageTable.tsx` → module `framework`
 - `scripts/build.js` → module `root`
 
-**Step 3b: No workspace definitions found (non-monorepo)**
+**Step 2b: No workspace definitions found (non-monorepo)**
 
 Group issues by their **top-level directory** from the `component` field (the first path segment after the project key). Files in the repo root go into a `root` group.
 
@@ -132,7 +96,7 @@ Example:
 
 Each group is identified as: `<rule key> — <module>` (e.g., `typescript:S1854 — frontend/awx`, `python:S1481 — src`).
 
-### Step 4: Sort by Remediation Priority
+### Step 3: Sort by Remediation Priority
 
 Within each category, sort groups by this priority order. Match by rule ID suffix (the numeric part is language-agnostic in SonarCloud — e.g., `S1128` appears as `typescript:S1128`, `python:S1128`, `java:S1128`, etc.):
 
@@ -149,7 +113,7 @@ Within each category, sort groups by this priority order. Match by rule ID suffi
 
 Rules not matching any priority bucket sort to the end, ordered by issue count descending.
 
-### Step 5: Estimate LOC Impact
+### Step 4: Estimate LOC Impact
 
 For each group, estimate the lines of code that will change:
 - Unused imports: ~1 LOC per issue (removal)
@@ -160,7 +124,7 @@ For each group, estimate the lines of code that will change:
 - Type safety: ~1-3 LOC per issue
 - Cognitive complexity: ~10-20 LOC per issue (refactoring)
 
-### Step 6: Present Summary Table
+### Step 5: Present Summary Table
 
 Display one table per category. Include total issue count in the heading.
 
@@ -458,8 +422,9 @@ This skill is designed for adoption by other teams and repos:
 1. **No hardcoded values** — all project-specific config via environment variables
 2. **Configurable base branch** — `SONAR_DEFAULT_BRANCH` defaults to `devel` but can be set to `main` or any branch
 3. **Automatic module detection** — detects monorepo workspaces from `package.json`, `pnpm-workspace.yaml`, `nx.json`, or `lerna.json`. For non-monorepo projects, groups issues by top-level directory. No repo-specific configuration required.
-4. **Validation commands** — set `SONAR_VALIDATE_COMMANDS` to your project's validation pipeline (e.g., `make lint && make test`)
-5. **PR template** — adjust to match the target repo's `.github/pull_request_template.md`
+4. **Fetch script** — `scripts/sonarcloud-fetch.py` uses only Python stdlib (no external dependencies). Handles pagination, authentication, and categorization deterministically.
+5. **Validation commands** — set `SONAR_VALIDATE_COMMANDS` to your project's validation pipeline (e.g., `make lint && make test`)
+6. **PR template** — adjust to match the target repo's `.github/pull_request_template.md`
 
 ### Quick Start for Other Teams
 

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -10,14 +10,14 @@ SonarCloud shows ~2700 open issues for this project. Engineers currently triage 
 
 ## Architecture Decision
 
-Direct SonarCloud API integration via `curl` in skill markdown — no custom API client, no MCP server, no coded application. Claude Code skills are instruction files. The amazon.aws PR proved this pattern works at scale.
+Hybrid approach: a Python script handles the mechanical API fetching and categorization (deterministic, token-efficient), while the LLM handles module detection, grouping, prioritization, and presentation (where reasoning about unfamiliar project structures adds value). No custom API client, no MCP server. The amazon.aws PR proved the SonarCloud API pattern works at scale.
 
 ---
 
 ## Prerequisites
 
 - **`gh`** (GitHub CLI) — must be installed and authenticated (`gh auth login`). Used by `/sonarcloud-fix` to create PRs and post e2e trigger comments.
-- **`curl`** — used for SonarCloud API calls.
+- **`python3`** (3.8+) — used by the fetch script (`scripts/sonarcloud-fetch.py`). Uses only Python stdlib (no external dependencies).
 
 ---
 
@@ -26,7 +26,10 @@ Direct SonarCloud API integration via `curl` in skill markdown — no custom API
 ```
 .claude/
   skills/
-    sonarcloud-remediation.md     — Full workflow logic (analyze + fix)
+    sonarcloud-remediation/
+      sonarcloud-remediation.md   — Full workflow logic (analyze + fix)
+      scripts/
+        sonarcloud-fetch.py       — API fetching + categorization (stdlib-only Python)
   commands/
     sonarcloud-analyze.md         — /sonarcloud-analyze command (thin wrapper)
     sonarcloud-fix.md             — /sonarcloud-fix command (thin wrapper)
@@ -59,16 +62,9 @@ The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with
 
 Both commands support a `--help` flag that displays usage information and exits without performing any action.
 
-1. **Validate environment** — check `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` are set
-2. **Fetch issues** from SonarCloud API (`/api/issues/search`) with pagination (max 500/page); also fetch hotspots via `/api/hotspots/search`
-3. **Categorize by the 5 SonarCloud categories**:
-   - Security (vulnerabilities)
-   - Reliability (bugs)
-   - Maintainability (code smells)
-   - Security Hotspots (hotspots with status `TO_REVIEW`)
-   - Duplication (duplicated blocks — fetched via `/api/measures/component` or identified from code smell rules)
-4. **Within each category, group by SonarCloud rule + module** — modules are auto-detected from monorepo workspace definitions (`package.json` workspaces, `pnpm-workspace.yaml`, `nx.json`, `lerna.json`), or by top-level directory for non-monorepo projects — e.g., "Dead store (typescript:S1854) — frontend/awx (12 issues)"
-5. **Sort groups by remediation priority** (within each category):
+1. **Run the fetch script** (`scripts/sonarcloud-fetch.py`) — validates environment, fetches issues from SonarCloud API with pagination (max 500/page), fetches hotspots and duplication metrics, and categorizes into the 5 SonarCloud categories (Security, Reliability, Maintainability, Security Hotspots, Duplication). Outputs compact JSON to stdout.
+2. **Within each category, group by SonarCloud rule + module** — modules are auto-detected from monorepo workspace definitions (`package.json` workspaces, `pnpm-workspace.yaml`, `nx.json`, `lerna.json`), or by top-level directory for non-monorepo projects — e.g., "Dead store (typescript:S1854) — frontend/awx (12 issues)"
+3. **Sort groups by remediation priority** (within each category):
    1. Unused imports and variables
    2. Dead code / dead stores
    3. Duplicate string literals (extract to constants)
@@ -78,7 +74,7 @@ Both commands support a `--help` flag that displays usage information and exits 
    7. Cognitive complexity refactoring
    8. Security hotspot remediation
    9. Reliability bug fixes
-6. **Present a prioritized summary table** per category, using **continuous group numbering across all categories** (the group `#` is globally unique, not reset per category — this is the ID that `/sonarcloud-fix` uses to select groups):
+4. **Present a prioritized summary table** per category, using **continuous group numbering across all categories** (the group `#` is globally unique, not reset per category — this is the ID that `/sonarcloud-fix` uses to select groups):
    ```
    ## Maintainability (847 issues)
 
@@ -89,8 +85,8 @@ Both commands support a `--help` flag that displays usage information and exits 
    | 3 | Duplicate strings (typescript:S1192)| framework       |   12  | Minor    |   ~60    |
    ...
    ```
-7. **Flag groups exceeding 200 LOC** with a note that they will auto-split into multiple PRs
-8. **Support optional flags**: `--severity <level>` to filter by severity, `--module <name>` to filter by module
+5. **Flag groups exceeding 200 LOC** with a note that they will auto-split into multiple PRs
+6. **Support optional flags**: `--severity <level>` to filter by severity, `--module <name>` to filter by module
 
 ### Phase B — Fix (`/sonarcloud-fix`)
 
@@ -177,7 +173,7 @@ The skill is designed for adoption beyond aap-ui:
 
 | AC | Deliverable |
 |----|-------------|
-| AC1 (Skill Installation) | `.claude/skills/sonarcloud-remediation.md` + commands in `.claude/commands/` |
+| AC1 (Skill Installation) | `.claude/skills/sonarcloud-remediation/` (skill + fetch script) + commands in `.claude/commands/` |
 | AC2 (Authentication) | Skill validates env vars at runtime; `SONARCLOUD_TOKEN` for private projects; no secrets committed |
 | AC3 (Issue Analysis) | `/sonarcloud-analyze` with 5-category grouping, rule+module sub-groups (auto-detected), priority sorting, severity/module flags |
 | AC4 (Configuration) | Environment variables matching CI pipeline; configurable default branch |
@@ -197,9 +193,10 @@ The skill is designed for adoption beyond aap-ui:
 
 ## Files to Create
 
-1. **`.claude/skills/sonarcloud-remediation.md`** — Main skill file (~300-400 lines). Contains: env var validation, SonarCloud API curl templates, grouping/sorting logic, fix strategies, validation gates, PR creation workflow, portability notes.
-2. **`.claude/commands/sonarcloud-analyze.md`** — Thin command wrapper (~10-15 lines). Invokes the analyze phase of the skill.
-3. **`.claude/commands/sonarcloud-fix.md`** — Thin command wrapper (~10-15 lines). Invokes the fix phase of the skill.
+1. **`.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md`** — Main skill file (~400 lines). Contains: grouping/sorting logic, fix strategies, validation gates, PR creation workflow, portability notes. References the fetch script for API data.
+2. **`.claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py`** — Python script (~200 lines). Handles paginated SonarCloud API fetching, authentication, and categorization into 5 categories. Stdlib-only, outputs JSON to stdout.
+3. **`.claude/commands/sonarcloud-analyze.md`** — Thin command wrapper (~10-15 lines). Invokes the analyze phase of the skill.
+4. **`.claude/commands/sonarcloud-fix.md`** — Thin command wrapper (~10-15 lines). Invokes the fix phase of the skill.
 
 ---
 

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -67,7 +67,7 @@ Both commands support a `--help` flag that displays usage information and exits 
    - Maintainability (code smells)
    - Security Hotspots (hotspots with status `TO_REVIEW`)
    - Duplication (duplicated blocks — fetched via `/api/measures/component` or identified from code smell rules)
-4. **Within each category, group by SonarCloud rule + aap-ui workspace** (awx, eda, hub, framework, platform, common, chatbot) — e.g., "Dead store (typescript:S1854) — AWX (12 issues)"
+4. **Within each category, group by SonarCloud rule + module** — modules are auto-detected from monorepo workspace definitions (`package.json` workspaces, `pnpm-workspace.yaml`, `nx.json`, `lerna.json`), or by top-level directory for non-monorepo projects — e.g., "Dead store (typescript:S1854) — frontend/awx (12 issues)"
 5. **Sort groups by remediation priority** (within each category):
    1. Unused imports and variables
    2. Dead code / dead stores
@@ -82,15 +82,15 @@ Both commands support a `--help` flag that displays usage information and exits 
    ```
    ## Maintainability (847 issues)
 
-   | # | Group                              | Workspace | Count | Severity | Est. LOC |
-   |---|------------------------------------|-----------|-------|----------|----------|
-   | 1 | Unused imports (typescript:S1128)   | AWX       |   45  | Minor    |   ~90    |
-   | 2 | Dead stores (typescript:S1854)      | AWX       |   23  | Major    |   ~46    |
-   | 3 | Duplicate strings (typescript:S1192)| Framework |   12  | Minor    |   ~60    |
+   | # | Group                              | Module          | Count | Severity | Est. LOC |
+   |---|------------------------------------|-----------------|-------|----------|----------|
+   | 1 | Unused imports (typescript:S1128)   | frontend/awx    |   45  | Minor    |   ~90    |
+   | 2 | Dead stores (typescript:S1854)      | frontend/awx    |   23  | Major    |   ~46    |
+   | 3 | Duplicate strings (typescript:S1192)| framework       |   12  | Minor    |   ~60    |
    ...
    ```
 7. **Flag groups exceeding 200 LOC** with a note that they will auto-split into multiple PRs
-8. **Support optional flags**: `--severity <level>` to filter by severity, `--workspace <name>` to filter by workspace
+8. **Support optional flags**: `--severity <level>` to filter by severity, `--module <name>` to filter by module
 
 ### Phase B — Fix (`/sonarcloud-fix`)
 
@@ -100,7 +100,7 @@ The fix workflow uses a **2-step approval process** to give engineers full contr
 1. **Engineer selects one or more groups** from the analyze output (by number or name)
 2. **Read all affected files** for the selected group(s); analyze each issue in its code context
 3. **Present fixes as a group for human approval** — not individually. Display:
-   - Group summary: rule, workspace, count, severity
+   - Group summary: rule, module, count, severity
    - Table of all fixes: file, line, issue description, proposed change (before/after snippet)
    - Estimated total LOC changed
    - Risk assessment for the group (Low / Medium / High)
@@ -112,19 +112,19 @@ The fix workflow uses a **2-step approval process** to give engineers full contr
    - Run `SONAR_VALIDATE_COMMANDS` (default: `npm run tsc && npm run vitest`)
    - If validation fails, diagnose, fix, and re-validate before proceeding
 7. **Create branch** off the configured default branch (`SONAR_DEFAULT_BRANCH` or `devel`):
-   - Branch name: `sonar/<rule-key>-<workspace>` (e.g., `sonar/S1854-awx`)
+   - Branch name: `sonar/<rule-key>-<module-slug>` (e.g., `sonar/S1854-frontend-awx`)
 8. **Commit** with descriptive message referencing SonarCloud issue keys:
    ```
-   fix: remove dead stores in AWX components (SonarCloud S1854)
+   fix: remove dead stores in frontend/awx (SonarCloud S1854)
 
    Addresses 23 typescript:S1854 violations in frontend/awx/.
    SonarCloud keys: AZxx1, AZxx2, ...
    ```
 9. **Approval 1 — Apply & Test**: Pause and inform the engineer the branch is ready for local testing. They can review the diff, run additional tests, or commit manual adjustments. **Wait for explicit go-ahead before proceeding to PR creation.**
 10. **Approval 2 — Create PR(s)**: Present a summary of how many PRs will be created, LOC per PR, and target branch. Wait for explicit approval, then create PR(s):
-    - **PR title** must use the format: `SonarCloud Fix: <description> (<rule key>, <workspace>)` (e.g., `SonarCloud Fix: Remove dead stores (S1854, AWX)`). For batched PRs, append `[batch 1/N]`.
+    - **PR title** must use the format: `SonarCloud Fix: <description> (<rule key>, <module>)` (e.g., `SonarCloud Fix: Remove dead stores (S1854, frontend/awx)`). For batched PRs, append `[batch 1/N]`.
     - **PR body** follows `.github/pull_request_template.md`:
-      - **Summary**: Which SonarCloud rule was fixed, which workspace, issue count, link to SonarCloud dashboard
+      - **Summary**: Which SonarCloud rule was fixed, which module, issue count, link to SonarCloud dashboard
       - **Type of Change**: Bug fix or Enhancement (depending on category)
       - **Risk Analysis (required)**: Low for dead code/unused imports; Medium for code smell refactors touching shared paths; High for security/reliability fixes in shared components
       - **Testing**: Validation pass confirmed pre-PR. E2E trigger comment posted after PR creation.
@@ -138,7 +138,7 @@ The fix workflow uses a **2-step approval process** to give engineers full contr
 ### In scope (this story):
 - **Skill creation**: `/sonarcloud-analyze` and `/sonarcloud-fix` skills + command wrappers
 - **Documentation**: Setup instructions, env var configuration, troubleshooting, portability guide
-- **Validation testing**: Run the skills against 1-2 small groups (e.g., unused imports in one workspace) to verify end-to-end functionality — analyze, group-level approval, fix application, validation gates, branch/PR creation
+- **Validation testing**: Run the skills against 1-2 small groups (e.g., unused imports in one module) to verify end-to-end functionality — analyze, group-level approval, fix application, validation gates, branch/PR creation
 
 ### Follow-on stories:
 - **Remediation campaigns** — systematic use of the skills to fix outstanding SonarCloud issues, starting with low-risk categories (unused imports, dead stores, duplicate strings, unused params, commented-out code, type safety)
@@ -165,7 +165,7 @@ The skill is designed for adoption beyond aap-ui:
 
 1. **No hardcoded project keys** — everything via env vars
 2. **Configurable default branch** — `SONAR_DEFAULT_BRANCH` (defaults to `devel`)
-3. **Workspace grouping is optional** — if the target repo isn't a monorepo, issues group by directory instead
+3. **Automatic module detection** — detects monorepo workspaces from `package.json`, `pnpm-workspace.yaml`, `nx.json`, or `lerna.json`; falls back to top-level directory grouping for non-monorepo projects
 4. **Validation commands are configurable** — set `SONAR_VALIDATE_COMMANDS` to your project's pipeline; set `SONAR_E2E_TRIGGER_COMMENT` for your e2e trigger
 5. **Skill header includes setup instructions** — env var configuration, prerequisites, troubleshooting
 
@@ -177,7 +177,7 @@ The skill is designed for adoption beyond aap-ui:
 |----|-------------|
 | AC1 (Skill Installation) | `.claude/skills/sonarcloud-remediation.md` + commands in `.claude/commands/` |
 | AC2 (Authentication) | Skill validates env vars at runtime; `SONARCLOUD_TOKEN` for private projects; no secrets committed |
-| AC3 (Issue Analysis) | `/sonarcloud-analyze` with 5-category grouping, rule+workspace sub-groups, priority sorting, severity/workspace flags |
+| AC3 (Issue Analysis) | `/sonarcloud-analyze` with 5-category grouping, rule+module sub-groups (auto-detected), priority sorting, severity/module flags |
 | AC4 (Configuration) | Environment variables matching CI pipeline; configurable default branch |
 | AC5 (Documentation) | Skill header docs + command docs + setup/troubleshooting in skill preamble |
 | AC6 (Validation) | Tested against project SonarCloud data during implementation |
@@ -206,7 +206,7 @@ The skill is designed for adoption beyond aap-ui:
 1. Set env vars: `SONAR_ORGANIZATION=<your-org>`, `SONAR_PROJECT_KEY=<your-project-key>`
 2. Run `/sonarcloud-analyze --help` and `/sonarcloud-fix --help` — verify usage information is displayed
 3. Run `/sonarcloud-analyze` — verify it fetches issues, groups by 5 categories, sorts by priority, shows summary table with continuous group numbering
-4. Run `/sonarcloud-fix` — select a small group (e.g., unused imports in one workspace), verify group-level approval flow, LOC cap, branch creation, validation gates
+4. Run `/sonarcloud-fix` — select a small group (e.g., unused imports in one module), verify group-level approval flow, LOC cap, branch creation, validation gates
 5. Confirm validation commands pass before PR
 6. Verify Approval 1 pauses for engineer review before PR creation
 7. Verify Approval 2 presents PR summary and waits for explicit go-ahead

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -96,6 +96,7 @@ Both commands support a `--help` flag that displays usage information and exits 
 
 The fix workflow uses a **2-step approval process** to give engineers full control:
 
+0. **Configuration pre-check** — Before doing any work, display all environment variables (values, defaults, and descriptions) in a table and prompt the engineer to confirm they are correct. This prevents teams from accidentally running with wrong defaults (e.g., `npm run tsc && npm run vitest` when their project uses `make lint && make test`). Skipped if already confirmed in the same session.
 1. **Engineer selects one or more groups** from the analyze output (by number or name)
 2. **Read all affected files** for the selected group(s); analyze each issue in its code context
 3. **Present fixes as a group for human approval** — not individually. Display:

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -1,0 +1,202 @@
+# Final Implementation Plan — SonarCloud Remediation Skill
+
+## Context
+
+SonarCloud shows ~2700 open issues for this project. Engineers currently triage and fix these manually — navigating the dashboard, reviewing each issue, researching fixes, and creating PRs by hand. This story delivers a Claude Code skill that automates analysis and remediation with human-in-the-loop review, starting with low-risk fix categories to build trust.
+
+**Reference implementation**: [amazon.aws PR #2919](https://github.com/ansible-collections/amazon.aws/pull/2919) — proved that curl-based SonarCloud API calls in skill markdown work. We adapt this pattern for a TypeScript/React monorepo context.
+
+---
+
+## Architecture Decision
+
+Direct SonarCloud API integration via `curl` in skill markdown — no custom API client, no MCP server, no coded application. Claude Code skills are instruction files. The amazon.aws PR proved this pattern works at scale.
+
+---
+
+## File Structure
+
+```
+.claude/
+  skills/
+    sonarcloud-remediation.md     — Full workflow logic (analyze + fix)
+  commands/
+    sonarcloud-analyze.md         — /sonarcloud-analyze command (thin wrapper)
+    sonarcloud-fix.md             — /sonarcloud-fix command (thin wrapper)
+```
+
+**Existing files unchanged**: `commands/migrate-test.md`, `commands/review-pr.md`, `skills/pr_review.md`, `settings.json`
+
+---
+
+## Environment Variables
+
+No hardcoded project keys. The skill reads env vars (matching CI pipeline conventions):
+
+| Variable | Required | Example | Purpose |
+|----------|----------|---------|---------|
+| `SONAR_ORGANIZATION` | Yes | Your SonarCloud organization slug | SonarCloud org |
+| `SONAR_PROJECT_KEY` | Yes | Your SonarCloud project key | Project identifier |
+| `SONARCLOUD_TOKEN` | Only for private projects | — | API auth token |
+| `SONAR_DEFAULT_BRANCH` | No (default: `devel`) | `main` | Base branch for fix PRs |
+| `SONAR_VALIDATE_COMMANDS` | No (default: `npm run tsc && npm run vitest`) | `make lint && make test` | Validation commands that must pass before PR creation |
+| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | `/run-e2e` | Comment to post on PR to trigger e2e tests |
+
+The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with a clear error if missing.
+
+---
+
+## Workflow
+
+### Phase A — Analyze (`/sonarcloud-analyze`)
+
+1. **Validate environment** — check `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` are set
+2. **Fetch issues** from SonarCloud API (`/api/issues/search`) with pagination (max 500/page); also fetch hotspots via `/api/hotspots/search`
+3. **Categorize by the 5 SonarCloud categories**:
+   - Security (vulnerabilities)
+   - Reliability (bugs)
+   - Maintainability (code smells)
+   - Security Hotspots (hotspots with status `TO_REVIEW`)
+   - Duplication (duplicated blocks — fetched via `/api/measures/component` or identified from code smell rules)
+4. **Within each category, group by SonarCloud rule + aap-ui workspace** (awx, eda, hub, framework, platform, common, chatbot) — e.g., "Dead store (typescript:S1854) — AWX (12 issues)"
+5. **Sort groups by remediation priority** (within each category):
+   1. Unused imports and variables
+   2. Dead code / dead stores
+   3. Duplicate string literals (extract to constants)
+   4. Unused function parameters
+   5. Commented-out code removal
+   6. Simple type safety improvements
+   7. Cognitive complexity refactoring
+   8. Security hotspot remediation
+   9. Reliability bug fixes
+6. **Present a prioritized summary table** per category:
+   ```
+   ## Maintainability (847 issues)
+
+   | # | Group                              | Workspace | Count | Severity | Est. LOC |
+   |---|------------------------------------|-----------|-------|----------|----------|
+   | 1 | Unused imports (typescript:S1128)   | AWX       |   45  | Minor    |   ~90    |
+   | 2 | Dead stores (typescript:S1854)      | AWX       |   23  | Major    |   ~46    |
+   | 3 | Duplicate strings (typescript:S1192)| Framework |   12  | Minor    |   ~60    |
+   ...
+   ```
+7. **Flag groups exceeding 200 LOC** with a note that they will auto-split into multiple PRs
+8. **Support optional flags**: `--severity <level>` to filter by severity, `--workspace <name>` to filter by workspace
+
+### Phase B — Fix (`/sonarcloud-fix`)
+
+1. **Engineer selects one or more groups** from the analyze output (by number or name)
+2. **Read all affected files** for the selected group(s); analyze each issue in its code context
+3. **Present fixes as a group for human approval** — not individually. Display:
+   - Group summary: rule, workspace, count, severity
+   - Table of all fixes: file, line, issue description, proposed change (before/after snippet)
+   - Estimated total LOC changed
+   - Risk assessment for the group (Low / Medium / High)
+4. **Engineer approves, rejects, or modifies the group** (approve all / reject all / exclude specific files)
+5. **Apply approved fixes**, capping at ~200 LOC per PR:
+   - If the group exceeds 200 LOC, auto-split into multiple batches (by file or logical grouping)
+   - Each batch becomes its own PR
+6. **Validate — hard gate**:
+   - Run `SONAR_VALIDATE_COMMANDS` (default: `npm run tsc && npm run vitest`)
+   - If validation fails, diagnose, fix, and re-validate before proceeding
+7. **Create branch** off the configured default branch (`SONAR_DEFAULT_BRANCH` or `devel`):
+   - Branch name: `sonar/<rule-key>-<workspace>` (e.g., `sonar/S1854-awx`)
+8. **Commit** with descriptive message referencing SonarCloud issue keys:
+   ```
+   fix: remove dead stores in AWX components (SonarCloud S1854)
+
+   Addresses 23 typescript:S1854 violations in frontend/awx/.
+   SonarCloud keys: AZxx1, AZxx2, ...
+   ```
+9. **Create PR** following `.github/pull_request_template.md`:
+   - **Summary**: Which SonarCloud rule was fixed, which workspace, issue count, link to SonarCloud dashboard
+   - **Type of Change**: Bug fix or Enhancement (depending on category)
+   - **Risk Analysis (required)**: Low for dead code/unused imports; Medium for code smell refactors touching shared paths; High for security/reliability fixes in shared components
+   - **Testing**: Validation pass confirmed pre-PR. E2E trigger comment posted after PR creation.
+10. **Post `SONAR_E2E_TRIGGER_COMMENT`** (default: `/run-playwright`) comment on the PR to trigger e2e tests
+11. **Offer to continue** — return to group selection for the next batch
+
+---
+
+## Scope
+
+### In scope (this story):
+- **Skill creation**: `/sonarcloud-analyze` and `/sonarcloud-fix` skills + command wrappers
+- **Documentation**: Setup instructions, env var configuration, troubleshooting, portability guide
+- **Validation testing**: Run the skills against 1-2 small groups (e.g., unused imports in one workspace) to verify end-to-end functionality — analyze, group-level approval, fix application, validation gates, branch/PR creation
+
+### Follow-on stories:
+- **Remediation campaigns** — systematic use of the skills to fix outstanding SonarCloud issues, starting with low-risk categories (unused imports, dead stores, duplicate strings, unused params, commented-out code, type safety)
+- **Cross-team adoption** — contribute the skill to a shared marketplace repo for use across teams
+
+---
+
+## TypeScript/React Fix Strategies
+
+| Rule Pattern | Fix Strategy |
+|---|---|
+| Unused imports/variables | Remove dead references; verify no side-effect imports |
+| Dead stores | Remove unused assignments; check for intentional destructuring |
+| Duplicate strings | Extract to named `const` in same file or nearest shared module |
+| Unused function parameters | Remove if internal; prefix with `_` if interface-required |
+| Commented-out code | Remove entirely (git history preserves it) |
+| Type safety (`any`) | Add proper TypeScript types; use existing interfaces from workspace |
+
+---
+
+## Portability for Other Teams
+
+The skill is designed for adoption beyond aap-ui:
+
+1. **No hardcoded project keys** — everything via env vars
+2. **Configurable default branch** — `SONAR_DEFAULT_BRANCH` (defaults to `devel`)
+3. **Workspace grouping is optional** — if the target repo isn't a monorepo, issues group by directory instead
+4. **Validation commands are configurable** — set `SONAR_VALIDATE_COMMANDS` to your project's pipeline; set `SONAR_E2E_TRIGGER_COMMENT` for your e2e trigger
+5. **Skill header includes setup instructions** — env var configuration, prerequisites, troubleshooting
+
+---
+
+## AC Mapping
+
+| AC | Deliverable |
+|----|-------------|
+| AC1 (Skill Installation) | `.claude/skills/sonarcloud-remediation.md` + commands in `.claude/commands/` |
+| AC2 (Authentication) | Skill validates env vars at runtime; `SONARCLOUD_TOKEN` for private projects; no secrets committed |
+| AC3 (Issue Analysis) | `/sonarcloud-analyze` with 5-category grouping, rule+workspace sub-groups, priority sorting, severity/workspace flags |
+| AC4 (Configuration) | Environment variables matching CI pipeline; configurable default branch |
+| AC5 (Documentation) | Skill header docs + command docs + setup/troubleshooting in skill preamble |
+| AC6 (Validation) | Tested against project SonarCloud data during implementation |
+
+---
+
+## What This Does NOT Change
+
+- No changes to aap-ui application source code (this PR delivers the skill files only)
+- No new dependencies in package.json
+- No modifications to settings.json (env vars are set by the user, not committed)
+- No hardcoded project keys or tokens
+
+---
+
+## Files to Create
+
+1. **`.claude/skills/sonarcloud-remediation.md`** — Main skill file (~300-400 lines). Contains: env var validation, SonarCloud API curl templates, grouping/sorting logic, fix strategies, validation gates, PR creation workflow, portability notes.
+2. **`.claude/commands/sonarcloud-analyze.md`** — Thin command wrapper (~10-15 lines). Invokes the analyze phase of the skill.
+3. **`.claude/commands/sonarcloud-fix.md`** — Thin command wrapper (~10-15 lines). Invokes the fix phase of the skill.
+
+---
+
+## Verification
+
+1. Set env vars: `SONAR_ORGANIZATION=<your-org>`, `SONAR_PROJECT_KEY=<your-project-key>`
+2. Run `/sonarcloud-analyze` — verify it fetches issues, groups by 5 categories, sorts by priority, shows summary table
+3. Run `/sonarcloud-fix` — select a small group (e.g., unused imports in one workspace), verify group-level approval flow, LOC cap, branch creation, validation gates, PR creation
+4. Confirm validation commands pass before PR
+5. Verify PR follows `.github/pull_request_template.md` format with risk analysis
+
+---
+
+## Branch Strategy
+
+- Branch skill development from `devel` on origin
+- PR targets `devel`

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -47,7 +47,7 @@ No hardcoded project keys. The skill reads env vars (matching CI pipeline conven
 | `SONARCLOUD_TOKEN` | Only for private projects | — | API auth token |
 | `SONAR_DEFAULT_BRANCH` | No (default: `devel`) | `main` | Base branch for fix PRs |
 | `SONAR_VALIDATE_COMMANDS` | No (default: `npm run tsc && npm run vitest`) | `make lint && make test` | Validation commands that must pass before PR creation |
-| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | `/run-e2e` | Comment to post on PR to trigger e2e tests |
+| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | `/run-e2e` | Comment to post on PR to trigger e2e tests. Set to `none`, `skip`, `false`, or `""` to disable. |
 
 The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with a clear error if missing.
 

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -14,6 +14,13 @@ Direct SonarCloud API integration via `curl` in skill markdown — no custom API
 
 ---
 
+## Prerequisites
+
+- **`gh`** (GitHub CLI) — must be installed and authenticated (`gh auth login`). Used by `/sonarcloud-fix` to create PRs and post e2e trigger comments.
+- **`curl`** — used for SonarCloud API calls.
+
+---
+
 ## File Structure
 
 ```
@@ -50,6 +57,8 @@ The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with
 
 ### Phase A — Analyze (`/sonarcloud-analyze`)
 
+Both commands support a `--help` flag that displays usage information and exits without performing any action.
+
 1. **Validate environment** — check `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` are set
 2. **Fetch issues** from SonarCloud API (`/api/issues/search`) with pagination (max 500/page); also fetch hotspots via `/api/hotspots/search`
 3. **Categorize by the 5 SonarCloud categories**:
@@ -69,7 +78,7 @@ The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with
    7. Cognitive complexity refactoring
    8. Security hotspot remediation
    9. Reliability bug fixes
-6. **Present a prioritized summary table** per category:
+6. **Present a prioritized summary table** per category, using **continuous group numbering across all categories** (the group `#` is globally unique, not reset per category — this is the ID that `/sonarcloud-fix` uses to select groups):
    ```
    ## Maintainability (847 issues)
 
@@ -84,6 +93,8 @@ The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with
 8. **Support optional flags**: `--severity <level>` to filter by severity, `--workspace <name>` to filter by workspace
 
 ### Phase B — Fix (`/sonarcloud-fix`)
+
+The fix workflow uses a **2-step approval process** to give engineers full control:
 
 1. **Engineer selects one or more groups** from the analyze output (by number or name)
 2. **Read all affected files** for the selected group(s); analyze each issue in its code context
@@ -108,13 +119,16 @@ The skill validates `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` at runtime with
    Addresses 23 typescript:S1854 violations in frontend/awx/.
    SonarCloud keys: AZxx1, AZxx2, ...
    ```
-9. **Create PR** following `.github/pull_request_template.md`:
-   - **Summary**: Which SonarCloud rule was fixed, which workspace, issue count, link to SonarCloud dashboard
-   - **Type of Change**: Bug fix or Enhancement (depending on category)
-   - **Risk Analysis (required)**: Low for dead code/unused imports; Medium for code smell refactors touching shared paths; High for security/reliability fixes in shared components
-   - **Testing**: Validation pass confirmed pre-PR. E2E trigger comment posted after PR creation.
-10. **Post `SONAR_E2E_TRIGGER_COMMENT`** (default: `/run-playwright`) comment on the PR to trigger e2e tests
-11. **Offer to continue** — return to group selection for the next batch
+9. **Approval 1 — Apply & Test**: Pause and inform the engineer the branch is ready for local testing. They can review the diff, run additional tests, or commit manual adjustments. **Wait for explicit go-ahead before proceeding to PR creation.**
+10. **Approval 2 — Create PR(s)**: Present a summary of how many PRs will be created, LOC per PR, and target branch. Wait for explicit approval, then create PR(s):
+    - **PR title** must use the format: `SonarCloud Fix: <description> (<rule key>, <workspace>)` (e.g., `SonarCloud Fix: Remove dead stores (S1854, AWX)`). For batched PRs, append `[batch 1/N]`.
+    - **PR body** follows `.github/pull_request_template.md`:
+      - **Summary**: Which SonarCloud rule was fixed, which workspace, issue count, link to SonarCloud dashboard
+      - **Type of Change**: Bug fix or Enhancement (depending on category)
+      - **Risk Analysis (required)**: Low for dead code/unused imports; Medium for code smell refactors touching shared paths; High for security/reliability fixes in shared components
+      - **Testing**: Validation pass confirmed pre-PR. E2E trigger comment posted after PR creation.
+11. **Post `SONAR_E2E_TRIGGER_COMMENT`** (default: `/run-playwright`) comment on the PR to trigger e2e tests
+12. **Offer to continue** — return to group selection for the next batch
 
 ---
 
@@ -189,10 +203,14 @@ The skill is designed for adoption beyond aap-ui:
 ## Verification
 
 1. Set env vars: `SONAR_ORGANIZATION=<your-org>`, `SONAR_PROJECT_KEY=<your-project-key>`
-2. Run `/sonarcloud-analyze` — verify it fetches issues, groups by 5 categories, sorts by priority, shows summary table
-3. Run `/sonarcloud-fix` — select a small group (e.g., unused imports in one workspace), verify group-level approval flow, LOC cap, branch creation, validation gates, PR creation
-4. Confirm validation commands pass before PR
-5. Verify PR follows `.github/pull_request_template.md` format with risk analysis
+2. Run `/sonarcloud-analyze --help` and `/sonarcloud-fix --help` — verify usage information is displayed
+3. Run `/sonarcloud-analyze` — verify it fetches issues, groups by 5 categories, sorts by priority, shows summary table with continuous group numbering
+4. Run `/sonarcloud-fix` — select a small group (e.g., unused imports in one workspace), verify group-level approval flow, LOC cap, branch creation, validation gates
+5. Confirm validation commands pass before PR
+6. Verify Approval 1 pauses for engineer review before PR creation
+7. Verify Approval 2 presents PR summary and waits for explicit go-ahead
+8. Verify PR title uses `SonarCloud Fix:` prefix format
+9. Verify PR body follows `.github/pull_request_template.md` format with risk analysis
 
 ---
 

--- a/docs/sonarcloud-remediation-implementation-plan.md
+++ b/docs/sonarcloud-remediation-implementation-plan.md
@@ -146,16 +146,18 @@ The fix workflow uses a **2-step approval process** to give engineers full contr
 
 ---
 
-## TypeScript/React Fix Strategies
+## Fix Strategies by Rule Pattern
+
+These strategies apply across languages. Adapt to the project's language and conventions.
 
 | Rule Pattern | Fix Strategy |
 |---|---|
 | Unused imports/variables | Remove dead references; verify no side-effect imports |
-| Dead stores | Remove unused assignments; check for intentional destructuring |
-| Duplicate strings | Extract to named `const` in same file or nearest shared module |
-| Unused function parameters | Remove if internal; prefix with `_` if interface-required |
+| Dead stores | Remove unused assignments; check for intentional destructuring or unpacking |
+| Duplicate strings | Extract to named constant in same file or nearest shared module |
+| Unused function parameters | Remove if internal; prefix with `_` if required by interface, override, or callback |
 | Commented-out code | Remove entirely (git history preserves it) |
-| Type safety (`any`) | Add proper TypeScript types; use existing interfaces from workspace |
+| Type safety (e.g., `any` in TS, raw types in Java) | Replace with proper types using existing project type definitions |
 
 ---
 


### PR DESCRIPTION
## Summary

  Add a Claude Code skill for automated SonarCloud issue remediation with human-in-the-loop review.

###  New files:
  - .claude/skills/sonarcloud-remediation.md — core skill with full analyze + fix workflow
  - .claude/commands/sonarcloud-analyze.md — `/sonarcloud-analyze` command wrapper
  - .claude/commands/sonarcloud-fix.md — `/sonarcloud-fix` command wrapper

###  How it works:
  - `/sonarcloud-analyze` fetches all open issues from the SonarCloud API, groups them by category (Security, Reliability, Maintainability, Hotspots, Duplication) and by rule + module, then presents a prioritized summary table
  - `/sonarcloud-fix` lets the engineer select group(s) to remediate, presents fixes for group-level approval, applies changes (capped at ~200 LOC per PR), validates via configurable gate commands (npm run tsc && npm run vitest by default), and creates PRs — with two explicit approval checkpoints before anything is pushed

###  Portability: 

- No hardcoded repo-specific values. 
- Module detection is automatic (NPM/pnpm/Nx/Lerna workspaces, or top-level directories for non-monorepos). 
- All config is via environment variables (SONAR_DEFAULT_BRANCH, SONAR_VALIDATE_COMMANDS, SONAR_E2E_TRIGGER_COMMENT, etc.).

##  Type of Change

  - Other — Claude Code skill (no production code changes)

##  Risk Analysis — REQUIRED

- [x] **Low** — Narrowly scoped (adds .claude/ skill and command files only; no production code changes).

##  Testing

###  Prerequisites

  - gh (GitHub CLI) — installed and authenticated (gh auth login)
  - curl

###  Set environment variables:
```
  export SONAR_ORGANIZATION=<your-org>
  export SONAR_PROJECT_KEY=<your-project-key>
```

###  Test `/sonarcloud-analyze`

  1. `/sonarcloud-analyze --help` — verify usage info
  2. `/sonarcloud-analyze` — verify grouped summary tables with continuous numbering, priority sorting, and suggested `/sonarcloud-fix` commands
  3. `/sonarcloud-analyze --module frontend/awx` — verify results filtered to one module
  4. Unset a required env var and run again — verify clear error message

###  Test `/sonarcloud-fix`

  1. `/sonarcloud-fix --help` — verify usage info
  2. `/sonarcloud-fix` (no argument) — verify configuration pre-check is shown, then prompts for group selection
  3. Select a small, low-risk group (e.g., unused imports)
  4. Verify group-level fix presentation with risk assessment and approve/exclude/reject options
  5. Approve fixes — verify validation runs and passes
  6. Approval 1: Verify branch is created and skill pauses for local review
  7. Approval 2: Verify PR summary (count, LOC, target branch) is shown and skill waits for explicit go-ahead before creating PRs

###  Edge cases:
  - Wrong project key → clear error, not empty results
  - Group exceeding ~200 LOC → auto-splits into multiple PRs
  - Validation failure after fix → diagnoses, corrects, and re-validates

