### PR TITLE
fix(playwright): refactor inventory sync job test to target single inventory file

### DIFF
--- a/playwright/tests/integration/automation-execution/infrastructure/hosts/host-jobs.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/hosts/host-jobs.spec.ts
@@ -39,6 +39,8 @@ test.describe('Host Jobs Tab', () => {
       projectId: project.id,
       playbook: 'hello_world.yml',
     });
+
+    await JobTemplate.api.launch(page, jobTemplate.id);
   });
 
   test.afterEach(async ({ page }) => {
@@ -54,28 +56,6 @@ test.describe('Host Jobs Tab', () => {
     { tag: ['@not_mock'] },
     async ({ page }) => {
       test.setTimeout(120000);
-
-      await test.step('Launch job from inventory', async () => {
-        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Inventories');
-        await clickTableRow({ text: inventory.name }, page);
-        await page.getByRole('tab', { name: 'Job Templates' }).click();
-
-        await clickTableRowAction({ text: jobTemplate.name, action: 'Launch template' }, page);
-
-        await expect(page.getByTestId('page-title')).toHaveText(jobTemplate.name);
-        await expect(page.getByRole('tab', { name: 'Output' })).toHaveAttribute(
-          'aria-selected',
-          'true'
-        );
-
-        await expect(
-          page
-            .getByTestId('pending-status')
-            .or(page.getByTestId('waiting-status'))
-            .or(page.getByTestId('running-status'))
-            .or(page.getByTestId('success-status'))
-        ).toBeVisible({ timeout: 30000 });
-      });
 
       await test.step('Relaunch job from host jobs tab', async () => {
         await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Hosts');
@@ -102,10 +82,10 @@ test.describe('Host Jobs Tab', () => {
         await expect(page.getByRole('heading', { name: host.name, exact: true })).toBeVisible();
         await page.getByRole('tab', { name: 'Jobs' }).click();
 
-        await page.getByRole('toolbar').isVisible();
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 10000 });
         await clearTableFilters(page);
 
-        await expect(page.locator('tbody tr')).toHaveCount(2);
+        await expect(page.locator('tbody tr')).toHaveCount(2, { timeout: 30000 });
 
         await page.getByLabel('Select all').check();
         await page.getByLabel('toolbar actions').click();

--- a/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
+++ b/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
@@ -7,6 +7,9 @@ import { clickTableRowAction } from '../../../../commands/clickTableRowAction';
 import { clickTableRow } from '../../../../commands/clickTableRow';
 import { selectTableRow } from '../../../../commands/selectTableRow';
 import { clickPageAction } from '../../../../commands/clickPageAction';
+import { createE2EName } from '../../../../commands/createE2EName';
+import { waitForJobStatus } from '../../../../commands/waitForJobStatus';
+import { filterTable } from '../../../../commands/filterTable';
 
 test.beforeEach(setupBefore({ path: '/execution/jobs' }));
 test.afterEach(setupAfter);
@@ -241,42 +244,88 @@ test.describe('Jobs: Launch and Verify Output', () => {
     'can launch an Inventory Sync job, let it finish, and assert expected results on the output screen',
     { tag: ['@not_mock'] },
     async ({ page }) => {
-      test.setTimeout(5 * 60 * 1000);
+      test.setTimeout(3 * 60 * 1000);
       test.slow();
-      const organizationName = await Organization.ui.create(page);
-      const projectName = await Project.ui.create(page, {
-        organizationName,
-        scmUrl: 'https://github.com/ansible/test-playbooks',
+
+      // Setup via API — use a specific inventory file to avoid scanning the entire repo
+      const organization = await Organization.api.create(page);
+      const project = await Project.api.create(page, {
+        organization: organization.id,
+        scm_url: 'https://github.com/ansible/test-playbooks',
+      });
+      await Project.api.sync(page, project.id);
+
+      const inventory = await Inventory.api.create(page, {
+        organization: organization.id,
+      });
+      const inventorySource = await Inventory.api.createSource(page, inventory.id, {
+        name: createE2EName('inventory-source'),
+        source: 'scm',
+        sourceProject: project.id,
+        sourcePath: 'inventories/inventory.ini',
       });
 
-      // Wait for project to sync before creating inventory source
-      await Project.ui.sync(page, projectName);
+      try {
+        // Navigate to inventory source details and trigger sync via UI
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Inventories');
+        await filterTable({ filterLabel: 'Name', filterValue: inventory.name }, page);
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 10000 });
+        await page
+          .getByRole('row', { name: inventory.name })
+          .getByRole('link', { name: inventory.name })
+          .click();
+        await expect(
+          page.getByRole('main').getByRole('heading', { name: inventory.name }).first()
+        ).toBeVisible({ timeout: 30000 });
 
-      const { inventorySourceName, inventoryName } = await Inventory.ui.createSource(page, {
-        projectName,
-      });
+        await page.getByRole('tab', { name: 'Sources' }).click();
+        await page
+          .getByRole('row', { name: inventorySource.name })
+          .getByRole('link', { name: inventorySource.name })
+          .click();
+        await expect(
+          page.getByRole('main').getByRole('heading', { name: inventorySource.name }).first()
+        ).toBeVisible({ timeout: 30000 });
 
-      await clickPageAction('Sync inventory source', page);
+        const syncResponsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes('/inventory_sources/') &&
+            response.url().includes('/update/') &&
+            response.request().method() === 'POST' &&
+            response.status() === 202
+        );
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Inventories');
+        await clickPageAction('Sync inventory source', page);
+        const syncResponse = await syncResponsePromise;
+        const inventoryUpdate = (await syncResponse.json()) as { id: number };
 
-      await clickTableRow({ text: inventoryName }, page);
+        await waitForJobStatus(
+          {
+            jobType: 'inventory_updates',
+            jobId: inventoryUpdate.id,
+            desiredStatus: 'successful',
+            timeout: 120000,
+          },
+          page
+        );
 
-      await page.getByRole('tab', { name: 'Jobs' }).click();
+        // Navigate to the job via the Jobs list and verify success
+        const jobName = `${inventory.name} - ${inventorySource.name}`;
+        await navigateTo(page, 'Automation Execution', 'Jobs');
+        await filterTable({ filterLabel: 'Name', filterValue: jobName }, page);
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 10000 });
+        await page.getByRole('row', { name: jobName }).getByRole('link', { name: jobName }).click();
+        await expect(
+          page.getByRole('main').getByRole('heading', { name: jobName }).first()
+        ).toBeVisible({ timeout: 30000 });
 
-      await clickTableRow({ text: `${inventoryName} - ${inventorySourceName}` }, page);
-
-      await expect(page).toHaveURL(/\/jobs\/inventory\/\d+\/details/);
-
-      // Wait for job to complete
-      await expect(page.getByText('Success', { exact: true }).first()).toBeVisible({
-        timeout: 120000,
-      });
-      // Cleanup
-      await Inventory.ui.deleteSource(page, inventoryName, inventorySourceName);
-      await Inventory.ui.delete(page, inventoryName);
-      await Project.ui.delete(page, projectName);
-      await Organization.ui.delete(page, organizationName);
+        await expect(page).toHaveURL(/\/jobs\/inventory\/\d+\/output/);
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
+      } finally {
+        await Inventory.api.delete(page, inventory.id);
+        await Project.api.deleteByName(page, project.name);
+        await Organization.api.deleteByName(page, organization.name);
+      }
     }
   );
 });


### PR DESCRIPTION
## Summary
Failing tests: 
[tests/integration/automation-execution/jobs/jobs.spec.ts](https://app.currents.dev/instance/0bb0d02957515288)
[tests/integration/automation-execution/infrastructure/hosts/host-jobs.spec.ts](https://app.currents.dev/instance/02c938d665634c5b)

Test consistently failed/timed out because the inventory source had no sourcePath specified, so it scanned the entire ansible/test-playbooks repo (including files that generate 60,000+ hosts), causing the sync to take 7+ minutes and time out.

The fix specifies sourcePath: 'inventories/inventory.ini' to target a single 33-host inventory file instead of scanning the entire repo, reducing the sync from 7+ minutes to ~5 seconds.

Removed "Launch job from inventory" step: The inventory launch was creating a race condition (job might not have a host summary when needed) and isn't the focus of this test. It's already covered in inventory-host-regular.spec.ts.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
