### PR TITLE
AAP-72815 XLAB Add Dashboard Currency

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -182,9 +182,11 @@ describe('DashboardMainTableCard', () => {
       within(screen.getByTestId('cost-manual-automation-card')).getByText(/1[,.]?000/)
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('cost-automated-execution-card')).getByText('500')
+      within(screen.getByTestId('cost-automated-execution-card')).getByText('$500.00')
     ).toBeInTheDocument();
-    expect(within(screen.getByTestId('total-savings-card')).getByText('500')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('total-savings-card')).getByText('$500.00')
+    ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('total-hours-saved-card')).getByText(/50 h/)
     ).toBeInTheDocument();
@@ -201,9 +203,9 @@ describe('DashboardMainTableCard', () => {
       })
     );
     expect(
-      within(screen.getByTestId('cost-manual-automation-card')).getByText('0')
+      within(screen.getByTestId('cost-manual-automation-card')).getByText('$0.00')
     ).toBeInTheDocument();
-    expect(within(screen.getByTestId('total-savings-card')).getByText('0')).toBeInTheDocument();
+    expect(within(screen.getByTestId('total-savings-card')).getByText('$0.00')).toBeInTheDocument();
   });
 
   test('should display - in all value cards when details is undefined', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -179,7 +179,7 @@ describe('DashboardMainTableCard', () => {
   test('should display details values in value cards', () => {
     renderCard();
     expect(
-      within(screen.getByTestId('cost-manual-automation-card')).getByText(/1[,.]?000/)
+      within(screen.getByTestId('cost-manual-automation-card')).getByText('$1,000.00')
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('cost-automated-execution-card')).getByText('$500.00')

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -207,6 +207,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           title={t('Cost of manual automation')}
           help={t('Total cost if all jobs were run manually')}
           value={details?.cost_of_manual_automation ?? '-'}
+          formatAsCurrency={true}
           error={detailsError}
           errorStateTitle={t('Error loading manual automation cost')}
         ></DashboardValueCard>
@@ -215,6 +216,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           title={t('Cost of automated execution')}
           help={t('Total cost of running jobs on AAP')}
           value={details?.cost_of_automated_execution ?? '-'}
+          formatAsCurrency={true}
           error={detailsError}
           errorStateTitle={t('Error loading automated execution cost')}
         ></DashboardValueCard>
@@ -223,6 +225,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           title={t('Total savings/cost avoided')}
           help={t('Difference between manual and automated cost')}
           value={details?.total_saving ?? '-'}
+          formatAsCurrency={true}
           error={detailsError}
           errorStateTitle={t('Error loading total savings')}
         ></DashboardValueCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -104,7 +104,7 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
     >
       <FlexItem>
         <DashboardTableInputField
-          label={t('Hourly rate for manually running the job')}
+          label={t('Hourly rate for manually running the job ({{currency}})', { currency: '$' })}
           labelHelp={t(
             'The hourly labor cost used to estimate what it would cost to run these jobs manually. Used to calculate manual cost and savings in the table below.'
           )}
@@ -121,7 +121,7 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
       </FlexItem>
       <FlexItem>
         <DashboardTableInputField
-          label={t('Monthly AAP cost')}
+          label={t('Monthly AAP cost ({{currency}})', { currency: '$' })}
           labelHelp={t(
             'Monthly cost of running the Ansible Automation Platform. This value includes license, labor and infrastructure costs to run AAP. It is used to calculate the automation savings'
           )}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
@@ -83,7 +83,7 @@ describe('DashboardValueCard', () => {
     );
     expect(screen.getByText('Card Error')).toBeInTheDocument();
     expect(screen.getByText('Something failed')).toBeInTheDocument();
-    expect(screen.queryByText((12345).toLocaleString())).not.toBeInTheDocument();
+    expect(screen.queryByText((12345).toLocaleString('en-US'))).not.toBeInTheDocument();
   });
 
   test('should not render error state when error is not provided', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
@@ -24,7 +24,7 @@ describe('DashboardValueCard', () => {
       </MemoryRouter>
     );
     expect(screen.getByText('Test Title')).toBeInTheDocument();
-    expect(screen.getByText(/12[.,]345/)).toBeInTheDocument();
+    expect(screen.getByText('12,345', { exact: false })).toBeInTheDocument();
     expect(screen.getByText(/EUR/)).toBeInTheDocument();
   });
 
@@ -83,7 +83,7 @@ describe('DashboardValueCard', () => {
     );
     expect(screen.getByText('Card Error')).toBeInTheDocument();
     expect(screen.getByText('Something failed')).toBeInTheDocument();
-    expect(screen.queryByText(/12[.,]345/)).not.toBeInTheDocument();
+    expect(screen.queryByText((12345).toLocaleString())).not.toBeInTheDocument();
   });
 
   test('should not render error state when error is not provided', () => {
@@ -93,6 +93,62 @@ describe('DashboardValueCard', () => {
       </MemoryRouter>
     );
     expect(screen.queryByText('Card Error')).not.toBeInTheDocument();
-    expect(screen.getByText(/12[.,]345/)).toBeInTheDocument();
+    expect(screen.getByText('12,345', { exact: false })).toBeInTheDocument();
+  });
+
+  describe('formatAsCurrency', () => {
+    test('should format numeric value as USD currency when formatAsCurrency is true', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard
+            {...defaultProps}
+            value={2500}
+            valueSuffix={undefined}
+            formatAsCurrency={true}
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('$2,500.00')).toBeInTheDocument();
+    });
+
+    test('should use toLocaleString when formatAsCurrency is false', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard
+            {...defaultProps}
+            value={2500}
+            valueSuffix={undefined}
+            formatAsCurrency={false}
+          />
+        </MemoryRouter>
+      );
+      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
+      expect(screen.getByText('2,500')).toBeInTheDocument();
+    });
+
+    test('should use toLocaleString when formatAsCurrency is omitted', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} value={2500} valueSuffix={undefined} />
+        </MemoryRouter>
+      );
+      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
+      expect(screen.getByText('2,500')).toBeInTheDocument();
+    });
+
+    test('should still render valueSuffix alongside currency-formatted value', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard
+            {...defaultProps}
+            value={1000}
+            valueSuffix="*"
+            formatAsCurrency={true}
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByText(/\$1,000\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/\*/)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
@@ -3,14 +3,28 @@ import { Content, Flex, FlexItem } from '@patternfly/react-core';
 import { DashboardValueCardProps } from '../types';
 import { Link } from 'react-router-dom';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
+import { currencyFormatter } from '../../utilities/currencyFormatter';
 
 export function DashboardValueCard(props: DashboardValueCardProps) {
-  const { id, title, help, value, linkText, to, valueSuffix, error, errorStateTitle } = props;
+  const {
+    id,
+    title,
+    help,
+    value,
+    linkText,
+    to,
+    valueSuffix,
+    error,
+    errorStateTitle,
+    formatAsCurrency,
+  } = props;
+
+  const usFormat = 'en-US';
 
   const contentValue =
     typeof value === 'number' ? (
-      <span style={{ fontSize: 'xxx-large', fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
-        {value.toLocaleString()}
+      <span style={{ fontSize: 'xx-large', fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
+        {formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(usFormat)}
         {valueSuffix ? ` ${valueSuffix}` : ''}
       </span>
     ) : (

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -102,6 +102,7 @@ type DashboardCommonCardProps = {
 export type DashboardValueCardProps = DashboardCommonCardProps & {
   value: string | number;
   valueSuffix?: string;
+  formatAsCurrency?: boolean;
   linkText?: string;
   to?: string;
 };


### PR DESCRIPTION
## Summary
This pull request updates the automation dashboard to consistently display monetary values as formatted currency (USD) in both the UI and tests. It introduces a `formatAsCurrency` prop to the `DashboardValueCard` component and applies it to relevant cards, ensuring values like costs and savings are shown with a dollar sign and two decimal places. Additionally, input field labels are updated to clarify the currency being used.

**Currency formatting improvements:**

* Added a `formatAsCurrency` prop to the `DashboardValueCard` component, using a new `currencyFormatter` utility to display numbers as USD currency (e.g., `$2,500.00`). [[1]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8R6-R27) [[2]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbR105)
* Updated the dashboard summary cards (`cost_of_manual_automation`, `cost_of_automated_execution`, and `total_saving`) to use currency formatting by passing `formatAsCurrency={true}`. [[1]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R210) [[2]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R219) [[3]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R228)

**UI and label clarity:**

* Changed input field labels in `DashboardTableToolbarRow` to explicitly show the currency, e.g., "Hourly rate for manually running the job ($)". [[1]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L107-R107) [[2]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L124-R124)

**Test updates:**

* Adjusted tests for `DashboardMainTableCard` and `DashboardValueCard` to expect currency-formatted values (e.g., `$500.00` instead of `500`), and added tests for the new `formatAsCurrency` prop logic. [[1]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806L185-L187) [[2]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806L204-R208) [[3]](diffhunk://#diff-75ba12bdd16f3b6d794771faefbadfee6cc8639281c8fc6aa1c94230e307009bL27-R27) [[4]](diffhunk://#diff-75ba12bdd16f3b6d794771faefbadfee6cc8639281c8fc6aa1c94230e307009bL86-R86) [[5]](diffhunk://#diff-75ba12bdd16f3b6d794771faefbadfee6cc8639281c8fc6aa1c94230e307009bL96-R152)

These changes ensure consistency and clarity in how monetary values are displayed throughout the dashboard.
<!-- What changed and why? -->
[AAP-72815](https://redhat.atlassian.net/browse/AAP-72815)


## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->

<img width="2508" height="526" alt="image" src="https://github.com/user-attachments/assets/a09acb11-4455-4c08-be40-0a20989786d4" />


<img width="2508" height="526" alt="image" src="https://github.com/user-attachments/assets/d36ff949-3b3b-4dfc-a3be-e3ab246de218" />

