### PR TITLE
Update sonarcloud-remediation skill for self-hosted SonarQube and security hardening

### DIFF
--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -20,19 +20,16 @@ Fetches all open issues from SonarCloud, groups them by category and workspace, 
 | `--module <name>` | Only show issues in the specified module (auto-detected from repo structure — see skill docs) | `--module frontend/awx` |
 | `--help` | Show this usage information | |
 
-### Required Environment Variables
+### Environment Variables
 
-| Variable | Required | Purpose |
-|----------|----------|---------|
-| `SONAR_ORGANIZATION` | Yes | SonarCloud organization slug |
-| `SONAR_PROJECT_KEY` | Yes | SonarCloud project key |
-| `SONARCLOUD_TOKEN` | Only for private projects | API authentication token |
+All variables can be set beforehand **or** provided interactively when the command starts.
 
-Set them before running:
-```bash
-export SONAR_ORGANIZATION=your-org
-export SONAR_PROJECT_KEY=your-project-key
-```
+| Variable | When needed | Purpose |
+|----------|-------------|---------|
+| `SONAR_BASE_URL` | Optional | Base URL of the Sonar API. Defaults to `https://sonarcloud.io/api`. Set for self-hosted SonarQube. |
+| `SONAR_ORGANIZATION` | Phase A, B | SonarCloud organization slug. **Required for SonarCloud; optional for self-hosted SonarQube.** |
+| `SONAR_PROJECT_KEY` | Phase A, B | Sonar project key |
+| `SONARCLOUD_TOKEN` | Private projects only | API token. **Must be set as an env var** — the skill will never prompt for it. |
 
 ### Output
 

--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -10,7 +10,7 @@ If the user passes `--help`, display the usage information below and stop.
 /sonarcloud-analyze [options]
 ```
 
-Fetches all open issues from SonarCloud, groups them by category and workspace, and presents a prioritized summary report.
+Fetches all open issues from SonarCloud or SonarQube, groups them by category and workspace, and presents a prioritized summary report.
 
 ### Options
 
@@ -51,6 +51,8 @@ Add to `.claude/settings.json` to avoid permission prompts:
 
 ## Workflow
 
-1. Run the fetch script (`scripts/sonarcloud-fetch.py`) to fetch and categorize all issues
-2. Detect modules (from workspace definitions or top-level directories), group by rule + module, sort by remediation priority
-3. Present a prioritized summary table per category
+1. Detect hosting platform (GitHub or GitLab) from the git remote URL
+2. Collect any missing configuration interactively (org, project key). If `SONARCLOUD_TOKEN` is needed but not set, guide the user to set it and stop.
+3. Run the fetch script (`scripts/sonarcloud-fetch.py`) to fetch and categorize all issues
+4. Detect modules (from workspace definitions or top-level directories), group by rule + module, sort by remediation priority
+5. Present a prioritized summary table per category

--- a/.claude/commands/sonarcloud-analyze.md
+++ b/.claude/commands/sonarcloud-analyze.md
@@ -22,14 +22,14 @@ Fetches all open issues from SonarCloud, groups them by category and workspace, 
 
 ### Environment Variables
 
-All variables can be set beforehand **or** provided interactively when the command starts.
+All variables can be set beforehand **or** provided interactively when the command starts, **except `SONARCLOUD_TOKEN`** which must always be set as an environment variable.
 
 | Variable | When needed | Purpose |
 |----------|-------------|---------|
 | `SONAR_BASE_URL` | Optional | Base URL of the Sonar API. Defaults to `https://sonarcloud.io/api`. Set for self-hosted SonarQube. |
 | `SONAR_ORGANIZATION` | Phase A, B | SonarCloud organization slug. **Required for SonarCloud; optional for self-hosted SonarQube.** |
 | `SONAR_PROJECT_KEY` | Phase A, B | Sonar project key |
-| `SONARCLOUD_TOKEN` | Private projects only | API token. **Must be set as an env var** — the skill will never prompt for it. |
+| `SONARCLOUD_TOKEN` | Private projects only | API token. **Must be set as an environment variable before starting Claude** — never provided interactively. |
 
 ### Output
 

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -12,7 +12,7 @@ If the user passes `--help`, display the usage information below and stop.
 
 Remediates SonarCloud issues for a selected group with a 2-step approval process:
 1. **Approval 1 — Apply & Test**: Fixes are applied, validated, committed to a branch. You can test locally and make manual adjustments before proceeding.
-2. **Approval 2 — Create PR(s)**: After reviewing the branch, you explicitly approve PR creation. A summary of how many PRs will be created is shown first.
+2. **Approval 2 — Create PR(s)/MR(s)**: After reviewing the branch, you explicitly approve PR/MR creation. A summary of how many PRs/MRs will be created is shown first.
 
 ### Arguments
 
@@ -40,7 +40,7 @@ Add to `.claude/settings.json` to avoid permission prompts:
 
 ### Workflow
 
-1. **Configuration pre-check**: Display all environment variables (with values, defaults, and descriptions) and prompt for confirmation before proceeding. Skipped if already confirmed in the current session.
+1. **Configuration pre-check**: Prompt interactively for any missing Phase B variables (branch, validation commands, PR comment), then display all configuration for confirmation. Skipped if already confirmed in the current session.
 2. If no analysis exists in this session, run `/sonarcloud-analyze` first
 3. If no group argument provided, display available groups and prompt for selection
 4. Read affected files, present fixes as a group for review
