### PR TITLE
fix(instances): show health check button for all instance types

### DIFF
--- a/frontend/awx/administration/instances/hooks/useInstanceActions.test.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.test.tsx
@@ -1,0 +1,59 @@
+import { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import { Instance } from '../../../interfaces/Instance';
+import { cannotRunHealthCheckDueToPermissions } from './useInstanceActions';
+
+describe('cannotRunHealthCheckDueToPermissions', () => {
+  const mockTranslate = ((key: string) => key) as TFunction<'translation', undefined>;
+
+  it('should return error message when instance.related.health_check is missing', () => {
+    const instance: Partial<Instance> = {
+      id: 1,
+      hostname: 'test-instance',
+      node_type: 'execution',
+      related: {
+        jobs: '/api/v2/instances/1/jobs/',
+        instance_groups: '/api/v2/instances/1/instance_groups/',
+        peers: '/api/v2/instances/1/peers/',
+        receptor_addresses: '/api/v2/instances/1/receptor_addresses/',
+        // health_check is missing - user doesn't have RBAC permission
+      },
+    };
+
+    const result = cannotRunHealthCheckDueToPermissions(instance as Instance, mockTranslate);
+
+    expect(result).toBe('You do not have permission to run health checks on this instance.');
+  });
+
+  it('should return empty string when instance.related.health_check is present', () => {
+    const instance: Partial<Instance> = {
+      id: 1,
+      hostname: 'test-instance',
+      node_type: 'execution',
+      related: {
+        jobs: '/api/v2/instances/1/jobs/',
+        instance_groups: '/api/v2/instances/1/instance_groups/',
+        peers: '/api/v2/instances/1/peers/',
+        health_check: '/api/v2/instances/1/health_check/', // User has RBAC permission
+        receptor_addresses: '/api/v2/instances/1/receptor_addresses/',
+      },
+    };
+
+    const result = cannotRunHealthCheckDueToPermissions(instance as Instance, mockTranslate);
+
+    expect(result).toBe('');
+  });
+
+  it('should return error message when instance.related is undefined', () => {
+    const instance: Partial<Instance> = {
+      id: 1,
+      hostname: 'test-instance',
+      node_type: 'execution',
+      // related is undefined
+    };
+
+    const result = cannotRunHealthCheckDueToPermissions(instance as Instance, mockTranslate);
+
+    expect(result).toBe('You do not have permission to run health checks on this instance.');
+  });
+});

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -111,10 +111,7 @@ export function useInstanceDetailsActions() {
     isPinned: false,
   });
   const removeInstanceAction = useRemoveInstanceItemAction(isHidden);
-  const runHealthCheckAction = useRunHealthCheckRowAction(
-    refresh,
-    instance?.node_type !== 'execution'
-  );
+  const runHealthCheckAction = useRunHealthCheckRowAction(refresh, false);
 
   return useMemo<IPageAction<Instance>[]>(
     () => [editInstanceAction, removeInstanceAction, runHealthCheckAction],
@@ -198,11 +195,11 @@ export function cannotRunHealthCheckDueToManagedInstance(
 }
 
 export function cannotRunHealthCheckDueToPermissions(
-  activeAwxUser: AwxUser | null | undefined,
+  instance: Instance,
   t: TFunction<'translation', undefined>
 ) {
-  if (!activeAwxUser?.is_superuser && !activeAwxUser?.is_system_auditor)
-    return t(`Health checks cannot be run on instance do not have correct permissions.`);
+  if (!instance.related?.health_check)
+    return t(`You do not have permission to run health checks on this instance.`);
   return '';
 }
 

--- a/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
@@ -77,7 +77,6 @@ export function useRunHealthCheckRowAction(
   const { t } = useTranslation();
 
   const alertToaster = usePageAlertToaster();
-  const { activeAwxUser } = useAwxActiveUser();
 
   return useMemo<IPageAction<Instance>>(
     () => ({
@@ -87,7 +86,7 @@ export function useRunHealthCheckRowAction(
       isPinned: true,
       isDisabled: (instance) =>
         cannotRunHealthCheckDueToNodeType(instance, t) ||
-        cannotRunHealthCheckDueToPermissions(activeAwxUser, t) ||
+        cannotRunHealthCheckDueToPermissions(instance, t) ||
         cannotRunHealthCheckDueToManagedInstance(instance, t) ||
         cannotRunHealthCheckDueToPending(instance, t),
       isHidden: () => isHidden,
@@ -113,7 +112,7 @@ export function useRunHealthCheckRowAction(
           });
       },
     }),
-    [t, onComplete, alertToaster, activeAwxUser, isHidden]
+    [t, onComplete, alertToaster, isHidden]
   );
 }
 

