### PR TITLE
fix(workflow): ensure atomic node updates in workflow visualizer

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
@@ -1,5 +1,5 @@
 import { PageWizard, PageWizardStep, usePageAlertToaster } from '@ansible/ansible-ui-framework';
-import { useVisualizationController } from '@patternfly/react-topology';
+import { action, useVisualizationController } from '@patternfly/react-topology';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { awxErrorAdapter } from '../../../../common/adapters/awxErrorAdapter';
@@ -191,12 +191,18 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
       nodeToEdit.resource.extra_data = {};
     }
 
-    node.setLabel(getNodeLabel(nodeName, node_alias));
-    node.setData(nodeToEdit);
-    node.setState({ modified: true });
-    controller.setState({ ...controller.getState(), modified: true });
-    closeSidebar();
+    // Fix race condition: without action(), node updates are async and non-atomic.
+    // The save operation could read stale node data if it executes mid-update, losing changes.
+    action(() => {
+      node.setLabel(getNodeLabel(nodeName, node_alias));
+      node.setData(nodeToEdit);
+      node.setState({ modified: true });
+      controller.setState({ ...controller.getState(), modified: true });
+    })();
+
+    // Layout must happen after action() commits data to avoid operating on stale state
     controller.getGraph().layout();
+    closeSidebar();
 
     await Promise.resolve();
   };


### PR DESCRIPTION
## Summary
Job template updates in workflow templates were intermittently not getting saved when editing workflow nodes in the visualizer. This PR fixes the race condition causing this issue.

## Root Cause
When editing a workflow node (e.g., changing the job template), the node data updates (`setLabel`, `setData`, `setState`) were not wrapped in an atomic action. This created a race condition where the save operation could read stale node data if it executed before all the state updates completed.

The intermittent nature of the bug was due to timing - sometimes the save would happen after the updates completed (working correctly), and sometimes it would happen mid-update (losing changes).

## Solution
Wrapped all node/controller state updates in an `action()` call from PatternFly Topology. The `action()` wrapper ensures that all state mutations are committed atomically to the graph model before any observers (like the save operation) can read the data.

Also reordered operations to ensure `graph.layout()` happens after the data is committed, which is the correct sequencing.

## Changes
- Import `action` from `@patternfly/react-topology`
- Wrap `node.setLabel`, `node.setData`, `node.setState`, and `controller.setState` in `action()` to ensure atomic commit
- Move `graph.layout()` call after the action to ensure it operates on committed data
- Add comments explaining the fix

## Testing
This fix ensures that when a user changes a job template in a workflow node and saves, the changes are consistently persisted to the backend. The race condition that caused intermittent save failures is eliminated.

### Test Steps
1. Create a workflow template with 2 job templates
2. Edit one of the job templates in the workflow visualizer (change it to a different template)
3. Click Save
4. Verify the change is persisted (refresh the page and check the visualizer)
5. Repeat this several times to ensure the fix is consistent

## Files Modified
- `frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx`

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->