### PR TITLE
fix: replace direct i18next t import with useTranslation hook

### DIFF
--- a/framework/PageDashboard/PageDashboardCountBar.tsx
+++ b/framework/PageDashboard/PageDashboardCountBar.tsx
@@ -1,6 +1,6 @@
 import { ChartPie } from '@patternfly/react-charts/victory';
 import { Title } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { PageChartLegend } from './PageChartLegend';
 import { PageDashboardCard } from './PageDashboardCard';
@@ -15,6 +15,7 @@ export type PageDashboardCountBarProps = {
 };
 
 export function PageDashboardCountBar(props: PageDashboardCountBarProps) {
+  const { t } = useTranslation();
   return (
     <PageDashboardCard title={t('Resource Counts')} width="xxl">
       <div

--- a/framework/PageForm/Inputs/PageFormAsyncMultiSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormAsyncMultiSelect.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   Controller,
   FieldPath,
@@ -7,6 +6,7 @@ import {
   Validate,
   useFormContext,
 } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   PageAsyncMultiSelect,
   PageAsyncMultiSelectProps,
@@ -50,6 +50,7 @@ export function PageFormAsyncMultiSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: PageFormAsyncMultiSelectProps<TFieldValues, TFieldName>) {
+  const { t } = useTranslation();
   const id = useID(props);
 
   const { control, formState } = useFormContext<TFieldValues>();

--- a/framework/PageForm/Inputs/PageFormAsyncSingleSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormAsyncSingleSelect.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   Controller,
   FieldPath,
@@ -7,6 +6,7 @@ import {
   Validate,
   useFormContext,
 } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   PageAsyncSingleSelect,
   PageAsyncSingleSelectProps,
@@ -50,6 +50,7 @@ export function PageFormAsyncSingleSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: PageFormAsyncSingleSelectProps<TFieldValues, TFieldName>) {
+  const { t } = useTranslation();
   const id = useID(props);
 
   const { control, formState } = useFormContext<TFieldValues>();

--- a/framework/PageForm/Inputs/PageFormMultiSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormMultiSelect.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   Controller,
   FieldPath,
@@ -7,6 +6,7 @@ import {
   Validate,
   useFormContext,
 } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { PageMultiSelect, PageMultiSelectProps } from '../../PageInputs/PageMultiSelect';
 import { useID } from '../../hooks/useID';
 import { useFrameworkTranslations } from '../../useFrameworkTranslations';
@@ -36,6 +36,7 @@ export function PageFormMultiSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: PageFormMultiSelectProps<TFieldValues, TFieldName>) {
+  const { t } = useTranslation();
   const id = useID(props);
 
   const { control, formState } = useFormContext<TFieldValues>();

--- a/framework/PageForm/Inputs/PageFormSingleSelect.tsx
+++ b/framework/PageForm/Inputs/PageFormSingleSelect.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   Controller,
   FieldPath,
@@ -7,6 +6,7 @@ import {
   Validate,
   useFormContext,
 } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { PageSingleSelect, PageSingleSelectProps } from '../../PageInputs/PageSingleSelect';
 import { useID } from '../../hooks/useID';
 import { useFrameworkTranslations } from '../../useFrameworkTranslations';
@@ -37,6 +37,7 @@ export function PageFormSingleSelect<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: PageFormSingleSelectProps<TFieldValues, TFieldName>) {
+  const { t } = useTranslation();
   const id = useID(props);
 
   const { control, formState } = useFormContext<TFieldValues>();

--- a/framework/PageForm/Inputs/validation-hooks.tsx
+++ b/framework/PageForm/Inputs/validation-hooks.tsx
@@ -1,7 +1,8 @@
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { capitalizeFirstLetter } from '../../utils/strings';
 
 export function useRequiredValidationRule(label?: string, isRequired?: boolean) {
+  const { t } = useTranslation();
   return typeof label === 'string' && isRequired === true
     ? {
         value: true,

--- a/framework/PageWizard/PageWizardBody.tsx
+++ b/framework/PageWizard/PageWizardBody.tsx
@@ -1,5 +1,4 @@
 import { Alert, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useCallback, useEffect } from 'react';
 import { useFormState } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -17,6 +16,7 @@ export function PageWizardBody({
   isVertical,
   singleColumn,
 }: PageWizardBody) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { activeStep, stepData, onNext, onBack, submitError, isSubmitting } = usePageWizard();
 

--- a/framework/PageWizard/PageWizardProvider.tsx
+++ b/framework/PageWizard/PageWizardProvider.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   ReactNode,
   createContext,
@@ -8,6 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useURLSearchParams } from '../components/useURLSearchParams';
 import type { PageWizardState } from './PageWizardState';
 import type { PageWizardParentStep, PageWizardStep } from './types';
@@ -38,6 +38,7 @@ export function PageWizardProvider<DataT extends NonNullable<object>>(props: {
   /** A function that will be called when the wizard is submitted with the final data. */
   onSubmit: (wizardData: DataT) => Promise<void>;
 }) {
+  const { t } = useTranslation();
   const { steps, onSubmit } = props;
   const [isToggleExpanded, setToggleExpanded] = useState(false);
   const [activeStep, setActiveStep] = useState<PageWizardStep | null>(null);
@@ -118,7 +119,7 @@ export function PageWizardProvider<DataT extends NonNullable<object>>(props: {
       setActiveStep(nextStep);
       return Promise.resolve();
     },
-    [activeStep, steps, onSubmit, setSearchParams, wizardData, setSubmitError]
+    [activeStep, steps, onSubmit, setSearchParams, wizardData, setSubmitError, t]
   );
 
   const onBack = useCallback(() => {

--- a/framework/components/icons/ExpandIcon.tsx
+++ b/framework/components/icons/ExpandIcon.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@patternfly/react-core';
 import { AngleDownIcon } from '@patternfly/react-icons';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 export function ExpandIcon(props: {
   isExpanded: boolean;
@@ -8,6 +8,7 @@ export function ExpandIcon(props: {
   direction?: 'left' | 'right';
   size?: 'sm' | 'md' | 'lg';
 }) {
+  const { t } = useTranslation();
   return (
     <Icon size={props.size ?? 'md'}>
       <AngleDownIcon

--- a/frontend/awx/access/roles/components/AwxRoleExpandedRow.tsx
+++ b/frontend/awx/access/roles/components/AwxRoleExpandedRow.tsx
@@ -1,6 +1,6 @@
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { ExpandableRowContent } from '@patternfly/react-table';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { AwxRbacRole } from '../../../interfaces/AwxRbacRole';
 import { AwxRolePermissions } from './AwxRolePermissions';
@@ -10,6 +10,7 @@ interface AwxRoleExpandedRowProps {
 }
 
 export function AwxRoleExpandedRow(props: AwxRoleExpandedRowProps) {
+  const { t } = useTranslation();
   const { role } = props;
 
   const { data: roleDetails } = useGet<AwxRbacRole>(

--- a/frontend/awx/access/users/UserPage/UserTokenSecretsModal.tsx
+++ b/frontend/awx/access/users/UserPage/UserTokenSecretsModal.tsx
@@ -1,14 +1,15 @@
 import { PageDetail, PageDetails } from '@ansible/ansible-ui-framework';
 import { formatDateString } from '@ansible/ansible-ui-framework/utils/formatDateString';
 import { ClipboardCopy, Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Token } from '../../../interfaces/Token';
 
 export function UserTokenSecretsModal(props: {
   onClose: (value: SetStateAction<Token | undefined>) => void;
   newToken: Token;
 }) {
+  const { t } = useTranslation();
   const { token, refresh_token } = props.newToken;
   return (
     <Modal

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useIGInstanceToolbarActions.tsx
@@ -3,8 +3,8 @@ import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { useOptions } from '@ansible/common-ui/crud/useOptions';
 import { ButtonVariant } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { t } from 'i18next';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { IAwxView } from '../../../../common/useAwxView';
@@ -27,6 +27,7 @@ export function useIGInstanceToolbarActions(view: IAwxView<Instance>) {
 }
 
 function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
+  const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const { id } = params;
   const associateInstanceToIG = useAssociateInstanceToIG(view.unselectItemsAndRefresh, id ?? '');
@@ -53,11 +54,12 @@ function useIGInstanceAssociateToolbarAction(view: IAwxView<Instance>) {
           instanceGroupId: id ?? '',
         }),
     }),
-    [associateInstanceToIG, id, openAssociateInstanceModal, canAssociateInstance]
+    [associateInstanceToIG, id, openAssociateInstanceModal, canAssociateInstance, t]
   );
 }
 
 function useIGInstanceDisassociateToolbarAction(view: IAwxView<Instance>) {
+  const { t } = useTranslation();
   const disassociateInstance = useDisassociateInstanceFromIG(view.unselectItemsAndRefresh);
   const params = useParams<{ id: string }>();
   const { id } = params;
@@ -73,15 +75,16 @@ function useIGInstanceDisassociateToolbarAction(view: IAwxView<Instance>) {
       isPinned: true,
       onClick: disassociateInstance,
       isDisabled: (instances: Instance[]) =>
-        isDisassociateBtnDisabled(instances, instanceGroup?.name === 'controlplane'),
+        isDisassociateBtnDisabled(instances, instanceGroup?.name === 'controlplane', t),
     }),
-    [disassociateInstance, instanceGroup?.name]
+    [disassociateInstance, instanceGroup?.name, t]
   );
 }
 
 function isDisassociateBtnDisabled(
   itemsToDisassociate: Instance[],
-  verifyCannotDisassociate: boolean
+  verifyCannotDisassociate: boolean,
+  t: (key: string) => string
 ) {
   if (verifyCannotDisassociate) {
     const itemsUnableToDisassociate = itemsToDisassociate

--- a/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useInstanceGroupInstanceNameColumn.tsx
+++ b/frontend/awx/administration/instance-groups/InstanceGroupPage/hooks/useInstanceGroupInstanceNameColumn.tsx
@@ -1,6 +1,6 @@
 import { ITableColumn, useGetPageUrl } from '@ansible/ansible-ui-framework';
-import { t } from 'i18next';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { Instance } from '../../../../interfaces/Instance';
 import { AwxRoute } from '../../../../main/AwxRoutes';
@@ -9,6 +9,7 @@ export function useInstanceGroupInstanceNameColumn(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
 }) {
+  const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const params = useParams<{ id?: string }>();
   const { id } = params;
@@ -29,7 +30,7 @@ export function useInstanceGroupInstanceNameColumn(options?: {
       list: 'name',
       defaultSort: options?.disableSort ? false : true,
     }),
-    [getPageUrl, id, options]
+    [getPageUrl, id, options, t]
   );
   return column;
 }

--- a/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
+++ b/frontend/awx/administration/instances/components/InstanceForksSlider.tsx
@@ -1,10 +1,11 @@
 import { Slider, SliderOnChangeEvent } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { Instance } from '../../../interfaces/Instance';
 import { useInstanceActions } from '../hooks/useInstanceActions';
 
 export function InstanceForksSlider(props: { instance: Instance }) {
+  const { t } = useTranslation();
   const { instance } = props;
   const { instanceForks, handleInstanceForksSlider } = useInstanceActions(String(instance.id));
   const capacityAvailable = instance.cpu_capacity !== 0 && instance.mem_capacity !== 0;

--- a/frontend/awx/administration/management-jobs/components/ManagementJobsRetainDataModal.tsx
+++ b/frontend/awx/administration/management-jobs/components/ManagementJobsRetainDataModal.tsx
@@ -1,7 +1,7 @@
 import { PageFormSubmitHandler, PageFormTextInput } from '@ansible/ansible-ui-framework';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
 import { Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { AwxPageForm } from '../../../common/AwxPageForm';
 import { awxAPI } from '../../../common/api/awx-utils';
@@ -22,6 +22,7 @@ export interface ManagementJobRetainDaysInput {
 export function ManagementJobsRetainDataModal(
   props: ManagementJobsRetainDataModalProps & { popDialog: () => void }
 ) {
+  const { t } = useTranslation();
   const postRequest = usePostRequest<ManagementJobRetainDaysInput, SystemJobTemplate>();
   const navigate = useNavigate();
   const getJobOutputUrl = useGetJobOutputUrl();

--- a/frontend/awx/administration/notifiers/NotificationPage/NotificationDetails.tsx
+++ b/frontend/awx/administration/notifiers/NotificationPage/NotificationDetails.tsx
@@ -8,7 +8,6 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { StatusCell } from '@ansible/common-ui/Status';
 import { TextArea } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Link, useOutletContext } from 'react-router-dom';
 import { NotificationTemplate } from '../../../interfaces/NotificationTemplate';
@@ -85,6 +84,7 @@ export function NotificationDetails() {
 }
 
 function RenderMessages(props: Readonly<{ notificationTemplate: NotificationTemplate }>) {
+  const { t } = useTranslation();
   const messages = props.notificationTemplate.messages;
   return (
     <PageDetails numberOfColumns="single" disableScroll={true}>
@@ -164,6 +164,7 @@ function RenderMessages(props: Readonly<{ notificationTemplate: NotificationTemp
 }
 
 function RenderInnerDetail(props: Readonly<{ notificationTemplate: NotificationTemplate }>) {
+  const { t } = useTranslation();
   const { notificationTemplate } = props;
   return (
     <>
@@ -195,7 +196,7 @@ function RenderInnerDetail(props: Readonly<{ notificationTemplate: NotificationT
             return <></>;
           }
 
-          let caption = returnCaption(notificationTemplate.notification_type, key);
+          let caption = returnCaption(notificationTemplate.notification_type, key, t);
 
           if (!caption) {
             caption = key;
@@ -229,7 +230,7 @@ function RenderInnerDetail(props: Readonly<{ notificationTemplate: NotificationT
   );
 }
 
-function returnCaption(notification_type: string | null, key: string) {
+function returnCaption(notification_type: string | null, key: string, t: (key: string) => string) {
   if (notification_type === 'email') {
     if (key === 'username') return t('Username');
     if (key === 'password') return t('Password');

--- a/frontend/awx/administration/settings/AwxSettingsForm.tsx
+++ b/frontend/awx/administration/settings/AwxSettingsForm.tsx
@@ -8,8 +8,8 @@ import { PageFormFileUpload } from '@ansible/ansible-ui-framework/PageForm/Input
 import { PageFormSection } from '@ansible/ansible-ui-framework/PageForm/Utils/PageFormSection';
 import { usePatchRequest } from '@ansible/common-ui/crud/usePatchRequest';
 import { Button, FormGroup } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { AwxPageForm } from '../../common/AwxPageForm';
@@ -113,6 +113,7 @@ export function AwxSettingsForm(props: {
   options: Record<string, AwxSettingsOptionsAction>;
   data: object;
 }) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const patch = usePatchRequest();
   const openRevertAllSettingsModal = useRevertAllSettingsModal();

--- a/frontend/awx/administration/settings/PolicySettingsEdit.tsx
+++ b/frontend/awx/administration/settings/PolicySettingsEdit.tsx
@@ -17,8 +17,8 @@ import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { usePatchRequest } from '@ansible/common-ui/crud/usePatchRequest';
 import { Button, FormGroup } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 const CATEGORY_ID = 'policyascode';
@@ -67,6 +67,7 @@ export function PolicySettingsForm(props: {
   options: Record<string, AwxSettingsOptionsAction>;
   data: object;
 }) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const patch = usePatchRequest();
   const openRevertAllSettingsModal = useRevertAllSettingsModal();

--- a/frontend/awx/overview/cards/AwxJobActivityCard.tsx
+++ b/frontend/awx/overview/cards/AwxJobActivityCard.tsx
@@ -6,7 +6,6 @@ import { PageDashboardCard } from '@ansible/ansible-ui-framework/PageDashboard/P
 import { PageSingleSelect } from '@ansible/ansible-ui-framework/PageInputs/PageSingleSelect';
 import { useGetPageUrl } from '@ansible/ansible-ui-framework/PageNavigation/useGetPageUrl';
 import { Flex, FlexItem, ToggleGroup, ToggleGroupItem, Tooltip } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AwxRoute } from '../../main/AwxRoutes';
@@ -104,6 +103,7 @@ export function AwxJobActivityCard() {
 }
 
 function BarChartIcon() {
+  const { t } = useTranslation();
   return (
     <Tooltip content={t('Bar Chart')}>
       <svg width={24} height={24} style={{ marginBottom: -7, marginLeft: -6, marginRight: -6 }}>

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroupsModal.tsx
@@ -1,6 +1,6 @@
 import { MultiSelectDialog, usePageDialog } from '@ansible/ansible-ui-framework';
-import { t } from 'i18next';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
 import { InventoryGroup } from '../../../interfaces/InventoryGroup';
@@ -18,6 +18,7 @@ export function InventoryHostGroupsAddModal(props: {
   inventoryId: string;
   hostId: string;
 }) {
+  const { t } = useTranslation();
   const toolbarFilters = useHostsGroupsFilters(`inventories/${props.inventoryId ?? ''}/groups`);
   const tableColumns = useHostsGroupsColumns({ disableLinks: true });
 

--- a/frontend/eda/access/roles/components/EdaRoleExpandedRow.tsx
+++ b/frontend/eda/access/roles/components/EdaRoleExpandedRow.tsx
@@ -1,6 +1,6 @@
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { ExpandableRowContent } from '@patternfly/react-table';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { edaAPI } from '../../../common/eda-utils';
 import { EdaRbacRole } from '../../../interfaces/EdaRbacRole';
 import { EdaRolePermissions } from './EdaRolePermissions';
@@ -10,6 +10,7 @@ interface EdaRoleExpandedRowProps {
 }
 
 export function EdaRoleExpandedRow(props: EdaRoleExpandedRowProps) {
+  const { t } = useTranslation();
   const { role } = props;
 
   const { data: roleDetails } = useGet<EdaRbacRole>(

--- a/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorMappingDetails.tsx
+++ b/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorMappingDetails.tsx
@@ -6,8 +6,8 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { Divider, Label, LabelGroup } from '@patternfly/react-core';
-import { t } from 'i18next';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { AuthenticatorMap, AuthenticatorMapType } from '../../../interfaces/AuthenticatorMap';
 import { PlatformTeam } from '../../../interfaces/PlatformTeam';
@@ -134,6 +134,7 @@ export function PlatformAuthenticatorMappingDetails() {
 }
 
 function AttributesSubsection(props: Readonly<{ mapping: AuthenticatorMap }>) {
+  const { t } = useTranslation();
   const attributes = parseAttributes(JSON.stringify(props.mapping.triggers));
   const attributeDetails: React.ReactNode[] = [];
   attributes.forEach((attribute) => {
@@ -170,6 +171,7 @@ function AttributesSubsection(props: Readonly<{ mapping: AuthenticatorMap }>) {
 }
 
 function GroupsSubsection(props: Readonly<{ mapping: AuthenticatorMap }>) {
+  const { t } = useTranslation();
   const groups = parseGroups(JSON.stringify(props.mapping.triggers));
   const groupDetails: React.ReactNode[] = [];
 

--- a/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorMappingPage.tsx
+++ b/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorMappingPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { Authenticator } from '../../../interfaces/Authenticator';
 import { AuthenticatorMap } from '../../../interfaces/AuthenticatorMap';
@@ -16,6 +16,7 @@ import { gatewayAPI } from '../../../utils/gateway-api-utils';
 import { useMappingPageActions } from '../hooks/useMappingActions';
 
 export function PlatformAuthenticatorMappingPage() {
+  const { t } = useTranslation();
   const params = useParams<{ map_id: string; id: string }>();
   const map_id = params.map_id;
   const auth_id = params.id;

--- a/platform/access/authenticators/components/AuthenticatorForm.tsx
+++ b/platform/access/authenticators/components/AuthenticatorForm.tsx
@@ -6,7 +6,6 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { AwxItemsResponse } from '@ansible/awx-ui/common/AwxItemsResponse';
 import { requestGet } from '@ansible/common-ui/crud/Data';
-import { t } from 'i18next';
 import { useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -190,6 +189,7 @@ function AuthenticatorFormInputs(
     onTypeChange: (type: AuthenticatorTypeEnum) => void;
   }>
 ) {
+  const { t } = useTranslation();
   const currentType = useWatch<AuthenticatorFormValues, 'type'>({ name: 'type' });
   const { onTypeChange, plugins, authenticator } = props;
   const { setValue } = useFormContext<AuthenticatorFormValues>();

--- a/platform/access/organizations/components/EditPlatformOrganization.tsx
+++ b/platform/access/organizations/components/EditPlatformOrganization.tsx
@@ -9,8 +9,8 @@ import { requestGet } from '@ansible/common-ui/crud/Data';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { usePatchRequest } from '@ansible/common-ui/crud/usePatchRequest';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
-import { t } from 'i18next';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PlatformOrganization } from '../../../interfaces/PlatformOrganization';
 import { useHasAwxService } from '../../../main/GatewayServices';
@@ -49,6 +49,7 @@ function areArraysEqualInOrder<T>(arr1: T[], arr2: T[]): boolean {
 }
 
 export function EditPlatformOrganization() {
+  const { t } = useTranslation();
   const pageNavigate = usePageNavigate();
   const alertToaster = usePageAlertToaster();
   const params = useParams<{ id?: string }>();

--- a/platform/main/PlatformApp.tsx
+++ b/platform/main/PlatformApp.tsx
@@ -2,8 +2,8 @@ import { PageApp } from '@ansible/ansible-ui-framework';
 import { useAwxConfigState } from '@ansible/awx-ui/common/useAwxConfig';
 import { postRequest, requestGet } from '@ansible/common-ui/crud/Data';
 import { Banner, Button, Flex, FlexItem } from '@patternfly/react-core';
-import { t } from 'i18next';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import { useUserInteraction } from '../hooks/useUserInteraction';
 import { UIFlag } from '../settings/ui-flags/IUIFlag';
@@ -17,6 +17,7 @@ import { usePlatformNavigation } from './usePlatformNavigation';
 import { PageTitleProvider } from '@ansible/ansible-ui-framework/PageTitle/PageTitle';
 
 export function PlatformApp() {
+  const { t } = useTranslation();
   const navigation = usePlatformNavigation();
   const sessionResponse = useSWR<{ expires_in_seconds: number }>(
     gatewayAPI`/session/`,
@@ -58,7 +59,7 @@ export function PlatformApp() {
       );
     }
     return null;
-  }, [refreshSession, session]);
+  }, [refreshSession, session, t]);
 
   useUserInteraction(60000, () => {
     refreshSession().catch(() => {
@@ -113,7 +114,7 @@ export function PlatformApp() {
       );
     }
     return null;
-  }, [activePlatformUser?.is_superuser, awxConfig, managedCloudInstall]);
+  }, [activePlatformUser?.is_superuser, awxConfig, managedCloudInstall, t]);
 
   const controllerDownBanner = useMemo(() => {
     if (!serviceDown) return null;
@@ -153,7 +154,7 @@ export function PlatformApp() {
         {message}
       </Banner>
     );
-  }, [serviceDown, serviceDownStatusCode]);
+  }, [serviceDown, serviceDownStatusCode, t]);
 
   const personaViewSwitcherFlag = useUIFlag(UIFlag.PersonaViewSwitcher);
 

--- a/platform/overview/PlatformOverview.test.tsx
+++ b/platform/overview/PlatformOverview.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import { t } from 'i18next';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
@@ -29,13 +28,11 @@ vi.mock('./useManagedPlatformOverview', () => ({
 
 // Mock all the card components
 vi.mock('./cards/PlatformCountsCard', () => ({
-  PlatformCountsCard: () => (
-    <div data-testid="platform-counts-card">{t('Platform Counts Card')}</div>
-  ),
+  PlatformCountsCard: () => <div data-testid="platform-counts-card">Platform Counts Card</div>,
 }));
 
 vi.mock('@ansible/awx-ui/overview/cards/AwxJobActivityCard', () => ({
-  AwxJobActivityCard: () => <div data-testid="awx-job-activity-card">{t('Job Activity Card')}</div>,
+  AwxJobActivityCard: () => <div data-testid="awx-job-activity-card">Job Activity Card</div>,
 }));
 
 // Mock window.location for redirects

--- a/platform/resource/PlatformResource.tsx
+++ b/platform/resource/PlatformResource.tsx
@@ -4,12 +4,13 @@ import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingSt
 import { AwxItemsResponse } from '@ansible/awx-ui/common/AwxItemsResponse';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { Page } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router-dom';
 import { PlatformRoute } from '../main/PlatformRoutes';
 import { gatewayAPI } from '../utils/gateway-api-utils';
 
 export function PlatformResource() {
+  const { t } = useTranslation();
   const { resource_type, ansible_id, route } = useParams<{
     resource_type: string;
     ansible_id: string;


### PR DESCRIPTION
## Summary
- Replaces all `import { t } from 'i18next'` with the `useTranslation()` hook from `react-i18next` across 28 files in framework, AWX, EDA, and platform workspaces
- Ensures consistent translation context throughout the app by using the React hook instead of direct module imports
- Passes `t` as a parameter to non-React helper functions that cannot use hooks directly
- Leaves `i18next.t.bind(i18next)` in Zustand stores (`useDomains.tsx`, `useUIFlags.tsx`) as legitimate non-React context usage

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run eslint` passes
- [x] No remaining `import { t } from 'i18next'` in source files
- [ ] CI pipeline passes
- [ ] Verify translations still render correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)