### PR TITLE
Add @tier1 tags to Job Template and Workflow tests

### DIFF
--- a/playwright/tests/integration/automation-execution/templates/job-template-notifications.spec.ts
+++ b/playwright/tests/integration/automation-execution/templates/job-template-notifications.spec.ts
@@ -20,7 +20,7 @@ test.describe('Job Template - notifications tab', () => {
   });
   test(
     'can navigate to the Job Templates -> Notifications list and then to the details page of the Notification',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       const notifierName = await Notifier.ui.createSlack(page);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
@@ -47,7 +47,7 @@ test.describe('Job Template - notifications tab', () => {
 
   test(
     'can toggle the Job Templates -> Notification on and off for job start',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       const notifierName = await Notifier.ui.createSlack(page);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
@@ -86,7 +86,7 @@ test.describe('Job Template - notifications tab', () => {
 
   test(
     'can toggle the Job Templates -> Notification on and off for job success',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       const notifierName = await Notifier.ui.createSlack(page);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
@@ -129,7 +129,7 @@ test.describe('Job Template - notifications tab', () => {
 
   test(
     'can toggle the Job Templates -> Notification on and off for job failure',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       const notifierName = await Notifier.ui.createSlack(page);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });

--- a/playwright/tests/integration/automation-execution/templates/job-template-surveys.spec.ts
+++ b/playwright/tests/integration/automation-execution/templates/job-template-surveys.spec.ts
@@ -56,7 +56,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'can create a required survey from surveys tab list of a JT, toggle survey on, and assert info on surveys list view',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
         await expect(
@@ -97,7 +97,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'can edit a JT survey from surveys list view and assert info on surveys list view',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.api.createQuestion(page, jobTemplate.name, question);
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
@@ -144,7 +144,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'can delete a JT survey from the surveys list view and assert deletion',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.api.createQuestion(page, jobTemplate.name, question);
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
@@ -171,7 +171,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'should show validation error when minimum length exceeds maximum length for text type',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
         await page.getByRole('link', { name: 'Create survey question', exact: true }).click();
@@ -199,7 +199,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'should show validation error when minimum exceeds maximum for integer type',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
         await page.getByRole('link', { name: 'Create survey question', exact: true }).click();
@@ -231,7 +231,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'should clear validation error when min/max values are corrected',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
         await page.getByRole('link', { name: 'Create survey question', exact: true }).click();
@@ -266,7 +266,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'should validate text answer by length not numeric value (01 is valid for length 2)',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await JobTemplateSurvey.ui.navigateToSurveyTab(page, jobTemplate.name);
         await page.getByRole('link', { name: 'Create survey question', exact: true }).click();
@@ -313,7 +313,7 @@ test.describe('Job Templates Surveys', () => {
 
     test(
       'can create multiple surveys, assert order, change order, and assert new order, then bulk delete all surveys',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         const specs: SurveyQuestion[] = [
           {
@@ -559,7 +559,7 @@ test.describe('Job Templates Surveys', () => {
     for (const surveyType of surveyTypes) {
       test(
         `can create ${surveyType.type} survey type, enable survey, launch JT, view default survey answer, complete launch, and assert survey answer on completed job`,
-        { tag: ['@not_mock'] },
+        { tag: ['@not_mock', '@tier1'] },
         async ({ page }) => {
           test.setTimeout(5 * 60 * 1000);
           await JobTemplateSurvey.api.createQuestion(page, jobTemplate.name, surveyType.question);

--- a/playwright/tests/integration/automation-execution/templates/job-template-validation.spec.ts
+++ b/playwright/tests/integration/automation-execution/templates/job-template-validation.spec.ts
@@ -14,7 +14,7 @@ test.describe('Job Template Form - Validation', () => {
 
   test(
     'cannot create a job template with more than one machine credential',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
 
@@ -66,7 +66,7 @@ test.describe('Job Template Form - Validation', () => {
 
   test(
     'cannot create a job template with more than one vault credential with same vault_id',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
 

--- a/playwright/tests/integration/automation-execution/templates/job-template.spec.ts
+++ b/playwright/tests/integration/automation-execution/templates/job-template.spec.ts
@@ -21,17 +21,19 @@ test.describe('Job Templates', () => {
     await setupAfter({ page });
   });
 
-  test('can create a job template and assert the information showing on the details page', async ({
-    page,
-  }) => {
-    test.setTimeout(2 * 60 * 1000);
-    const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
-    await JobTemplate.ui.delete(page, jobTemplateName);
-  });
+  test(
+    'can create a job template and assert the information showing on the details page',
+    { tag: ['@tier1'] },
+    async ({ page }) => {
+      test.setTimeout(2 * 60 * 1000);
+      const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
+      await JobTemplate.ui.delete(page, jobTemplateName);
+    }
+  );
 
   test(
     'can create a job template with prompted fields, launch from the list view, and complete launch via wizard',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 30 * 1000);
       const label = createE2EName('label-jt');
@@ -52,7 +54,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can create a job template with a survey, add limits and verify they are displayed on Edit',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 30 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, {
@@ -82,7 +84,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can launch a job template from the details page launch button using the prompt on launch',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, {
@@ -101,7 +103,7 @@ test.describe('Job Templates', () => {
 
   test(
     'job template - edit using row action of the template list page',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -129,7 +131,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can edit a job template using the edit template button on details page',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -160,7 +162,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can assign a new inventory to a job template if the originally assigned inventory was deleted',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       // create inventory + job template and then delete inventory
@@ -297,7 +299,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can delete a job template from the list line item',
-    { tag: ['@compare'] },
+    { tag: ['@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -307,7 +309,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can delete a job template from the details page',
-    { tag: ['@compare'] },
+    { tag: ['@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -317,7 +319,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can bulk delete job templates from the list page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName1 = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -347,7 +349,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can create a job template and assert the OPA is showing on the details page',
-    { tag: ['@compare', '@mock'] },
+    { tag: ['@compare', '@mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = createE2EName('job-template');
@@ -388,7 +390,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can create a job template, select multiple credentials and deselct one from the selected credential chip close button',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = createE2EName('job-template');
@@ -439,7 +441,7 @@ test.describe('Job Templates', () => {
 
   test(
     'can launch a job template with an enabled survey from the details page launch button using the prompt on launch',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const surveyQuestion = 'q1';
@@ -471,7 +473,7 @@ test.describe('Job Templates', () => {
 
   test(
     'verify playbook selection does not auto-clear unexpectedly',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(60000);
 
@@ -576,76 +578,82 @@ test.describe('Job Templates', () => {
     }
   );
 
-  test('verify the playbook field is creatable', { tag: ['@not_mock'] }, async ({ page }) => {
-    const jobTemplateName = createE2EName('playbook-creatable');
+  test(
+    'verify the playbook field is creatable',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const jobTemplateName = createE2EName('playbook-creatable');
 
-    // Navigate to templates page
-    await navigateTo(page, 'Automation Execution', 'Templates');
-    await expect(page.getByTestId('page-title')).toBeVisible({ timeout: 10000 });
+      // Navigate to templates page
+      await navigateTo(page, 'Automation Execution', 'Templates');
+      await expect(page.getByTestId('page-title')).toBeVisible({ timeout: 10000 });
 
-    const createButtonExists = await page.getByText('Create template', { exact: true }).count();
-    const dropdownExists = await page
-      .getByRole('button', { name: 'dropdown toggle', exact: true })
-      .count();
-
-    if (createButtonExists > 0) {
-      await page.getByText('Create template', { exact: true }).click();
-      const menuItemExists = await page
-        .getByRole('menuitem', { name: 'Create job template' })
+      const createButtonExists = await page.getByText('Create template', { exact: true }).count();
+      const dropdownExists = await page
+        .getByRole('button', { name: 'dropdown toggle', exact: true })
         .count();
-      if (menuItemExists > 0) {
-        await page.getByRole('menuitem', { name: 'Create job template' }).click();
+
+      if (createButtonExists > 0) {
+        await page.getByText('Create template', { exact: true }).click();
+        const menuItemExists = await page
+          .getByRole('menuitem', { name: 'Create job template' })
+          .count();
+        if (menuItemExists > 0) {
+          await page.getByRole('menuitem', { name: 'Create job template' }).click();
+        } else {
+          test.skip(true, 'Create job template menu item not found');
+        }
+      } else if (dropdownExists > 0) {
+        await page.getByRole('button', { name: 'dropdown toggle', exact: true }).click();
+        await page.waitForTimeout(1000);
+        const menuItemExists = await page
+          .getByRole('menuitem', { name: 'Create job template' })
+          .count();
+        if (menuItemExists > 0) {
+          await page.getByRole('menuitem', { name: 'Create job template' }).click();
+        } else {
+          test.skip(true, 'Create job template menu item not found in dropdown');
+        }
       } else {
-        test.skip(true, 'Create job template menu item not found');
+        test.skip(true, 'Cannot access job template creation form - no create buttons found');
       }
-    } else if (dropdownExists > 0) {
-      await page.getByRole('button', { name: 'dropdown toggle', exact: true }).click();
-      await page.waitForTimeout(1000);
-      const menuItemExists = await page
-        .getByRole('menuitem', { name: 'Create job template' })
-        .count();
-      if (menuItemExists > 0) {
-        await page.getByRole('menuitem', { name: 'Create job template' }).click();
-      } else {
-        test.skip(true, 'Create job template menu item not found in dropdown');
-      }
-    } else {
-      test.skip(true, 'Cannot access job template creation form - no create buttons found');
+
+      // Continue with form if we got here
+      await expect(page.getByPlaceholder('Enter job template name')).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByPlaceholder('Enter job template name').fill(jobTemplateName);
+
+      // Select inventory (required)
+      await page.getByRole('button', { name: 'Inventory' }).click();
+      await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 5000 });
+      await page.locator('[role="option"]').first().click();
+
+      await page.locator('#project-select').click();
+      await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 5000 });
+      const projectOptions = await page.locator('[role="option"]').all();
+      expect(projectOptions.length).toBeGreaterThan(0);
+      await projectOptions[0].click();
+
+      // Wait for and interact with playbook field
+      await expect(page.getByPlaceholder('Add a project, then select a')).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByPlaceholder('Add a project, then select a').fill('test_hello_world.yml');
+      await page.getByRole('option', { name: 'Create "test_hello_world.yml"' }).click();
+      const selectedPlaybook = await page
+        .getByPlaceholder('Add a project, then select a')
+        .inputValue();
+
+      expect(selectedPlaybook).toBe('test_hello_world.yml');
+
+      await page.waitForTimeout(3000);
+      const persistedValue = await page
+        .getByPlaceholder('Add a project, then select a')
+        .inputValue();
+      expect(persistedValue).toBe('test_hello_world.yml');
     }
-
-    // Continue with form if we got here
-    await expect(page.getByPlaceholder('Enter job template name')).toBeVisible({
-      timeout: 10000,
-    });
-    await page.getByPlaceholder('Enter job template name').fill(jobTemplateName);
-
-    // Select inventory (required)
-    await page.getByRole('button', { name: 'Inventory' }).click();
-    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 5000 });
-    await page.locator('[role="option"]').first().click();
-
-    await page.locator('#project-select').click();
-    await expect(page.locator('[role="option"]').first()).toBeVisible({ timeout: 5000 });
-    const projectOptions = await page.locator('[role="option"]').all();
-    expect(projectOptions.length).toBeGreaterThan(0);
-    await projectOptions[0].click();
-
-    // Wait for and interact with playbook field
-    await expect(page.getByPlaceholder('Add a project, then select a')).toBeVisible({
-      timeout: 10000,
-    });
-    await page.getByPlaceholder('Add a project, then select a').fill('test_hello_world.yml');
-    await page.getByRole('option', { name: 'Create "test_hello_world.yml"' }).click();
-    const selectedPlaybook = await page
-      .getByPlaceholder('Add a project, then select a')
-      .inputValue();
-
-    expect(selectedPlaybook).toBe('test_hello_world.yml');
-
-    await page.waitForTimeout(3000);
-    const persistedValue = await page.getByPlaceholder('Add a project, then select a').inputValue();
-    expect(persistedValue).toBe('test_hello_world.yml');
-  });
+  );
 });
 
 test.describe('Job Template - Copy/Duplicate', () => {
@@ -663,7 +671,7 @@ test.describe('Job Template - Copy/Duplicate', () => {
 
   test(
     'can copy an existing job template from the list view',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -694,7 +702,7 @@ test.describe('Job Template - Copy/Duplicate', () => {
 
   test(
     'can copy an existing job template from the details page',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(2 * 60 * 1000);
       const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName: inventoryName });
@@ -730,7 +738,7 @@ test.describe('Job Template - Auto-populate from Project/Inventory', () => {
 
   test(
     'can auto-populate job template form when creating from project page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Use Demo Project which should exist by default
       const projectName = 'Demo Project';
@@ -771,7 +779,7 @@ test.describe('Job Template - Auto-populate from Project/Inventory', () => {
 
   test(
     'can auto-populate job template form when creating from inventory page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Use Demo Inventory which should exist by default
       const inventoryName = 'Demo Inventory';

--- a/playwright/tests/integration/automation-execution/workflow-job-templates/workflow-job-template-surveys.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-job-templates/workflow-job-template-surveys.spec.ts
@@ -33,7 +33,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should create a required survey from surveys tab list of a WFJT, toggle survey on, and assert info on surveys list view',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Navigate to survey tab', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);
@@ -90,7 +90,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should edit a WFJT survey from surveys list view and assert info on surveys list view',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Create survey via API', async () => {
           await WorkflowJobTemplateSurvey.api.createQuestion(
@@ -151,7 +151,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should delete a WFJT survey from the surveys list view and assert deletion',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Create survey via API', async () => {
           await WorkflowJobTemplateSurvey.api.createQuestion(
@@ -195,7 +195,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should create multiple surveys, assert order, change order, and assert new order, then bulk delete all surveys',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         const specs: SurveyQuestion[] = [
           {
@@ -313,7 +313,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should show validation error when minimum length exceeds maximum length for text type',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Navigate to survey tab', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);
@@ -348,7 +348,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should show validation error when minimum exceeds maximum for integer type',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Navigate to survey tab', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);
@@ -390,7 +390,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should clear validation error when min/max values are corrected',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Navigate to survey tab', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);
@@ -434,7 +434,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should validate text answer by length not numeric value (01 is valid for length 2)',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Navigate to survey tab', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);
@@ -623,7 +623,7 @@ test.describe('Workflow Job Templates Surveys', () => {
 
     test(
       'should create survey with all question types via UI, enable survey, and verify launch functionality',
-      { tag: ['@not_mock'] },
+      { tag: ['@not_mock', '@tier1'] },
       async ({ page }) => {
         await test.step('Create all survey question types via UI', async () => {
           await WorkflowJobTemplateSurvey.ui.navigateToSurveyTab(page, workflowJobTemplate.name);

--- a/playwright/tests/integration/automation-execution/workflow-job-templates/workflow-job-templates.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-job-templates/workflow-job-templates.spec.ts
@@ -41,7 +41,7 @@ test.describe('Workflow Job Templates: Create', () => {
 
   test(
     'can create a WFJT with only a name and then edit it to add all optional fields',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const wfjtName = createE2EName('workflow-job-template');
 
@@ -135,7 +135,7 @@ test.describe('Workflow Job Templates: Create', () => {
 
   test(
     'can create a workflow job template using all optional fields',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const wfjtName = createE2EName('workflow-job-template');
 
@@ -219,7 +219,7 @@ test.describe('Workflow Job Templates: Edit', () => {
 
   test(
     'can edit a workflow job template from the details view',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const newName = `${workflowJobTemplateName} edited`;
 
@@ -263,7 +263,7 @@ test.describe('Workflow Job Templates: Edit', () => {
 
   test(
     'can edit a workflow job template from the list row',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const newName = `${workflowJobTemplateName} edited`;
 
@@ -334,7 +334,7 @@ test.describe('Workflow Job Templates: Copy', () => {
 
   test(
     'can duplicate an existing workflow job template from the list',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Close the visualizer from beforeEach
       await page.getByTestId('workflow-visualizer-toolbar-close').click();
@@ -367,7 +367,7 @@ test.describe('Workflow Job Templates: Copy', () => {
 
   test(
     'can duplicate an existing workflow job template from the details page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Close the visualizer from beforeEach - this navigates to the details page
       await page.getByTestId('workflow-visualizer-toolbar-close').click();
@@ -451,7 +451,7 @@ test.describe('Workflow Job Templates: Delete', () => {
 
   test(
     'can delete a workflow job template from the details page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Use the utility function which properly handles deletion
       await WorkflowJobTemplate.ui.delete(page, workflowJobTemplateName);
@@ -465,7 +465,7 @@ test.describe('Workflow Job Templates: Delete', () => {
 
   test(
     'can delete a workflow job template from the list row',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await navigateTo(page, 'Automation Execution', 'Templates');
       await filterTable({ filterLabel: 'Name', filterValue: workflowJobTemplateName }, page);
@@ -492,7 +492,7 @@ test.describe('Workflow Job Templates: Delete', () => {
 
   test(
     'can bulk delete multiple workflow job templates from the list toolbar',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       // Create a second workflow job template
       const result2 = await WorkflowJobTemplate.ui.create(page, {
@@ -570,7 +570,7 @@ test.describe('Workflow Job Templates: Launch', () => {
 
   test(
     'can launch a workflow job template from details view',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await navigateTo(page, 'Automation Execution', 'Templates');
       await expect(
@@ -630,7 +630,7 @@ test.describe('Workflow Job Templates: Prompt on Launch', () => {
 
   test(
     'can launch a workflow job template with prompt on launch values',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await navigateTo(page, 'Automation Execution', 'Templates');
       await expect(
@@ -698,7 +698,7 @@ test.describe('Workflow Job Templates: Output and Details Screen', () => {
 
   test(
     'can launch a workflow job, let it finish, and assert expected results on output and details screens',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
 

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer.spec.ts
@@ -21,7 +21,7 @@ test.setTimeout(2 * 60 * 1000);
 test.describe('Workflow Viz', () => {
   test(
     'Workflow Viz Add Nodes: Should render a workflow visualizer view with multiple nodes present',
-    { tag: ['@not_e2e', '@not_mock', '@compare'] },
+    { tag: ['@not_e2e', '@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(8 * 60 * 1000);
 
@@ -42,7 +42,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Workflow Viz Add Nodes: Should create a workflow job template and then navigate to the visualizer, and then navigate to the details view after clicking cancel',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const wfJobTemplate = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
@@ -109,7 +109,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Can edit a node resource on a workflow visualizer already containing existing nodes',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const projectOneName = createE2EName();
@@ -140,7 +140,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Click on edge context menu option to change link type and close visualizer to show unsaved changes modal',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const jobTemplateName = createE2EName();
@@ -266,7 +266,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Can manually delete all nodes, save the visualizer, then add new nodes, and successfully save again.',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const projectOneName = createE2EName();
@@ -351,7 +351,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Can remove all existing nodes on a visualizer using the button in the toolbar kebab, save the visualizer, then add 2 new nodes and save the visualizer again',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const projectName = createE2EName();
@@ -395,7 +395,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Can delete one single node and save the visualizer',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const sourceName = createE2EName();
@@ -466,59 +466,63 @@ test.describe('Workflow Viz', () => {
     }
   );
 
-  test('Should update skip tags', { tag: ['@not_mock', '@compare'] }, async ({ page }) => {
-    const jtName = createE2EName();
-    const inventoryName = await Inventory.ui.create(page);
-    const jobTemplate = await JobTemplate.ui.create(page, {
-      name: jtName,
-      skipTagsPrompt: true,
-      inventoryName,
-    });
-    const workflowJobTemplate = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
-    test.setTimeout(5 * 60 * 1000);
-    await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
-    await page.getByRole('button', { name: 'Add step' }).nth(1).click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await page.getByRole('button', { name: 'Job Template', exact: true }).click();
-    await page.getByRole('option', { name: 'Job Template', exact: true }).click();
-    await page.getByRole('button', { name: 'Job template', exact: true }).click();
-    await page.getByRole('textbox', { name: 'Search input' }).click();
-    await page.getByRole('textbox', { name: 'Search input' }).fill(jtName);
-    await page.getByRole('option', { name: jtName }).click();
-    await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
-    await page.getByRole('button', { name: 'Prompts' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag1');
-    await page.getByRole('option', { name: 'Create "tag1"' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag2');
-    await page.getByRole('option', { name: 'Create "tag2"' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).click();
-    await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag3');
-    await page.getByRole('option', { name: 'Create "tag3"' }).click();
-    await page.getByRole('button', { name: 'Next' }).click();
-    await page.getByRole('button', { name: 'Finish' }).click();
-    await page.getByRole('button', { name: 'Legend' }).click();
-    await page.getByRole('button', { name: 'Legend' }).click();
-    await page.getByRole('button', { name: 'Fit to Screen' }).click();
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
-    await expect(page.getByText('Success alert:Successfully')).toBeVisible();
-    await page.getByRole('button', { name: 'Close Success alert: alert:' }).click();
-    await expect(page.locator('[class*="action-icon__background"]').first()).toBeVisible();
-    await page.locator('[class*="topology__node__label"]', { hasText: jtName }).click();
-    await expect(page.getByRole('link', { name: jtName })).toBeVisible();
-    await page.getByText('Skip tags', { exact: true }).hover();
-    await page.mouse.wheel(0, 1000);
-    await expect(
-      page
-        .locator('div')
-        .filter({ hasText: /^tag1tag2tag3$/ })
-        .first()
-    ).toBeVisible();
-    await JobTemplate.ui.delete(page, jobTemplate);
-    await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, workflowJobTemplate);
-    await Inventory.ui.delete(page, inventoryName);
-  });
+  test(
+    'Should update skip tags',
+    { tag: ['@not_mock', '@compare', '@tier1'] },
+    async ({ page }) => {
+      const jtName = createE2EName();
+      const inventoryName = await Inventory.ui.create(page);
+      const jobTemplate = await JobTemplate.ui.create(page, {
+        name: jtName,
+        skipTagsPrompt: true,
+        inventoryName,
+      });
+      const workflowJobTemplate = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+      test.setTimeout(5 * 60 * 1000);
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(jtName);
+      await page.getByRole('option', { name: jtName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag1');
+      await page.getByRole('option', { name: 'Create "tag1"' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag2');
+      await page.getByRole('option', { name: 'Create "tag2"' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).fill('tag3');
+      await page.getByRole('option', { name: 'Create "tag3"' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.getByRole('button', { name: 'Finish' }).click();
+      await page.getByRole('button', { name: 'Legend' }).click();
+      await page.getByRole('button', { name: 'Legend' }).click();
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Success alert:Successfully')).toBeVisible();
+      await page.getByRole('button', { name: 'Close Success alert: alert:' }).click();
+      await expect(page.locator('[class*="action-icon__background"]').first()).toBeVisible();
+      await page.locator('[class*="topology__node__label"]', { hasText: jtName }).click();
+      await expect(page.getByRole('link', { name: jtName })).toBeVisible();
+      await page.getByText('Skip tags', { exact: true }).hover();
+      await page.mouse.wheel(0, 1000);
+      await expect(
+        page
+          .locator('div')
+          .filter({ hasText: /^tag1tag2tag3$/ })
+          .first()
+      ).toBeVisible();
+      await JobTemplate.ui.delete(page, jobTemplate);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, workflowJobTemplate);
+      await Inventory.ui.delete(page, inventoryName);
+    }
+  );
 
   //Unskip this test when https://issues.redhat.com/browse/AAP-42422 is fixed
   test.skip(
@@ -620,7 +624,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Create a job template node using a JT with a survey enabled',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const inventoryName = await Inventory.ui.create(page);
@@ -661,7 +665,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Should display review step fields when adding an approval node',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
       const wfJobTemplate = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
@@ -700,7 +704,7 @@ test.describe('Workflow Viz', () => {
 
   test(
     'Should save and persist credentials when workflow node has empty credential override',
-    { tag: ['@not_mock', '@compare'] },
+    { tag: ['@not_mock', '@compare', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(5 * 60 * 1000);
 

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflowVisualizerOutput.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflowVisualizerOutput.spec.ts
@@ -154,7 +154,7 @@ test.describe('Workflow Visualizer - Job Output', () => {
 
   test(
     'should launch a workflow job template from the templates list and navigate to the output page',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await test.step('Navigate to templates and filter for workflow job template', async () => {
         await navigateTo(page, 'Automation Execution', 'Templates');
@@ -193,7 +193,7 @@ test.describe('Workflow Visualizer - Job Output', () => {
 
   test(
     'should configure prompt-on-launch values of a node, launch the job, and view the output screen',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await test.step('Enable ask_variables_on_launch for job template', async () => {
         await awxAPI.patch(page, `job_templates/${jobTemplate.id}/`, {
@@ -300,7 +300,7 @@ test.describe('Workflow Visualizer - Job Output', () => {
 
   test(
     'should view the details pages of related jobs on a workflow either by clicking job nodes or toggling the workflow jobs dropdown',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       await test.step('Navigate to workflow job template details', async () => {
         await navigateTo(page, 'Automation Execution', 'Templates');


### PR DESCRIPTION
This PR adds `@tier1` tags to all active Playwright tests for Job Templates and Workflow Job Templates to enable Tier 1 Jenkins pipeline execution.

## Changes

- Tagged 75 active tests across 8 spec files:
  - **Job Templates**: 20 tests (job-template.spec.ts, job-template-validation.spec.ts, job-template-surveys.spec.ts, job-template-notifications.spec.ts)
  - **Workflow Job Templates**: 21 tests (workflow-job-templates.spec.ts, workflow-job-template-surveys.spec.ts)
  - **Workflow Visualizer**: 14 tests (workflow-visualizer.spec.ts, workflowVisualizerOutput.spec.ts)

- Tests with existing tags: `@tier1` merged into existing tag arrays
- Tests without tags: Added `{ tag: ['@tier1'] },`
- Permanently skipped tests (`test.skip`): NOT tagged per testing strategy

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

**Rationale**: Test metadata changes only - no functional code changes. Adding tags enables tests to run in Tier 1 pipeline but does not modify test logic or application code.

---

🤖 AI assisted