### PR TITLE
fix(AAP-74625): change runtime_feature_flag default to true

### DIFF
--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
@@ -52,7 +52,7 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
     expect(result.current.isEnabled).toBe(false);
   });
 
-  it('should return false on API error', async () => {
+  it('should return true on API error', async () => {
     server.use(http.get('/api/gateway/v1/settings/feature_flags/', () => HttpResponse.error()));
 
     const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled(), { wrapper });
@@ -60,6 +60,6 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
-    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isEnabled).toBe(true);
   });
 });

--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.ts
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.ts
@@ -10,7 +10,7 @@ export function useRuntimeFeatureFlagsEnabled() {
   const response = useSWR<FeatureFlagsSettings>(gatewayAPI`/settings/feature_flags/`, requestGet);
 
   return {
-    isEnabled: response.data?.RUNTIME_FEATURE_FLAGS ?? false,
+    isEnabled: response.data?.RUNTIME_FEATURE_FLAGS ?? true,
     isLoading: !response.data && !response.error,
   };
 }


### PR DESCRIPTION
## Summary

Closes: [AAP-74625](https://redhat.atlassian.net/browse/AAP-74625)

Updates the `useRuntimeFeatureFlagsEnabled` hook's client-side fallback from `false` to `true`, aligning the frontend default with the backend change that now defaults `RUNTIME_FEATURE_FLAGS` to `True`.

Previously, if the settings API hadn't loaded yet or errored, the UI would treat runtime feature flags as disabled. With the backend now enabling runtime flags by default, the frontend fallback should match so users see consistent behavior during initial page load.

### Files changed
- `platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.ts` — `?? false` → `?? true`
- `platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx` — Updated API error test expectation to `true`

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

- Requires companion gateway PR that changes `RUNTIME_FEATURE_FLAGS` default to `True` in `aap_gateway_api/defaults.py` and `registered_preferences.py`.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

1. Start the platform dev server
2. Navigate to Settings > Feature Flags — page should render (not "Page Not Found") without any explicit backend configuration
3. Verify that toggling a run-time feature flag works by default
4. Set `RUNTIME_FEATURE_FLAGS=False` on the backend and verify the Feature Flags page shows "Page Not Found"

### Screenshots

<!-- N/A — no visual changes, only default behavior change -->
