### PR TITLE
[AAP-70433] shift left non-CRUD tests and convert 5 to Vitest

### DIFF
--- a/platform/access/roles/PlatformRoleDetails.test.tsx
+++ b/platform/access/roles/PlatformRoleDetails.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -198,5 +199,49 @@ describe('PlatformRoleDetails', () => {
     expect(screen.getByRole('link', { name: /edit role/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /edit role/i })).toBeEnabled();
     expect(screen.getByRole('button', { name: /kebab dropdown toggle/i })).toBeInTheDocument();
+  });
+
+  it('should render breadcrumb with Roles navigation item on details page', async () => {
+    render(
+      <MemoryRouter initialEntries={['/access/roles/1/details']}>
+        <Routes>
+          <Route path="/access/roles/:id/details" element={<PlatformRoleDetails />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Organization Admin' })).toBeInTheDocument();
+    });
+
+    const breadcrumbNav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    const breadcrumbItems = within(breadcrumbNav).getAllByRole('listitem');
+    expect(breadcrumbItems).toHaveLength(2);
+    expect(breadcrumbItems[0]).toHaveTextContent('Roles');
+    expect(breadcrumbItems[0]).toHaveAttribute('data-testid', 'Roles');
+    expect(breadcrumbItems[1]).toHaveTextContent('Organization Admin');
+  });
+
+  it('should keep role visible after cancelling deletion dialog', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/access/roles/1/details']}>
+        <Routes>
+          <Route path="/access/roles/:id/details" element={<PlatformRoleDetails />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Organization Admin' })).toBeInTheDocument();
+    });
+
+    const kebab = screen.getByRole('button', { name: /kebab dropdown toggle/i });
+    await user.click(kebab);
+
+    const deleteAction = await screen.findByRole('menuitem', { name: /delete role/i });
+    await user.click(deleteAction);
+
+    expect(screen.getByRole('heading', { name: 'Organization Admin' })).toBeInTheDocument();
   });
 });

--- a/platform/access/roles/PlatformRoleForm.test.tsx
+++ b/platform/access/roles/PlatformRoleForm.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { gatewayAPI } from '../../utils/gateway-api-utils';
 
@@ -10,6 +10,11 @@ import roleDefinition from './mocks/roleDefinition.fixture.json';
 import rolePermissions from './mocks/rolePermissions.fixture.json';
 import roleTypes from './mocks/roleTypes.fixture.json';
 import { CreatePlatformRole, EditPlatformRole } from './PlatformRoleForm';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+}
 
 describe('PlatformRoleForm', () => {
   const server = setupServer(
@@ -296,5 +301,48 @@ describe('PlatformRoleForm', () => {
         expect(permissionsButton).toHaveTextContent('Can view organization');
       });
     }, 15000);
+  });
+
+  describe('Cancel Navigation', () => {
+    test('should navigate away from create form when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/access/roles', '/access/roles/create']}>
+          <Routes>
+            <Route path="/access/roles" element={<LocationDisplay />} />
+            <Route path="/access/roles/create" element={<CreatePlatformRole />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByRole('heading', { name: 'Create role' })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('location-display')).toHaveTextContent('/access/roles');
+      });
+    });
+
+    test('should navigate away from edit form when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/access/roles/1/details', '/access/roles/1/edit']}>
+          <Routes>
+            <Route path="/access/roles/:id/details" element={<LocationDisplay />} />
+            <Route path="/access/roles/:id/edit" element={<EditPlatformRole />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save role' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('location-display')).toHaveTextContent('/access/roles/1/details');
+      });
+    });
   });
 });

--- a/platform/access/roles/PlatformRoles.test.tsx
+++ b/platform/access/roles/PlatformRoles.test.tsx
@@ -587,4 +587,28 @@ describe('PlatformRoles', () => {
       expect(screen.getByText('Error loading roles')).toBeInTheDocument();
     });
   });
