### PR TITLE
chore(dependabot): excludes prettier and typescript from devDependency batching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@
           update-types:
             - "minor"
             - "patch"
+          exclude-patterns:
+            - "prettier"
+            - "typescript"


### PR DESCRIPTION


## Summary

Excludes `prettier` and `typescript` from dev dependency batching. `typescript` does not follow semver and `prettier` often includes breaking changes in minor versions.

Note, these dependencies _should_ still get PRs opened by dependabot, they just won't be batched.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify) - Tooling/automation

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

N/A

## Testing

N/A

### Manual Testing

N/A

### Screenshots

N/A
