### PR TITLE
fix(hub): enable dark mode support for HCC insights build

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionContents.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionContents.tsx
@@ -209,7 +209,7 @@ const hoverOrSelected = `
     margin-bottom: -4px;
     cursor: pointer;
     text-decoration: underline;
-    text-decoration-color: blue; /* Sets the underline color to blue */
+    text-decoration-color: var(--pf-t--global--text--color--link--default);
     text-decoration-thickness: 2px; /* Sets the thickness of the underline */
     text-underline-offset: 8px; /* Sets the space between the text and the underline */
 `;

--- a/frontend/hub/common/ImportLogNavigationArrow.tsx
+++ b/frontend/hub/common/ImportLogNavigationArrow.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const arrowStyle = `
-  color: white;
+  color: var(--pf-t--color--white);
   &:hover {
     cursor: pointer;
   }

--- a/frontend/hub/common/utils/getLogMessageColor.tsx
+++ b/frontend/hub/common/utils/getLogMessageColor.tsx
@@ -10,7 +10,7 @@ export function getLogMessageColor(messageLevel: string) {
   );
 
   if (messageLevel === 'INFO') {
-    return 'white';
+    return 'var(--pf-t--color--white)';
   }
   return res;
 }

--- a/frontend/hub/insights-tests/HubRoot.test.tsx
+++ b/frontend/hub/insights-tests/HubRoot.test.tsx
@@ -110,41 +110,6 @@ describe('HubRoot', () => {
   });
 });
 
-describe('useForceLight', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-    document.documentElement.classList.remove('pf-v6-theme-dark');
-  });
-
-  it('should remove pf-v6-theme-dark class on render', () => {
-    document.documentElement.classList.add('pf-v6-theme-dark');
-
-    render(
-      <MemoryRouter>
-        <HubRoot />
-      </MemoryRouter>
-    );
-
-    expect(document.documentElement.classList.contains('pf-v6-theme-dark')).toBe(false);
-  });
-
-  it('should revert dark mode class if re-added', async () => {
-    render(
-      <MemoryRouter>
-        <HubRoot />
-      </MemoryRouter>
-    );
-
-    // Simulate PageSettingsProvider re-adding dark class
-    document.documentElement.classList.add('pf-v6-theme-dark');
-
-    // MutationObserver should revert it
-    // Give it a tick for the observer to fire
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(document.documentElement.classList.contains('pf-v6-theme-dark')).toBe(false);
-  });
-});
-
 describe('HubRoot with missing chrome methods', () => {
   it('should handle missing identifyApp gracefully', () => {
     // Temporarily override mock to have undefined identifyApp

--- a/frontend/hub/insights/HubRoot.tsx
+++ b/frontend/hub/insights/HubRoot.tsx
@@ -23,31 +23,6 @@ import { HubContextProvider } from '../common/useHubContext';
 import { HubInsightsApp } from './HubInsightsApp';
 
 /**
- * Force light theme for the Insights/CRC build.
- *
- * CRC Chrome loads both PF v5 and PF v6 CSS. PF v6's dark theme tokens
- * use :where() (zero specificity) and get overridden, causing PF v6
- * components to render with broken colors in dark mode. Until Chrome
- * properly supports PF v6 dark theme, we force light mode.
- */
-function useForceLight() {
-  useEffect(() => {
-    const html = document.documentElement;
-    html.classList.remove('pf-v6-theme-dark');
-
-    // Observe and revert if PageSettingsProvider re-adds it
-    const observer = new MutationObserver(() => {
-      if (html.classList.contains('pf-v6-theme-dark')) {
-        html.classList.remove('pf-v6-theme-dark');
-      }
-    });
-    observer.observe(html, { attributes: true, attributeFilter: ['class'] });
-
-    return () => observer.disconnect();
-  }, []);
-}
-
-/**
  * Main entry component for Insights/CRC deployment.
  * This component is exposed via Module Federation and loaded by the Chrome shell.
  *
@@ -66,9 +41,6 @@ function HubRoot() {
     void chrome?.identifyApp?.('automation-hub');
     chrome?.updateDocumentTitle?.('Automation Hub');
   }, [chrome]);
-
-  // Force light theme — CRC Chrome doesn't support PF v6 dark mode properly
-  useForceLight();
 
   // Note: No BrowserRouter here - Chrome provides the router context
   return (

--- a/frontend/hub/my-imports/components/ImportLog.tsx
+++ b/frontend/hub/my-imports/components/ImportLog.tsx
@@ -14,7 +14,7 @@ const EmptyImportConsole = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: var(--pf-t--color--white);
 `;
 
 interface IProps {


### PR DESCRIPTION
## Summary

Remove the `useForceLight()` workaround that blocked dark mode in the Insights/CRC build, and replace all hardcoded color values (`white`, `blue`) with PatternFly v6 CSS variable tokens so the Hub UI renders correctly in both light and dark themes.

[AAP-71489] All HCC tenants must verify dark mode compatibility by May 15th 2026.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Manual Testing

1. Open the Hub insights build with dark mode enabled in CRC Chrome
2. Verify the import log console shows white text on dark background in both light and dark themes
3. Verify collection content type tabs show theme-aware underline color
4. Verify navigation arrows in the import log are visible in both themes

### Changes

- **`HubRoot.tsx`** — Removed `useForceLight()` hook and MutationObserver that stripped `pf-v6-theme-dark` class
- **`ImportLogNavigationArrow.tsx`** — `color: white` → `var(--pf-t--color--white)` (PF base token)
- **`ImportLog.tsx`** — `color: white` → `var(--pf-t--color--white)` in empty console state
- **`getLogMessageColor.tsx`** — INFO level color `'white'` → `'var(--pf-t--color--white)'`
- **`CollectionContents.tsx`** — `text-decoration-color: blue` → `var(--pf-t--global--text--color--link--default)`
- **`HubRoot.test.tsx`** — Removed `useForceLight` test suite

Note: The log console uses `var(--pf-t--color--gray--95)` for its background (a PF base token that stays near-black in both themes). The white text tokens are also base tokens (`--pf-t--color--white`), ensuring the dark-background log console renders consistently regardless of theme.

Assisted-by: Claude Code / Opus 4.6 (Anthropic)