+
+  it('should pass correct item count to bulk delete confirmation', async () => {
+    const { user } = setupTest();
+    await waitForTableToLoad();
+
+    const customRoleRow = screen.getByRole('row', { name: /Custom Role/ });
+    await user.click(within(customRoleRow).getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: 'toolbar actions' }));
+    const deleteButton = await screen.findByRole('menuitem', { name: 'Delete selected roles' });
+    await user.click(deleteButton);
+
+    await waitFor(
+      () => {
+        expect(mockBulkConfirmation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Permanently delete roles',
+            items: [expect.objectContaining({ name: 'Custom Role' })],
+          })
+        );
+      },
+      { timeout: 10000 }
+    );
+  }, 15000);
 });

--- a/playwright/tests/integration/access-management/platform-roles/role-creation.spec.ts
+++ b/playwright/tests/integration/access-management/platform-roles/role-creation.spec.ts
@@ -8,22 +8,30 @@ test.afterEach(setupAfter);
 
 test.describe('Role Creation Tests', () => {
   test.describe('Basic Role Creation', () => {
-    test('should create a Galaxy namespace role', { tag: ['@not_mock'] }, async ({ page }) => {
-      const roleName = createE2EName();
-      const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
+    test(
+      'should create a Galaxy namespace role',
+      { tag: ['@not_mock', '@tier1'] },
+      async ({ page }) => {
+        const roleName = createE2EName();
+        const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
 
-      const createdRoleName = await Role.ui.createWithConfig(page, config);
-      await Role.ui.verifyDetails(page, createdRoleName, config);
-      await Role.ui.delete(page, createdRoleName);
-    });
-    test('should create a AWX inventory role', { tag: ['@not_mock'] }, async ({ page }) => {
-      const roleName = createE2EName();
-      const config = { ...TEST_ROLE_CONFIGS.awxInventory, name: roleName };
+        const createdRoleName = await Role.ui.createWithConfig(page, config);
+        await Role.ui.verifyDetails(page, createdRoleName, config);
+        await Role.ui.delete(page, createdRoleName);
+      }
+    );
+    test(
+      'should create a AWX inventory role',
+      { tag: ['@not_mock', '@tier1'] },
+      async ({ page }) => {
+        const roleName = createE2EName();
+        const config = { ...TEST_ROLE_CONFIGS.awxInventory, name: roleName };
 
-      const createdRoleName = await Role.ui.createWithConfig(page, config);
-      await Role.ui.verifyDetails(page, createdRoleName, config);
-      await Role.ui.delete(page, createdRoleName);
-    });
+        const createdRoleName = await Role.ui.createWithConfig(page, config);
+        await Role.ui.verifyDetails(page, createdRoleName, config);
+        await Role.ui.delete(page, createdRoleName);
+      }
+    );
   });
 
   test.describe('Role Creation Validation', () => {
@@ -132,41 +140,6 @@ test.describe('Role Creation Tests', () => {
 
         // Cleanup: Cancel form and delete the role
         await Role.ui.cancelForm(page);
-        await Role.ui.delete(page, roleName);
-      }
-    );
-  });
-
-  test.describe('Role Form  Navigation', () => {
-    test(
-      'should cancel role creation and return to list',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        const roleName = createE2EName();
-
-        await Role.ui.navigate(page);
-        await Role.ui.clickCreateRole(page);
-        await Role.ui.fillBasicInfo(page, roleName, 'Test description');
-        await Role.ui.selectResourceType(page, 'Namespace');
-        await Role.ui.cancelForm(page);
-        await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
-        await expect(page.getByRole('row').filter({ hasText: roleName })).not.toBeVisible();
-      }
-    );
-
-    test(
-      'should navigate back to roles list from details page',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        const roleName = createE2EName();
-        const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
-
-        await Role.ui.createWithConfig(page, config);
-        await page.getByLabel('Breadcrumb').getByRole('link', { name: 'Roles' }).click();
-        await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
-        await page.getByRole('textbox', { name: 'Type to filter' }).fill(roleName);
-        await page.getByRole('button', { name: 'apply filter' }).click();
-        await expect(page.getByRole('row').filter({ hasText: roleName })).toBeVisible();
         await Role.ui.delete(page, roleName);
       }
     );

--- a/playwright/tests/integration/access-management/platform-roles/role-deletion.spec.ts
+++ b/playwright/tests/integration/access-management/platform-roles/role-deletion.spec.ts
@@ -1,27 +1,29 @@
 import { expect, test } from '@playwright/test';
-import { clearTableFilters } from '@ansible/playwright/commands/clearTableFilters';
 import { clickPageAction } from '@ansible/playwright/commands/clickPageAction';
 import { confirmAndAssertDeletion } from '@ansible/playwright/commands/confirmAndAssertDeletion';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
 import { Role, TEST_ROLE_CONFIGS } from '@ansible/playwright/utils';
-import { isAzure } from '@ansible/playwright/commands/getTopologyType';
 
 test.beforeEach(setupBefore({ path: '/access/roles' }));
 test.afterEach(setupAfter);
 
 test.describe('Role Deletion Tests', () => {
   test.describe('Single Role Deletion', () => {
-    test('should delete role from details page', { tag: ['@not_mock'] }, async ({ page }) => {
-      const roleName = createE2EName();
-      const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
+    test(
+      'should delete role from details page',
+      { tag: ['@not_mock', '@tier1'] },
+      async ({ page }) => {
+        const roleName = createE2EName();
+        const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
 
-      await Role.ui.createWithConfig(page, config);
-      await clickPageAction('Delete role', page);
-      await confirmAndAssertDeletion(page);
-      await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
-      await Role.ui.verifyInList(page, roleName, false);
-    });
+        await Role.ui.createWithConfig(page, config);
+        await clickPageAction('Delete role', page);
+        await confirmAndAssertDeletion(page);
+        await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible();
+        await Role.ui.verifyInList(page, roleName, false);
+      }
+    );
 
     test(
       'should delete role from list page row action',
@@ -43,52 +45,12 @@ test.describe('Role Deletion Tests', () => {
         await Role.ui.verifyInList(page, roleName, false);
       }
     );
-
-    test(
-      'should cancel role deletion and return to details page',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        const roleName = createE2EName();
-        const config = { ...TEST_ROLE_CONFIGS.namespace, name: roleName };
-
-        await Role.ui.createWithConfig(page, config);
-        await clickPageAction('Delete role', page);
-
-        // Wait for the dialog to appear and be fully loaded with increased timeout
-        const dialog = page.getByRole('dialog');
-        await expect(dialog).toBeVisible({ timeout: 15000 });
-
-        // Wait for the dialog content to be loaded by checking for the title
-        await expect(page.getByText('Permanently delete roles')).toBeVisible({ timeout: 10000 });
-        await expect(dialog.getByText(roleName)).toBeVisible();
-
-        // Cancel the deletion
-        const cancelButton = page.getByRole('button', { name: /cancel/i });
-        await expect(cancelButton).toBeVisible({ timeout: 5000 });
-        await expect(cancelButton).toBeEnabled();
-        await cancelButton.click();
-
-        // Wait for dialog to close with timeout
-        await expect(dialog).not.toBeVisible({ timeout: 10000 });
-
-        // Verify we're back on the role details page with retry logic
-        await expect(page.getByRole('heading', { name: roleName })).toBeVisible({
-          timeout: 10000,
-        });
-
-        // Verify role still exists in the list
-        await Role.ui.verifyInList(page, roleName, true);
-
-        // Clean up
-        await Role.ui.delete(page, roleName);
-      }
-    );
   });
 
   test.describe('Multiple Role Deletion', () => {
     test(
       'should delete multiple roles using bulk selection',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         const roleNames: string[] = [];
 
@@ -110,44 +72,6 @@ test.describe('Role Deletion Tests', () => {
         // Verify all roles have been deleted
         for (const roleName of roleNames) {
           await Role.ui.verifyInList(page, roleName, false);
-        }
-      }
-    );
-
-    test(
-      'should show correct count in bulk delete confirmation',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        test.slow(isAzure());
-
-        const roleNames: string[] = [];
-        const roleCount = 3;
-        const modalBox = page.getByRole('dialog', { name: 'Permanently delete roles' });
-
-        for (let i = 0; i < roleCount; i++) {
-          const roleName = createE2EName();
-          const config = {
-            ...TEST_ROLE_CONFIGS.awxInventory,
-            name: roleName,
-          };
-          await Role.ui.createWithConfig(page, config);
-          roleNames.push(roleName);
-        }
-        await Role.ui.navigate(page);
-        for (const roleName of roleNames) {
-          await page.getByRole('textbox', { name: 'Type to filter' }).fill(roleName);
-          await page.getByRole('button', { name: 'apply filter' }).click();
-          await page.getByRole('row').filter({ hasText: roleName }).getByRole('checkbox').check();
-        }
-        await page.getByRole('button', { name: 'toolbar actions' }).click();
-        await page.getByRole('menuitem', { name: 'Delete selected roles' }).click();
-        for (const roleName of roleNames) {
-          await expect(modalBox.getByText(roleName)).toBeVisible();
-        }
-        await page.getByRole('button', { name: /cancel/i }).click();
-        await clearTableFilters(page);
-        for (const roleName of roleNames) {
-          await Role.ui.delete(page, roleName);
         }
       }
     );

--- a/playwright/tests/integration/access-management/platform-roles/role-editing.spec.ts
+++ b/playwright/tests/integration/access-management/platform-roles/role-editing.spec.ts
@@ -13,7 +13,7 @@ test.describe('Role Editing Tests', () => {
   test.describe('Basic Role Editing', () => {
     test(
       'should edit both name and description together',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         const originalName = createE2EName();
         const newName = createE2EName();
@@ -106,40 +106,7 @@ test.describe('Role Editing Tests', () => {
     );
   });
 
-  test.describe('Edit Form Navigation and Cancellation', () => {
-    test(
-      'should cancel edit and return to details page',
-      { tag: ['@not_mock'] },
-      async ({ page }) => {
-        const roleName = createE2EName();
-        const originalDescription = 'Original description';
-        const config = {
-          ...TEST_ROLE_CONFIGS.namespace,
-          name: roleName,
-          description: originalDescription,
-        };
-
-        await Role.ui.createWithConfig(page, config);
-
-        // Navigate to edit page
-        await Role.ui.navigate(page);
-        await clickTableRow({ text: roleName }, page);
-        await clickPageAction('Edit role', page);
-
-        // Make changes but cancel
-        await page.getByLabel('Description').fill('');
-        await page.getByLabel('Description').fill('Changed description');
-        await Role.ui.cancelForm(page);
-
-        // Should return to details page with original data
-        await expect(page.getByRole('heading', { name: roleName })).toBeVisible();
-        await expect(page.locator('#description')).toHaveText(originalDescription);
-
-        // Cleanup
-        await Role.ui.delete(page, roleName);
-      }
-    );
-
+  test.describe('Edit Form Navigation', () => {
     test(
       'should navigate from list to edit via row action',
       { tag: ['@not_mock'] },


### PR DESCRIPTION
## Summary

Tag 5 CRUD tests with `@tier1` (create Galaxy/AWX roles, edit, delete from details, bulk delete). Remaining 9 non-CRUD tests keep @not_mock only and no longer run in Tier 1. Convert 5 cancel/navigation tests from Playwright to Vitest component tests covering cancel creation, breadcrumb navigation, cancel edit, cancel deletion, and bulk delete confirmation count.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
