### PR TITLE
fix: use optional chaining in AWX components (SonarCloud S6582)

### DIFF
--- a/frontend/awx/access/common/useAccessColumns.tsx
+++ b/frontend/awx/access/common/useAccessColumns.tsx
@@ -71,7 +71,7 @@ export function useAccessColumns(
                         <Label
                           variant="outline"
                           key={role.id}
-                          onClose={() => deleteRole && deleteRole(role, user)}
+                          onClose={() => deleteRole?.(role, user)}
                           closeBtnAriaLabel={t(`Remove {{roleName}} chip`, { roleName: role.name })}
                         >
                           {role.name}
@@ -90,7 +90,7 @@ export function useAccessColumns(
                         <Label
                           variant="outline"
                           key={role.id}
-                          onClose={() => deleteRole && deleteRole(role, user)}
+                          onClose={() => deleteRole?.(role, user)}
                           closeBtnAriaLabel={t(`Remove {{roleName}} chip`, { roleName: role.name })}
                         >
                           {role.name}

--- a/frontend/awx/access/credential-types/CredentialTypes.tsx
+++ b/frontend/awx/access/credential-types/CredentialTypes.tsx
@@ -41,7 +41,7 @@ export function CredentialTypes() {
     awxAPI`/credential_types/`
   );
 
-  const canCreateCredentialType = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateCredentialType = Boolean(data?.actions?.['POST']);
 
   return (
     <PageLayout>

--- a/frontend/awx/access/credential-types/hooks/useCredentialTypeActions.tsx
+++ b/frontend/awx/access/credential-types/hooks/useCredentialTypeActions.tsx
@@ -23,7 +23,7 @@ export function useCredentialTypeToolbarActions(
   const getPageUrl = useGetPageUrl();
   const deleteCredentialTypes = useDeleteCredentialTypes(onCredentialTypesDeleted);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/credential_types/`);
-  const canCreateCredentialType = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateCredentialType = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<CredentialType>[]>(
     () => [

--- a/frontend/awx/access/credentials/CredentialForm.tsx
+++ b/frontend/awx/access/credentials/CredentialForm.tsx
@@ -675,7 +675,7 @@ function CredentialSubForm({
     setIsTestButtonEnabledSubForm(verify.length >= requiredFieldsInSubForm?.length);
   }, [watchedRequiredFields, setIsTestButtonEnabledSubForm, requiredFieldsInSubForm]);
 
-  if (!credentialType || !credentialType?.inputs?.fields) {
+  if (!credentialType?.inputs?.fields) {
     return null;
   }
 
@@ -735,7 +735,7 @@ function CredentialSubForm({
                     accumulatedPluginValues,
                   });
                 }}
-                fieldInitialValue={initialValues && initialValues[field?.id]}
+                fieldInitialValue={initialValues?.[field?.id]}
               />
             );
           } else if (credentialType.kind === 'ssh' && field.id === 'become_method') {
@@ -756,7 +756,7 @@ function CredentialSubForm({
                 key={field.id}
                 field={field}
                 credentialType={credentialType}
-                fieldInitialValue={initialValues && initialValues[field?.id]}
+                fieldInitialValue={initialValues?.[field?.id]}
                 isDisabled={
                   field.id === 'vault_id' && credentialType.kind === 'vault' && isEditMode
                 }

--- a/frontend/awx/access/credentials/components/CredentialTypeDetail.tsx
+++ b/frontend/awx/access/credentials/components/CredentialTypeDetail.tsx
@@ -14,7 +14,7 @@ export function CredentialTypeDetail(props: {
   const { inputs, field, inputSources } = props;
   const { t } = useTranslation();
   const { id, label, type, ask_at_runtime, help_text = '' } = field;
-  if (id && inputSources && inputSources[id]) {
+  if (id && inputSources?.[id]) {
     return (
       <React.Fragment key={id}>
         <PageDetail helpText={help_text} label={label + ' *'}>

--- a/frontend/awx/access/credentials/hooks/useCredentialsColumns.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialsColumns.tsx
@@ -56,7 +56,7 @@ export function useCredentialsColumns(options?: { disableSort?: boolean; disable
         id: 'credential_type',
         header: t('Credential type'),
         cell: (credential) => {
-          return credentialTypesMap && credentialTypesMap[credential.credential_type]
+          return credentialTypesMap?.[credential.credential_type]
             ? credentialTypesMap[credential.credential_type]
             : t('Unknown');
         },

--- a/frontend/awx/access/teams/Teams.tsx
+++ b/frontend/awx/access/teams/Teams.tsx
@@ -31,7 +31,7 @@ export function Teams() {
   const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/teams/`
   );
-  const canCreateTeam = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateTeam = Boolean(data?.actions?.['POST']);
   usePersistentFilters('teams');
   const config = useAwxConfig();
 

--- a/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
+++ b/frontend/awx/access/teams/hooks/useTeamToolbarActions.tsx
@@ -24,7 +24,7 @@ export function useTeamToolbarActions(view: IAwxView<Team>) {
   const selectUsersAssignTeams = useSelectUsersAssignTeams();
   // const selectUsersRemoveTeams = useSelectUsersRemoveTeams();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/teams/`);
-  const canCreateTeam = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateTeam = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<Team>[]>(
     () => [

--- a/frontend/awx/access/users/UserPage/UserTeams.tsx
+++ b/frontend/awx/access/users/UserPage/UserTeams.tsx
@@ -50,7 +50,7 @@ function UserTeamsInternal(props: { user: AwxUser }) {
   const { data, isLoading: isLoadingUserOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/users/`
   );
-  const canAddUserToTeam = Boolean(data && data.actions && data.actions['POST']);
+  const canAddUserToTeam = Boolean(data?.actions?.['POST']);
 
   const toolbarActions = useMemo<IPageAction<Team>[]>(
     () => [

--- a/frontend/awx/access/users/Users.tsx
+++ b/frontend/awx/access/users/Users.tsx
@@ -63,7 +63,7 @@ export function Users() {
   const { data, isLoading: isLoadingUserOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/users/`
   );
-  const canCreateUser = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateUser = Boolean(data?.actions?.['POST']);
 
   const toolbarActions = useMemo<IPageAction<AwxUser>[]>(
     () => [

--- a/frontend/awx/administration/execution-environments/ExecutionEnvironmentsList.tsx
+++ b/frontend/awx/administration/execution-environments/ExecutionEnvironmentsList.tsx
@@ -42,7 +42,7 @@ export function ExecutionEnvironmentsList({
     onDelete: view.unselectItemsAndRefresh,
     onCopy: view.refresh,
   });
-  const canCreateExecutionEnvironment = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateExecutionEnvironment = Boolean(data?.actions?.['POST']);
   const toolbarActions = useExecutionEnvToolbarActions(view);
 
   if (isLoadingExecutionEnvOptions) return <PageLoadingTable />;

--- a/frontend/awx/administration/execution-environments/hooks/useExecutionEnvToolbarActions.tsx
+++ b/frontend/awx/administration/execution-environments/hooks/useExecutionEnvToolbarActions.tsx
@@ -23,7 +23,7 @@ export function useExecutionEnvToolbarActions(view: IAwxView<ExecutionEnvironmen
   const deleteExecutionEnvironments = useDeleteExecutionEnvironments(view.unselectItemsAndRefresh);
 
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/execution_environments/`);
-  const canCreateExecutionEnvironment = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateExecutionEnvironment = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<ExecutionEnvironment>[]>(
     () => [

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -35,7 +35,7 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/instance_groups/${id ?? ''}/instances/`
   );
-  const canAssociateInstance = Boolean(data && data.actions && data.actions['POST']);
+  const canAssociateInstance = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<Instance>>(
     () => ({

--- a/frontend/awx/administration/instance-groups/hooks/useInstanceGroupActions.tsx
+++ b/frontend/awx/administration/instance-groups/hooks/useInstanceGroupActions.tsx
@@ -21,7 +21,7 @@ export function useDisableCreateInstanceGroup() {
   const { t } = useTranslation();
   return useMemo(
     () =>
-      data && data.actions && data.actions['POST']
+      data?.actions?.['POST']
         ? undefined
         : t(
             'You do not have permission to create an instance group. Please contact your organization administrator if there is an issue with your access.'

--- a/frontend/awx/administration/instance-groups/hooks/useInstanceGroupColumns.tsx
+++ b/frontend/awx/administration/instance-groups/hooks/useInstanceGroupColumns.tsx
@@ -11,7 +11,7 @@ export function useInstanceGroupsColumns(options?: {
   disableLinks?: boolean;
 }) {
   const { t } = useTranslation();
-  const disableLinks = options && options.disableLinks;
+  const disableLinks = options?.disableLinks;
   const getPageUrl = useGetPageUrl();
   const createdColumn = useCreatedColumn(options);
   const modifiedColumn = useModifiedColumn(options);

--- a/frontend/awx/administration/instances/components/InstancesList.tsx
+++ b/frontend/awx/administration/instances/components/InstancesList.tsx
@@ -42,7 +42,7 @@ export function InstancesList(props: {
   const { data, isLoading: isLoadingInstanceOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(instanceGroupId ? awxAPI`/instance_groups/${instanceGroupId}/instances/` : awxAPI`/instances/`);
-  const canCreateInstance = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateInstance = Boolean(data?.actions?.['POST']);
 
   usePersistentFilters('instances');
 

--- a/frontend/awx/administration/instances/hooks/useSelectAssociatePeers.tsx
+++ b/frontend/awx/administration/instances/hooks/useSelectAssociatePeers.tsx
@@ -45,8 +45,7 @@ function PeerInstanceModal(props: PeerInstanceModalProps) {
         !instance.peers?.includes(receptor.id) &&
         !(instance.id === receptor.instance) &&
         !receptor.is_internal &&
-        instances &&
-        instances.some((instance) => instance.id === receptor.instance)
+        instances?.some((instance) => instance.id === receptor.instance)
     );
 
     peeredReceptorIds = filteredReceptors.map((receptor) => String(receptor.instance));

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersColumns.tsx
@@ -36,7 +36,7 @@ export function useNotifiersColumns(params?: { runningNotifications?: RunningNot
       {
         header: t('Status'),
         cell: (template: NotificationTemplate) => {
-          if (runningNotifications && runningNotifications[template.id]) {
+          if (runningNotifications?.[template.id]) {
             return <StatusCell status={'running'}></StatusCell>;
           }
           return (

--- a/frontend/awx/administration/notifiers/hooks/useNotifiersToolbarActions.tsx
+++ b/frontend/awx/administration/notifiers/hooks/useNotifiersToolbarActions.tsx
@@ -26,9 +26,7 @@ export function useNotifiersToolbarActions(
   const notificationsOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/notification_templates/`
   ).data;
-  const canAddNotificationTemplate = Boolean(
-    notificationsOptions && notificationsOptions.actions && notificationsOptions.actions['POST']
-  );
+  const canAddNotificationTemplate = Boolean(notificationsOptions?.actions?.['POST']);
 
   return useMemo<IPageAction<NotificationTemplate>[]>(
     () => [

--- a/frontend/awx/analytics/Reports/AutomationCalculator.tsx
+++ b/frontend/awx/analytics/Reports/AutomationCalculator.tsx
@@ -328,10 +328,9 @@ export function AutomationCalculatorInternal(props: {
       cluster_id: filterState.cluster_id ?? [],
       template_id: filterState.template_id ?? [],
       inventory_id: filterState.inventory_id ?? [],
-      quick_date_range:
-        filterState.quick_date_range && filterState.quick_date_range.length
-          ? filterState.quick_date_range[0]
-          : 'roi_last_year',
+      quick_date_range: filterState.quick_date_range?.length
+        ? filterState.quick_date_range[0]
+        : 'roi_last_year',
       job_type: [],
       sort_options: sortOption.value,
       sort_order: sortOrder,

--- a/frontend/awx/analytics/components/Chart/convertApi.ts
+++ b/frontend/awx/analytics/components/Chart/convertApi.ts
@@ -58,7 +58,7 @@ export const convertApiToData = (result: ApiReturnType): ChartData => {
       });
       return {
         ...item,
-        childName: s && s.name ? s.name : '',
+        childName: s?.name ?? '',
       };
     });
   }

--- a/frontend/awx/analytics/useAnalyticsView.ts
+++ b/frontend/awx/analytics/useAnalyticsView.ts
@@ -155,7 +155,7 @@ export function useAnalyticsView<T extends object, DataType extends object = Any
   let defaultSortDirection: 'asc' | 'desc' | undefined = initialDefaultSortDirection;
 
   // If a column is defined with defaultSort:true use that column to set the default sort, otherwise use the first column
-  if (tableColumns && tableColumns.length) {
+  if (tableColumns?.length) {
     const defaultSortColumn = tableColumns.find((column) => column.defaultSort) ?? tableColumns[0];
     defaultSort = defaultSortColumn?.sort;
     defaultSortDirection = defaultSortColumn?.defaultSortDirection;
@@ -280,7 +280,7 @@ export function fillFilters(
           payloadData[key] = values[0];
         } else {
           for (const value of values) {
-            if (payloadData && payloadData[key] && Array.isArray(payloadData[key])) {
+            if (payloadData?.[key] && Array.isArray(payloadData[key])) {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-call
               payloadData[key].push(value);
             }

--- a/frontend/awx/common/CredentialLabel.tsx
+++ b/frontend/awx/common/CredentialLabel.tsx
@@ -26,9 +26,7 @@ function CredentialLabel(props: { credential: Credential | SummaryFieldCredentia
     type = toTitleCase(credential.kind || '');
   }
   const vault_id =
-    credential.kind === 'vault' &&
-    (credential as Credential).inputs &&
-    (credential as Credential).inputs?.vault_id
+    credential.kind === 'vault' && (credential as Credential).inputs?.vault_id
       ? (credential as Credential).inputs?.vault_id
       : undefined;
 

--- a/frontend/awx/common/JobColumns.tsx
+++ b/frontend/awx/common/JobColumns.tsx
@@ -143,11 +143,7 @@ export function useJobSourceColumn<T extends UnifiedJob>(
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventory_sources/`);
   const inventorySourceChoices = useMemo(
     () =>
-      data &&
-      data.actions &&
-      data.actions['GET'] &&
-      data.actions['GET'].source &&
-      Array.isArray(data.actions['GET'].source.choices)
+      Array.isArray(data?.actions?.['GET']?.source?.choices)
         ? data.actions['GET'].source.choices
         : [],
     [data]

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -55,7 +55,7 @@ export function useAwxView<T extends { id: number }>(options: {
   let defaultSortDirection: 'asc' | 'desc' | undefined = options.defaultSortDirection;
 
   // If a column is defined with defaultSort:true use that column to set the default sort, otherwise use the first column
-  if (tableColumns && tableColumns.length) {
+  if (tableColumns?.length) {
     const defaultSortColumn = tableColumns.find((column) => column.defaultSort) ?? tableColumns[0];
     defaultSort = defaultSortColumn?.sort;
     defaultSortDirection = defaultSortColumn?.defaultSortDirection;

--- a/frontend/awx/common/useDynamicFilters.tsx
+++ b/frontend/awx/common/useDynamicFilters.tsx
@@ -176,7 +176,7 @@ export function useDynamicToolbarFilters(props: DynamicToolbarFiltersProps) {
 
       filterableFields.forEach((field) => {
         // Check if key is in preFilledValueKeys
-        let isPreFilled = preFilledValueKeys && preFilledValueKeys[field.key] ? true : false;
+        let isPreFilled = preFilledValueKeys?.[field.key] ? true : false;
         if (knownAwxFilterKeys[field.key]) {
           isPreFilled = true;
         }

--- a/frontend/awx/overview/cards/AwxRecentInventoriesCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentInventoriesCard.tsx
@@ -21,7 +21,7 @@ export function AwxRecentInventoriesCard() {
   const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/`
   );
-  const canCreateInventory = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateInventory = Boolean(data?.actions?.['POST']);
 
   const view = useAwxView<Inventory>({
     url: awxAPI`/inventories/`,

--- a/frontend/awx/overview/cards/AwxRecentJobsCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentJobsCard.tsx
@@ -33,12 +33,8 @@ export function AwxRecentJobsCard() {
   const { data: wfJobTemplateActions, isLoading: isLoadingWFJobTemplateOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/workflow_job_templates/`);
-  const canCreateJobTemplate = Boolean(
-    jobTemplateActions && jobTemplateActions.actions && jobTemplateActions.actions['POST']
-  );
-  const canCreateWFJobTemplate = Boolean(
-    wfJobTemplateActions && wfJobTemplateActions.actions && wfJobTemplateActions.actions['POST']
-  );
+  const canCreateJobTemplate = Boolean(jobTemplateActions?.actions?.['POST']);
+  const canCreateWFJobTemplate = Boolean(wfJobTemplateActions?.actions?.['POST']);
 
   if (isLoadingJobTemplateOptions || isLoadingWFJobTemplateOptions) {
     return (

--- a/frontend/awx/overview/cards/AwxRecentProjectsCard.tsx
+++ b/frontend/awx/overview/cards/AwxRecentProjectsCard.tsx
@@ -27,7 +27,7 @@ export function AwxRecentProjectsCard() {
   const { data, isLoading: isLoadingOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/projects/`
   );
-  const canCreateProject = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateProject = Boolean(data?.actions?.['POST']);
 
   let columns = useProjectsColumns();
   columns = useDashboardColumns(columns);

--- a/frontend/awx/resources/groups/GroupHosts.tsx
+++ b/frontend/awx/resources/groups/GroupHosts.tsx
@@ -32,7 +32,7 @@ export function GroupHosts() {
   const { data: hostOptions, isLoading: isLoadingHostOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/hosts/`);
-  const canCreateHost = Boolean(hostOptions && hostOptions.actions && hostOptions.actions['POST']);
+  const canCreateHost = Boolean(hostOptions?.actions?.['POST']);
 
   usePersistentFilters('inventories');
 

--- a/frontend/awx/resources/groups/GroupRelatedGroups.tsx
+++ b/frontend/awx/resources/groups/GroupRelatedGroups.tsx
@@ -33,9 +33,7 @@ export function GroupRelatedGroups() {
   const { data: groupsOptions, isLoading } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/groups/`
   );
-  const canCreateGroup = Boolean(
-    groupsOptions && groupsOptions.actions && groupsOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupsOptions?.actions?.['POST']);
 
   const isConstructed = params.inventory_type === 'constructed_inventory';
 

--- a/frontend/awx/resources/groups/hooks/useRelatedGroupsEmptyStateActions.tsx
+++ b/frontend/awx/resources/groups/hooks/useRelatedGroupsEmptyStateActions.tsx
@@ -30,9 +30,7 @@ export function useRelatedGroupsEmptyStateActions(view: IAwxView<InventoryGroup>
   const groupOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/${params.id ?? ''}/groups/`
   ).data;
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST']);
 
   const onSelectedGroups = useCallback(
     async (selectedGroups: InventoryGroup[]) => {

--- a/frontend/awx/resources/groups/hooks/useRelatedGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/groups/hooks/useRelatedGroupsToolbarActions.tsx
@@ -42,9 +42,7 @@ export function useRelatedGroupsToolbarActions(view: IAwxView<InventoryGroup>) {
   const groupOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/${params.id ?? ''}/groups/`
   ).data;
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST']);
 
   const onSelectedGroups = useCallback(
     async (selectedGroups: InventoryGroup[]) => {

--- a/frontend/awx/resources/hosts/Hosts.tsx
+++ b/frontend/awx/resources/hosts/Hosts.tsx
@@ -35,7 +35,7 @@ export function Hosts() {
   const { data, isLoading: isLoadingHostOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/hosts/`
   );
-  const canCreateHost = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateHost = Boolean(data?.actions?.['POST']);
 
   return (
     <PageLayout>

--- a/frontend/awx/resources/hosts/hooks/useHostsEmptyStateActions.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostsEmptyStateActions.tsx
@@ -35,7 +35,7 @@ export function useHostsEmptyStateActions(view: IAwxView<AwxHost>) {
   const hostOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/${params.id ?? ''}/hosts/`
   ).data;
-  const canCreateHost = Boolean(hostOptions && hostOptions.actions && hostOptions.actions['POST']);
+  const canCreateHost = Boolean(hostOptions?.actions?.['POST']);
 
   const onSelectedHosts = useCallback(
     async (selectedHosts: AwxHost[]) => {

--- a/frontend/awx/resources/hosts/hooks/useHostsToolbarActions.tsx
+++ b/frontend/awx/resources/hosts/hooks/useHostsToolbarActions.tsx
@@ -23,7 +23,7 @@ export function useHostsToolbarActions(view: IAwxView<AwxHost>) {
   const deleteHosts = useDeleteHosts(view.unselectItemsAndRefresh);
 
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/hosts/`);
-  const canCreateHost = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateHost = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<AwxHost>[]>(
     () => [

--- a/frontend/awx/resources/inventories/Inventories.tsx
+++ b/frontend/awx/resources/inventories/Inventories.tsx
@@ -38,7 +38,7 @@ export function Inventories() {
   const { data, isLoading: isLoadingInventoryOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/inventories/`);
-  const canCreateInventory = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateInventory = Boolean(data?.actions?.['POST']);
   const toolbarFilters = useInventoriesFilters();
   const tableColumns = useInventoriesColumns();
   const view = useAwxView<Inventory>({

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -35,9 +35,7 @@ export function InventoryGroups() {
   const { data: groupOptions, isLoading: isLoadingGroupOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/groups/`);
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST'] && !constructed_inventory
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST'] && !constructed_inventory);
 
   let emptyStateTitle = '';
   let emptyStateDescription = '';

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
@@ -36,10 +36,7 @@ export function InventoryHosts() {
     OptionsResponse<ActionsResponse>
   >(awxAPI`/hosts/`);
   const canCreateHost = Boolean(
-    hostOptions &&
-      hostOptions.actions &&
-      hostOptions.actions['POST'] &&
-      params.inventory_type === 'inventory'
+    hostOptions?.actions?.['POST'] && params.inventory_type === 'inventory'
   );
 
   let emptyStateTitle = '';

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -50,9 +50,7 @@ export function InventorySources() {
   const { data: sourceOptions, isLoading: isLoadingSourceOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/inventory_sources/`);
-  const canCreateSource = Boolean(
-    sourceOptions && sourceOptions.actions && sourceOptions.actions['POST']
-  );
+  const canCreateSource = Boolean(sourceOptions?.actions?.['POST']);
 
   usePersistentFilters('inventories');
 

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsHostsToolbarActions.tsx
@@ -37,7 +37,7 @@ export function useInventoriesGroupsHostsToolbarActions(view: IAwxView<AwxHost>)
   });
 
   const hostOptions = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/hosts/`).data;
-  const canCreateHost = Boolean(hostOptions && hostOptions.actions && hostOptions.actions['POST']);
+  const canCreateHost = Boolean(hostOptions?.actions?.['POST']);
 
   const onSelectedHosts = useCallback(
     async (selectedHosts: AwxHost[]) => {

--- a/frontend/awx/resources/inventories/hooks/useInventoriesGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesGroupsToolbarActions.tsx
@@ -32,9 +32,7 @@ export function useInventoriesGroupsToolbarActions(view: IAwxView<InventoryGroup
     awxAPI`/inventories/${params.id ?? ''}/groups/`
   ).data;
 
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST']);
 
   const selectedItems = view.selectedItems || [];
   const runCommandAction = useRunCommandAction<InventoryGroup>({
@@ -113,9 +111,7 @@ export function useRunCommandAction<T extends { name: string }>(
   const adhocOptions = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/inventories/${params.id ?? ''}/ad_hoc_commands/`
   ).data;
-  const canRunAdHocCommand = Boolean(
-    adhocOptions && adhocOptions.actions && adhocOptions.actions['POST']
-  );
+  const canRunAdHocCommand = Boolean(adhocOptions?.actions?.['POST']);
 
   const onClick = useCallback(
     (selectedItems: T[]) => {

--- a/frontend/awx/resources/inventories/hooks/useInventoriesHostsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesHostsToolbarActions.tsx
@@ -34,7 +34,7 @@ export function useInventoriesHostsToolbarActions(view: IAwxView<AwxHost>) {
   });
 
   const hostOptions = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/hosts/`).data;
-  const canCreateHost = Boolean(hostOptions && hostOptions.actions && hostOptions.actions['POST']);
+  const canCreateHost = Boolean(hostOptions?.actions?.['POST']);
 
   return useMemo<IPageAction<AwxHost>[]>(() => {
     const actions: IPageAction<AwxHost>[] = [];

--- a/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesSourcesToolbarActions.tsx
@@ -34,9 +34,7 @@ export function useInventoriesSourcesToolbarActions(
     awxAPI`/inventory_sources/`
   ).data;
 
-  const canCreateSource = Boolean(
-    sourceOptions && sourceOptions.actions && sourceOptions.actions['POST']
-  );
+  const canCreateSource = Boolean(sourceOptions?.actions?.['POST']);
 
   const { activeAwxUser } = useAwxActiveUser();
 

--- a/frontend/awx/resources/inventories/hooks/useInventoriesToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventoriesToolbarActions.tsx
@@ -21,7 +21,7 @@ export function useInventoriesToolbarActions(view: IAwxView<Inventory>) {
   const pageNavigate = usePageNavigate();
   const deleteInventories = useDeleteInventories(view.unselectItemsAndRefresh);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventories/`);
-  const canCreateInventory = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateInventory = Boolean(data?.actions?.['POST']);
 
   return useMemo<IPageAction<Inventory>[]>(() => {
     const actions: IPageAction<Inventory>[] = [

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -49,9 +49,7 @@ export function InventoryHostGroups(props: { page: string }) {
   const { data: groupOptions, isLoading: isLoadingGroupOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(awxAPI`/groups/`);
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST']);
 
   usePersistentFilters('inventories');
 

--- a/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/hooks/useHostsGroupsToolbarActions.tsx
@@ -25,9 +25,7 @@ export function useHostsGroupsToolbarActions(
   const disassociateGroups = useDisassociateGroups(view.unselectItemsAndRefresh, hostId);
 
   const groupOptions = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/groups/`).data;
-  const canCreateGroup = Boolean(
-    groupOptions && groupOptions.actions && groupOptions.actions['POST']
-  );
+  const canCreateGroup = Boolean(groupOptions?.actions?.['POST']);
 
   const openInventoryHostsGroupsAddModal = useInventoryHostGroupsAddModal();
   const associateGroups = useAssociateGroupsToHost(view.unselectItemsAndRefresh, hostId);

--- a/frontend/awx/resources/projects/ProjectPage/ProjectForm.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectForm.tsx
@@ -93,7 +93,7 @@ export function EditProject() {
   const id = Number(params.id);
   const { data: project } = useGet<Project>(awxAPI`/projects/${id.toString()}/`);
 
-  if (project && project.scm_type === '') {
+  if (project?.scm_type === '') {
     project.scm_type = 'manual';
   }
 

--- a/frontend/awx/resources/projects/Projects.tsx
+++ b/frontend/awx/resources/projects/Projects.tsx
@@ -39,7 +39,7 @@ export function Projects() {
   const { data, isLoading: isLoadingProjectOptions } = useOptions<OptionsResponse<ActionsResponse>>(
     awxAPI`/projects/`
   );
-  const canCreateProject = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateProject = Boolean(data?.actions?.['POST']);
   const { refresh } = view;
   usePersistentFilters('projects');
 

--- a/frontend/awx/resources/projects/hooks/useProjectToolbarActions.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectToolbarActions.tsx
@@ -20,7 +20,7 @@ export function useProjectToolbarActions(onComplete: (projects: Project[]) => vo
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/projects/`);
-  const canCreateProject = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateProject = Boolean(data?.actions?.['POST']);
 
   const deleteProjects = useDeleteProjects(onComplete);
   const cancelProjects = useCancelProjects(onComplete);

--- a/frontend/awx/resources/templates/TemplatePage/TemplateDetails.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateDetails.test.tsx
@@ -9,7 +9,7 @@ const mockWebhookKey = { webhook_key: 'test-webhook-key-value' };
 
 vi.mock('@ansible/common-ui/crud/useGet', () => ({
   useGet: vi.fn((url: string | undefined) => {
-    if (url && url.includes('webhook_key')) {
+    if (url?.includes('webhook_key')) {
       return { data: mockWebhookKey };
     }
     return { data: null };

--- a/frontend/awx/resources/templates/TemplatesList.tsx
+++ b/frontend/awx/resources/templates/TemplatesList.tsx
@@ -95,13 +95,9 @@ export function TemplatesList(props: Readonly<TemplatesListProps>) {
     OptionsResponse<ActionsResponse>
   >(awxAPI`/workflow_job_templates/`);
 
-  const canCreateJobTemplate = Boolean(
-    jobTemplateActions && jobTemplateActions.actions && jobTemplateActions.actions['POST']
-  );
+  const canCreateJobTemplate = Boolean(jobTemplateActions?.actions?.['POST']);
 
-  const canCreateWFJobTemplate = Boolean(
-    wfJobTemplateActions && wfJobTemplateActions.actions && wfJobTemplateActions.actions['POST']
-  );
+  const canCreateWFJobTemplate = Boolean(wfJobTemplateActions?.actions?.['POST']);
 
   const isLoadingPermissions = isLoadingJobTemplateActions || isLoadingWfJobTemplateActions;
 

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplateDetails.test.tsx
@@ -9,7 +9,7 @@ const mockWebhookKey = { webhook_key: 'test-webhook-key-value' };
 
 vi.mock('@ansible/common-ui/crud/useGet', () => ({
   useGet: vi.fn((url: string | undefined) => {
-    if (url && url.includes('webhook_key')) {
+    if (url?.includes('webhook_key')) {
       return { data: mockWebhookKey };
     }
     return { data: null };

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/CustomNode.tsx
@@ -54,7 +54,7 @@ export const CustomNode: FC<
       onSelect={(e) => {
         if (!jobType) return;
         setSidebarMode('view');
-        onSelect && onSelect(e);
+        onSelect?.(e);
       }}
       truncateLength={20}
       raiseLabelOnHover={false}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/NodeContextMenu.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/NodeContextMenu.tsx
@@ -97,7 +97,7 @@ export function NodeContextMenu(props: { element: Node<NodeModel, GraphNodeData>
         icon={item.icon}
         isDanger={item.isDanger}
         onClick={() => {
-          item?.onClick && item.onClick();
+          item?.onClick?.();
         }}
       >
         {item.label}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -109,7 +109,7 @@ export function useSaveVisualizer(templateId: string) {
           }
         );
 
-        if (workflowNode && workflowNode.id) {
+        if (workflowNode?.id) {
           await postWorkflowNodeApproval(
             awxAPI`/workflow_job_template_nodes/${workflowNode.id.toString()}/create_approval_template/`,
             {
@@ -140,7 +140,7 @@ export function useSaveVisualizer(templateId: string) {
           }
         );
 
-        if (workflowNode && workflowNode.id) {
+        if (workflowNode?.id) {
           // wf approval node doesn't exist, create it
           if (nodeTemplate.id === -1) {
             await postWorkflowNodeApproval(

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSelectedNode.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSelectedNode.tsx
@@ -11,7 +11,7 @@ export function useSelectedNode() {
   const { selectedIds } = controller.getState<SelectionHandlerState>();
 
   const node = useMemo<GraphNode | undefined>(() => {
-    const selectedId = selectedIds && selectedIds[0];
+    const selectedId = selectedIds?.[0];
 
     if (selectedId) {
       return controller.getNodeById(selectedId) as GraphNode;

--- a/frontend/awx/resources/templates/hooks/useSurveyToolbarActions.tsx
+++ b/frontend/awx/resources/templates/hooks/useSurveyToolbarActions.tsx
@@ -38,7 +38,7 @@ export function useSurveyToolbarActions(
       ? awxAPI`/${isJobTemplate ? 'job_templates' : 'workflow_job_templates'}/${id.toString()}/`
       : ''
   );
-  const canModifySurvey = Boolean(options && options.actions && options.actions['PUT']);
+  const canModifySurvey = Boolean(options?.actions?.['PUT']);
 
   return useMemo<IPageAction<Spec>[]>(
     () => [

--- a/frontend/awx/resources/templates/hooks/useSurveyView.tsx
+++ b/frontend/awx/resources/templates/hooks/useSurveyView.tsx
@@ -50,7 +50,7 @@ export function useSurveyView(options: { url: string }): ISurveyView {
 
   const selection = useSelected<Spec>(data?.spec ?? [], getSpecKey);
 
-  if (data && data.spec !== undefined) {
+  if (data?.spec !== undefined) {
     itemCountRef.current.itemCount = data.spec.length;
   } else if (data && data.spec === undefined) {
     itemCountRef.current.itemCount = 0;

--- a/frontend/awx/views/jobs/JobExpanded.tsx
+++ b/frontend/awx/views/jobs/JobExpanded.tsx
@@ -24,11 +24,7 @@ export function JobExpanded(job: UnifiedJob) {
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventory_sources/`);
   const inventorySourceChoices = useMemo(
     () =>
-      data &&
-      data.actions &&
-      data.actions['GET'] &&
-      data.actions['GET'].source &&
-      Array.isArray(data.actions['GET'].source.choices)
+      Array.isArray(data?.actions?.['GET']?.source?.choices)
         ? data.actions['GET'].source.choices
         : [],
     [data]

--- a/frontend/awx/views/jobs/JobOutput/util.ts
+++ b/frontend/awx/views/jobs/JobOutput/util.ts
@@ -20,7 +20,7 @@ export function isHostEvent(jobEvent: JobEvent) {
   const { event, event_data, host, type } = jobEvent;
   let isHost;
 
-  if (typeof host === 'number' || (event_data && event_data.res)) {
+  if (typeof host === 'number' || event_data?.res) {
     isHost = true;
   } else if (type === 'project_update_event' && event !== 'runner_on_skipped' && event_data?.host) {
     isHost = true;

--- a/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsColumns.tsx
@@ -29,11 +29,7 @@ export function useJobsColumns(options?: { disableSort?: boolean; disableLinks?:
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/inventory_sources/`);
   const inventorySourceChoices = useMemo(
     () =>
-      data &&
-      data.actions &&
-      data.actions['GET'] &&
-      data.actions['GET'].source &&
-      Array.isArray(data.actions['GET'].source.choices)
+      Array.isArray(data?.actions?.['GET']?.source?.choices)
         ? data.actions['GET'].source.choices
         : [],
     [data]

--- a/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
+++ b/frontend/awx/views/jobs/hooks/useRelaunchJob.tsx
@@ -57,10 +57,7 @@ export function useRelaunchJob(jobRelaunchParams?: JobRelaunch) {
 
       // Relaunch job
 
-      if (
-        (relaunchConfig as JobRelaunch).passwords_needed_to_start &&
-        (relaunchConfig as JobRelaunch).passwords_needed_to_start?.length
-      ) {
+      if ((relaunchConfig as JobRelaunch).passwords_needed_to_start?.length) {
         pageNavigate(AwxRoute.TemplateLaunchWithPasswordsWizard, {
           params: { id: job.id, job_type: 'playbook' },
         });

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -81,7 +81,7 @@ export function SchedulesList(props: {
   const { data, isLoading: isLoadingScheduleOptions } = useOptions<
     OptionsResponse<ActionsResponse>
   >(apiEndPoint ?? awxAPI`/schedules/`);
-  const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateSchedule = Boolean(data?.actions?.['POST']);
 
   const toolbarActions = useScheduleToolbarActions(
     view.unselectItemsAndRefresh,

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -54,7 +54,7 @@ export function RuleForm(
     timezone = 'America/New_York',
     startDateTime: { date, time },
   } = wizardData as ScheduleFormWizard;
-  const isRulesStep = activeStep && activeStep.id === 'rules';
+  const isRulesStep = activeStep?.id === 'rules';
   const weekdayOptions = useGetWeekdayOptions();
   const frequencyOptions = useGetFrequencyOptions();
   const monthOptions = useGetMonthOptions();

--- a/frontend/awx/views/schedules/hooks/useRuleRowActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useRuleRowActions.tsx
@@ -20,7 +20,7 @@ export function useRuleRowActions(
 
   return useMemo<IPageAction<RuleListItemType>[]>(() => {
     if (!setIsOpen) return [];
-    const isExceptionStep = wizard.activeStep && wizard.activeStep.id === 'exceptions';
+    const isExceptionStep = wizard.activeStep?.id === 'exceptions';
     const existingRules = context.getValues('rules') as RuleListItemType[];
     const existingExceptions = context.getValues('exceptions') as RuleListItemType[];
 

--- a/frontend/awx/views/schedules/hooks/useSchedulesActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useSchedulesActions.tsx
@@ -26,7 +26,7 @@ export function useSchedulesActions(options: {
   const { t } = useTranslation();
   const deleteSchedule = useDeleteSchedules(options?.onScheduleDeleteCompleted);
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/schedules/`);
-  const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateSchedule = Boolean(data?.actions?.['POST']);
   const handleToggleSchedule: (schedule: Schedule, enabled: boolean) => Promise<void> = useCallback(
     async (schedule, enabled) => {
       const patchedSchedule = await requestPatch<Schedule>(

--- a/frontend/awx/views/schedules/hooks/useSchedulesToolbarActions.tsx
+++ b/frontend/awx/views/schedules/hooks/useSchedulesToolbarActions.tsx
@@ -17,7 +17,7 @@ export function useScheduleToolbarActions(
 ) {
   const { t } = useTranslation();
   const { data } = useOptions<OptionsResponse<ActionsResponse>>(awxAPI`/schedules/`);
-  const canCreateSchedule = Boolean(data && data.actions && data.actions['POST']);
+  const canCreateSchedule = Boolean(data?.actions?.['POST']);
 
   const deleteSchedules = useDeleteSchedules(onComplete);
 


### PR DESCRIPTION
## Summary

Resolves **82 SonarCloud S6582 violations** across **68 files** in the AWX workspace by replacing verbose null-guard patterns with optional chaining (`?.`).

**SonarCloud Rule:** [typescript:S6582 – Prefer using an optional chain expression](https://sonarcloud.io/project/issues?id=ansible_ansible-ui&rules=typescript:S6582)

### Common patterns fixed

| Before | After |
|--------|-------|
| `Boolean(data && data.actions && data.actions['POST'])` | `Boolean(data?.actions?.['POST'])` |
| `deleteRole && deleteRole(role, user)` | `deleteRole?.(role, user)` |
| `map && map[key]` | `map?.[key]` |
| `s && s.name ? s.name : ''` | `s?.name ?? ''` |
| `item?.onClick && item.onClick()` | `item?.onClick?.()` |

All changes are mechanical refactors — no logic changes.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Validation performed

- `npm run tsc` — **passes** (all 8 projects)
- `npm run vitest` (AWX workspace) — **3 pre-existing failures**, none in modified files

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

No manual testing required — all changes are mechanical syntax transformations that preserve identical runtime behavior. TypeScript compiler confirms type safety.