### PR TITLE
AAP-74592 XLAB  Dashboard cards overflows based on window width

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -11,15 +11,20 @@ import { DashboardTableInputField } from './DashboardTableInputField';
 import { DashboardTableToolbarRow } from './DashboardTableToolbarRow';
 import { DashboardValueCard } from './DashboardValueCard';
 import { usePutRequest } from '../../../../common/crud/usePutRequest';
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import useResizeObserver from '@react-hook/resize-observer';
 
 interface IJobTemplateModify {
   time_taken_manually_execute_minutes: number;
   time_taken_create_automation_minutes: number;
 }
+
+// 24-column grid system for responsive layout
+// Uses 1625px instead of PageDashboard's 1662px to account for card padding
+const GRID_COLUMN_WIDTH = 1625 / 24; // ~67.7px per column
 
 export function DashboardMainTableCard(props: IAutomationDashboardView) {
   const {
@@ -36,6 +41,20 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
   const { activeAwxUser } = useAwxActiveUser();
   const putRequest = usePutRequest<IJobTemplateModify, IJobTemplateModify>();
   const alertToaster = usePageAlertToaster();
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [columns, setColumns] = useState(1);
+
+  const calculateGridColumns = (width: number) =>
+    Math.max(1, Math.floor(width / GRID_COLUMN_WIDTH));
+
+  useLayoutEffect(() => {
+    setColumns(calculateGridColumns(ref.current?.clientWidth ?? 0));
+  }, []);
+
+  useResizeObserver(ref, (entry) => {
+    setColumns(calculateGridColumns(entry.contentRect.width));
+  });
 
   const [errors, setErrors] = useState<Record<
     number,
@@ -188,19 +207,10 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
   ];
 
   return (
-    <PageDashboardCard
-      id={'ad-main-table-card'}
-      width="xxl"
-      style={{ gridColumn: 'span 24', maxHeight: 'unset', height: 'fit-content' }}
-      isCompact={false}
-      canCollapse={false}
-    >
+    <PageDashboardCard id={'ad-main-table-card'} width="xxl" isCompact canCollapse={false}>
       <div
-        style={{
-          display: 'grid',
-          gap: '1rem',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(32px, 1fr))',
-        }}
+        ref={ref}
+        style={{ display: 'grid', gap: 16, gridTemplateColumns: `repeat(${columns}, 1fr)` }}
       >
         <DashboardValueCard
           id="cost-manual-automation-card"

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, FlexItem, Switch } from '@patternfly/react-core';
-import { PageFormGroup } from '@ansible/ansible-ui-framework/PageForm/Inputs/PageFormGroup';
 import { useTranslation } from 'react-i18next';
 import { DashboardTableInputField } from './DashboardTableInputField';
 import { DashboardTableToolbarProps, ISubscriptionCosts } from '../types';
