### PR TITLE
Fix/edit role content type null handling for System roles

### DIFF
--- a/platform/access/roles/PlatformRoleForm.test.tsx
+++ b/platform/access/roles/PlatformRoleForm.test.tsx
@@ -176,6 +176,118 @@ describe('PlatformRoleForm', () => {
     });
   });
 
+  describe('Form submission payload', () => {
+    test('should send content_type as null when System is selected on create', async () => {
+      const user = userEvent.setup();
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(gatewayAPI`/role_definitions/`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: 99, ...capturedBody });
+        })
+      );
+
+      const { findByRole, getByRole, getByText, getByLabelText } = render(
+        <MemoryRouter initialEntries={['/access/roles/create']}>
+          <Routes>
+            <Route path={'/access/roles/create'} element={<CreatePlatformRole />} />
+            <Route path={'/access/roles/:id/details'} element={<div>Details</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await user.type(getByRole('textbox', { name: 'Name' }), 'System role');
+      await user.type(getByRole('textbox', { name: 'Description' }), 'A system role');
+
+      const resourceTypeButton = getByRole('button', { name: 'Resource type' });
+      await user.click(resourceTypeButton);
+      await user.click(getByText('System'));
+
+      const permissionsButton = await findByRole(
+        'button',
+        { name: 'Permissions' },
+        { timeout: 10000 }
+      );
+      await user.click(permissionsButton);
+      await user.click(getByLabelText('Can view Ansible repository'));
+      await user.click(document.body);
+
+      await user.click(getByRole('button', { name: 'Create role' }));
+
+      await waitFor(() => {
+        expect(capturedBody).toBeDefined();
+      });
+      expect(capturedBody?.content_type).toBeNull();
+    }, 15000);
+
+    test('should send content_type as null when editing a System role', async () => {
+      const user = userEvent.setup();
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.get(gatewayAPI`/role_definitions/2/`, () => {
+          return HttpResponse.json({
+            ...roleDefinition,
+            id: 2,
+            content_type: null,
+            permissions: ['galaxy.view_ansiblerepository'],
+          });
+        }),
+        http.patch(gatewayAPI`/role_definitions/2/`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: 2, ...capturedBody });
+        })
+      );
+
+      const { findByRole } = render(
+        <MemoryRouter initialEntries={['/access/roles/2/edit']}>
+          <Routes>
+            <Route path={'/access/roles/:id/edit'} element={<EditPlatformRole />} />
+            <Route path={'/access/roles/:id/details'} element={<div>Details</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      const saveButton = await findByRole('button', { name: 'Save role' });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(capturedBody).toBeDefined();
+      });
+      expect(capturedBody?.content_type).toBeNull();
+    }, 15000);
+
+    test('should preserve non-null content_type when editing a non-System role', async () => {
+      const user = userEvent.setup();
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.patch(gatewayAPI`/role_definitions/1/`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: 1, ...capturedBody });
+        })
+      );
+
+      const { findByRole } = render(
+        <MemoryRouter initialEntries={['/access/roles/1/edit']}>
+          <Routes>
+            <Route path={'/access/roles/:id/edit'} element={<EditPlatformRole />} />
+            <Route path={'/access/roles/:id/details'} element={<div>Details</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      const saveButton = await findByRole('button', { name: 'Save role' });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(capturedBody).toBeDefined();
+      });
+      expect(capturedBody?.content_type).toBe('eda.activation');
+    }, 15000);
+  });
+
   describe('Permission Selection Validation', () => {
     test('should show permissions only after selecting resource type', async () => {
       const user = userEvent.setup();

--- a/platform/access/roles/PlatformRoleForm.tsx
+++ b/platform/access/roles/PlatformRoleForm.tsx
@@ -83,7 +83,11 @@ export function EditPlatformRole(props: Readonly<{ breadcrumbLabelForPreviousPag
   const patchRequest = usePatchRequest<Partial<PlatformRole>, PlatformRole>();
 
   const onSubmit: PageFormSubmitHandler<PlatformRole> = async (data) => {
-    await patchRequest(gatewayAPI`/role_definitions/${id.toString()}/`, data);
+    const toUpdateRole: PlatformRole = {
+      ...data,
+      content_type: data.content_type === ContentTypeEnum.System ? null : data.content_type,
+    };
+    await patchRequest(gatewayAPI`/role_definitions/${id.toString()}/`, toUpdateRole);
     pageNavigate(PlatformRoute.RoleDetails, { params: { id } });
   };
   const onCancel = () => void navigate(-1);


### PR DESCRIPTION
## Summary

`EditPlatformRole`'s `defaultValue` converts a `null` `content_type` (System roles) to `ContentTypeEnum.System` (`"null"` string) for display in the form dropdown. However, `onSubmit` was not converting it back to `null` before sending the PATCH request, unlike `CreatePlatformRole` which already handled this. This caused the API to receive the string `"null"` instead of `null` when editing a System role.

Added the same `ContentTypeEnum.System` → `null` conversion in `EditPlatformRole.onSubmit` to match `CreatePlatformRole`, and added Vitest tests to verify the submitted payload for both create and edit flows.

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Navigate to Access > Roles
2. Create a new role with "System" resource type — verify it saves successfully
3. Edit an existing System role — verify it saves without errors and `content_type` remains `null` in the API response

### Vitest

Three new tests added to `PlatformRoleForm.test.tsx`:
- `should send content_type as null when System is selected on create` — intercepts POST payload
- `should send content_type as null when editing a System role` — intercepts PATCH payload for a role with `content_type: null`
- `should preserve non-null content_type when editing a non-System role` — intercepts PATCH payload for a role with `content_type: "eda.activation"`