### PR TITLE
test(AAP-70435): consolidate org CRUD, notification toggle, and role inheritance tests

### DIFF
--- a/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
+++ b/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
@@ -1,0 +1,219 @@
+import { renderHook } from '@testing-library/react';
+import { IPageActionSwitchSingle, PageActionType } from '@ansible/ansible-ui-framework';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NotificationTemplate } from '../../../interfaces/NotificationTemplate';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockPostRequest = vi.fn().mockResolvedValue({});
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({
+  postRequest: (...args: unknown[]) => mockPostRequest(...args) as Promise<unknown>,
+}));
+
+import { useNotificationActions } from './useNotificationActions';
+
+const mockNotificationTemplate: NotificationTemplate = {
+  id: 1,
+  name: 'Slack Notifier',
+  type: 'notification_template',
+  url: '/api/v2/notification_templates/1/',
+  created: '2024-01-01T00:00:00Z',
+  modified: '2024-01-01T00:00:00Z',
+  description: 'Slack notification',
+  notification_type: 'slack',
+  organization: 1,
+  summary_fields: {
+    organization: { id: 1, name: 'Default', description: '' },
+    created_by: { id: 1, username: 'admin' },
+    modified_by: { id: 1, username: 'admin' },
+    recent_notifications: [
+      { id: 1, status: 'successful', error: '', created: '2024-01-01T00:00:00Z' },
+    ],
+    user_capabilities: { copy: true, edit: true, delete: true },
+  },
+  messages: undefined,
+  notification_configuration: {},
+};
+
+const enabledNotification: NotificationTemplate = {
+  ...mockNotificationTemplate,
+  id: 1,
+};
+
+const mockRefresh = vi.fn();
+
+const baseProps = {
+  notificationApproval: undefined as NotificationTemplate[] | undefined,
+  notificationApprovalRefresh: mockRefresh,
+  notificationStarted: undefined as NotificationTemplate[] | undefined,
+  notificationStartedRefresh: mockRefresh,
+  notificationSuccess: undefined as NotificationTemplate[] | undefined,
+  notificationSuccessRefresh: mockRefresh,
+  notificationError: undefined as NotificationTemplate[] | undefined,
+  notificationErrorRefresh: mockRefresh,
+  resourceType: 'organizations',
+  resourceId: '1',
+};
+
+function findSwitchAction(actions: ReturnType<typeof useNotificationActions>, label: string) {
+  return actions.find((a) => a.type === PageActionType.Switch && a.label === label) as
+    | IPageActionSwitchSingle<NotificationTemplate>
+    | undefined;
+}
+
+describe('useNotificationActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should include approval toggle for organizations', () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const labels = result.current
+      .filter((a) => 'label' in a)
+      .map((a) => ('label' in a ? a.label : ''));
+
+    expect(labels).toContain('Approval');
+    expect(labels).toContain('Start');
+    expect(labels).toContain('Success');
+    expect(labels).toContain('Failure');
+    expect(result.current.filter((a) => 'label' in a)).toHaveLength(4);
+  });
+
+  test('should include approval toggle for workflow_job_templates', () => {
+    const { result } = renderHook(() =>
+      useNotificationActions({ ...baseProps, resourceType: 'workflow_job_templates' })
+    );
+
+    const labels = result.current
+      .filter((a) => 'label' in a)
+      .map((a) => ('label' in a ? a.label : ''));
+
+    expect(labels).toContain('Approval');
+  });
+
+  test('should exclude approval toggle for non-organization resources', () => {
+    const { result } = renderHook(() =>
+      useNotificationActions({ ...baseProps, resourceType: 'job_templates' })
+    );
+
+    const labels = result.current
+      .filter((a) => 'label' in a)
+      .map((a) => ('label' in a ? a.label : ''));
+
+    expect(labels).not.toContain('Approval');
+    expect(labels).toContain('Start');
+    expect(labels).toContain('Success');
+    expect(labels).toContain('Failure');
+    expect(result.current.filter((a) => 'label' in a)).toHaveLength(3);
+  });
+
+  test('should detect enabled notification via isSwitchOn', () => {
+    const { result } = renderHook(() =>
+      useNotificationActions({ ...baseProps, notificationApproval: [enabledNotification] })
+    );
+
+    const action = findSwitchAction(result.current, 'Approval');
+    expect(action).toBeDefined();
+    expect(action!.isSwitchOn(mockNotificationTemplate)).toBe(true);
+  });
+
+  test('should detect disabled notification via isSwitchOn', () => {
+    const { result } = renderHook(() =>
+      useNotificationActions({ ...baseProps, notificationApproval: [] })
+    );
+
+    const action = findSwitchAction(result.current, 'Approval');
+    expect(action).toBeDefined();
+    expect(action!.isSwitchOn(mockNotificationTemplate)).toBe(false);
+  });
+
+  test('should call correct API endpoint when toggling approval on', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Approval');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, true);
+
+    expect(mockPostRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/1/notification_templates_approvals/'),
+      expect.objectContaining({ id: 1 })
+    );
+  });
+
+  test('should call correct API endpoint when toggling start notification', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Start');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, true);
+
+    expect(mockPostRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/1/notification_templates_started/'),
+      expect.objectContaining({ id: 1 })
+    );
+  });
+
+  test('should call correct API endpoint when toggling success notification', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Success');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, true);
+
+    expect(mockPostRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/1/notification_templates_success/'),
+      expect.objectContaining({ id: 1 })
+    );
+  });
+
+  test('should call correct API endpoint when toggling failure notification', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Failure');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, true);
+
+    expect(mockPostRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/1/notification_templates_error/'),
+      expect.objectContaining({ id: 1 })
+    );
+  });
+
+  test('should send disassociate flag when toggling notification off', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Approval');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, false);
+
+    expect(mockPostRequest).toHaveBeenCalledWith(
+      expect.stringContaining('/notification_templates_approvals/'),
+      expect.objectContaining({ id: 1, disassociate: true })
+    );
+  });
+
+  test('should refresh all notification lists after toggle', async () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Start');
+    expect(action).toBeDefined();
+    await action!.onToggle(mockNotificationTemplate, true);
+
+    expect(mockRefresh).toHaveBeenCalledTimes(4);
+  });
+
+  test('should generate correct aria labels for enabled/disabled states', () => {
+    const { result } = renderHook(() => useNotificationActions(baseProps));
+
+    const action = findSwitchAction(result.current, 'Approval');
+    expect(action).toBeDefined();
+    expect(action!.ariaLabel(true)).toContain('disable');
+    expect(action!.ariaLabel(false)).toContain('enable');
+  });
+});

