### PR TITLE
fix: increase Playwright globalTimeout default from 60 to 90 minutes

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -15,7 +15,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env'), override: true });
  */
 // Use verbose configuration by default for better debugging
 const isCI = !!process.env.CI;
-const jobTimeoutMinutes = Number(process.env.TIMEOUT_MINUTES) || 60;
+const jobTimeoutMinutes = Number(process.env.TIMEOUT_MINUTES) || 90;
 const config: PlaywrightTestConfig = {
   testDir: '.',
   fullyParallel: false,


### PR DESCRIPTION
## Summary

- Increases the default `TIMEOUT_MINUTES` from 60 to 90 in `playwright.config.ts`
- This changes the effective `globalTimeout` from 55 minutes to 85 minutes

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Problem

The Playwright `globalTimeout` (55 minutes) is too tight for the current test suite size (~530+ tests). When a shard can't finish all its specs within 55 minutes, Playwright halts the run and all remaining tests are silently reported as "pending/skipped" — including the job template tests.

**Evidence from Currents.dev:**
- Every ephemeral PR run in both upstream (ansible-ui) and downstream (aap-ui) completes in exactly 55.0 minutes (the timeout ceiling)
- Upstream run (PR-3206): 47 tests starved out of 526
- Downstream run (PR-2660): 79 tests starved out of 574
- This started around **April 13, 2026** when the test suite crossed ~530 tests
- Currents shows 137/137 specs "completed" because Playwright reports skipped specs back with 0 duration and all tests pending
- The test suite currently needs ~65-75 minutes to complete naturally

## Risk Details

| Risk | Assessment |
|---|---|
| **Functional impact** | None — this only changes the CI timeout ceiling, not test behavior |
| **Hung run exposure** | Increases from 55 min to 85 min before a truly hung run is killed. The Tekton pipeline has a 7-hour task timeout as an outer safety net |
| **Override capability** | The `TIMEOUT_MINUTES` env var still takes precedence, so any CI pipeline can set its own value |
| **Scope** | Only affects CI runs (`isCI` guard). Local development is unaffected (`globalTimeout` remains `undefined`) |

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

- [ ] Verify ephemeral PR runs no longer skip job template tests
- [ ] Verify the `TIMEOUT_MINUTES` env var still overrides the default when set
- [ ] Monitor Currents.dev to confirm runs complete with 0 pending tests (excluding intentional `test.skip()` calls)