### PR TITLE
SonarCloud Fix: Remove unused variables (S1481, frontend/hub)

### DIFF
--- a/frontend/hub/interfaces/transform.cjs
+++ b/frontend/hub/interfaces/transform.cjs
@@ -171,7 +171,6 @@ function serializeObjectInterface(schema, depth, interfaceName, needImport) {
       // type, description, format : 'date-time'
       const type = property.type;
       const description = property.description;
-      const format = property.format;
 
       const tabs = '\t\t\t\t';
 
@@ -254,7 +253,6 @@ fs.readFile(filePath, 'utf8', (err, data) => {
 
         fileContent += add('/* eslint-disable @typescript-eslint/no-empty-interface */');
 
-        let canCreateFile = true;
 
         if (pathSchemas[interfaceName]) {
           interfacePath = pathSchemas[interfaceName]?.path;


### PR DESCRIPTION
## Summary

Remove 2 unused variable declarations in `frontend/hub/interfaces/transform.cjs`.
Addresses SonarCloud rule `javascript:S1481` (2 violations).

- Removed unused `format` variable (line 174)
- Removed unused `canCreateFile` variable (line 257)

SonarCloud dashboard: https://sonarcloud.io/project/issues?id=ansible_ansible-ui&rules=javascript:S1481

## Type of Change

- [x] Enhancement

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (removing unused variable declarations has no runtime effect).

## Testing

Validation passed: `node --check` syntax validation (sandbox `npm run tsc` blocked by pre-existing NX/webpack environment issue, unrelated to this change).