--- a/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
+++ b/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
@@ -40,11 +40,6 @@ const mockNotificationTemplate: NotificationTemplate = {
   notification_configuration: {},
 };
 
-const enabledNotification: NotificationTemplate = {
-  ...mockNotificationTemplate,
-  id: 1,
-};
-
 const mockRefresh = vi.fn();
 
 const baseProps = {
@@ -119,7 +114,7 @@ describe('useNotificationActions', () => {
 
   test('should detect enabled notification via isSwitchOn', () => {
     const { result } = renderHook(() =>
-      useNotificationActions({ ...baseProps, notificationApproval: [enabledNotification] })
+      useNotificationActions({ ...baseProps, notificationApproval: [mockNotificationTemplate] })
     );
 
     const action = findSwitchAction(result.current, 'Approval');
@@ -146,7 +141,7 @@ describe('useNotificationActions', () => {
 
     expect(mockPostRequest).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/1/notification_templates_approvals/'),
-      expect.objectContaining({ id: 1 })
+      { id: 1 }
     );
   });
 
@@ -159,7 +154,7 @@ describe('useNotificationActions', () => {
 
     expect(mockPostRequest).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/1/notification_templates_started/'),
-      expect.objectContaining({ id: 1 })
+      { id: 1 }
     );
   });
 
@@ -172,7 +167,7 @@ describe('useNotificationActions', () => {
 
     expect(mockPostRequest).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/1/notification_templates_success/'),
-      expect.objectContaining({ id: 1 })
+      { id: 1 }
     );
   });
 
@@ -185,7 +180,7 @@ describe('useNotificationActions', () => {
 
     expect(mockPostRequest).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/1/notification_templates_error/'),
-      expect.objectContaining({ id: 1 })
+      { id: 1 }
     );
   });
 

--- a/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
+++ b/frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx
@@ -60,10 +60,14 @@ const baseProps = {
   resourceId: '1',
 };
 
+function isSwitchSingle(
+  action: ReturnType<typeof useNotificationActions>[number]
+): action is IPageActionSwitchSingle<NotificationTemplate> {
+  return action.type === PageActionType.Switch && 'onToggle' in action;
+}
+
 function findSwitchAction(actions: ReturnType<typeof useNotificationActions>, label: string) {
-  return actions.find((a) => a.type === PageActionType.Switch && a.label === label) as
-    | IPageActionSwitchSingle<NotificationTemplate>
-    | undefined;
+  return actions.filter(isSwitchSingle).find((a) => a.label === label);
 }
 
 describe('useNotificationActions', () => {

--- a/platform/access/organizations/hooks/useOrganizationActions.test.tsx
+++ b/platform/access/organizations/hooks/useOrganizationActions.test.tsx
@@ -44,16 +44,17 @@ vi.mock('../hooks/useDeleteOrganizations', () => ({
 
 import { useOrganizationRowActions, useOrganizationPageActions } from './useOrganizationActions';
 
+function isSingleButton(
+  action: ReturnType<typeof useOrganizationRowActions>[number]
+): action is IPageActionButtonSingle<PlatformOrganization> {
+  return action.type === PageActionType.Button && action.selection === PageActionSelection.Single;
+}
+
 function findSingleButtonAction(
   actions: ReturnType<typeof useOrganizationRowActions>,
   label: string
 ) {
-  return actions.find(
-    (a) =>
-      a.type === PageActionType.Button &&
-      a.selection === PageActionSelection.Single &&
-      a.label === label
-  ) as IPageActionButtonSingle<PlatformOrganization> | undefined;
+  return actions.filter(isSingleButton).find((a) => a.label === label);
 }
 
 const mockOrganization: PlatformOrganization = {

--- a/platform/access/organizations/hooks/useOrganizationActions.test.tsx
+++ b/platform/access/organizations/hooks/useOrganizationActions.test.tsx
@@ -30,12 +30,14 @@ vi.mock('react-router-dom', () => ({
   useParams: () => ({ id: '42' }),
 }));
 
+const mockUseOptionsReturn = vi.fn().mockReturnValue({
+  data: { actions: { POST: true, PUT: true, PATCH: true } },
+  isLoading: false,
+  error: null,
+});
+
 vi.mock('@ansible/common-ui/crud/useOptions', () => ({
-  useOptions: () => ({
-    data: { actions: { POST: true, PUT: true, PATCH: true } },
-    isLoading: false,
-    error: null,
-  }),
+  useOptions: (...args: unknown[]) => mockUseOptionsReturn(...args) as unknown,
 }));
 
 vi.mock('../hooks/useDeleteOrganizations', () => ({
@@ -178,5 +180,24 @@ describe('useOrganizationPageActions', () => {
       mockManagedOrganization
     );
     expect(disabledMessage).toBeTruthy();
+  });
+
+  test('should disable delete due to insufficient permissions', () => {
+    mockUseOptionsReturn.mockReturnValue({
+      data: { actions: {} },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useOrganizationPageActions(mockUnselectItemsAndRefresh));
+
+    const deleteAction = findSingleButtonAction(result.current, 'Delete organization');
+    expect(deleteAction).toBeDefined();
+    const disabledMessage = (deleteAction!.isDisabled as (item: PlatformOrganization) => string)(
+      mockOrganization
+    );
+    expect(disabledMessage).toBe(
+      'The organization cannot be deleted due to insufficient permissions.'
+    );
   });
 });

--- a/platform/access/organizations/hooks/useOrganizationActions.test.tsx
+++ b/platform/access/organizations/hooks/useOrganizationActions.test.tsx
@@ -1,0 +1,181 @@
+import { renderHook } from '@testing-library/react';
+import {
+  IPageActionButtonSingle,
+  PageActionSelection,
+  PageActionType,
+} from '@ansible/ansible-ui-framework';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { PlatformOrganization } from '../../../interfaces/PlatformOrganization';
+
+const mockPageNavigate = vi.fn();
+const mockDeleteOrganizations = vi.fn();
+const mockUnselectItemsAndRefresh = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@ansible/ansible-ui-framework', async () => {
+  const actual = await vi.importActual('@ansible/ansible-ui-framework');
+  return {
+    ...actual,
+    useGetPageUrl: () => (route: string) => `/mock/${route}`,
+    usePageNavigate: () => mockPageNavigate,
+  };
+});
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: '42' }),
+}));
+
+vi.mock('@ansible/common-ui/crud/useOptions', () => ({
+  useOptions: () => ({
+    data: { actions: { POST: true, PUT: true, PATCH: true } },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../hooks/useDeleteOrganizations', () => ({
+  useDeleteOrganizations: () => mockDeleteOrganizations,
+}));
+
+import { useOrganizationRowActions, useOrganizationPageActions } from './useOrganizationActions';
+
+function findSingleButtonAction(
+  actions: ReturnType<typeof useOrganizationRowActions>,
+  label: string
+) {
+  return actions.find(
+    (a) =>
+      a.type === PageActionType.Button &&
+      a.selection === PageActionSelection.Single &&
+      a.label === label
+  ) as IPageActionButtonSingle<PlatformOrganization> | undefined;
+}
+
+const mockOrganization: PlatformOrganization = {
+  id: 42,
+  name: 'Test Organization',
+  description: 'A test organization',
+  url: '/api/gateway/v1/organizations/42/',
+  created: '2024-01-01T00:00:00Z',
+  created_by: 1,
+  modified: '2024-01-01T00:00:00Z',
+  modified_by: 1,
+  managed: false,
+  related: {
+    created_by: '/api/gateway/v1/users/1/',
+    modified_by: '/api/gateway/v1/users/1/',
+    teams: '/api/gateway/v1/organizations/42/teams/',
+  },
+  summary_fields: {
+    created_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    modified_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+  },
+};
+
+const mockManagedOrganization: PlatformOrganization = {
+  ...mockOrganization,
+  id: 1,
+  name: 'Default',
+  managed: true,
+};
+
+describe('useOrganizationRowActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should return edit and delete actions', () => {
+    const { result } = renderHook(() => useOrganizationRowActions(mockUnselectItemsAndRefresh));
+
+    expect(findSingleButtonAction(result.current, 'Edit organization')).toBeDefined();
+    expect(findSingleButtonAction(result.current, 'Delete organization')).toBeDefined();
+  });
+
+  test('should navigate to edit route when edit action is clicked', () => {
+    const { result } = renderHook(() => useOrganizationRowActions(mockUnselectItemsAndRefresh));
+
+    const editAction = findSingleButtonAction(result.current, 'Edit organization');
+    expect(editAction).toBeDefined();
+    editAction!.onClick(mockOrganization);
+
+    expect(mockPageNavigate).toHaveBeenCalledWith(
+      'platform-edit-organization',
+      expect.objectContaining({ params: { id: 42 } })
+    );
+  });
+
+  test('should call delete when delete action is clicked', () => {
+    const { result } = renderHook(() => useOrganizationRowActions(mockUnselectItemsAndRefresh));
+
+    const deleteAction = findSingleButtonAction(result.current, 'Delete organization');
+    expect(deleteAction).toBeDefined();
+    deleteAction!.onClick(mockOrganization);
+
+    expect(mockDeleteOrganizations).toHaveBeenCalledWith([mockOrganization]);
+  });
+
+  test('should disable delete for system managed organizations', () => {
+    const { result } = renderHook(() => useOrganizationRowActions(mockUnselectItemsAndRefresh));
+
+    const deleteAction = findSingleButtonAction(result.current, 'Delete organization');
+    expect(deleteAction).toBeDefined();
+    expect(typeof deleteAction!.isDisabled).toBe('function');
+    const disabledMessage = (deleteAction!.isDisabled as (item: PlatformOrganization) => string)(
+      mockManagedOrganization
+    );
+    expect(disabledMessage).toBeTruthy();
+  });
+
+  test('should allow delete for non-managed organizations', () => {
+    const { result } = renderHook(() => useOrganizationRowActions(mockUnselectItemsAndRefresh));
+
+    const deleteAction = findSingleButtonAction(result.current, 'Delete organization');
+    expect(deleteAction).toBeDefined();
+    const disabledMessage = (deleteAction!.isDisabled as (item: PlatformOrganization) => string)(
+      mockOrganization
+    );
+    expect(disabledMessage).toBe('');
+  });
+});
+
+describe('useOrganizationPageActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should return edit and delete actions for the details page', () => {
+    const { result } = renderHook(() => useOrganizationPageActions(mockUnselectItemsAndRefresh));
+
+    expect(findSingleButtonAction(result.current, 'Edit organization')).toBeDefined();
+    expect(findSingleButtonAction(result.current, 'Delete organization')).toBeDefined();
+  });
+
+  test('should navigate to edit route when details page edit action is clicked', () => {
+    const { result } = renderHook(() => useOrganizationPageActions(mockUnselectItemsAndRefresh));
+
+    const editAction = findSingleButtonAction(result.current, 'Edit organization');
+    expect(editAction).toBeDefined();
+    editAction!.onClick(mockOrganization);
+
+    expect(mockPageNavigate).toHaveBeenCalledWith(
+      'platform-edit-organization',
+      expect.objectContaining({ params: { id: 42 } })
+    );
+  });
+
+  test('should disable delete for managed organizations on details page', () => {
+    const { result } = renderHook(() => useOrganizationPageActions(mockUnselectItemsAndRefresh));
+
+    const deleteAction = findSingleButtonAction(result.current, 'Delete organization');
+    expect(deleteAction).toBeDefined();
+    const disabledMessage = (deleteAction!.isDisabled as (item: PlatformOrganization) => string)(
+      mockManagedOrganization
+    );
+    expect(disabledMessage).toBeTruthy();
+  });
+});

