### PR TITLE
test(eda): stabilize event-persistence integration tests

### DIFF
--- a/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
+++ b/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
@@ -455,6 +455,11 @@ test.describe('Rulebook Activations - Event Persistence', () => {
       // Save the changes
       await page.getByRole('button', { name: 'Save rulebook activation' }).click();
 
+      // Wait for navigation back to details page
+      await expect(page.getByRole('heading', { name: activationName, exact: true })).toBeVisible({
+        timeout: 10000,
+      });
+
       // Verify persistence is disabled and credential is null
       await expect(page.getByTestId('enable-persistence')).not.toBeVisible();
 

--- a/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
+++ b/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
@@ -251,7 +251,13 @@ test.describe('Rulebook Activations - Event Persistence', () => {
     }
   );
 
-  test(
+  // Skipped: AAP installs a hidden default rule engine credential (_DEFAULT_EDA_RULE_ENGINE_CREDS)
+  // that is filtered from API responses (eda-server eda_credential.py). Because this credential
+  // always exists at install time, enabling persistence without selecting a credential never
+  // produces an error — the backend silently uses the default. The test's expected error cannot
+  // be triggered unless the instance is built without a managed DB. Behavior is in flux (UXD
+  // discussions tracked under AAP-77521). Re-evaluate when default credential visibility changes.
+  test.skip(
     'should show error when persistence enabled without credential and no default exists',
     { tag: ['@not_mock'] },
     async ({ page }) => {

--- a/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
+++ b/playwright/tests/integration/automation-decisions/rulebook-activations/event-persistence.spec.ts
@@ -28,7 +28,7 @@ test.describe('Rulebook Activations - Event Persistence', () => {
     // Create a rule engine credential for event persistence
     ruleEngineCredentialName = await EdaCredential.ui.create(page, {
       organizationName,
-      credentialTypeName: 'Rule Engine',
+      credentialTypeName: 'Event-Driven Ansible Rule Engine',
     });
   });
 
@@ -103,7 +103,9 @@ test.describe('Rulebook Activations - Event Persistence', () => {
       await page.getByRole('button', { name: 'Create rulebook activation' }).click();
 
       // Verify details page shows persistence enabled
-      await expect(page.getByRole('heading', { name: activationName, exact: true })).toBeVisible();
+      await expect(page.getByRole('heading', { name: activationName, exact: true })).toBeVisible({
+        timeout: 10000,
+      });
 
       // Check that persistence is enabled on details page
       await expect(page.getByTestId('enable-persistence')).toBeVisible();

--- a/playwright/utils/edaCredential.ts
+++ b/playwright/utils/edaCredential.ts
@@ -103,14 +103,16 @@ export const EdaCredential = {
         await page.getByRole('textbox', { name: 'Username' }).fill('test');
         await page.getByRole('textbox', { name: 'Password' }).click();
         await page.getByRole('textbox', { name: 'Password' }).fill('test');
-      } else if (credentialTypeName === 'Rule Engine') {
+      } else if (credentialTypeName === 'Event-Driven Ansible Rule Engine') {
         // Rule Engine credentials require Postgres DB Host and DB Name
         await page.getByRole('textbox', { name: 'Postgres DB Host' }).fill('localhost');
         await page.getByRole('textbox', { name: 'Postgres DB Name' }).fill('test_db');
       }
 
       await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
+      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible({
+        timeout: 10000,
+      });
       return credentialName;
     },
 


### PR DESCRIPTION
## Summary

Stabilize the EDA event-persistence Playwright integration tests:

- **Fix credential type mismatch:** The test and `edaCredential` utility used `'Rule Engine'`
  but the actual credential type name is `'Event-Driven Ansible Rule Engine'`. This caused
  the Postgres fields to be skipped during credential creation, failing form validation.
- **Skip untriggerable test:** AAP installs a hidden default rule engine credential
  (`_DEFAULT_EDA_RULE_ENGINE_CREDS`) that the backend uses silently. The "error when no
  credential selected" test can never trigger in a standard install. Marked `.skip` until
  default credential visibility is resolved.
- **Fix race condition:** Added explicit waits for details-page navigation after save
  before asserting `not.toBeVisible()` on details elements. Also increased post-creation
  heading timeouts to 10s.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes,
copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

All three tests were run locally against a live AAP instance. The two active tests pass;
the skipped test is annotated with rationale.