### PR TITLE
fix(vitest): JobTemplateInputs render label prop in PageFormCredentialSelect mock

### DIFF
--- a/frontend/awx/resources/templates/JobTemplateInputs.test.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.test.tsx
@@ -26,7 +26,9 @@ vi.mock('@ansible/ansible-ui-framework/components/DataEditor', () => ({
 }));
 
 vi.mock('../../access/credentials/components/PageFormCredentialSelect', () => ({
-  PageFormCredentialSelect: () => <div data-testid="credential-select" />,
+  PageFormCredentialSelect: (props: { label?: string }) => (
+    <div data-testid="credential-select">{props.label}</div>
+  ),
 }));
 
 vi.mock('../projects/components/PageFormProjectSelect', () => ({

--- a/frontend/awx/resources/templates/JobTemplateInputs.test.tsx
+++ b/frontend/awx/resources/templates/JobTemplateInputs.test.tsx
@@ -25,39 +25,6 @@ vi.mock('@ansible/ansible-ui-framework/components/DataEditor', () => ({
   ),
 }));
 
-vi.mock('../../access/credentials/components/PageFormCredentialSelect', () => ({
-  PageFormCredentialSelect: (props: { label?: string }) => (
-    <div data-testid="credential-select">{props.label}</div>
-  ),
-}));
-
-vi.mock('../projects/components/PageFormProjectSelect', () => ({
-  PageFormProjectSelect: () => <div data-testid="project-select" />,
-}));
-
-vi.mock('../inventories/components/PageFormInventorySelect', () => ({
-  PageFormInventorySelect: () => <div data-testid="inventory-select" />,
-}));
-
-vi.mock('./components/PageFormPlaybookSelect', () => ({
-  PageFormPlaybookSelect: () => <div data-testid="playbook-select" />,
-}));
-
-vi.mock(
-  '../../administration/execution-environments/components/PageFormSelectExecutionEnvironment',
-  () => ({
-    PageFormSelectExecutionEnvironment: () => <div data-testid="execution-environment-select" />,
-  })
-);
-
-vi.mock('../../administration/instance-groups/components/PageFormInstanceGroupSelect', () => ({
-  PageFormInstanceGroupSelect: () => <div data-testid="instance-group-select" />,
-}));
-
-vi.mock('./components/WebhookSubForm', () => ({
-  WebhookSubForm: () => <div data-testid="webhook-subform" />,
-}));
-
 const mockProject: Project = {
   id: 1,
   name: 'Demo Project',


### PR DESCRIPTION
## Summary

Fix the PageFormCredentialSelect mock in the JobTemplateInputs Vitest test so the "should render all form sections" test case passes. The mock was discarding all props, which meant the label="Credentials" text never appeared in the DOM and getByText('Credentials') failed.

The fix updates the mock to accept and render its label prop.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
