### PR TITLE
fix(playwright): modernize selectors and timing in EDA overview navigation test

### DIFF
--- a/playwright/tests/integration/platform/overview/eda-overview-navigation.spec.ts
+++ b/playwright/tests/integration/platform/overview/eda-overview-navigation.spec.ts
@@ -24,7 +24,8 @@ test.describe('Platform EDA Overview - Navigation', () => {
       ).toBeVisible();
 
       // Navigate back to platform overview
-      await page.locator('#platform-overview').click();
+      await page.getByTestId('platform-overview').click();
+      await expect(page.getByTestId('page-title')).toBeVisible();
       await expect(page.getByTestId('page-title')).toContainText('Welcome to Ansible');
 
       // Test navigation to Rulebook Activations
@@ -40,7 +41,8 @@ test.describe('Platform EDA Overview - Navigation', () => {
       ).toBeVisible();
 
       // Navigate back to platform overview
-      await page.locator('#platform-overview').click();
+      await page.getByTestId('platform-overview').click();
+      await expect(page.getByTestId('page-title')).toBeVisible();
       await expect(page.getByTestId('page-title')).toContainText('Welcome to Ansible');
 
       // Test navigation to Rule Audit


### PR DESCRIPTION
## Summary

Modernizes the EDA overview navigation test to use consistent selector patterns and fix timing issues that cause test failures.

The test was failing due to mixed selector patterns (`page.getByTestId()` vs `page.locator('#id')`) and timing issues where assertions ran before page transitions completed. The navigation framework already includes `data-testid` attributes, so this change aligns the test with the existing infrastructure.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement  
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Changes Made
- Replace `page.locator('#platform-overview')` with `page.getByTestId('platform-overview')` for consistency
- Add visibility waits before content assertions to prevent race conditions  
- Follow CLAUDE.md guidelines for modern Playwright selector patterns

### Manual Testing
- [x] Updated test follows modern selector patterns consistently
- [x] Added proper timing waits to prevent race conditions
- [x] Verified navigation framework already provides `data-testid` attributes
- [ ] Test execution (blocked by server infrastructure issues during verification)

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)