### PR TITLE
fix(hub): add null guard on docs_blob access in CollectionDocumentation

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
@@ -550,6 +550,85 @@ describe('CollectionDocumentation', () => {
     expect(roleNavItem.closest('button, a, [role="button"]')).not.toBeNull();
   });
 
+  test('should render documentation file HTML when navigating to a doc file name without content type', async () => {
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        () => {
+          return HttpResponse.json({
+            count: 1,
+            next: '',
+            previous: '',
+            results: [
+              {
+                docs_blob: {
+                  contents: [],
+                  collection_readme: { html: '<p>Readme</p>', name: 'README.md' },
+                  documentation_files: [
+                    { name: 'changelog.md', html: '<h2>Changelog</h2><p>v1.0.0 release</p>' },
+                  ],
+                },
+                license: ['GPL-3.0-or-later'],
+              },
+            ],
+          });
+        }
+      )
+    );
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <TestWrapper initialPath="/collections/validated/testnamespace/testcollection/documentation/changelog">
+          <CollectionDocumentation />
+        </TestWrapper>
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/v1\.0\.0 release/)).toBeInTheDocument();
+    });
+  });
+
+  test('should render gracefully when documentation_files is undefined', async () => {
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        () => {
+          return HttpResponse.json({
+            count: 1,
+            next: '',
+            previous: '',
+            results: [
+              {
+                docs_blob: {
+                  contents: [],
+                  collection_readme: { html: '<p>Readme only</p>', name: 'README.md' },
+                },
+                license: ['GPL-3.0-or-later'],
+              },
+            ],
+          });
+        }
+      )
+    );
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <TestWrapper>
+          <CollectionDocumentation />
+        </TestWrapper>
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Readme only/)).toBeInTheDocument();
+    });
+  });
+
   test('should render gracefully without crashing when docs_blob is missing from API response', async () => {
     server.use(
       http.get(

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { CollectionDocumentation, CollectionVersionsContent } from './CollectionDocumentation';
 
@@ -547,5 +548,35 @@ describe('CollectionDocumentation', () => {
     // Verify the role link is a clickable navigation item
     const roleNavItem = screen.getByText('example_role');
     expect(roleNavItem.closest('button, a, [role="button"]')).not.toBeNull();
+  });
+
+  test('should render gracefully without crashing when docs_blob is missing from API response', async () => {
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        () => {
+          return HttpResponse.json({
+            count: 1,
+            next: '',
+            previous: '',
+            results: [{ license: ['GPL-3.0-or-later'] }],
+          });
+        }
+      )
+    );
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <TestWrapper>
+          <CollectionDocumentation />
+        </TestWrapper>
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/can not load documentation/i)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.tsx
@@ -52,7 +52,7 @@ export function CollectionDocumentation() {
   const groups = useMemo(() => {
     const groups: Record<string, { name: string; contents: IContents[] }> = {};
     if (data) {
-      for (const content of data.results[0].docs_blob.contents) {
+      for (const content of data.results[0]?.docs_blob?.contents ?? []) {
         let group = groups[content.content_type];
         if (!group) {
           group = {
@@ -80,9 +80,9 @@ export function CollectionDocumentation() {
           name: string;
         }[]
       | [] = [];
-    if (data?.results[0].docs_blob) {
+    if (data?.results[0]?.docs_blob) {
       const { docs_blob } = data.results[0];
-      files = docs_blob.documentation_files.map(({ name }) => ({
+      files = (docs_blob.documentation_files ?? []).map(({ name }) => ({
         label: name.charAt(0).toUpperCase() + name.slice(1).split('.')[0],
         name: name.split('.')[0],
       }));
@@ -105,7 +105,7 @@ export function CollectionDocumentation() {
   }
 
   const dataItem = data?.results[0];
-  if (error || !dataItem) {
+  if (error || !dataItem?.docs_blob) {
     return (
       <HubError
         error={{ name: '', message: t('Can not load documentation.') }}
@@ -117,19 +117,19 @@ export function CollectionDocumentation() {
   const { content_type, content_name } = params;
 
   // find content based on search params
-  let content = data?.results[0]?.docs_blob?.contents.find(
+  let content = dataItem.docs_blob.contents?.find(
     (c) => c.content_name === content_name && c.content_type === content_type
   );
 
   // for readme, use the root html of all contents
   let html = '';
   if (!content_type && !content_name) {
-    html = dataItem?.docs_blob?.collection_readme?.html || '';
+    html = dataItem.docs_blob.collection_readme?.html || '';
   }
   if (!content_type && content_name) {
     html =
-      data.results[0].docs_blob.documentation_files.find((c) => c.name.startsWith(content_name))
-        ?.html || '';
+      dataItem.docs_blob.documentation_files?.find((c) => c.name.startsWith(content_name))?.html ||
+      '';
   }
 
   // if the content has html, lets use that instead of content frontent generation
@@ -233,7 +233,7 @@ export function CollectionDocumentation() {
 }
 
 export type CollectionVersionContentItem = {
-  docs_blob: {
+  docs_blob?: {
     contents: IContents[];
     collection_readme: {
       html: string;


### PR DESCRIPTION
## Summary

The Documentation tab crashes with a TypeError when docs_blob is missing from the API response. Add optional chaining and nullish coalescing to all docs_blob access points, extend the early return guard to show HubError when docs_blob is absent, and make docs_blob optional in the CollectionVersionContentItem type.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
