### PR TITLE
fix(hub): override node-forge to 1.4.0 for CVE-2026-33894

### DIFF
--- a/frontend/hub/insights/package-lock.json
+++ b/frontend/hub/insights/package-lock.json
@@ -9464,9 +9464,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/frontend/hub/insights/package.json
+++ b/frontend/hub/insights/package.json
@@ -38,5 +38,14 @@
     "webpack": "^5.90.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.0"
+  },
+  "overrides": {
+    "@redhat-cloud-services/frontend-components-config": {
+      "webpack-dev-server": {
+        "selfsigned": {
+          "node-forge": "1.4.0"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Pin `node-forge` to `1.4.0` (fixed version) in `frontend/hub/insights` via npm overrides to remediate [CVE-2026-33894](https://nvd.nist.gov/vuln/detail/CVE-2026-33894) — RSASSA PKCS#1 v1.5 signature forgery via ASN.1 extra field stuffing.

The vulnerable `node-forge@1.3.3` was a transitive dev dependency via `webpack-dev-server` → `selfsigned`. Actual risk is **Low** (dev-only, vulnerable code path not invoked, no direct imports), but Red Hat Product Security lists `automation-platform-ui` as affected (CVSS 7.5, Important).

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

### Manual Testing

```bash
cd frontend/hub/insights
npm install --legacy-peer-deps
npm list node-forge
# Should show: node-forge@1.4.0 (overridden)
```

### Screenshots

N/A — no visual/UI changes.

---

<details>
<summary>CVE Audit Report: CVE-2026-33894</summary>

## Vulnerability Summary

| Field              | Details                                                                                                     |
| ------------------ | ----------------------------------------------------------------------------------------------------------- |
| CVE ID             | CVE-2026-33894                                                                                              |
| Description        | Forge (node-forge) RSASSA PKCS#1 v1.5 signature verification accepts forged signatures for low public exponent keys (e=3) via ASN.1 extra field stuffing (Bleichenbacher-style forgery) |
| Affected Package   | `node-forge`                                                                                                |
| Affected Versions  | All versions prior to 1.4.0                                                                                 |
| Fixed Version      | 1.4.0                                                                                                       |
| CVSS Score         | 7.5                                                                                                         |
| Severity           | Important                                                                                                   |
| Ecosystem          | npm                                                                                                         |
| Red Hat Assessment | Affects products — specifically `automation-platform-ui` in Red Hat Ansible Automation Platform 2            |
| Risk Level         | **Low**                                                                                                     |
| References         | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-33894), [GHSA-ppp5-5v6c-4jwp](https://github.com/advisories/GHSA-ppp5-5v6c-4jwp), [Red Hat](https://access.redhat.com/security/cve/CVE-2026-33894) |

## Risk Assessment

### Actual Risk

- **Red Hat Product Security assessment**: Affects products — `automation-platform-ui` is explicitly listed
- **Dependency usage context**: Development only — transitive dev dependency via `webpack-dev-server` → `selfsigned`
- **Exposure level**: None — does not ship in production builds
- **Exploitability**: Low — requires low exponent RSA keys (e=3); vulnerable code path not invoked by `selfsigned`
- **Active exploitation status**: No known active exploitation
- **Code path analysis**: Vulnerable RSA signature verification code path is **not used** — `selfsigned` only does certificate generation. No direct `node-forge` imports in source code.

**Risk level rationale**: Despite CVSS 7.5 / Important, actual risk is **Low** because:

1. `node-forge@1.3.3` only present in `frontend/hub/insights` as a transitive dev dependency
2. Dependency chain is exclusively for local dev server TLS certificate generation
3. Vulnerable RSA signature verification code path is not invoked by `selfsigned`
4. Root `package-lock.json` already had `node-forge@1.4.0`
5. No source code imports `node-forge` directly

## Scan Results

| File | Version | Dependency Type | Status |
| ---- | ------- | --------------- | ------ |
| `package-lock.json` (root) | 1.4.0 | Transitive (via `selfsigned@2.4.1`) | **Not Affected** |
| `frontend/hub/insights/package-lock.json` | 1.3.3 | Transitive dev (via `frontend-components-config` → `webpack-dev-server` → `selfsigned`) | **Affected** |

### Dependency Chains

**Root** — Not affected:
```
@ansible/ui@1.0.0 → selfsigned@2.4.1 → node-forge@1.4.0 ✓
```

**Hub Insights** — Affected (before fix):
```
@ansible/hub-insights-build@1.0.0 → @redhat-cloud-services/frontend-components-config@6.7.53
  → webpack-dev-server@5.1.0 → selfsigned@2.4.1 → node-forge@1.3.3 ✗
```

### Downstream Impact

No downstream repository relationship knowledge base available.

## Remediation Applied

Added npm override in `frontend/hub/insights/package.json` pinning `node-forge` to `1.4.0` via the full dependency chain.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)