### PR TITLE
fix(playwright): add retry logic for Documentation tab Pulp indexing delay

### DIFF
--- a/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
+++ b/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
@@ -702,8 +702,26 @@ test.describe('Hub Collections - Details Page', () => {
 
         await navigateToCollectionDetails(page, uploaded);
 
-        // Click on the Documentation tab
-        await page.getByRole('tab', { name: 'Documentation' }).click();
+        // Click on the Documentation tab with retry logic for Pulp indexing delay.
+        // docs_blob may not be available immediately after collection approval,
+        // causing the tab to render a NotFound page instead of documentation content.
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          await page.getByRole('tab', { name: 'Documentation' }).click();
+
+          try {
+            await expect(page.getByPlaceholder('Find content')).toBeVisible({ timeout: 10000 });
+            break;
+          } catch {
+            if (attempt === 3) {
+              const mainContent = await page.locator('main').textContent();
+              throw new Error(
+                `Documentation tab did not render after 3 attempts. Page shows: ${mainContent?.slice(0, 200)}`
+              );
+            }
+            await page.waitForTimeout(2000);
+            await page.getByTestId('collection-detail-tab').click();
+          }
+        }
 
         // Verify documentation content renders (not an error state)
         await expect(page.getByRole('heading', { name: 'Page not found' })).not.toBeVisible();
@@ -711,9 +729,6 @@ test.describe('Hub Collections - Details Page', () => {
         // Verify the page does not show a generic error boundary
         const mainContent = page.locator('main');
         await expect(mainContent).not.toContainText('Error', { timeout: 10000 });
-
-        // Verify documentation structure rendered (drawer with navigation panel)
-        await expect(page.getByPlaceholder('Find content')).toBeVisible({ timeout: 10000 });
       }
     );
   });


### PR DESCRIPTION
## Summary

Add retry logic to the Collection Details Documentation tab test. After collection approval, Pulp may not index `docs_blob` immediately, causing the Documentation tab to render "Page not found" instead of content. The test now retries up to 3 times with 2-second delays, navigating back to the Install tab before re-clicking Documentation on each retry.

**Timing tradeoff:** The original code waited a single 10s timeout for `Find content` to appear, then failed. The new retry loop adds at most ~24s of additional wait in the worst case (2 extra cycles of 10s visibility timeout + 2s delay). On the happy path (docs indexed promptly), there is zero added delay — the first attempt succeeds within the same 10s window as before. This is a worthwhile tradeoff: the test was failing intermittently in CI due to Pulp indexing lag that exceeds 10s but resolves within 30s, and a ~24s worst-case increase is negligible compared to the cost of a flaky test blocking the pipeline.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

The change is a Playwright test fix — verified by running the affected test against a live AAP instance.

Assisted-by: Claude Code / Opus 4.6 (Anthropic)