### PR TITLE
test: shift left redundant settings patterns

### DIFF
--- a/playwright/tests/integration/settings/feature-flags.spec.ts
+++ b/playwright/tests/integration/settings/feature-flags.spec.ts
@@ -10,61 +10,6 @@ const platformUIWithoutSlash = platformUI.endsWith('/') ? platformUI.slice(0, -1
 
 test.afterEach(setupAfter);
 
-test.describe('Feature Flags - Page Visibility', () => {
-  test('should show Feature Flags nav item when RUNTIME_FEATURE_FLAGS is enabled', async ({
-    page,
-  }) => {
-    await SettingsFeatureFlags.mock.settings(page, { runtimeFeatureFlags: true });
-    await FeatureFlags.mock.list(page);
-    await login(page, platformUIWithoutSlash + '/overview');
-
-    const nav = page.locator('.pf-v6-c-nav');
-    await expect(nav).toBeVisible();
-
-    const settingsItem = nav
-      .locator('li')
-      .filter({ hasText: /^Settings/i })
-      .first();
-    await expect(settingsItem).toBeVisible();
-
-    if (!(await settingsItem.evaluate((el) => el.classList.contains('pf-m-expanded')))) {
-      await settingsItem.getByRole('button').click();
-    }
-
-    const featureFlagsLink = settingsItem.locator('li').filter({ hasText: /^Feature Flags/i });
-    await expect(featureFlagsLink).toBeVisible();
-
-    await featureFlagsLink.getByRole('link').click();
-    await expect(page.getByRole('heading', { name: 'Feature Flags' }).first()).toBeVisible();
-  });
-
-  test('should hide Feature Flags nav item when RUNTIME_FEATURE_FLAGS is disabled', async ({
-    page,
-  }) => {
-    await SettingsFeatureFlags.mock.settings(page, { runtimeFeatureFlags: false });
-    await login(page, platformUIWithoutSlash + '/overview');
-
-    const nav = page.locator('.pf-v6-c-nav');
-    await expect(nav).toBeVisible();
-
-    const settingsItem = nav
-      .locator('li')
-      .filter({ hasText: /^Settings/i })
-      .first();
-    await expect(settingsItem).toBeVisible();
-
-    if (!(await settingsItem.evaluate((el) => el.classList.contains('pf-m-expanded')))) {
-      await settingsItem.getByRole('button').click();
-    }
-
-    const featureFlagsLink = settingsItem.locator('li').filter({ hasText: /^Feature Flags/i });
-    await expect(featureFlagsLink).toBeHidden();
-
-    await page.goto(platformUIWithoutSlash + '/settings/feature-flags');
-    await expect(page.getByText('Page not found')).toBeVisible({ timeout: 30000 });
-  });
-});
-
 test.describe('Feature Flags - Toggle', () => {
   test('should open confirmation dialog and toggle a feature flag', async ({ page }) => {
     await SettingsFeatureFlags.mock.settings(page, { runtimeFeatureFlags: true });
@@ -306,17 +251,6 @@ test.describe('Feature Flags - Access Control', () => {
   test.afterEach(async ({ page }) => {
     await User.api.delete(page, normalUser.id).catch(() => {});
     await User.api.delete(page, auditorUser.id).catch(() => {});
-  });
-
-  test('should show Feature Flags page with toggle switches for admin', async ({ page }) => {
-    await SettingsFeatureFlags.mock.settings(page, { runtimeFeatureFlags: true });
-    await FeatureFlags.mock.list(page);
-    await page.goto(platformUIWithoutSlash + '/settings/feature-flags');
-
-    await expect(page.getByRole('heading', { name: 'Feature Flags' }).first()).toBeVisible({
-      timeout: 30000,
-    });
-    await expect(page.getByTestId('toggle-switch').first()).toBeVisible();
   });
 
   test('should show Feature Flags page as read-only for auditor', async ({ page }) => {

--- a/playwright/tests/integration/settings/feature-flags.spec.ts
+++ b/playwright/tests/integration/settings/feature-flags.spec.ts
@@ -257,14 +257,10 @@ test.describe('Feature Flags - Access Control', () => {
     await SettingsFeatureFlags.mock.settings(page, { runtimeFeatureFlags: true });
     await FeatureFlags.mock.list(page);
     await logout(page);
-    await page.goto(platformUIWithoutSlash + '/overview');
-    await expect(page).toHaveTitle(/Ansible Automation Platform/, { timeout: 30000 });
-    await page.fill('#pf-login-username-id', auditorUser.username);
-    await page.fill('#pf-login-password-id', userPassword);
-    await page.click('button[type="submit"]');
-    await expect(
-      page.getByTestId('toolbar').getByRole('button', { name: auditorUser.username })
-    ).toBeVisible();
+    await login(page, platformUIWithoutSlash + '/overview', {
+      username: auditorUser.username,
+      password: userPassword,
+    });
 
     await navigateTo(page, 'Settings', 'Feature Flags');
     await expect(page.getByRole('heading', { name: 'Feature Flags' }).first()).toBeVisible();


### PR DESCRIPTION
## Summary

Shifts redundant settings tests out of Tier 1.

**Removed 3 tests from `feature-flags.spec.ts`** (8 → 5 tests):

- **"show Feature Flags nav item when enabled"** and **"hide Feature Flags nav item when disabled"** — These are config-visibility checks using mocked routes. The source hook `useRuntimeFeatureFlagsEnabled` already has comprehensive Vitest coverage (`useRuntimeFeatureFlagsEnabled.test.tsx`), making these Playwright tests redundant.
- **"show Feature Flags page with toggle switches for admin"** — This is a strict subset of the "toggle a feature flag" test, which already navigates to the page as admin and verifies toggle switches are visible before interacting with them.

**Unchanged (already pre-merge by default):**

- `troubleshooting-settings.spec.ts` (1 test) — Same edit pattern as job/policy settings; no `@tier1` tag
- `logging-settings.spec.ts` (1 test) — Same edit pattern as job/policy settings; no `@tier1` tag

**No new Vitest needed** — existing unit tests already cover the removed paths:
- `useRuntimeFeatureFlagsEnabled.test.tsx` — nav visibility gating
- `FeatureFlagsPage.test.tsx` — page rendering
- `useFeatureFlagToggleModal.test.tsx` — toggle modal behavior

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Will trigger `/run-playwright` once preliminary checks pass.

### Manual Testing

- Remaining 5 feature flag tests should pass against a live AAP instance
- Troubleshooting and logging tests remain unchanged and should continue passing


Made with [Cursor](https://cursor.com)