### PR TITLE
fix(workflow): show error when node update fails due to validation

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -259,7 +259,7 @@ export function useSaveVisualizer(templateId: string) {
     }
 
     async function updateExistingNodes(editedNodes: GraphNode[]) {
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
         editedNodes.map(async (node) => {
           const updatedNodePayload: Partial<CreateWorkflowNodePayload> = {};
           const nodeData = node.getData() as GraphNodeData;
@@ -346,6 +346,15 @@ export function useSaveVisualizer(templateId: string) {
           );
         })
       );
+
+      // Check for any failures and throw an error with details
+      const failures = results.filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      );
+      if (failures.length > 0) {
+        // Throw the first error to propagate it to the UI
+        throw failures[0].reason;
+      }
     }
 
     function handleNodeDeletion(node: GraphNode) {


### PR DESCRIPTION
## Summary

Workflow Visualizer now properly displays error messages when workflow node updates fail due to API validation errors, instead of misleadingly showing success.

## Problem

When saving a Workflow Job Template with validation conflicts (e.g., trying to update extra variables on a workflow node when the underlying Job Template has Labels assigned but "Prompt on Launch" is not checked for Labels), the UI would:

1. Show a success message to the user
2. Silently fail to save the changes
3. Return a 400 error in the API (only visible in network tab)

This created a confusing experience where users assumed their workflow saved successfully when it actually didn't.

## Root Cause

The `updateExistingNodes` function in `useSaveVisualizer.tsx` used `Promise.allSettled` which never throws errors. Even when API calls returned 400 validation errors, the save operation appeared to complete successfully and showed a success toast.

## Changes

- Modified `updateExistingNodes` to check results from `Promise.allSettled` for rejections
- When failures are detected, throw the first error to propagate it to the error handler
- UI now properly catches and displays validation errors to users via the existing error handling in `WorkflowVisualizerToolbar`

## Test Scenario (from Jira)

**Before fix:**
1. Create a Job Template with at least one Label assigned
2. Do NOT check "Prompt on Launch" for Labels
3. Check "Prompt on Launch" for Extra Variables
4. Create a Workflow Job Template and add the JT as a node
5. Try to set/update variables on the workflow node
6. **Result**: UI shows success but changes are not saved (400 error in API)

**After fix:**
- Same steps 1-5
- **Result**: UI shows error message with validation details from the API

## Impact

- Users will now see clear error messages when workflow node updates fail
- No more silent failures that cause confusion
- Improves user trust in the save operation
- Reduces support burden from users reporting "saves that didn't work"
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)