### PR TITLE
fix(hub): add namespace param to approval modal collection search

### DIFF
--- a/frontend/hub/collections/hooks/useCopyToRepository.tsx
+++ b/frontend/hub/collections/hooks/useCopyToRepository.tsx
@@ -98,7 +98,7 @@ function CopyToRepositoryModal(props: {
   useEffect(() => {
     async function getSelected() {
       const repos = await request(
-        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${collection.collection_version?.name}&version=${collection.collection_version?.version}`
+        hubAPI`/v3/plugin/ansible/search/collection-versions/?limit=100&name=${collection.collection_version?.name}&version=${collection.collection_version?.version}&namespace=${collection.collection_version?.namespace}`
       );
 
       if (repos.data?.length > 0) {


### PR DESCRIPTION
## Summary

The approval modal's collection-versions search query was missing the `namespace` parameter. When two collections share the same name and version but have different namespaces (e.g., `hashicorp.terraform 2.0.0` and `cloud.terraform 2.0.0`), the modal returns both, sees that one is already in the approved repository, and incorrectly blocks approval of the other.

Added `namespace` to the search query to scope results to the correct collection.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Find or create two collections with the same name and version but different namespaces (e.g., `hashicorp.terraform 2.0.0` and `cloud.terraform 2.0.0`)
2. Approve one of them into the approved repository
3. Attempt to approve the other — verify the approval modal correctly allows it instead of blocking with "already approved"
4. Verify the "copy to repository" modal also correctly identifies which repos contain only the targeted collection