### PR TITLE
SonarCloud Fix: Mark React props as readonly (S6759, platform) [batch 2/2]

### DIFF
--- a/platform/access/users/components/PlatformAwxUserIdLookup.tsx
+++ b/platform/access/users/components/PlatformAwxUserIdLookup.tsx
@@ -17,7 +17,7 @@ import { gatewayAPI } from '../../../utils/gateway-api-utils';
  * looks this user up in the gateway API to get its ansible_id and uses the ansible_id to
  * look the user up in AWX. It then renders the child component passing the AWX user ID to it as a prop.
  */
-export function PlatformAwxUserIdLookup(props: { children: ReactNode }) {
+export function PlatformAwxUserIdLookup(props: Readonly<{ children: ReactNode }>) {
   const params = useParams<{ id: string }>();
   const { t } = useTranslation();
   const { data: user } = useGetItem<PlatformUser>(gatewayAPI`/users/`, params.id);

--- a/platform/access/users/components/PlatformEdaUserIdLookup.tsx
+++ b/platform/access/users/components/PlatformEdaUserIdLookup.tsx
@@ -12,7 +12,7 @@ import { useParams } from 'react-router-dom';
 import { PlatformUser } from '../../../interfaces/PlatformUser';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 
-export function PlatformEdaUserIdLookup(props: { children: ReactNode }) {
+export function PlatformEdaUserIdLookup(props: Readonly<{ children: ReactNode }>) {
   const params = useParams<{ id: string }>();
   const { t } = useTranslation();
   const { data: user } = useGetItem<PlatformUser>(gatewayAPI`/users/`, params.id);

--- a/platform/access/users/components/PlatformHubUserIdLookup.tsx
+++ b/platform/access/users/components/PlatformHubUserIdLookup.tsx
@@ -11,7 +11,7 @@ import { useHubResource } from '../../../hooks/useHubResource';
 import { PlatformUser } from '../../../interfaces/PlatformUser';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 
-export function PlatformHubUserIdLookup(props: { children: ReactNode }) {
+export function PlatformHubUserIdLookup(props: Readonly<{ children: ReactNode }>) {
   const params = useParams<{ id: string }>();
   const { t } = useTranslation();
   const { data: user } = useGetItem<PlatformUser>(gatewayAPI`/users/`, params.id);

--- a/platform/access/users/components/PlatformUserForm.tsx
+++ b/platform/access/users/components/PlatformUserForm.tsx
@@ -362,7 +362,7 @@ export function EditPlatformUser() {
   );
 }
 
-function PlatformUserInputs(props: { isCreate?: boolean }) {
+function PlatformUserInputs(props: Readonly<{ isCreate?: boolean }>) {
   const { t } = useTranslation();
 
   const USER_TYPE_OPTIONS = [

--- a/platform/access/users/components/PlatformUsersAssignRoles.tsx
+++ b/platform/access/users/components/PlatformUsersAssignRoles.tsx
@@ -33,7 +33,9 @@ interface ResourceRolePair {
   role: PlatformRole;
 }
 
-export function PlatformUsersAssignRoles(props: { id?: string; userRolesRoute?: string }) {
+export function PlatformUsersAssignRoles(
+  props: Readonly<{ id?: string; userRolesRoute?: string }>
+) {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const getPageUrl = useGetPageUrl();

--- a/platform/common/PlatformServiceNavigation.tsx
+++ b/platform/common/PlatformServiceNavigation.tsx
@@ -3,7 +3,9 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGatewayService } from '../main/GatewayServices';
 
-export function PlatformServiceNavigation(props: { awx?: string; eda?: string; hub?: string }) {
+export function PlatformServiceNavigation(
+  props: Readonly<{ awx?: string; eda?: string; hub?: string }>
+) {
   const { t } = useTranslation();
   const awxService = useGatewayService('controller');
   const edaService = useGatewayService('eda');

--- a/platform/hooks/useActivePlatformUser.tsx
+++ b/platform/hooks/useActivePlatformUser.tsx
@@ -14,7 +14,7 @@ export function useActivePlatformUser() {
   return useContext(ActivePlatformUserContext) as PlatformUser;
 }
 
-export function ActivePlatformUserProvider(props: { children?: ReactNode }) {
+export function ActivePlatformUserProvider(props: Readonly<{ children?: ReactNode }>) {
   const [activeUser, setActiveUser] = useState<PlatformUser | null | undefined>(undefined);
   const userResponse = useGet<PlatformItemsResponse<PlatformUser>>(gatewayAPI`/me/`);
   useEffect(() => {

--- a/platform/main/GatewayServices.tsx
+++ b/platform/main/GatewayServices.tsx
@@ -20,7 +20,7 @@ export function useGatewayServices() {
   return useContext(GatewayServicesContext);
 }
 
-export function GatewayServicesProvider(props: { children: ReactNode }) {
+export function GatewayServicesProvider(props: Readonly<{ children: ReactNode }>) {
   const [gatewayServices, setGatewayServices] = useState<GatewayServices>();
   const result = useSWR<{
     apis: {

--- a/platform/main/GatewayUIAuth.tsx
+++ b/platform/main/GatewayUIAuth.tsx
@@ -10,7 +10,7 @@ export function useGatewayUIAuth() {
   return useContext(ManagedCloudInstallContext);
 }
 
-export function GatewayUIAuthProvider(props: { children: ReactNode }) {
+export function GatewayUIAuthProvider(props: Readonly<{ children: ReactNode }>) {
   const response = useSWR<UIAuth>(gatewayAPI`/ui_auth/`, requestGet);
   return (
     <ManagedCloudInstallContext.Provider value={response?.data}>

--- a/platform/main/PlatformActiveUserProvider.tsx
+++ b/platform/main/PlatformActiveUserProvider.tsx
@@ -16,7 +16,7 @@ export function usePlatformActiveUser() {
   return useContext(PlatformActiveUserContext);
 }
 
-export function PlatformActiveUserProvider(props: { children: ReactNode }) {
+export function PlatformActiveUserProvider(props: Readonly<{ children: ReactNode }>) {
   const response = useSWR<PlatformItemsResponse<PlatformUser>>(gatewayAPI`/me/`, requestGet, {
     dedupingInterval: 0,
     refreshInterval: 10 * 1000,

--- a/platform/main/PlatformLogin.tsx
+++ b/platform/main/PlatformLogin.tsx
@@ -20,7 +20,7 @@ const Logo = styled(PlatformLogo)`
   }
 `;
 
-export function PlatformLogin(props: { children: ReactNode }) {
+export function PlatformLogin(props: Readonly<{ children: ReactNode }>) {
   const { activePlatformUser } = usePlatformActiveUser();
   const { data: options } = useGet<UIAuth>(gatewayAPI`/ui_auth/`);
   const { t } = useTranslation();

--- a/platform/main/PlatformSubscription.tsx
+++ b/platform/main/PlatformSubscription.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { SubscriptionWizard } from '../settings/SubscriptionWizard';
 import { useHasAwxService } from './GatewayServices';
 
-export function PlatformSubscription(props: { children: ReactNode }) {
+export function PlatformSubscription(props: Readonly<{ children: ReactNode }>) {
   const { t } = useTranslation();
   const { awxConfig, awxConfigError, serviceDown, refreshAwxConfig } = useAwxConfigState();
 

--- a/platform/overview/PlatformOverview.tsx
+++ b/platform/overview/PlatformOverview.tsx
@@ -91,7 +91,9 @@ export function PlatformOverview() {
   );
 }
 
-export function GalleryCardHeader(props: { icon?: ReactNode; title: string; subtitle: string }) {
+export function GalleryCardHeader(
+  props: Readonly<{ icon?: ReactNode; title: string; subtitle: string }>
+) {
   return (
     <CardHeader>
       <Split style={{ width: '100%' }}>

--- a/platform/overview/quickstarts/QuickStartProvider.tsx
+++ b/platform/overview/quickstarts/QuickStartProvider.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuickStarts } from './useQuickStarts';
 
-export function QuickStartProvider(props: { children: ReactNode }) {
+export function QuickStartProvider(props: Readonly<{ children: ReactNode }>) {
   const { t, i18n } = useTranslation();
   const [activeQuickStartID, setActiveQuickStartID] = useState('');
   const [allQuickStartStates, setAllQuickStartStates] = useState<AllQuickStartStates>({});

--- a/platform/resource/PlatformAwxOrganization.tsx
+++ b/platform/resource/PlatformAwxOrganization.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformAwxOrganization(props: { route?: string }) {
+export function PlatformAwxOrganization(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const platformResponse = useGetItem<Organization>(awxAPI`/organizations/`, id);

--- a/platform/resource/PlatformAwxTeam.tsx
+++ b/platform/resource/PlatformAwxTeam.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformAwxTeam(props: { route?: string }) {
+export function PlatformAwxTeam(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const platformResponse = useGetItem<Team>(awxAPI`/teams/`, id);

--- a/platform/resource/PlatformAwxUser.tsx
+++ b/platform/resource/PlatformAwxUser.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformAwxUser(props: { route?: string }) {
+export function PlatformAwxUser(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const platformResponse = useGetItem<AwxUser>(awxAPI`/users/`, id);

--- a/platform/resource/PlatformEdaOrganization.tsx
+++ b/platform/resource/PlatformEdaOrganization.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformEdaOrganization(props: { route?: string }) {
+export function PlatformEdaOrganization(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const platformResponse = useGetItem<EdaOrganization>(edaAPI`/organizations/`, id);

--- a/platform/resource/PlatformEdaTeam.tsx
+++ b/platform/resource/PlatformEdaTeam.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformEdaTeam(props: { route?: string }) {
+export function PlatformEdaTeam(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const platformResponse = useGetItem<EdaTeam>(edaAPI`/teams/`, id);

--- a/platform/resource/PlatformEdaUser.tsx
+++ b/platform/resource/PlatformEdaUser.tsx
@@ -10,7 +10,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { usePlatformActiveUser } from '../main/PlatformActiveUserProvider';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformEdaUser(props: { route?: string }) {
+export function PlatformEdaUser(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id: idFromParam } = useParams<{ id: string }>();
   const { activePlatformUser: activeUser } = usePlatformActiveUser();

--- a/platform/resource/PlatformHubTeam.tsx
+++ b/platform/resource/PlatformHubTeam.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformHubTeam(props: { route?: string }) {
+export function PlatformHubTeam(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id: idFromParam } = useParams<{ id: string }>();
   const id = idFromParam;

--- a/platform/resource/PlatformHubUser.tsx
+++ b/platform/resource/PlatformHubUser.tsx
@@ -10,7 +10,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { usePlatformActiveUser } from '../main/PlatformActiveUserProvider';
 import { PlatformRoute } from '../main/PlatformRoutes';
 
-export function PlatformHubUser(props: { route?: string }) {
+export function PlatformHubUser(props: Readonly<{ route?: string }>) {
   const { t } = useTranslation();
   const { id: idFromParam } = useParams<{ id: string }>();
   const { activePlatformUser: activeUser } = usePlatformActiveUser();

--- a/platform/settings/GatewaySettingsDetails.tsx
+++ b/platform/settings/GatewaySettingsDetails.tsx
@@ -16,7 +16,7 @@ import { useNavigate, useOutletContext } from 'react-router-dom';
 import { GatewaySettingsOption } from './GatewaySettingOptions';
 import { useGatewaySettingsCategories } from './GatewaySettingsCategories';
 
-export function GatewaySettingsDetails(props: { categoryId: string }) {
+export function GatewaySettingsDetails(props: Readonly<{ categoryId: string }>) {
   const { t } = useTranslation();
   const { settings, options, hasWritePermissions } = useOutletContext<{
     options: {

--- a/platform/settings/GatewaySettingsEdit.tsx
+++ b/platform/settings/GatewaySettingsEdit.tsx
@@ -28,7 +28,7 @@ import { GatewaySettingsOption, UrlOption } from './GatewaySettingOptions';
 import { useGatewaySettingsCategories } from './GatewaySettingsCategories';
 import { useRevertAllGatewaySettingsModal } from './useRevertAllGatewaySettingsModal';
 
-export function GatewaySettingsEdit(props: { categoryId?: string }) {
+export function GatewaySettingsEdit(props: Readonly<{ categoryId?: string }>) {
   const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const openRevertAllSettingsModal = useRevertAllGatewaySettingsModal();

--- a/platform/settings/SubscriptionWizard.tsx
+++ b/platform/settings/SubscriptionWizard.tsx
@@ -43,7 +43,7 @@ interface SubscriptionWizardData {
   agree: boolean;
 }
 
-export function SubscriptionWizard(props: { onSuccess: () => void }) {
+export function SubscriptionWizard(props: Readonly<{ onSuccess: () => void }>) {
   const { t } = useTranslation();
   const { refreshAwxConfig } = useAwxConfigState();
 


### PR DESCRIPTION
## Summary

Addresses the remaining 25 typescript:S6759 violations in the platform module by wrapping React component props with `Readonly<>` type. This completes the S6759 remediation for the platform module.

**Scope:** Batch 2 of 2 — covers files 36-65 from the platform module.

**Files modified:** 25 files across `platform/*` subdirectories including:
- Users (components, hooks)
- Common navigation
- Hooks (useActivePlatformUser)
- Main services (GatewayServices, PlatformLogin, etc.)
- Overview (PlatformOverview, QuickStartProvider)
- Resources (AWX/EDA/Hub organization/team/user components)
- Settings (GatewaySettingsDetails, SubscriptionWizard)

**Related:** This PR completes the work started in #3156 (batch 1/2).

**SonarCloud dashboard:** https://sonarcloud.io/project/issues?id=ansible_ansible-ui&rules=typescript%3AS6759

## Type of Change

- [x] Enhancement

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped. This change only adds TypeScript type safety (compile-time only) with no runtime behavior changes. The `Readonly<>` wrapper prevents accidental prop mutations but doesn't affect how components execute.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

**Validation performed:**
- ✅ TypeScript syntax validation passed on all modified files
- ✅ Pre-commit hooks (eslint, prettier) passed

**No manual UI testing needed** — this is a type-level change with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)