@@ -99,73 +98,79 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
   return (
     <Flex
       style={{ paddingTop: '1rem', paddingBottom: '1rem' }}
-      direction={{ default: 'row' }}
-      alignItems={{ default: 'alignItemsCenter' }}
+      direction={{ xl: 'row', default: 'column' }}
+      alignItems={{ xl: 'alignItemsCenter', default: 'alignItemsFlexStart' }}
+      rowGap={{ default: 'rowGapMd' }}
     >
-      <FlexItem>
-        <DashboardTableInputField
-          label={t('Hourly rate for manually running the job ({{currency}})', { currency: '$' })}
-          labelHelp={t(
-            'The hourly labor cost used to estimate what it would cost to run these jobs manually. Used to calculate manual cost and savings in the table below.'
-          )}
-          id="engineer_avg_hourly_rate"
-          value={costState?.engineer_avg_hourly_rate}
-          min={1}
-          max={1000000}
-          onChange={(value) => {
-            void toolbarChangeHandler(value, 'engineer_avg_hourly_rate');
-          }}
-          readOnly={controlsDisabled}
-          error={errors?.engineer_avg_hourly_rate}
-        />
-      </FlexItem>
-      <FlexItem>
-        <DashboardTableInputField
-          label={t('Monthly AAP cost ({{currency}})', { currency: '$' })}
-          labelHelp={t(
-            'Monthly cost of running the Ansible Automation Platform. This value includes license, labor and infrastructure costs to run AAP. It is used to calculate the automation savings'
-          )}
-          id="monthly_subscription_cost"
-          value={costState?.monthly_subscription_cost}
-          min={1}
-          max={1000000}
-          onChange={(value) => {
-            void toolbarChangeHandler(value, 'monthly_subscription_cost');
-          }}
-          readOnly={controlsDisabled}
-          error={errors?.monthly_subscription_cost}
-        />
-      </FlexItem>
-      <FlexItem>
-        <PageFormGroup
-          fieldId={SWITCH_ID}
-          data-testid={SWITCH_ID + '-form-group'}
-          label={t('Include time taken to create automation into calculation')}
-        >
+      <Flex direction={{ md: 'row', default: 'column' }} rowGap={{ default: 'rowGapMd' }}>
+        <FlexItem>
+          <DashboardTableInputField
+            label={t('Hourly rate for manually running the job ({{currency}})', { currency: '$' })}
+            labelHelp={t(
+              'The hourly labor cost used to estimate what it would cost to run these jobs manually. Used to calculate manual cost and savings in the table below.'
+            )}
+            id="engineer_avg_hourly_rate"
+            value={costState?.engineer_avg_hourly_rate}
+            min={1}
+            max={1000000}
+            onChange={(value) => {
+              void toolbarChangeHandler(value, 'engineer_avg_hourly_rate');
+            }}
+            readOnly={controlsDisabled}
+            error={errors?.engineer_avg_hourly_rate}
+          />
+        </FlexItem>
+        <FlexItem>
+          <DashboardTableInputField
+            label={t('Monthly AAP cost ({{currency}})', { currency: '$' })}
+            labelHelp={t(
+              'Monthly cost of running the Ansible Automation Platform. This value includes license, labor and infrastructure costs to run AAP. It is used to calculate the automation savings'
+            )}
+            id="monthly_subscription_cost"
+            value={costState?.monthly_subscription_cost}
+            min={1}
+            max={1000000}
+            onChange={(value) => {
+              void toolbarChangeHandler(value, 'monthly_subscription_cost');
+            }}
+            readOnly={controlsDisabled}
+            error={errors?.monthly_subscription_cost}
+          />
+        </FlexItem>
+      </Flex>
+      <Flex
+        direction={{ md: 'row', default: 'column' }}
+        alignItems={{ md: 'alignItemsCenter', default: 'alignItemsFlexStart' }}
+        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+        grow={{ default: 'grow' }}
+        rowGap={{ default: 'rowGapLg' }}
+      >
+        <FlexItem>
           <Switch
             id={SWITCH_ID + '-toggle'}
             data-testid={SWITCH_ID + '-toggle'}
-            aria-label={t('Include time taken to create automation into calculation')}
+            label={t('Include time taken to create automation into calculation')}
             isChecked={costState?.include_template_creation_time_in_costs === true}
             onChange={(_e, value) => {
               void toolbarChangeHandler(value, 'include_template_creation_time_in_costs');
             }}
+            hasCheckIcon
             isDisabled={controlsDisabled}
           />
-        </PageFormGroup>
-      </FlexItem>
-      <FlexItem style={{ alignSelf: 'flex-end', marginLeft: 'auto' }}>
-        <Button
-          id="btn-export-csv"
-          data-testid="btn-export-csv"
-          variant="secondary"
-          onClick={onExportCsv}
-          // TODO: Remove `|| true` once CSV export is implemented on the BE.
-          isDisabled={controlsDisabled || (itemCount ?? 0) === 0 || !onExportCsv || true}
-        >
-          {t('Export as CSV')}
-        </Button>
-      </FlexItem>
+        </FlexItem>
+        <FlexItem alignSelf={{ md: 'alignSelfFlexEnd', default: 'alignSelfFlexStart' }}>
+          <Button
+            id="btn-export-csv"
+            data-testid="btn-export-csv"
+            variant="secondary"
+            onClick={onExportCsv}
+            // TODO: Remove `|| true` once CSV export is implemented on the BE.
+            isDisabled={controlsDisabled || (itemCount ?? 0) === 0 || !onExportCsv || true}
+          >
+            {t('Export as CSV')}
+          </Button>
+        </FlexItem>
+      </Flex>
     </Flex>
   );
 }


### PR DESCRIPTION
## Summary
[AAP-74592](https://redhat.atlassian.net/browse/AAP-74592)

This pull request improves the responsiveness and layout of the automation dashboard components, particularly focusing on the main table card and toolbar row. The changes introduce a dynamic grid system for better adaptation to varying screen sizes and refactor the toolbar for enhanced alignment and usability.

**Responsive Layout Enhancements:**

- Implemented a responsive 24-column grid system in `DashboardMainTableCard`, dynamically adjusting the number of columns based on the card's width using `useLayoutEffect`, `useRef`, and `@react-hook/resize-observer`. This ensures the dashboard adapts smoothly to different screen sizes. [[1]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L14-R28) [[2]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R45-R58) [[3]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L191-R213)

**Toolbar Refactoring and Accessibility:**

- Refactored `DashboardTableToolbarRow` to use PatternFly's `Flex` layout more effectively, allowing for responsive direction, alignment, and spacing based on screen size. This improves the toolbar's appearance and usability on both large and small screens. [[1]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L102-R105) [[2]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L139-R161) [[3]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42R174)
- Removed the unused `PageFormGroup` import and replaced the form group for the switch with a direct `Switch` component, simplifying the code and improving accessibility. [[1]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L2) [[2]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L139-R161)

**Minor Improvements:**

- Added the `hasCheckIcon` property to the `Switch` for clearer visual feedback.
- Improved label handling and alignment for toolbar controls.

These changes collectively enhance the dashboard's adaptability and user experience, especially on different device sizes.
<!-- What changed and why? -->

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="1117" height="1449" alt="before" src="https://github.com/user-attachments/assets/7f331707-66a8-459b-93c3-14a8fdbf879c" />
<img width="1009" height="1201" alt="after" src="https://github.com/user-attachments/assets/1cd3b3d3-764e-4625-889f-b37cb8ef59b9" />
