### PR TITLE
[AAP-70106] fix: use dynamic copyright year in About modal

### DIFF
--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -77,7 +77,10 @@ describe('PlatformAbout', () => {
     const dialog = await screen.findByRole('dialog');
 
     expect(within(dialog).getByText(/Ansible Automation Platform/)).toBeInTheDocument();
-    expect(within(dialog).getByText(/Copyright.*Red Hat/)).toBeInTheDocument();
+    const currentYear = new Date().getFullYear().toString();
+    expect(
+      within(dialog).getByText(new RegExp(`Copyright ${currentYear} Red Hat`))
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(within(dialog).getByText('Automation Controller Version')).toBeInTheDocument();

--- a/platform/main/PlatformAbout.tsx
+++ b/platform/main/PlatformAbout.tsx
@@ -30,7 +30,9 @@ export const PlatformAbout: React.FunctionComponent<{
         setPageDialog(undefined)
       }
       productName={t('Ansible Automation Platform {{version}}', { version: platformVersion })}
-      trademark="Copyright 2025 Red Hat, Inc."
+      trademark={t(`Copyright {{fullYear}} Red Hat, Inc.`, {
+        fullYear: new Date().getFullYear(),
+      })}
       brandImageAlt={t('Brand Logo')}
       brandImageSrc={settings?.activeTheme === 'dark' ? platformLogoWhite : platformLogo}
     >


### PR DESCRIPTION
## Summary

The PlatformAbout modal hardcoded "Copyright 2025 Red Hat, Inc." instead of
computing the year dynamically. This replaces the static string with
`new Date().getFullYear()` wrapped in the `t()` i18n function, matching the
pattern already used in the common `AboutModal` component.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Start the dev server (`npm start` from `/platform`)
2. Open https://localhost:4100
3. Click the help menu in the masthead → "About"
4. Verify the copyright year shows the current year (2026)

### Unit Tests

- Updated `PlatformAbout.test.tsx` to assert the current year appears in the copyright string
- All 5 existing tests pass

Before:
<img width="1392" height="1522" alt="Screenshot 2026-05-04 at 1 42 16 PM" src="https://github.com/user-attachments/assets/3d1de879-e9f9-4617-94b3-4e44155c1eb5" />

After:
<img width="1392" height="1522" alt="Screenshot 2026-05-04 at 1 41 29 PM" src="https://github.com/user-attachments/assets/af570039-717b-42e5-8331-354d3a7edb10" />