@@ -49,10 +49,10 @@ Add to `.claude/settings.json` to avoid permission prompts:
    - Run validation commands (hard gate — must pass)
    - Create branch and commit changes
    - **Pause**: Inform the engineer the branch is ready for local testing. They can review the diff, run additional tests, or commit manual adjustments. Wait for explicit go-ahead.
-6. **Approval 2 — Create PR(s):**
-   - Present a summary: number of PRs to be created, LOC per PR, target branch
-   - Wait for explicit approval before creating any PR
-   - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, frontend/awx)`)
-   - PR body follows `.github/pull_request_template.md`
+6. **Approval 2 — Create PR(s)/MR(s):**
+   - Present a summary: number of PRs/MRs to be created, LOC per PR/MR, target branch
+   - Wait for explicit approval before creating any PR/MR
+   - Create PR(s)/MR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, frontend/awx)`)
+   - PR/MR body follows repo template (`.github/pull_request_template.md` or `.gitlab/merge_request_templates/`)
    - Post `SONAR_PR_COMMENT` on each PR/MR (if configured)
 7. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -21,15 +21,15 @@ Remediates SonarCloud issues for a selected group with a 2-step approval process
 | `group` | Group number or name from `/sonarcloud-analyze` output. If omitted, you will be prompted to select interactively. | `3` or `S1854-frontend-awx` |
 | `--help` | Show this usage information | |
 
-### Required Environment Variables
+### Environment Variables
 
-Same as `/sonarcloud-analyze`, plus optional:
+Same as `/sonarcloud-analyze`, plus these Phase B variables (set beforehand or provided interactively):
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `SONAR_DEFAULT_BRANCH` | `devel` | Base branch for fix PRs |
-| `SONAR_VALIDATE_COMMANDS` | `npm run tsc && npm run vitest` | Validation gate commands |
-| `SONAR_E2E_TRIGGER_COMMENT` | `/run-playwright` | Comment posted on PR to trigger e2e tests. Set to `none`, `skip`, `false`, or `""` to disable. |
+| Variable | Purpose |
+|----------|---------|
+| `SONAR_DEFAULT_BRANCH` | Base branch for fix PRs (e.g. `main`, `devel`) |
+| `SONAR_VALIDATE_COMMANDS` | Validation commands that must pass before PR creation |
+| `SONAR_PR_COMMENT` | Comment posted on each PR/MR (e.g. `/run-playwright`). Set to `none`, `skip`, `false`, or `""` to disable. |
 
 ### Permissions
 
@@ -54,5 +54,5 @@ Add to `.claude/settings.json` to avoid permission prompts:
    - Wait for explicit approval before creating any PR
    - Create PR(s) with title prefixed `SonarCloud Fix:` (e.g., `SonarCloud Fix: Remove dead stores (S1854, frontend/awx)`)
    - PR body follows `.github/pull_request_template.md`
-   - Post e2e trigger comment on each PR
+   - Post `SONAR_PR_COMMENT` on each PR/MR (if configured)
 7. Offer to continue with the next group

--- a/.claude/commands/sonarcloud-fix.md
+++ b/.claude/commands/sonarcloud-fix.md
@@ -23,7 +23,7 @@ Remediates SonarCloud issues for a selected group with a 2-step approval process
 
 ### Environment Variables
 
-Same as `/sonarcloud-analyze`, plus these Phase B variables (set beforehand or provided interactively):
+Same as `/sonarcloud-analyze` (including the requirement that `SONARCLOUD_TOKEN` must be an env var, never interactive), plus these Phase B variables (set beforehand or provided interactively):
 
 | Variable | Purpose |
 |----------|---------|

--- a/.claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
+++ b/.claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Fetch SonarCloud issues, hotspots, and duplication metrics.
+Fetch issues, hotspots, and duplication metrics from SonarCloud or SonarQube.
 
 Reads SONAR_PROJECT_KEY, SONAR_ORGANIZATION, and optionally
-SONARCLOUD_TOKEN from environment variables. Outputs categorized
-JSON to stdout. Diagnostics go to stderr.
+SONARCLOUD_TOKEN from environment variables. Set SONAR_BASE_URL to
+target a self-hosted SonarQube instance (defaults to SonarCloud).
+Outputs categorized JSON to stdout. Diagnostics go to stderr.
 
 Usage:
     python3 sonarcloud-fetch.py
@@ -19,8 +20,10 @@ import urllib.error
 import urllib.request
 from base64 import b64encode
 from datetime import datetime, timezone
+from urllib.parse import quote
 
-BASE_URL = "https://sonarcloud.io/api"
+SONARCLOUD_DEFAULT_URL = "https://sonarcloud.io/api"
+BASE_URL = os.environ.get("SONAR_BASE_URL", "").strip().rstrip("/") or SONARCLOUD_DEFAULT_URL
 PAGE_SIZE = 500
 MAX_RESULTS = 10000
 DUPLICATION_RULE_SUFFIXES = {"S1192"}
