### PR TITLE
fix(hub): defer theme management to Chrome shell in Insights build

### DIFF
--- a/framework/PageFramework.test.tsx
+++ b/framework/PageFramework.test.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { PageFramework } from './PageFramework';
+
+Object.defineProperty(globalThis, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe('PageFramework', () => {
+  test('should render children', () => {
+    render(
+      <PageFramework defaultRefreshInterval={30}>
+        <div data-testid="child">Hello</div>
+      </PageFramework>
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('Hello');
+  });
+
+  test('should pass disableThemeManagement to PageSettingsProvider', () => {
+    render(
+      <PageFramework defaultRefreshInterval={30} disableThemeManagement>
+        <div data-testid="child">Hello</div>
+      </PageFramework>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(document.documentElement.classList.contains('pf-v6-theme-dark')).toBe(false);
+  });
+});

--- a/framework/PageFramework.tsx
+++ b/framework/PageFramework.tsx
@@ -15,10 +15,17 @@ import { FrameworkTranslationsProvider } from './useFrameworkTranslations';
  * @example
  * <PageFramework>...</PageFramework>
  */
-export function PageFramework(props: { children: ReactNode; defaultRefreshInterval: number }) {
+export function PageFramework(props: {
+  children: ReactNode;
+  defaultRefreshInterval: number;
+  disableThemeManagement?: boolean;
+}) {
   return (
     <FrameworkTranslationsProvider>
-      <PageSettingsProvider defaultRefreshInterval={props.defaultRefreshInterval}>
+      <PageSettingsProvider
+        defaultRefreshInterval={props.defaultRefreshInterval}
+        disableThemeManagement={props.disableThemeManagement}
+      >
         <PageNavigationRoutesProvider>
           <PageDialogProvider>
             <PageAlertToasterProvider>

--- a/framework/PageSettings/PageSettingsProvider.test.tsx
+++ b/framework/PageSettings/PageSettingsProvider.test.tsx
@@ -219,6 +219,12 @@ describe('PageSettingsProvider', () => {
       });
     });
 
+    const disabledThemeWrapper = ({ children }: { children: ReactNode }) => (
+      <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
+        {children}
+      </PageSettingsProvider>
+    );
+
     test('should not modify document theme class when disableThemeManagement is true and theme is dark', async () => {
       vi.mocked(globalThis.matchMedia).mockImplementation((query: string) => ({
         matches: query === '(prefers-color-scheme: dark)',
@@ -231,13 +237,7 @@ describe('PageSettingsProvider', () => {
         dispatchEvent: vi.fn(),
       }));
 
-      const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
-          {children}
-        </PageSettingsProvider>
-      );
-
-      const { result } = renderHook(() => usePageSettings(), { wrapper });
+      const { result } = renderHook(() => usePageSettings(), { wrapper: disabledThemeWrapper });
 
       await waitFor(() => {
         expect(result.current.activeTheme).toBe('dark');
@@ -260,13 +260,7 @@ describe('PageSettingsProvider', () => {
         dispatchEvent: vi.fn(),
       }));
 
-      const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
-          {children}
-        </PageSettingsProvider>
-      );
-
-      const { result } = renderHook(() => usePageSettings(), { wrapper });
+      const { result } = renderHook(() => usePageSettings(), { wrapper: disabledThemeWrapper });
 
       await waitFor(() => {
         expect(result.current.activeTheme).toBe('light');

--- a/framework/PageSettings/PageSettingsProvider.test.tsx
+++ b/framework/PageSettings/PageSettingsProvider.test.tsx
@@ -218,6 +218,62 @@ describe('PageSettingsProvider', () => {
         expect(result.current.theme).toBe('light');
       });
     });
+
+    test('should not modify document theme class when disableThemeManagement is true and theme is dark', async () => {
+      vi.mocked(globalThis.matchMedia).mockImplementation((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
+          {children}
+        </PageSettingsProvider>
+      );
+
+      const { result } = renderHook(() => usePageSettings(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.activeTheme).toBe('dark');
+      });
+
+      expect(document.documentElement.classList.contains('pf-v6-theme-dark')).toBe(false);
+    });
+
+    test('should not modify document theme class when disableThemeManagement is true and theme is light', async () => {
+      document.documentElement.classList.add('pf-v6-theme-dark');
+
+      vi.mocked(globalThis.matchMedia).mockImplementation(() => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
+          {children}
+        </PageSettingsProvider>
+      );
+
+      const { result } = renderHook(() => usePageSettings(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.activeTheme).toBe('light');
+      });
+
+      expect(document.documentElement.classList.contains('pf-v6-theme-dark')).toBe(true);
+    });
   });
 
   describe('SWR Configuration', () => {

--- a/framework/PageSettings/PageSettingsProvider.tsx
+++ b/framework/PageSettings/PageSettingsProvider.tsx
@@ -62,6 +62,7 @@ export function usePageSettings() {
 export function PageSettingsProvider(props: {
   children?: ReactNode;
   defaultRefreshInterval: number;
+  disableThemeManagement?: boolean;
 }) {
   const [settings, setSettingsState] = useState<IPageSettings>(() => {
     const preferencesStorage = localStorage.getItem('user-preferences');
@@ -105,12 +106,14 @@ export function PageSettingsProvider(props: {
       if (settings.activeTheme === activeTheme) return settings;
       return { ...settings, activeTheme };
     });
-    if (activeTheme === 'dark') {
-      document.documentElement.classList.add('pf-v6-theme-dark');
-    } else {
-      document.documentElement.classList.remove('pf-v6-theme-dark');
+    if (!props.disableThemeManagement) {
+      if (activeTheme === 'dark') {
+        document.documentElement.classList.add('pf-v6-theme-dark');
+      } else {
+        document.documentElement.classList.remove('pf-v6-theme-dark');
+      }
     }
-  }, [activeTheme]);
+  }, [activeTheme, props.disableThemeManagement]);
 
   return (
     <SWRConfig

--- a/frontend/hub/insights/HubRoot.tsx
+++ b/frontend/hub/insights/HubRoot.tsx
@@ -44,7 +44,7 @@ function HubRoot() {
 
   // Note: No BrowserRouter here - Chrome provides the router context
   return (
-    <PageFramework defaultRefreshInterval={10}>
+    <PageFramework defaultRefreshInterval={10} disableThemeManagement>
       <HubActiveUserProvider>
         <HubContextProvider>
           <HubInsightsApp />

--- a/playwright-insights/hub-insights.spec.ts
+++ b/playwright-insights/hub-insights.spec.ts
@@ -272,13 +272,6 @@ test.describe('Hub Insights Chrome integration', () => {
     await loginAndNavigateToHub(page);
   });
 
-  test('should force light mode (no pf-v6-theme-dark class)', async ({ page }) => {
-    const hasDarkClass = await page.evaluate(() =>
-      document.documentElement.classList.contains('pf-v6-theme-dark')
-    );
-    expect(hasDarkClass).toBe(false);
-  });
-
   test('should not render Hub standalone masthead', async ({ page }) => {
     await expect(page.locator('[data-cy="hub-masthead"]')).not.toBeVisible({ timeout: 5_000 });
   });


### PR DESCRIPTION
## Summary

When running in the HCC Insights Chrome shell, the Hub UI was managing its own
theme CSS classes (`pf-v6-theme-dark`), conflicting with the Chrome shell's
theme management. This adds a `disableThemeManagement` prop to `PageFramework`
and `PageSettingsProvider` so the Insights build can defer theme handling to the
Chrome shell instead of competing with it.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Connect to VPN
- run `npm ci` from root
- run `cd frontend/hub` 
- run `npm run insights:install`
- run `npm run insights:cloud`
- Navigate to `https://stage.foo.redhat.com:1337/ansible/automation-hub`
- Click the gear icon, and ensure you can toggle between light and dark mode

### Screenshots

Before:

https://github.com/user-attachments/assets/6470fcbc-e1d3-4a19-9371-5bd0558ac6ae

After:

https://github.com/user-attachments/assets/3300f6d4-f01d-403f-827d-34c8b9c08242





Assisted-by: Claude Code / Opus 4.6 (Anthropic)