--- a/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
@@ -57,7 +57,6 @@ export function useRunHealthCheckToolbarAction(
 ) {
   const { t } = useTranslation();
   const runHealthCheck = useRunHealthCheck(view.unselectItemsAndRefresh);
-  const { activeAwxUser } = useAwxActiveUser();
 
   return useMemo<IPageAction<Instance>>(
     () => ({
@@ -73,14 +72,14 @@ export function useRunHealthCheckToolbarAction(
         instances.some(
           (instance) =>
             cannotRunHealthCheckDueToNodeType(instance, t) ||
-            cannotRunHealthCheckDueToPermissions(activeAwxUser, t) ||
+            cannotRunHealthCheckDueToPermissions(instance, t) ||
             cannotRunHealthCheckDueToManagedInstance(instance, t) ||
             cannotRunHealthCheckDueToPending(instance, t)
         )
           ? 'Cannot run health checks on one or more of the selected instances'
           : '',
     }),
-    [t, runHealthCheck, isPinned, isHidden, activeAwxUser]
+    [t, runHealthCheck, isPinned, isHidden]
   );
 }
 


### PR DESCRIPTION
## Summary
Health check button was disabled for users with platform admin roles because the permission check only allowed superusers and system auditors. Platform admins with appropriate RBAC permissions should be able to run health checks.

## Root Cause
The `cannotRunHealthCheckDueToPermissions` function was checking if the user had `is_superuser` or `is_system_auditor` flags. This hardcoded approach ignored AWX's RBAC system, which can grant health check permissions to other roles (like platform admins) without those flags.

## Solution
Changed the permission check to use `instance.related.health_check` instead of hardcoded user flags. AWX's backend populates the `related` object with endpoints the user has permission to access based on RBAC. If `related.health_check` is present, the user can run health checks. If it's absent, they can't.

This is the proper way to check permissions in AWX UI - trust the backend's RBAC evaluation rather than implementing permission logic in the frontend.

## Changes
- `frontend/awx/administration/instances/hooks/useInstanceActions.tsx:197-204` - Changed `cannotRunHealthCheckDueToPermissions` to check `instance.related.health_check` instead of `activeAwxUser.is_superuser || is_system_auditor`
- `frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx:88-90` - Updated caller to pass `instance` instead of `activeAwxUser`
- `frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx:75-76` - Updated caller to pass `instance` instead of `activeAwxUser`
- Added unit tests to verify RBAC-based permission logic

## Testing
### Unit Tests
Added `useInstanceActions.test.tsx` with tests for:
1. Button disabled when `related.health_check` is missing (no permission)
2. Button enabled when `related.health_check` is present (has permission)
3. Button disabled when `related` is undefined

### Manual Testing
1. Create a user with platform admin role (but not superuser/system_auditor)
2. Grant them RBAC permission to run health checks on instances
3. Navigate to an execution instance details page
4. Verify health check button is enabled (not grayed out)
5. Click the button and verify health check runs successfully

## Type of Change
- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis
- [x] **Low** — Changes permission check from hardcoded flags to RBAC-aware field. AWX backend already enforces RBAC, so this just makes the UI consistent with backend permissions. Other validation (node type, managed instance, pending checks) remains unchanged.

## Final commit includes:
  ✅ RBAC permission fix (the actual bug - checking instance.related.health_check)
  ✅ isHidden: false change (better UX - show disabled with tooltip instead of hiding)
  ✅ Unit tests for RBAC logic (with proper TypeScript types)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>