@@ -40,10 +43,8 @@ def _build_ssl_context():
         return ssl.create_default_context(cafile=certifi.where())
     except ImportError:
         ctx = ssl.create_default_context()
-        try:
-            urllib.request.urlopen("https://sonarcloud.io", timeout=5, context=ctx)
-        except (urllib.error.URLError, ssl.SSLError):
-            ctx = ssl.create_default_context()
+        if os.environ.get("SONAR_INSECURE", "").strip() == "1":
+            print("WARNING: TLS verification disabled (SONAR_INSECURE=1)", file=sys.stderr)
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
         return ctx
@@ -77,13 +78,19 @@ def _rule_suffix(rule):
     return rule
 
 
-def fetch_issues(project_key, ssl_ctx):
+def _org_param(organization):
+    if organization:
+        return f"&organization={quote(organization, safe='')}"
+    return ""
+
+
+def fetch_issues(project_key, organization, ssl_ctx):
     items = []
     page = 1
     total = None
 
     while True:
-        url = f"{BASE_URL}/issues/search?componentKeys={project_key}&resolved=false&ps={PAGE_SIZE}&p={page}"
+        url = f"{BASE_URL}/issues/search?componentKeys={quote(project_key, safe='')}{_org_param(organization)}&resolved=false&ps={PAGE_SIZE}&p={page}"
         data = _request(url, ssl_ctx)
 
         if total is None:
@@ -105,7 +112,7 @@ def fetch_issues(project_key, ssl_ctx):
         if fetched >= total or fetched >= MAX_RESULTS:
             if total > MAX_RESULTS:
                 print(
-                    f"Warning: SonarCloud API limits results to {MAX_RESULTS}. "
+                    f"Warning: Sonar API limits results to {MAX_RESULTS}. "
                     "Use severity/type filters for complete data.",
                     file=sys.stderr,
                 )
@@ -117,13 +124,13 @@ def fetch_issues(project_key, ssl_ctx):
     return {"total": total, "items": items}
 
 
-def fetch_hotspots(project_key, ssl_ctx):
+def fetch_hotspots(project_key, organization, ssl_ctx):
     items = []
     page = 1
     total = None
 
     while True:
-        url = f"{BASE_URL}/hotspots/search?projectKey={project_key}&status=TO_REVIEW&ps={PAGE_SIZE}&p={page}"
+        url = f"{BASE_URL}/hotspots/search?projectKey={quote(project_key, safe='')}{_org_param(organization)}&status=TO_REVIEW&ps={PAGE_SIZE}&p={page}"
         data = _request(url, ssl_ctx)
 
         if total is None:
@@ -152,9 +159,9 @@ def fetch_hotspots(project_key, ssl_ctx):
     return {"total": total, "items": items}
 
 
-def fetch_duplication(project_key, ssl_ctx):
+def fetch_duplication(project_key, organization, ssl_ctx):
     url = (
-        f"{BASE_URL}/measures/component?component={project_key}"
+        f"{BASE_URL}/measures/component?component={quote(project_key, safe='')}{_org_param(organization)}"
         "&metricKeys=duplicated_lines_density,duplicated_blocks,duplicated_files"
     )
     data = _request(url, ssl_ctx)
@@ -198,6 +205,8 @@ def categorize(issues_items, hotspots_items):
             categories["Maintainability"].append(issue)
             if suffix in DUPLICATION_RULE_SUFFIXES:
                 categories["Duplication"].append(issue)
+        else:
+            categories.setdefault("Other", []).append(issue)
 
     return categories
 
@@ -205,23 +214,37 @@ def categorize(issues_items, hotspots_items):
 def main():
     project_key = os.environ.get("SONAR_PROJECT_KEY", "").strip()
     organization = os.environ.get("SONAR_ORGANIZATION", "").strip()
+    is_sonarcloud = BASE_URL == SONARCLOUD_DEFAULT_URL
 
-    if not project_key or not organization:
-        error = {
-            "error": "SONAR_PROJECT_KEY and SONAR_ORGANIZATION environment variables are required.",
-        }
+    if not project_key:
+        error = {"error": "SONAR_PROJECT_KEY environment variable is required."}
         print(json.dumps(error, indent=2))
-        print("ERROR: Set SONAR_PROJECT_KEY and SONAR_ORGANIZATION before running.", file=sys.stderr)
+        print("ERROR: Set SONAR_PROJECT_KEY before running.", file=sys.stderr)
+        sys.exit(1)
+
+    if is_sonarcloud and not organization:
+        error = {"error": "SONAR_ORGANIZATION is required when using SonarCloud (sonarcloud.io)."}
+        print(json.dumps(error, indent=2))
+        print("ERROR: Set SONAR_ORGANIZATION before running (required for SonarCloud).", file=sys.stderr)
         sys.exit(1)
 
     ssl_ctx = _build_ssl_context()
 
     try:
-        print(f"Fetching SonarCloud data for {project_key}...", file=sys.stderr)
-        issues = fetch_issues(project_key, ssl_ctx)
-        hotspots = fetch_hotspots(project_key, ssl_ctx)
-        duplication = fetch_duplication(project_key, ssl_ctx)
+        server_label = "SonarCloud" if is_sonarcloud else BASE_URL
+        print(f"Fetching data from {server_label} for {project_key}...", file=sys.stderr)
+        issues = fetch_issues(project_key, organization, ssl_ctx)
+        hotspots = fetch_hotspots(project_key, organization, ssl_ctx)
+        duplication = fetch_duplication(project_key, organization, ssl_ctx)
     except urllib.error.HTTPError as e:
