### PR TITLE
fix(instances): allow health checks on managed instances

### DIFF
--- a/frontend/awx/administration/instances/hooks/useInstanceActions.test.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.test.tsx
@@ -1,0 +1,52 @@
+import { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import { Instance } from '../../../interfaces/Instance';
+import { cannotRunHealthCheckDueToManagedInstance } from './useInstanceActions';
+
+describe('cannotRunHealthCheckDueToManagedInstance', () => {
+  const mockTranslate = ((key: string) => key) as TFunction<'translation', undefined>;
+
+  it('should allow health checks on managed instances', () => {
+    const managedInstance: Partial<Instance> = {
+      id: 1,
+      hostname: 'managed-instance',
+      node_type: 'execution',
+      managed: true,
+    };
+
+    const result = cannotRunHealthCheckDueToManagedInstance(
+      managedInstance as Instance,
+      mockTranslate
+    );
+
+    expect(result).toBe('');
+  });
+
+  it('should allow health checks on non-managed instances', () => {
+    const nonManagedInstance: Partial<Instance> = {
+      id: 2,
+      hostname: 'non-managed-instance',
+      node_type: 'execution',
+      managed: false,
+    };
+
+    const result = cannotRunHealthCheckDueToManagedInstance(
+      nonManagedInstance as Instance,
+      mockTranslate
+    );
+
+    expect(result).toBe('');
+  });
+
+  it('should allow health checks when managed property is undefined', () => {
+    const instance: Partial<Instance> = {
+      id: 3,
+      hostname: 'instance-no-managed-field',
+      node_type: 'execution',
+    };
+
+    const result = cannotRunHealthCheckDueToManagedInstance(instance as Instance, mockTranslate);
+
+    expect(result).toBe('');
+  });
+});

--- a/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceActions.tsx
@@ -190,10 +190,9 @@ export function cannotRunHealthCheckDueToNodeType(
 }
 
 export function cannotRunHealthCheckDueToManagedInstance(
-  instance: Instance,
-  t: TFunction<'translation', undefined>
+  _instance: Instance,
+  _t: TFunction<'translation', undefined>
 ) {
-  if (instance?.managed) return t(`Health checks cannot be run on a managed instance.`);
   return '';
 }
 

--- a/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceRowActions.tsx
@@ -17,7 +17,6 @@ import { Instance } from '../../../interfaces/Instance';
 import { Settings } from '../../../interfaces/Settings';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import {
-  cannotRunHealthCheckDueToManagedInstance,
   cannotRunHealthCheckDueToNodeType,
   cannotRunHealthCheckDueToPending,
   cannotRunHealthCheckDueToPermissions,
@@ -88,7 +87,6 @@ export function useRunHealthCheckRowAction(
       isDisabled: (instance) =>
         cannotRunHealthCheckDueToNodeType(instance, t) ||
         cannotRunHealthCheckDueToPermissions(activeAwxUser, t) ||
-        cannotRunHealthCheckDueToManagedInstance(instance, t) ||
         cannotRunHealthCheckDueToPending(instance, t),
       isHidden: () => isHidden,
       icon: HeartbeatIcon,

--- a/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instances/hooks/useInstanceToolbarActions.tsx
@@ -17,7 +17,6 @@ import { Settings } from '../../../interfaces/Settings';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import {
   cannotRemoveInstances,
-  cannotRunHealthCheckDueToManagedInstance,
   cannotRunHealthCheckDueToNodeType,
   cannotRunHealthCheckDueToPending,
   cannotRunHealthCheckDueToPermissions,
@@ -74,7 +73,6 @@ export function useRunHealthCheckToolbarAction(
           (instance) =>
             cannotRunHealthCheckDueToNodeType(instance, t) ||
             cannotRunHealthCheckDueToPermissions(activeAwxUser, t) ||
-            cannotRunHealthCheckDueToManagedInstance(instance, t) ||
             cannotRunHealthCheckDueToPending(instance, t)
         )
           ? 'Cannot run health checks on one or more of the selected instances'


### PR DESCRIPTION
AI generated
## Summary

Fixes AAP-57219 by removing the `instance.managed` check that prevented health checks from running on managed instances.

Previously, the health check button was disabled for managed instances even when users had proper permissions. This fix allows health checks to run on managed instances.

## Changes

- Removed `cannotRunHealthCheckDueToManagedInstance()` call from `isDisabled` blocks in:
  - `useInstanceRowActions.tsx` 
  - `useInstanceToolbarActions.tsx`
- Updated `cannotRunHealthCheckDueToManagedInstance()` to return empty string (keeping function signature for compatibility)
- Added vitest tests (`useInstanceActions.test.tsx`) to verify health checks are allowed on managed instances

## Test Coverage

Added 3 vitest tests covering:
- Health checks allowed on managed instances (`managed: true`)
- Health checks allowed on non-managed instances (`managed: false`)
- Health checks allowed when managed property is undefined

All tests passing ✅

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)