--- a/playwright/tests/integration/access-management/organizations/organization-notifications.spec.ts
+++ b/playwright/tests/integration/access-management/organizations/organization-notifications.spec.ts
@@ -8,7 +8,6 @@ import { Organization, Notifier } from '@ansible/playwright/utils';
 test.beforeEach(setupBefore({ path: '/access/organizations' }));
 test.afterEach(setupAfter);
 
-// Notifications Tab for Organizations tests (converted from Cypress)
 test.describe('Notifications Tab for Organizations', () => {
   let organizationName: string;
   let notifierName: string;
@@ -24,16 +23,14 @@ test.describe('Notifications Tab for Organizations', () => {
   });
 
   test(
-    'can navigate to the Organizations -> Notifications list and then to the details page of the Notification',
+    'should navigate to the notification details page from the organization notifications list',
     { tag: ['@not_mock'] },
     async ({ page }) => {
       await navigateTo(page, 'Access Management', 'Organizations');
       await clickTableRow({ text: organizationName }, page);
 
-      // Navigate to Notifications tab
       await page.getByRole('tab', { name: 'Notifications' }).click();
 
-      // Filter to find the notification
       await filterTable(
         {
           pageTitle: organizationName,
@@ -43,29 +40,24 @@ test.describe('Notifications Tab for Organizations', () => {
         page
       );
 
-      // Verify notification appears in table
       await expect(page.locator('tbody tr')).toHaveCount(1);
       await expect(page.locator('tbody')).toContainText(notifierName);
 
-      // Click on notification name to navigate to details
       await page.getByRole('link', { name: notifierName }).click();
 
-      // Verify we're on the notification details page
       await expect(page.getByRole('heading', { name: notifierName })).toBeVisible();
     }
   );
 
   test(
-    'can toggle the Organizations -> Notification on and off for job approval',
+    'should toggle the notification on and off for job approval',
     { tag: ['@not_mock'] },
     async ({ page }) => {
       await navigateTo(page, 'Access Management', 'Organizations');
       await clickTableRow({ text: organizationName }, page);
 
-      // Navigate to Notifications tab
       await page.getByRole('tab', { name: 'Notifications' }).click();
 
-      // Filter to find the notification
       await filterTable(
         {
           pageTitle: organizationName,
@@ -75,33 +67,27 @@ test.describe('Notifications Tab for Organizations', () => {
         page
       );
 
-      // Verify notification appears in table
       await expect(page.locator('tbody tr')).toHaveCount(1);
       await expect(page.locator('tbody')).toContainText(notifierName);
 
-      // Enable approval notification
       await page.getByLabel('Click to enable approval').click();
 
-      // Verify approval is enabled and then disable it
       await expect(page.getByLabel('Click to disable approval')).toBeVisible({ timeout: 5000 });
       await page.getByLabel('Click to disable approval').click();
 
-      // Verify approval is disabled again
       await expect(page.getByLabel('Click to enable approval')).toBeVisible({ timeout: 5000 });
     }
   );
 
   test(
-    'can toggle the Organizations -> Notification on and off for job start',
+    'should toggle notifications on and off for job start, success, and failure',
     { tag: ['@not_mock'] },
     async ({ page }) => {
       await navigateTo(page, 'Access Management', 'Organizations');
       await clickTableRow({ text: organizationName }, page);
 
-      // Navigate to Notifications tab
       await page.getByRole('tab', { name: 'Notifications' }).click();
 
-      // Filter to find the notification
       await filterTable(
         {
           pageTitle: organizationName,
@@ -111,93 +97,27 @@ test.describe('Notifications Tab for Organizations', () => {
         page
       );
 
-      // Verify notification appears in table
       await expect(page.locator('tbody tr')).toHaveCount(1);
       await expect(page.locator('tbody')).toContainText(notifierName);
 
-      // Enable start notification (use first() if multiple exist)
+      // Toggle start notification
       await page.getByLabel('Click to enable start').first().click();
-
-      // Verify start is enabled and then disable it
       await expect(page.getByLabel('Click to disable start').first()).toBeVisible({
         timeout: 5000,
       });
       await page.getByLabel('Click to disable start').first().click();
-
-      // Verify start is disabled and enable it again
       await expect(page.getByLabel('Click to enable start').first()).toBeVisible({ timeout: 5000 });
-      await page.getByLabel('Click to enable start').first().click();
-    }
-  );
 
-  test(
-    'can toggle the Organizations -> Notification on and off for job success',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      await navigateTo(page, 'Access Management', 'Organizations');
-      await clickTableRow({ text: organizationName }, page);
-
-      // Navigate to Notifications tab
-      await page.getByRole('tab', { name: 'Notifications' }).click();
-
-      // Filter to find the notification
-      await filterTable(
-        {
-          pageTitle: organizationName,
-          filterLabel: 'Name',
-          filterValue: notifierName,
-        },
-        page
-      );
-
-      // Verify notification appears in table
-      await expect(page.locator('tbody tr')).toHaveCount(1);
-      await expect(page.locator('tbody')).toContainText(notifierName);
-
-      // Enable success notification
+      // Toggle success notification
       await page.getByLabel('Click to enable success').click();
-
-      // Verify success is enabled and then disable it
       await expect(page.getByLabel('Click to disable success')).toBeVisible({ timeout: 5000 });
       await page.getByLabel('Click to disable success').click();
-
-      // Verify success is disabled again
       await expect(page.getByLabel('Click to enable success')).toBeVisible({ timeout: 5000 });
-    }
-  );
 
-  test(
-    'can toggle the Organizations -> Notification on and off for job failure',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      await navigateTo(page, 'Access Management', 'Organizations');
-      await clickTableRow({ text: organizationName }, page);
-
-      // Navigate to Notifications tab
-      await page.getByRole('tab', { name: 'Notifications' }).click();
-
-      // Filter to find the notification
-      await filterTable(
-        {
-          pageTitle: organizationName,
-          filterLabel: 'Name',
-          filterValue: notifierName,
-        },
-        page
-      );
-
-      // Verify notification appears in table
-      await expect(page.locator('tbody tr')).toHaveCount(1);
-      await expect(page.locator('tbody')).toContainText(notifierName);
-
-      // Enable failure notification
+      // Toggle failure notification
       await page.getByLabel('Click to enable failure').click();
-
-      // Verify failure is enabled and then disable it
       await expect(page.getByLabel('Click to disable failure')).toBeVisible({ timeout: 5000 });
       await page.getByLabel('Click to disable failure').click();
-
-      // Verify failure is disabled again
       await expect(page.getByLabel('Click to enable failure')).toBeVisible({ timeout: 5000 });
     }
   );

--- a/playwright/tests/integration/access-management/organizations/organization.spec.ts
+++ b/playwright/tests/integration/access-management/organizations/organization.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
 import { clickTableRowAction } from '@ansible/playwright/commands/clickTableRowAction';
 import { confirmAndAssertDeletion } from '@ansible/playwright/commands/confirmAndAssertDeletion';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
@@ -11,116 +10,58 @@ import { Organization } from '../../../../utils/organization';
 test.beforeEach(setupBefore({ path: '/access/organizations' }));
 test.afterEach(setupAfter);
 
-test('organization - create and delete', { tag: ['@tier1'] }, async ({ page }) => {
-  const organizationName = await Organization.ui.create(page);
-  await Organization.ui.delete(page, organizationName);
-});
-
-test('organization - create/edit', { tag: ['@not_mock', '@tier1'] }, async ({ page }) => {
-  const organizationName = createE2EName();
-  const opaPolicyPath = 'test/test';
-  await navigateTo(page, 'Access Management', 'Organizations');
-  await page.getByText('Create organization', { exact: true }).click();
-
-  await page.getByRole('textbox', { name: 'Name' }).fill(organizationName);
-  await expect(page.getByRole('textbox', { name: 'Policy enforcement' })).toBeVisible();
-  await page.getByRole('textbox', { name: 'Policy enforcement' }).click();
-  await page.getByRole('textbox', { name: 'Policy enforcement' }).fill(opaPolicyPath);
-  await page.getByRole('button', { name: 'Next' }).click();
-  await expect(page.locator('dl')).toContainText('Policy enforcement');
-  await expect(page.getByTestId('policy-enforcement')).toContainText(opaPolicyPath);
-  await expect(
-    page.getByRole('heading', {
-      name: 'Info alert: New organizations can take up to 15 minutes to propagate across the system.',
-    })
-  ).toBeVisible();
-  await page.getByRole('button', { name: 'Finish' }).click();
-
-  await expect(page.getByRole('heading', { name: organizationName, exact: true })).toBeVisible();
-  await expect(page.locator('dl')).toContainText('Policy enforcement');
-  await expect(page.getByTestId('policy-enforcement')).toContainText(opaPolicyPath);
-  await page.getByRole('button', { name: 'Edit organization' }).click();
-  await page.getByRole('textbox', { name: 'Name' }).fill(`${organizationName}-edited`);
-  await page.getByRole('textbox', { name: 'Policy enforcement' }).fill(`${opaPolicyPath}-edit`);
-  await page.getByRole('button', { name: 'Next' }).click();
-  await expect(page.locator('dl')).toContainText(`${organizationName}-edited`);
-  await expect(page.locator('dl')).toContainText(`${opaPolicyPath}-edit`);
-  await page.getByRole('button', { name: 'Finish' }).click();
-
-  await expect(
-    page.getByRole('heading', { name: `${organizationName}-edited`, exact: true })
-  ).toBeVisible();
-  await expect(page.locator('dl')).toContainText(`${opaPolicyPath}-edit`);
-  await Organization.ui.delete(page, `${organizationName}-edited`);
-});
-
-// Shifted left: Redundant UI path - edit already covered in tier1 via details page
-test('edits an organization from the list view', { tag: ['@not_mock'] }, async ({ page }) => {
-  // Create organization first
-  const organizationName = await Organization.ui.create(page);
-  const editedName = `${createE2EName()} from list page`;
-
-  await navigateTo(page, 'Access Management', 'Organizations');
-
-  // Find and edit the organization from list view
-  await clickTableRowAction(
-    {
-      pageTitle: 'Organizations',
-      text: organizationName,
-      action: 'Edit organization',
-    },
-    page
-  );
-
-  await expect(page.getByRole('heading', { name: `Edit ${organizationName}` })).toBeVisible();
-  await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
-  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
-
-  await page.getByRole('button', { name: 'Next' }).click();
-  await page.getByRole('button', { name: 'Finish' }).click();
-
-  await expect(page.getByRole('heading', { name: editedName, exact: true })).toBeVisible();
-
-  // Clean up
-  await Organization.ui.delete(page, editedName);
-});
-
-// Shifted left: Redundant UI path - same operation as list view, both covered in tier1 create/edit test
-test('edits an organization from the details view', { tag: ['@not_mock'] }, async ({ page }) => {
-  // Create organization first
-  const organizationName = await Organization.ui.create(page);
-  const editedName = `${createE2EName()} from details page`;
-
-  await navigateTo(page, 'Access Management', 'Organizations');
-  await clickTableRow({ text: organizationName }, page);
-
-  await expect(page.getByRole('heading', { name: organizationName, exact: true })).toBeVisible();
-  await page.getByRole('button', { name: 'Edit organization' }).click();
-
-  await expect(page.getByRole('heading', { name: `Edit ${organizationName}` })).toBeVisible();
-  await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
-  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
-
-  await page.getByRole('button', { name: 'Next' }).click();
-  await page.getByRole('button', { name: 'Finish' }).click();
-
-  await expect(page.getByRole('heading', { name: editedName, exact: true })).toBeVisible();
-
-  // Clean up
-  await Organization.ui.delete(page, editedName);
-});
-
-// Shifted left: Redundant UI path - delete already covered in tier1 via details page
 test(
-  'deletes an organization from the organizations list view',
+  'should create an organization with policy enforcement, edit it, and delete it',
+  { tag: ['@not_mock', '@tier1'] },
+  async ({ page }) => {
+    const organizationName = createE2EName();
+    const opaPolicyPath = 'test/test';
+
+    await navigateTo(page, 'Access Management', 'Organizations');
+    await page.getByText('Create organization', { exact: true }).click();
+
+    await page.getByRole('textbox', { name: 'Name' }).fill(organizationName);
+    await expect(page.getByRole('textbox', { name: 'Policy enforcement' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'Policy enforcement' }).click();
+    await page.getByRole('textbox', { name: 'Policy enforcement' }).fill(opaPolicyPath);
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.locator('dl')).toContainText('Policy enforcement');
+    await expect(page.getByTestId('policy-enforcement')).toContainText(opaPolicyPath);
+    await expect(
+      page.getByRole('heading', {
+        name: 'Info alert: New organizations can take up to 15 minutes to propagate across the system.',
+      })
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Finish' }).click();
+
+    await expect(page.getByRole('heading', { name: organizationName, exact: true })).toBeVisible();
+    await expect(page.locator('dl')).toContainText('Policy enforcement');
+    await expect(page.getByTestId('policy-enforcement')).toContainText(opaPolicyPath);
+
+    await page.getByRole('button', { name: 'Edit organization' }).click();
+    await page.getByRole('textbox', { name: 'Name' }).fill(`${organizationName}-edited`);
+    await page.getByRole('textbox', { name: 'Policy enforcement' }).fill(`${opaPolicyPath}-edit`);
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.locator('dl')).toContainText(`${organizationName}-edited`);
+    await expect(page.locator('dl')).toContainText(`${opaPolicyPath}-edit`);
+    await page.getByRole('button', { name: 'Finish' }).click();
+
+    await expect(
+      page.getByRole('heading', { name: `${organizationName}-edited`, exact: true })
+    ).toBeVisible();
+    await expect(page.locator('dl')).toContainText(`${opaPolicyPath}-edit`);
+    await Organization.ui.delete(page, `${organizationName}-edited`);
+  }
+);
+
+test(
+  'should delete an organization from the list view',
   { tag: ['@not_mock'] },
   async ({ page }) => {
-    // Create organization first
     const organizationName = await Organization.ui.create(page);
 
     await navigateTo(page, 'Access Management', 'Organizations');
 
-    // Find and delete the organization from list view
     await clickTableRowAction(
       {
         pageTitle: 'Organizations',
@@ -135,18 +76,15 @@ test(
   }
 );
 
-// Shifted left: Bulk operation - convenience feature, not core functionality
 test(
-  'bulk creates and deletes organizations from the organizations list toolbar',
+  'should bulk create and delete organizations from the list toolbar',
   { tag: ['@not_mock'] },
   async ({ page }) => {
-    // Create two organizations first
     const org1Name = await Organization.ui.create(page);
     const org2Name = await Organization.ui.create(page);
 
     await navigateTo(page, 'Access Management', 'Organizations');
 
-    // Select first organization
     await selectTableRow(
       {
         pageTitle: 'Organizations',
@@ -156,7 +94,6 @@ test(
       page
     );
 
-    // Select second organization
     await selectTableRow(
       {
         pageTitle: 'Organizations',
@@ -167,7 +104,6 @@ test(
       page
     );
 
-    // Delete both organizations
     await page.getByRole('button', { name: 'Actions' }).click();
     await page.getByRole('menuitem', { name: 'Delete organizations' }).click();
 

--- a/playwright/tests/integration/access-management/teams/team-roles.spec.ts
+++ b/playwright/tests/integration/access-management/teams/team-roles.spec.ts
@@ -1,24 +1,21 @@
 import { expect, test } from '@playwright/test';
-import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
-import { User, Team, Credential } from '@ansible/playwright/utils';
+import { Team, Credential } from '@ansible/playwright/utils';
 
 test.describe('Platform Teams - Roles Tab', () => {
   let credentialName: string;
   let teamName: string;
-  let userName: string;
 
   test.beforeEach(setupBefore({ path: '/access/teams' }));
 
   test.afterEach(async ({ page }) => {
     await Team.api.deleteByName(page, teamName).catch(() => {});
     await Credential.api.deleteByName(page, credentialName).catch(() => {});
-    await User.api.deleteByName(page, userName).catch(() => {});
     await setupAfter({ page });
   });
 
   test(
-    'assign a role to a team and then remove it',
+    'should assign a role to a team and then remove it',
     { tag: ['@team', '@not_mock'] },
     async ({ page }) => {
       credentialName = await Credential.ui.create(page);
@@ -58,65 +55,6 @@ test.describe('Platform Teams - Roles Tab', () => {
       await expect(
         page.getByRole('heading', { name: 'No roles assigned to this team' })
       ).toBeVisible();
-    }
-  );
-
-  test(
-    'verify user inherits team roles when added to team',
-    {
-      tag: ['@team', '@not_mock'],
-    },
-    async ({ page }) => {
-      userName = await User.ui.create(page).then((r) => (typeof r === 'string' ? r : r.userName));
-      credentialName = await Credential.ui.create(page);
-      teamName = await Team.ui.create(page, { organizationName: 'Default' });
-
-      //Assign role to team
-      await page.getByRole('tab', { name: 'Roles' }).click();
-      await expect(page.getByRole('button', { name: 'Assign roles' })).toBeVisible();
-      await page.getByRole('button', { name: 'Assign role' }).click();
-      await page.getByLabel('Breadcrumb').getByText('Assign roles').click();
-      await expect(page.getByRole('heading', { name: 'Assign roles' })).toBeVisible();
-      await page.getByRole('textbox', { name: 'Type to filter' }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).fill('Credential');
-      await page.locator('[id="select-create-typeahead-awx.credential"]').click();
-      await page.getByRole('button', { name: 'Next' }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).fill(credentialName);
-      await page.getByRole('button', { name: 'apply filter' }).click();
-      await page.getByRole('checkbox', { name: 'Select row' }).check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).fill('Admin');
-      await page.getByRole('textbox', { name: 'Type to filter' }).press('Enter');
-      await page.getByRole('checkbox', { name: 'Select all rows' }).check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await expect(page.getByRole('region', { name: 'Resources' })).toContainText(credentialName);
-      await expect(page.getByRole('region', { name: 'Platform roles' })).toContainText(
-        'Credential Admin'
-      );
-      await page.getByRole('button', { name: 'Finish' }).click();
-
-      await expect(page.getByRole('heading', { name: teamName })).toBeVisible();
-
-      //Assign user to team
-      await page.getByRole('tab', { name: 'Users' }).click();
-      await expect(page.getByRole('button', { name: 'Assign users' })).toBeVisible();
-      await page.getByRole('button', { name: 'Assign users' }).click();
-      await expect(page.getByRole('heading', { name: 'Assign users' })).toBeVisible();
-      await page.getByRole('textbox', { name: 'Type to filter' }).click();
-      await page.getByRole('textbox', { name: 'Type to filter' }).fill(userName);
-      await page.getByRole('textbox', { name: 'Type to filter' }).press('Enter');
-      await page.getByRole('checkbox', { name: 'Select all rows' }).check();
-      await page.getByRole('button', { name: 'Assign users' }).click();
-
-      await clickTableRow({ text: userName, filterLabel: 'Username' }, page);
-      await page.getByRole('tab', { name: 'Roles' }).click();
-      const row = page.locator('table tr', { hasText: teamName });
-
-      // Verify the row contains the team name and inheritance description
-      await expect(row).toContainText(teamName);
-      await expect(row).toContainText('Team Member');
     }
   );
 });


### PR DESCRIPTION
## Summary

Consolidates redundant Playwright integration tests to reduce the Tier 1 testing footprint.

**Playwright consolidation (14 → 8 tests, -6 from Tier 1):**

- **`organization.spec.ts`** (6 → 3): Merged separate "create and delete" + "create/edit" into a single create → edit → delete CRUD flow. Removed standalone "edit from list view" and "edit from details view" tests (same form/API, only entry point differs; covered by Vitest below).
- **`organization-notifications.spec.ts`** (5 → 3): Kept the PM-confirmed critical job approval toggle. Consolidated the 3 identical toggle tests (start, success, failure) into one test exercising all three sequentially.
- **`team-roles.spec.ts`** (2 → 1): Removed "verify user inherits team roles when added to team" — fully covered by the more thorough test in `team-role-inheritance.spec.ts` which also verifies resource Team Access and User Access tabs.

**New Vitest coverage (20 tests) backfilling removed integration paths:**

- **`useOrganizationActions.test.tsx`** (8 tests): Covers the `useOrganizationRowActions` and `useOrganizationPageActions` hooks — edit navigation to correct route, delete handler invocation, managed org delete protection. Both list-view and details-page entry points are powered by these hooks.
- **`useNotificationActions.test.tsx`** (12 tests): Covers the notification toggle hook — correct action set per resource type (orgs get approval toggle, others don't), `isSwitchOn` state detection, API endpoint correctness for all 4 toggle types, disassociate flag, refresh behavior, and aria labels.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Will trigger `/run-playwright` once preliminary checks pass.

### Manual Testing

- All modified Playwright tests should pass against a live AAP instance
- Both new Vitest files pass locally: `npx vitest run platform/access/organizations/hooks/useOrganizationActions.test.tsx frontend/awx/resources/notifications/hooks/useNotificationActions.test.tsx`


Made with [Cursor](https://cursor.com)