### PR TITLE
fix(ci): support SonarCloud analysis for fork PRs

### DIFF
--- a/.github/workflows/platform-pull-request.yml
+++ b/.github/workflows/platform-pull-request.yml
@@ -220,10 +220,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: vitest-coverage
-    if: always()
+    if: always() && github.event_name == 'push'
     permissions:
       contents: read
-      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -237,22 +236,7 @@ jobs:
           path: coverage/combined
         continue-on-error: true
 
-      - name: SonarQube Scan (PR)
-        if: github.event_name == 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v6
-        env:
-          SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
-        with:
-          args: >
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
-            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
-
       - name: SonarQube Scan (Branch)
-        if: github.event_name == 'push'
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -53,8 +53,9 @@ jobs:
 
       - name: Checkout PR Code
         run: |
-          gh pr checkout ${{ steps.pr.outputs.number }}
+          gh pr checkout "$PR_NUMBER"
         env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Vitest Coverage

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -1,0 +1,77 @@
+# Generated with AI assistance: Claude Code (Anthropic)
+name: SonarQube PR Analysis
+
+on:
+  workflow_run:
+    workflows:
+      - Platform PR
+    types:
+      - completed
+
+permissions: read-all
+jobs:
+  sonarcloud:
+    name: SonarQube PR Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && (github.event.workflow_run.conclusion == 'success'
+          || github.event.workflow_run.conclusion == 'failure')
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR Number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_number
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract PR Number
+        id: pr
+        run: |
+          echo "number=$(head -n1 pr_number.txt | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Get PR Details
+        uses: octokit/request-action@v2.x
+        id: pr_info
+        with:
+          route: GET /repos/{repo}/pulls/{number}
+          repo: ${{ github.event.repository.full_name }}
+          number: ${{ steps.pr.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout PR Code
+        run: |
+          gh pr checkout ${{ steps.pr.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Vitest Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: vitest-coverage
+          path: coverage/combined
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+        continue-on-error: true
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
+        with:
+          args: >
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ steps.pr.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ fromJson(steps.pr_info.outputs.data).head.ref }}
+            -Dsonar.pullrequest.base=${{ fromJson(steps.pr_info.outputs.data).base.ref }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -8,7 +8,10 @@ on:
     types:
       - completed
 
-permissions: read-all
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 jobs:
   sonarcloud:
     name: SonarQube PR Analysis


### PR DESCRIPTION
## Summary

SonarCloud checks fail on PRs from forks because GitHub Actions
does not expose secrets (`SONAR_TOKEN`) to `pull_request` events
originated from forked repositories.

**Fix:** Add a new `workflow_run`-triggered workflow (`sonar_pr.yml`)
that runs SonarCloud analysis after the Platform PR workflow completes.
`workflow_run` always executes in the base repository's context, so it
has access to secrets even when the triggering PR came from a fork.
The push-to-devel scan stays inline in `platform-pull-request.yml`
since push events always have secret access.

## Type of Change

- [x] Enhancement

## Risk Analysis - REQUIRED

- [x] **Medium** — Changes CI workflow structure for SonarCloud
  scanning. Other CI jobs (tests, linting, success gate) are unchanged.

## Testing

This can only be fully tested after merge, since `workflow_run`
workflows must exist on the default branch to be triggered.

Post-merge verification:
1. Open a PR from a fork → verify `SonarQube PR Analysis` fires
   and SonarCloud posts results
2. Open a PR from an upstream branch → verify no regression
3. Push to main/devel → verify inline branch scan still works

Assisted-by: Claude Code / Opus 4.6 (Anthropic)