+        if e.code == 400 and not organization:
+            msg = (
+                "Bad request (HTTP 400). This may mean SONAR_ORGANIZATION is "
+                "required for this Sonar instance. Set SONAR_ORGANIZATION and retry."
+            )
+            print(json.dumps({"error": msg, "hint": "missing_organization"}, indent=2))
+            print(f"ERROR: {msg}", file=sys.stderr)
+            sys.exit(1)
         messages = {
             401: "Authentication failed (HTTP 401). Check SONARCLOUD_TOKEN.",
             403: "Access forbidden (HTTP 403). Token may lack permissions or project key may be wrong.",

--- a/.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md
+++ b/.claude/skills/sonarcloud-remediation/sonarcloud-remediation.md
@@ -8,23 +8,22 @@ Fetch SonarCloud issues, analyze and group them, suggest fixes, and create focus
 
 ### Prerequisites
 
-- **`gh`** (GitHub CLI) — must be installed and authenticated (`gh auth login`). Used by `/sonarcloud-fix` to create PRs and post e2e trigger comments.
+- **`gh`** (GitHub CLI) or **`glab`** (GitLab CLI) — one must be installed and authenticated, matching the repo's hosting platform. Used by `/sonarcloud-fix` to create PRs/MRs and post comments. The skill auto-detects the platform from the git remote URL.
 - **`python3`** (3.8+) — used by the fetch script (`scripts/sonarcloud-fetch.py`). Uses only Python stdlib (no external dependencies).
 
-### Required Environment Variables
+### Environment Variables
 
-| Variable | Required | Purpose |
-|----------|----------|---------|
-| `SONAR_ORGANIZATION` | Yes | SonarCloud organization slug |
-| `SONAR_PROJECT_KEY` | Yes | SonarCloud project key |
-| `SONARCLOUD_TOKEN` | Only for private projects | API authentication token |
-| `SONAR_DEFAULT_BRANCH` | No (default: `devel`) | Base branch for fix PRs |
-| `SONAR_VALIDATE_COMMANDS` | No (default: `npm run tsc && npm run vitest`) | Validation commands that must pass before PR creation |
-| `SONAR_E2E_TRIGGER_COMMENT` | No (default: `/run-playwright`) | Comment to post on PR to trigger e2e tests. Set to `none`, `skip`, `false`, or empty string `""` to disable. |
+All variables can be set as environment variables beforehand **or** provided interactively when the skill starts. Interactive prompting avoids requiring engineers to exit the session to configure the environment.
 
-### Validate Environment
-
-The fetch script validates that `SONAR_PROJECT_KEY` and `SONAR_ORGANIZATION` are set, and handles authentication automatically when `SONARCLOUD_TOKEN` is present. For public projects, no token is needed.
+| Variable | When needed | Purpose |
+|----------|-------------|---------|
+| `SONAR_BASE_URL` | Phase A, B (optional) | Base URL of the Sonar API. Defaults to `https://sonarcloud.io/api`. Set this to target a self-hosted SonarQube instance (e.g. `https://sonarqube.corp.redhat.com/api`). |
+| `SONAR_ORGANIZATION` | Phase A, B | SonarCloud organization slug. **Required for SonarCloud; optional for self-hosted SonarQube.** |
+| `SONAR_PROJECT_KEY` | Phase A, B | Sonar project key |
+| `SONARCLOUD_TOKEN` | Private projects only | API authentication token. **Must be set as an environment variable before starting Claude** — the skill will never prompt for or handle this value directly. Works with both SonarCloud and SonarQube tokens. |
+| `SONAR_DEFAULT_BRANCH` | Phase B | Base branch for fix PRs (e.g. `main`, `devel`) |
+| `SONAR_VALIDATE_COMMANDS` | Phase B | Validation commands that must pass before PR creation (e.g. `npm run tsc && npm run vitest`) |
+| `SONAR_PR_COMMENT` | Phase B (optional) | Comment to post automatically on each newly created PR/MR. Commonly used to trigger CI workflows (e.g. `/run-playwright`). If not provided, no comment is posted. Set to `none`, `skip`, `false`, or empty string `""` to explicitly disable. |
 
 ---
 
@@ -32,9 +31,56 @@ The fetch script validates that `SONAR_PROJECT_KEY` and `SONAR_ORGANIZATION` are
 
 Invoked via `/sonarcloud-analyze`. Fetches all open issues and presents a prioritized, grouped report.
 
+### Step 0: Collect Configuration
+
+Before fetching data, detect the hosting platform and collect required variables.
+
+**Step 0a: Detect hosting platform**
+
+Read the git remote URL to determine whether this is a GitHub or GitLab repository:
+
+```bash
+git remote get-url origin
+```
+
+- If the URL contains `github.com` → **GitHub** (use `gh` CLI)
+- If the URL contains `gitlab` → **GitLab** (use `glab` CLI)
+- If unclear, ask the engineer: "Is this repo hosted on GitHub or GitLab?"
+
+Store the detected platform for use in Phase B.
+
+**Step 0b: Collect SonarCloud variables**
+
+Check whether the required variables are available as environment variables. For any that are missing, prompt the engineer interactively using AskUserQuestion.
+
+1. If `SONAR_ORGANIZATION` is not set and the target is SonarCloud (no `SONAR_BASE_URL` override), ask: "What is your SonarCloud organization slug?" For self-hosted SonarQube instances, `SONAR_ORGANIZATION` is optional — skip this prompt.
+2. If `SONAR_PROJECT_KEY` is not set, ask: "What is your Sonar project key?"
+3. If `SONARCLOUD_TOKEN` is not set and the project is private, **do not prompt for the token**. Instead, guide the engineer to set it up themselves and restart Claude:
+   > "This project requires a `SONARCLOUD_TOKEN` for API access. Please set it as an environment variable and restart Claude:
+   >
+   > ```bash
+   > export SONARCLOUD_TOKEN=<your-token>
+   > ```
+   >
+   > You can generate a token at your Sonar instance's account security page (e.g. https://sonarcloud.io/account/security for SonarCloud). Once the variable is set, restart Claude and re-run the command."
+
+   Then **stop the workflow** — do not proceed without the token in the environment.
+
+After collecting the required values, also remind the engineer: "If you plan to fix issues after analysis, I'll need a few more values later — the base branch name and your validation commands. You can provide them now or when we get to the fix phase."
+
+If the engineer provides Phase B values at this point (`SONAR_DEFAULT_BRANCH`, `SONAR_VALIDATE_COMMANDS`, `SONAR_PR_COMMENT`), store them for later use and skip re-prompting in Phase B Step 0.
+
+Use the collected values for the remainder of the session.
+
 ### Step 1: Fetch and Categorize Issues
 
-Run the fetch script to retrieve all SonarCloud data:
+Run the fetch script to retrieve all SonarCloud data. If `SONAR_ORGANIZATION` or `SONAR_PROJECT_KEY` were provided interactively (not via environment variables), pass them as inline environment variables. **Never pass `SONARCLOUD_TOKEN` on the command line** — it must already be in the environment.
+
+```bash
+SONAR_PROJECT_KEY=<value> SONAR_ORGANIZATION=<value> python3 .claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
+```
+
+If all values are already set as environment variables, run the script directly:
 
 ```bash
 python3 .claude/skills/sonarcloud-remediation/scripts/sonarcloud-fetch.py
@@ -55,6 +101,7 @@ If the script exits with code 1, read the `error` field from its JSON output and
 - Missing env vars → prompt the user to set them
 - HTTP 401 → invalid token
 - HTTP 404 → wrong project key
+- `"hint": "missing_organization"` → the Sonar instance requires an organization. Prompt the user: "This Sonar instance requires an organization. What is your Sonar organization slug?" Then re-run the fetch script with `SONAR_ORGANIZATION` set to the provided value.
 
 Parse the JSON output. Use the `categories` object as the starting point for Step 2.
 
@@ -177,6 +224,8 @@ Good starting groups for `/sonarcloud-fix`:
   /sonarcloud-fix 2   — Dead stores (23 issues, ~35 LOC, Low risk)
 ```
 
+**Tip:** If you plan to fix issues after analysis, it's best to have `SONAR_DEFAULT_BRANCH` and `SONAR_VALIDATE_COMMANDS` ready. You can set them as environment variables beforehand, or provide them interactively when Phase B starts.
+
 ### Optional Filters
 
 If the user provides flags, apply them before grouping:
@@ -192,32 +241,47 @@ Invoked via `/sonarcloud-fix`. The engineer selects groups from the analyze outp
 
 ### Step 0: Configuration Pre-Check
 
-**Before doing any work**, display all non-sensitive configuration values so the engineer can verify them. Use the AskUserQuestion tool to confirm.
+**Before doing any work**, check all required Phase B configuration. If any variables are missing and were not already provided during Phase A Step 0, prompt the engineer interactively using AskUserQuestion.
 
-Display:
+**Step 0a: Collect missing Phase B variables**
+
+If `SONAR_DEFAULT_BRANCH` is not set (env var or earlier prompt), ask:
+> "What is the base branch for fix PRs? (e.g. `main`, `devel`)"
+
+If `SONAR_VALIDATE_COMMANDS` is not set (env var or earlier prompt), ask:
+> "What validation commands must pass before a PR can be created? (e.g. `npm run tsc && npm run vitest`, `make lint && make test`)"
+
+If `SONAR_PR_COMMENT` is not set (env var or earlier prompt), ask:
+> "Do you want a comment posted automatically on each PR/MR? This is commonly used to trigger CI workflows (e.g. `/run-playwright`). Provide the comment text, or type 'skip' to disable."
+
+Use the values provided for the remainder of the session.
+
+**Step 0b: Display configuration summary**
+
+Display all non-sensitive configuration values so the engineer can verify them:
 
 ```
 ## Configuration
 
-| Variable                  | Value                          | Source  | Description                                        |
-|---------------------------|--------------------------------|---------|----------------------------------------------------|
-| SONAR_ORGANIZATION        | your-org                       | env     | SonarCloud organization slug                       |
-| SONAR_PROJECT_KEY         | your-project-key               | env     | SonarCloud project key                             |
-| SONARCLOUD_TOKEN          | (set)                          | env     | API token for private projects                     |
-| SONAR_DEFAULT_BRANCH      | devel                          | default | Branch that fix PRs will target                    |
-| SONAR_VALIDATE_COMMANDS   | npm run tsc && npm run vitest  | default | Commands that must pass before a PR can be created |
-| SONAR_E2E_TRIGGER_COMMENT | /run-playwright                | default | Comment posted on PR to trigger e2e test pipeline. Set to none/skip/false/"" to disable |
+| Variable                  | Value                          | Source      | Description                                        |
+|---------------------------|--------------------------------|-------------|----------------------------------------------------|
+| SONAR_ORGANIZATION        | your-org                       | env         | SonarCloud organization slug                       |
+| SONAR_PROJECT_KEY         | your-project-key               | env         | SonarCloud project key                             |
+| SONARCLOUD_TOKEN          | (set)                          | env         | API token for private projects                     |
+| SONAR_DEFAULT_BRANCH      | main                           | interactive | Branch that fix PRs will target                    |
+| SONAR_VALIDATE_COMMANDS   | make lint && make test         | interactive | Commands that must pass before a PR can be created |
+| SONAR_PR_COMMENT          | /run-playwright                | env         | Comment posted automatically on each PR/MR         |
 ```
 
-- Show `(set)` or `(not set)` for `SONARCLOUD_TOKEN` — never display the actual value
-- Show `env` in the Source column if the variable is explicitly set, `default` if using the built-in default
-- If `SONAR_E2E_TRIGGER_COMMENT` is set to `none`, `skip`, `false`, or an empty string, show `(disabled)` in the Value column
-- **Highlight any variables using defaults** so they stand out
+- Show `(set)` or `(not set)` for `SONARCLOUD_TOKEN` — never display the actual value. This variable is always sourced from the environment (never interactive).
+- In the Source column, show `env` if from an environment variable or `interactive` if provided via prompt
+- If `SONAR_PR_COMMENT` was skipped or not provided, show `(not set — no comment will be posted)` in the Value column
+- If `SONAR_PR_COMMENT` is set to `none`, `skip`, `false`, or an empty string, show `(disabled)` in the Value column
 
-Then ask: "Do these settings look correct? If any need updating, set the environment variables and re-run the command."
+Then ask: "Do these settings look correct? If any need updating, let me know."
 
 - If the engineer confirms → proceed to Step 1
-- If the engineer says values need updating → stop and let them update env vars before retrying
+- If the engineer wants to change a value → prompt for the new value and update the session configuration
 
 **Skip this pre-check** if it was already confirmed earlier in the same session.
 
@@ -291,11 +355,10 @@ Apply all approved fixes using the Edit tool.
 
 **Validation — Hard Gate:**
 
-After applying fixes, the validation commands **must pass before proceeding**:
+After applying fixes, run the validation commands using the value from the environment variable or the value provided interactively in Step 0.
 
 ```bash
-VALIDATE_CMD="${SONAR_VALIDATE_COMMANDS:-npm run tsc && npm run vitest}"
-eval "$VALIDATE_CMD"
+eval "$SONAR_VALIDATE_COMMANDS"
 ```
 
 If validation fails:
@@ -307,10 +370,10 @@ If validation fails:
 
 ### Step 6: Create Branch and Commit (Approval 1)
 
-**Branch** off the configured default branch:
+**Branch** off the configured default branch, using the value from the environment variable or the value provided interactively in Step 0.
+
 ```bash
-DEFAULT_BRANCH="${SONAR_DEFAULT_BRANCH:-devel}"
-git checkout -b "sonar/<rule-key>-<module-slug>" "origin/${DEFAULT_BRANCH}"
+git checkout -b "sonar/<rule-key>-<module-slug>" "origin/$SONAR_DEFAULT_BRANCH"
 ```
 
 Branch naming: `sonar/<rule-key>-<module-slug>` where `<module-slug>` is the module name with `/` replaced by `-` (e.g., `sonar/S1854-frontend-awx`, `sonar/S1128-framework`, `sonar/S1481-src`)
@@ -329,7 +392,7 @@ SonarCloud issue keys: AZxx1, AZxx2, ...
 Branch `sonar/S1854-frontend-awx` is ready with N commits.
 
 You can now:
-  - Review the diff: git diff origin/devel...HEAD
+  - Review the diff: git diff origin/<SONAR_DEFAULT_BRANCH>...HEAD
   - Run additional tests locally
   - Make manual adjustments and commit them to this branch
 
@@ -338,28 +401,28 @@ When you're satisfied, let me know and I'll create the PR.
 
 **Wait for the engineer's explicit go-ahead before proceeding to PR creation.** Do NOT create the PR automatically.
 
-### Step 7: Create PR (Approval 2)
+### Step 7: Create PR/MR (Approval 2)
 
-Before creating any PRs, present a summary:
+Before creating any PRs/MRs, present a summary:
 
 ```
-Ready to create PR(s):
+Ready to create PR(s)/MR(s):
 
-| # | Branch                  | Files | LOC changed | Target     |
-|---|-------------------------|-------|-------------|------------|
-| 1 | sonar/S1854-frontend-awx        |   12  |    ~46      | devel      |
-| 2 | sonar/S1854-frontend-awx-batch2 |    8  |    ~38      | devel      |
+| # | Branch                          | Files | LOC changed | Target              |
+|---|-------------------------------|-------|-------------|---------------------|
+| 1 | sonar/S1854-frontend-awx        |   12  |    ~46      | <SONAR_DEFAULT_BRANCH> |
+| 2 | sonar/S1854-frontend-awx-batch2 |    8  |    ~38      | <SONAR_DEFAULT_BRANCH> |
 
-Total: 2 PR(s) targeting `devel`.
+Total: 2 PR(s)/MR(s) targeting `<SONAR_DEFAULT_BRANCH>`.
 
-Proceed with PR creation?
+Proceed?
 ```
 
-**Wait for explicit approval.** Then for each PR:
+**Wait for explicit approval.** Then for each PR/MR:
 
-**PR Title — REQUIRED format:**
+**Title — REQUIRED format:**
 
-All PR titles **must** start with the prefix `SonarCloud Fix:` followed by a short description of the issue area being addressed. Use this pattern:
+All titles **must** start with the prefix `SonarCloud Fix:` followed by a short description of the issue area being addressed. Use this pattern:
 
 ```
 SonarCloud Fix: <brief description of fix> (<rule key>, <module>)
@@ -372,10 +435,17 @@ Examples:
 - `SonarCloud Fix: Reduce cognitive complexity (S3776, frontend/eda)`
 - `SonarCloud Fix: Remove commented-out code (S125, src)`
 
-For batched PRs, append the batch number:
+For batched PRs/MRs, append the batch number:
 - `SonarCloud Fix: Remove dead stores (S1854, frontend/awx) [batch 1/2]`
 
-If the repo has a `.github/pull_request_template.md`, follow its structure for the PR body. Otherwise, use this default format:
+**Creating the PR/MR:**
+
+Use the platform detected in Phase A Step 0:
+
+- **GitHub**: `gh pr create --title "<title>" --body "<body>" --base <SONAR_DEFAULT_BRANCH>`
+- **GitLab**: `glab mr create --title "<title>" --description "<body>" --target-branch <SONAR_DEFAULT_BRANCH>`
+
+**Body/description:** If the repo has a PR/MR template (`.github/pull_request_template.md` or `.gitlab/merge_request_templates/`), follow its structure. Otherwise, use this default format:
 
 ```markdown
 ## Summary
@@ -404,27 +474,27 @@ Adjust **Type of Change** and **Risk Analysis** based on the fix category:
 - Cognitive complexity refactoring → **Medium**
 - Security/reliability fixes → **Medium** to **High**
 
-### Step 8: Trigger E2E and Continue
+### Step 8: Post PR/MR Comment and Continue
 
-1. Check `SONAR_E2E_TRIGGER_COMMENT`. If set to `none`, `skip`, `false`, or an empty string `""`, **skip posting** the e2e trigger comment entirely. Otherwise, post the comment on each newly created PR:
-   ```bash
-   E2E_COMMENT="${SONAR_E2E_TRIGGER_COMMENT:-/run-playwright}"
-   gh pr comment <PR_NUMBER> --body "$E2E_COMMENT"
-   ```
+1. Check `SONAR_PR_COMMENT`. If the variable is **not set**, **skip** this step entirely. If set to `none`, `skip`, `false`, or an empty string `""`, also **skip**. Otherwise, post the comment on each newly created PR/MR using the detected platform:
+   - **GitHub**: `gh pr comment <PR_NUMBER> --body "$SONAR_PR_COMMENT"`
+   - **GitLab**: `glab mr note <MR_NUMBER> --message "$SONAR_PR_COMMENT"`
 2. Offer to continue — return to group selection for the next batch
 
 ---
 
 ## Portability
 
-This skill is designed for adoption by other teams and repos:
+This skill is designed for adoption across repositories:
 
-1. **No hardcoded values** — all project-specific config via environment variables
-2. **Configurable base branch** — `SONAR_DEFAULT_BRANCH` defaults to `devel` but can be set to `main` or any branch
-3. **Automatic module detection** — detects monorepo workspaces from `package.json`, `pnpm-workspace.yaml`, `nx.json`, or `lerna.json`. For non-monorepo projects, groups issues by top-level directory. No repo-specific configuration required.
-4. **Fetch script** — `scripts/sonarcloud-fetch.py` uses only Python stdlib (no external dependencies). Handles pagination, authentication, and categorization deterministically.
-5. **Validation commands** — set `SONAR_VALIDATE_COMMANDS` to your project's validation pipeline (e.g., `make lint && make test`)
-6. **PR template** — adjust to match the target repo's `.github/pull_request_template.md`
+1. **No hardcoded values** — all project-specific config via environment variables or interactive prompts
+2. **SonarCloud and SonarQube** — works with SonarCloud (default) and self-hosted SonarQube instances via `SONAR_BASE_URL`. Organization parameter is automatically omitted for self-hosted instances where it is not required.
+3. **Configurable base branch** — `SONAR_DEFAULT_BRANCH` set via env var or provided interactively
+4. **Automatic module detection** — detects monorepo workspaces from `package.json`, `pnpm-workspace.yaml`, `nx.json`, or `lerna.json`. For non-monorepo projects, groups issues by top-level directory. No repo-specific configuration required.
+5. **Fetch script** — `scripts/sonarcloud-fetch.py` uses only Python stdlib (no external dependencies). Handles pagination, authentication, and categorization deterministically.
+6. **Validation commands** — `SONAR_VALIDATE_COMMANDS` set via env var or provided interactively
+7. **GitHub and GitLab** — auto-detects hosting platform from git remote URL; uses `gh` or `glab` accordingly
+8. **PR/MR template** — automatically adapts to the target repo's `.github/pull_request_template.md` or `.gitlab/merge_request_templates/`
 
 ### Quick Start for Other Teams
 
@@ -432,9 +502,10 @@ This skill is designed for adoption by other teams and repos:
 export SONAR_ORGANIZATION=your-org
 export SONAR_PROJECT_KEY=your-project-key
 export SONARCLOUD_TOKEN=your-token        # only for private projects
+export SONAR_BASE_URL=https://sonarqube.corp.example.com/api  # only for self-hosted SonarQube
 export SONAR_DEFAULT_BRANCH=main                          # if not devel
 export SONAR_VALIDATE_COMMANDS="make lint && make test"    # your validation pipeline
-export SONAR_E2E_TRIGGER_COMMENT="/run-e2e"                # your e2e trigger comment, or "none" to disable
+export SONAR_PR_COMMENT="/run-e2e"                         # your PR comment, or "none" to disable
 ```
 
 Then use `/sonarcloud-analyze` and `/sonarcloud-fix`.
@@ -445,9 +516,11 @@ Then use `/sonarcloud-analyze` and `/sonarcloud-fix`.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "ERROR: SONAR_ORGANIZATION and SONAR_PROJECT_KEY must be set" | Missing env vars | Export `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` |
-| Empty results from API | Wrong project key or org | Verify at `https://sonarcloud.io/project/overview?id=<PROJECT_KEY>` |
-| 401 from API | Private project without token | Export `SONARCLOUD_TOKEN` |
+| Prompted for organization/project key | Not set as env vars | Set env vars beforehand, or provide values when prompted interactively |
+| Empty results from API | Wrong project key or org | Verify the project exists on your Sonar instance (e.g. `https://sonarcloud.io/project/overview?id=<PROJECT_KEY>` for SonarCloud, or `<SONAR_BASE_URL>/dashboard?id=<PROJECT_KEY>` for self-hosted) |
+| 401 from API | Private project without token | Set `SONARCLOUD_TOKEN` as an environment variable (`export SONARCLOUD_TOKEN=<your-token>`), then restart Claude. Generate a token from your Sonar instance's account security page |
+| Connection error to self-hosted instance | Wrong URL or TLS issue | Verify `SONAR_BASE_URL` is correct (include `/api` suffix). For self-signed certificates, set `SONAR_INSECURE=1` |
+| Prompted for Phase B config | Not set as env vars | Set env vars beforehand, or provide values when prompted. You can also provide Phase B values during Phase A to avoid a second prompt. |
 | Validation command fails after fix | Fix introduced a build/lint/type error | Review the error, adjust the fix, re-run `SONAR_VALIDATE_COMMANDS` |
 | Tests fail after fix | Fix broke a test | Check if the test relied on removed code; update the test and re-run validation |
 | Pagination missed issues | More than 500 issues per query | The skill paginates automatically; if issues are still missing, try filtering by severity or type |


### PR DESCRIPTION
  ## Summary

  Updates the sonarcloud-remediation Claude Code skill to serve as a baseline for evaluating
  improvements to similar sonarcloud skills in the public ai-forge repo. Key changes:

  - **SSL verification by default** — all API calls verify TLS certificates; opt out via
  `SONAR_INSECURE=true` for self-hosted instances with self-signed certs
  - **No interactive token prompts** — `SONARCLOUD_TOKEN` must be set as an environment variable
  before starting Claude; it is never accepted interactively to avoid leaking secrets into
  conversation context
  - **URL-encoding of org and project key** — `SONAR_ORGANIZATION` and `SONAR_PROJECT_KEY` are
  URL-encoded in API calls to handle special characters safely
  - **"Others" category for unrecognized issue types** — issues that don't map to Security,
  Reliability, or Maintainability are grouped under an "Others" bucket instead of being silently
  dropped
  - **Organization passed in all API calls** — ensures correct scoping for SonarCloud multi-org
  setups
  - **Overridable `SONAR_BASE_URL`** — defaults to `https://sonarcloud.io/api` but can be set to a
  self-hosted SonarQube instance URL
  - **Updated `--help` content** — sonarcloud-analyze and sonarcloud-fix commands document SonarQube
  and GitLab support
  - **Renamed env vars** — commands updated to match renamed environment variables
  (`SONAR_ORGANIZATION`, `SONAR_PROJECT_KEY`, `SONAR_BASE_URL`)

  ## Context

  This branch will be used as a baseline to evaluate what improvements can be made to similar
  sonarcloud skills in the public ai-forge repo.

  ## Test plan

  - [ ] Verify `sonarcloud-analyze` fetches and groups issues correctly against a SonarCloud project
  - [ ] Verify `sonarcloud-fix` applies fixes and creates PRs as expected