### PR TITLE
chore(security): npm hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,23 @@
-  version: 2
-  updates:
-    - package-ecosystem: "npm"
-      directory: "/"
-      schedule:
-        interval: "weekly"
-      # "increase" is required for npm workspaces monorepos. Without it, Dependabot skips
-      # updating workspace package.json files when the existing range (e.g. ^1.0.0) already
-      # satisfies the new version — so no PR is created. See: https://github.com/dependabot/dependabot-core/issues/5226
-      versioning-strategy: increase
-      groups:
-        # Batches all non-major devDependency updates into a single PR.
-        # Major devDependency bumps and all production dependency updates get individual PRs.
-        non-major-dev:
-          dependency-type: "development"
-          update-types:
-            - "minor"
-            - "patch"
-          exclude-patterns:
-            - "prettier"
-            - "typescript"
+version: 2
+cooldown:
+  default-days: 7
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # "increase" is required for npm workspaces monorepos. Without it, Dependabot skips
+    # updating workspace package.json files when the existing range (e.g. ^1.0.0) already
+    # satisfies the new version — so no PR is created. See: https://github.com/dependabot/dependabot-core/issues/5226
+    versioning-strategy: increase
+    groups:
+      # Batches all non-major devDependency updates into a single PR.
+      # Major devDependency bumps and all production dependency updates get individual PRs.
+      non-major-dev:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "prettier"
+          - "typescript"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 ignore-scripts=true
+
+# Follows CISA guidance on the subject - https://www.cisa.gov/news-events/alerts/2026/04/20/supply-chain-compromise-impacts-axios-node-package-manager
 min-release-age=7


### PR DESCRIPTION
## Summary

- Sets minimum release age for installing NPM dependencies
- Disables postinstall scripts
- Configures `dependabot` cooldown

## Type of Change

- [x] Other (please specify) - security

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Check out this branch - `npm install` should still work as expected
- Pipelines should remain green

### Screenshots

N/A
