### PR TITLE
SonarCloud Fix: Remove unused variables (S1481, frontend/hub)

### DIFF
--- a/frontend/hub/interfaces/transform.cjs
+++ b/frontend/hub/interfaces/transform.cjs
@@ -171,8 +171,6 @@ function serializeObjectInterface(schema, depth, interfaceName, needImport) {
       // type, description, format : 'date-time'
       const type = property.type;
       const description = property.description;
-      const format = property.format;
-
       const tabs = '\t\t\t\t';
 
       if (description) {
@@ -253,8 +251,6 @@ fs.readFile(filePath, 'utf8', (err, data) => {
         fileContent += add('');
 
         fileContent += add('/* eslint-disable @typescript-eslint/no-empty-interface */');
-
-        let canCreateFile = true;
 
         if (pathSchemas[interfaceName]) {
           interfacePath = pathSchemas[interfaceName]?.path;


### PR DESCRIPTION
## Summary

Remove 2 unused variable declarations in `frontend/hub/interfaces/transform.cjs`.
Addresses SonarCloud rule `javascript:S1481` (2 violations).

- Remove unused `format` variable (line 174)
- Remove unused `canCreateFile` variable (line 257)

SonarCloud dashboard: https://sonarcloud.io/project/issues?id=ansible_ansible-ui&rules=javascript:S1481

## Type of Change

- [x] Enhancement

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (removing unused variable declarations has no runtime effect).

## Testing

Validated with `node --check` (syntax passes). `npm run tsc` has a pre-existing NX environment issue unrelated to this change.

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).