### PR TITLE
SonarCloud Fix: Remove unused variables (S1481, frontend/hub)

### DIFF
--- a/frontend/hub/interfaces/transform.cjs
+++ b/frontend/hub/interfaces/transform.cjs
@@ -171,8 +171,6 @@ function serializeObjectInterface(schema, depth, interfaceName, needImport) {
       // type, description, format : 'date-time'
       const type = property.type;
       const description = property.description;
-      const format = property.format;
-
       const tabs = '\t\t\t\t';
 
       if (description) {
@@ -253,8 +251,6 @@ fs.readFile(filePath, 'utf8', (err, data) => {
         fileContent += add('');
 
         fileContent += add('/* eslint-disable @typescript-eslint/no-empty-interface */');
-
-        let canCreateFile = true;
 
         if (pathSchemas[interfaceName]) {
           interfacePath = pathSchemas[interfaceName]?.path;


### PR DESCRIPTION
## Summary
- Remove 2 unused local variables in `frontend/hub/interfaces/transform.cjs` flagged by SonarCloud rule `javascript:S1481`
  - `format` (line 174) — declared but never read
  - `canCreateFile` (line 257) — declared but never read
- SonarCloud issue keys: AZ3f1dIAPxvmA1t7knyU, AZ3f1dIAPxvmA1t7knyX

## Test plan
- [x] `npm run tsc` passes (no type errors introduced)
- [ ] Verify SonarCloud issues resolve after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)