### PR TITLE
AAP-74855 XLAB Automation dashboard UX polish

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -243,7 +243,7 @@ describe('AutomationDashboard', () => {
 
   test('should render links for successful and failed job value cards', () => {
     render(testWrapper());
-    expect(screen.getByText('See all successful jobs in AAP')).toBeInTheDocument();
-    expect(screen.getByText('See all failed jobs in AAP')).toBeInTheDocument();
+    expect(screen.getByText('See all successful jobs')).toBeInTheDocument();
+    expect(screen.getByText('See all failed jobs')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -134,6 +134,8 @@ const mockView: IAutomationDashboardView = {
   refresh: vi.fn(),
   exportCsv: vi.fn(),
   exportPdf: vi.fn(),
+  isFilterStateDefault: true,
+  registerClearCallback: vi.fn(),
 };
 
 // ─── Test wrapper ─────────────────────────────────────────────────────────────

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -5,8 +5,8 @@ import {
   PageLayout,
   useGetPageUrl,
 } from '@ansible/ansible-ui-framework';
-import { Button } from '@patternfly/react-core';
-import { useState } from 'react';
+import { Button, Grid, GridItem } from '@patternfly/react-core';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { AwxRoute } from '../../main/AwxRoutes';
 import {
   DashboardChartCard,
@@ -18,6 +18,15 @@ import {
 
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
 import { DashboardToolbar } from './components/DashboardToolbar';
+import styled from 'styled-components';
+import useResizeObserver from '@react-hook/resize-observer';
+
+const AutomationDashboardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+const Divisor = 1662 / 24;
 
 export function AutomationDashboard() {
   const { t } = useTranslation();
@@ -42,128 +51,184 @@ export function AutomationDashboard() {
   };
 
   const noDataString = t('No jobs have been run.');
+  const ref = useRef<HTMLDivElement>(null);
+  const [gridColumns, setGridColumns] = useState(1);
+
+  useLayoutEffect(() => {
+    const width = Math.max(1, Math.floor((ref.current?.clientWidth ?? 0) / Divisor));
+    setGridColumns(Math.min(25, width));
+  }, []);
+
+  useResizeObserver(ref, (entry) => {
+    const width = Math.max(1, Math.floor((entry.contentRect.width ?? 0) / Divisor));
+    setGridColumns(Math.min(25, width));
+  });
 
   return (
-    <PageLayout>
-      <PageHeader
-        title={t('Automation Dashboard')}
-        titleHelpTitle={t('Automation Dashboard')}
-        titleHelp={description}
-        description={description}
-        controls={
-          <Button
-            data-testid="save-as-pdf-button"
-            // TODO: Remove `|| true` once PDF export is implemented on the BE.
-            isDisabled={loading || exporting || !view?.mainTableView?.itemCount || true}
-            variant="secondary"
-            onClick={() => void handleExportPdf()}
-          >
-            {t('Save as PDF')}
-          </Button>
-        }
-      />
-      <DashboardToolbar toolbarFilters={toolbarFilters} {...view.mainTableView} />
-      <PageDashboard>
-        <DashboardValueCard
-          id="successful-jobs-card"
-          title={t('Successful jobs')}
-          help={t(
-            'Number of job runs that completed without error in the selected period. Use the ratio between successful and failed jobs to track automation health and reliability over time.'
-          )}
-          linkText={t('See all successful jobs')}
-          to={getPageUrl(AwxRoute.Jobs) + '?status=successful'}
-          value={details?.total_number_of_successful_jobs ?? noDataString}
-          error={view.detailsError}
-          errorStateTitle={t('Error loading successful jobs')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="failed-jobs-card"
-          title={t('Failed jobs')}
-          help={t(
-            'Number of job runs that ended in failure in the selected period. Review failed jobs to fix playbooks, credentials, or inventory issues and improve success rates.'
-          )}
-          linkText={t('See all failed jobs')}
-          to={getPageUrl(AwxRoute.Jobs) + '?status=failed'}
-          value={details?.total_number_of_failed_jobs ?? noDataString}
-          error={view.detailsError}
-          errorStateTitle={t('Error loading failed jobs')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="unique-hosts-card"
-          title={t('Hosts automated')}
-          help={t(
-            'Number of hosts that executed at least one automation job in the selected period. Indicates how much of your inventory is actively automated and can help with license or capacity planning.'
-          )}
-          value={details?.total_number_of_unique_hosts ?? noDataString}
-          error={view.detailsError}
-          errorStateTitle={t('Error loading unique hosts')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="automation-hours-card"
-          title={t('Hours of automation')}
-          help={t(
-            'Sum of all job runtimes in the selected period. Reflects total automation workload and can inform capacity planning and resource allocation.'
-          )}
-          value={details?.total_hours_of_automation ?? noDataString}
-          valueSuffix="h"
-          error={view.detailsError}
-          errorStateTitle={t('Error loading hours of automation')}
-        ></DashboardValueCard>
+    <AutomationDashboardWrapper ref={ref}>
+      <PageLayout>
+        <PageHeader
+          title={t('Automation Dashboard')}
+          titleHelpTitle={t('Automation Dashboard')}
+          titleHelp={description}
+          description={description}
+          controls={
+            <Button
+              data-testid="save-as-pdf-button"
+              // TODO: Remove `|| true` once PDF export is implemented on the BE.
+              isDisabled={loading || exporting || !view?.mainTableView?.itemCount || true}
+              variant="secondary"
+              onClick={() => void handleExportPdf()}
+            >
+              {t('Save as PDF')}
+            </Button>
+          }
+        />
+        <DashboardToolbar
+          toolbarFilters={toolbarFilters}
+          {...view.mainTableView}
+          registerClearCallback={view.registerClearCallback}
+        />
+        <PageDashboard>
+          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+              <DashboardValueCard
+                id="successful-jobs-card"
+                title={t('Successful jobs')}
+                help={t(
+                  'Number of job runs that completed without error in the selected period. Use the ratio between successful and failed jobs to track automation health and reliability over time.'
+                )}
+                linkText={t('See all successful jobs')}
+                to={getPageUrl(AwxRoute.Jobs) + '?status=successful'}
+                value={details?.total_number_of_successful_jobs ?? noDataString}
+                error={view.detailsError}
+                errorStateTitle={t('Error loading successful jobs')}
+              ></DashboardValueCard>
+              <DashboardValueCard
+                id="failed-jobs-card"
+                title={t('Failed jobs')}
+                help={t(
+                  'Number of job runs that ended in failure in the selected period. Review failed jobs to fix playbooks, credentials, or inventory issues and improve success rates.'
+                )}
+                linkText={t('See all failed jobs')}
+                to={getPageUrl(AwxRoute.Jobs) + '?status=failed'}
+                value={details?.total_number_of_failed_jobs ?? noDataString}
+                error={view.detailsError}
+                errorStateTitle={t('Error loading failed jobs')}
+              ></DashboardValueCard>
+              <DashboardValueCard
+                id="unique-hosts-card"
+                title={t('Hosts automated')}
+                help={t(
+                  'Number of hosts that executed at least one automation job in the selected period. Indicates how much of your inventory is actively automated and can help with license or capacity planning.'
+                )}
+                value={details?.total_number_of_unique_hosts ?? noDataString}
+                error={view.detailsError}
+                errorStateTitle={t('Error loading unique hosts')}
+              ></DashboardValueCard>
+              <DashboardValueCard
+                id="automation-hours-card"
+                title={t('Hours of automation')}
+                help={t(
+                  'Sum of all job runtimes in the selected period. Reflects total automation workload and can inform capacity planning and resource allocation.'
+                )}
+                value={details?.total_hours_of_automation ?? noDataString}
+                valueSuffix="h"
+                error={view.detailsError}
+                errorStateTitle={t('Error loading hours of automation')}
+              ></DashboardValueCard>
+            </Grid>
+          </GridItem>
+          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+              <DashboardTableCard
+                id="top-projects-card"
+                title={t('Top 5 projects')}
+                help={t(
+                  'Projects ranked by total job count in the selected period. Helps identify which projects are driving the most automation activity.'
+                )}
+                firstColumnHeader={t('Project name')}
+                errorStateTitle={t('Error loading projects')}
+                items={details?.top_projects ?? []}
+                error={view.detailsError}
+                loading={view.detailsLoading}
+                clearAllFilters={view.mainTableView.clearAllFilters}
+                filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
+                emptyStateTitle={
+                  view?.mainTableView?.itemCount
+                    ? t('No projects to rank')
+                    : t('No project data yet')
+                }
+                emptyStateDescription={
+                  view?.mainTableView?.itemCount
+                    ? t(
+                        'Automation data exists, but no runs are currently associated with projects.'
+                      )
+                    : t('Project data will appear after your first automation runs.')
+                }
+              ></DashboardTableCard>
+              <DashboardTableCard
+                id="top-users-card"
+                title={t('Top 5 users')}
+                help={t(
+                  'Users ranked by automation runs they triggered or that ran in their context in the selected period. Shows individual adoption and activity.'
+                )}
+                firstColumnHeader={t('User name')}
+                errorStateTitle={t('Error loading users')}
+                items={details?.top_users ?? []}
+                error={view.detailsError}
+                loading={view.detailsLoading}
+                clearAllFilters={view.mainTableView.clearAllFilters}
+                filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
+                emptyStateTitle={
+                  view?.mainTableView?.itemCount ? t('No users to rank') : t('No user data yet')
+                }
+                emptyStateDescription={
+                  view?.mainTableView?.itemCount
+                    ? t(
+                        'Automation data exists, but no runs are currently attributed to individual users.'
+                      )
+                    : t('User data will appear after your first automation runs.')
+                }
+              ></DashboardTableCard>
+            </Grid>
+          </GridItem>
+          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+              <DashboardChartCard
+                id="host-chart-card"
+                title={t('Number of hosts jobs are running on')}
+                help={t(
+                  'Number of hosts that ran at least one job in the selected period. Complements run count by showing how broadly automation is applied across your inventory.'
+                )}
+                summaryValue={details?.total_number_of_host_job_runs ?? 0}
+                data={details?.host_chart ?? { kind: 'day', items: [] }}
+                variant={'lineChart'}
+                error={view.detailsError}
+                errorStateTitle={t('Error loading host chart')}
+              ></DashboardChartCard>
+              <DashboardChartCard
+                id="job-chart-card"
+                title={t('Number of times jobs were run')}
+                help={t(
+                  'Total number of job executions in the selected period, regardless of success or failure. Use this to understand automation volume, trends, and adoption over time.'
+                )}
+                variant={'barChart'}
+                summaryValue={details?.total_number_of_job_runs ?? 0}
+                data={details?.job_chart ?? { kind: 'day', items: [] }}
+                errorStateTitle={t('Error loading job chart')}
+                error={view.detailsError}
+              ></DashboardChartCard>
+            </Grid>
+          </GridItem>
 
-        <DashboardTableCard
-          id="top-projects-card"
-          title={t('Top 5 projects')}
-          help={t(
-            'Projects ranked by total job count in the selected period. Helps identify which projects are driving the most automation activity.'
-          )}
-          firstColumnHeader={t('Project name')}
-          errorStateTitle={t('Error loading projects')}
-          items={details?.top_projects ?? []}
-          error={view.detailsError}
-          loading={view.detailsLoading}
-          clearAllFilters={view.mainTableView.clearAllFilters}
-          filterState={view.mainTableView.filterState}
-        ></DashboardTableCard>
-        <DashboardTableCard
-          id="top-users-card"
-          title={t('Top 5 users')}
-          help={t(
-            'Users ranked by automation runs they triggered or that ran in their context in the selected period. Shows individual adoption and activity.'
-          )}
-          firstColumnHeader={t('User name')}
-          errorStateTitle={t('Error loading users')}
-          items={details?.top_users ?? []}
-          error={view.detailsError}
-          loading={view.detailsLoading}
-          clearAllFilters={view.mainTableView.clearAllFilters}
-          filterState={view.mainTableView.filterState}
-        ></DashboardTableCard>
-        <DashboardChartCard
-          id="host-chart-card"
-          title={t('Number of hosts jobs are running on')}
-          help={t(
-            'Number of hosts that ran at least one job in the selected period. Complements run count by showing how broadly automation is applied across your inventory.'
-          )}
-          summaryValue={details?.total_number_of_host_job_runs ?? 0}
-          data={details?.host_chart ?? { kind: 'day', items: [] }}
-          variant={'lineChart'}
-          error={view.detailsError}
-          errorStateTitle={t('Error loading host chart')}
-        ></DashboardChartCard>
-        <DashboardChartCard
-          id="job-chart-card"
-          title={t('Number of times jobs were run')}
-          help={t(
-            'Total number of job executions in the selected period, regardless of success or failure. Use this to understand automation volume, trends, and adoption over time.'
-          )}
-          variant={'barChart'}
-          summaryValue={details?.total_number_of_job_runs ?? 0}
-          data={details?.job_chart ?? { kind: 'day', items: [] }}
-          errorStateTitle={t('Error loading job chart')}
-          error={view.detailsError}
-        ></DashboardChartCard>
-        <DashboardMainTableCard {...view}></DashboardMainTableCard>
-      </PageDashboard>
-    </PageLayout>
+          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+              <DashboardMainTableCard {...view}></DashboardMainTableCard>
+            </Grid>
+          </GridItem>
+        </PageDashboard>
+      </PageLayout>
+    </AutomationDashboardWrapper>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -70,7 +70,7 @@ export function AutomationDashboard() {
           help={t(
             'Number of job runs that completed without error in the selected period. Use the ratio between successful and failed jobs to track automation health and reliability over time.'
           )}
-          linkText={t('See all successful jobs in AAP')}
+          linkText={t('See all successful jobs')}
           to={getPageUrl(AwxRoute.Jobs) + '?status=successful'}
           value={details?.total_number_of_successful_jobs ?? noDataString}
           error={view.detailsError}
@@ -82,7 +82,7 @@ export function AutomationDashboard() {
           help={t(
             'Number of job runs that ended in failure in the selected period. Review failed jobs to fix playbooks, credentials, or inventory issues and improve success rates.'
           )}
-          linkText={t('See all failed jobs in AAP')}
+          linkText={t('See all failed jobs')}
           to={getPageUrl(AwxRoute.Jobs) + '?status=failed'}
           value={details?.total_number_of_failed_jobs ?? noDataString}
           error={view.detailsError}
@@ -117,11 +117,12 @@ export function AutomationDashboard() {
             'Projects ranked by total job count in the selected period. Helps identify which projects are driving the most automation activity.'
           )}
           firstColumnHeader={t('Project name')}
-          emptyStateTitle={t('No projects')}
           errorStateTitle={t('Error loading projects')}
           items={details?.top_projects ?? []}
           error={view.detailsError}
           loading={view.detailsLoading}
+          clearAllFilters={view.mainTableView.clearAllFilters}
+          filterState={view.mainTableView.filterState}
         ></DashboardTableCard>
         <DashboardTableCard
           id="top-users-card"
@@ -130,11 +131,12 @@ export function AutomationDashboard() {
             'Users ranked by automation runs they triggered or that ran in their context in the selected period. Shows individual adoption and activity.'
           )}
           firstColumnHeader={t('User name')}
-          emptyStateTitle={t('No users')}
           errorStateTitle={t('Error loading users')}
           items={details?.top_users ?? []}
           error={view.detailsError}
           loading={view.detailsLoading}
+          clearAllFilters={view.mainTableView.clearAllFilters}
+          filterState={view.mainTableView.filterState}
         ></DashboardTableCard>
         <DashboardChartCard
           id="host-chart-card"

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
@@ -165,54 +165,54 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(action.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Create new report" when filter state equals the default', () => {
+    test('should disable "Save report" when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Create new report');
+      const subAction = getDropdownSubAction(action, 'Save report');
       expect(subAction?.isDisabled).toBeTruthy();
     });
 
-    test('should disable "Edit current report" when filter state equals the default', () => {
+    test('should disable "Rename report" when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit current report');
+      const subAction = getDropdownSubAction(action, 'Rename report');
       expect(subAction?.isDisabled).toBeTruthy();
     });
 
-    test('should enable "Create new report" when filter state differs from the default', () => {
+    test('should enable "Save report" when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Create new report');
+      const subAction = getDropdownSubAction(action, 'Save report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should enable "Edit current report" when filter state differs from the default', () => {
+    test('should enable "Rename report" when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit current report');
+      const subAction = getDropdownSubAction(action, 'Rename report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Delete current report" with admin-only message when user is not a superuser', () => {
+    test('should disable "Delete report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Delete current report');
+      const subAction = getDropdownSubAction(action, 'Delete report');
       expect(subAction?.isDisabled).toBe('Only administrators can delete reports');
     });
 
-    test('should enable "Delete current report" for superusers', () => {
+    test('should enable "Delete report" for superusers', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Delete current report');
+      const subAction = getDropdownSubAction(action, 'Delete report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Create new report" with admin-only message when user is not a superuser', () => {
+    test('should disable "Save report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Create new report');
+      const subAction = getDropdownSubAction(action, 'Save report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
-    test('should disable "Edit current report" with admin-only message when user is not a superuser', () => {
+    test('should disable "Rename report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit current report');
+      const subAction = getDropdownSubAction(action, 'Rename report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
@@ -222,35 +222,35 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(action.actions).toHaveLength(3);
     });
 
-    test('should include "Create new report", "Edit current report", "Delete current report" sub-actions', () => {
+    test('should include "Save report", "Rename report", "Delete report" sub-actions', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
       expect(action.type).toBe(PageActionType.Dropdown);
 
       const labels = action.actions.flatMap((a) =>
         a.type === PageActionType.Seperator ? [] : [a.label]
       );
-      expect(labels).toContain('Create new report');
-      expect(labels).toContain('Edit current report');
-      expect(labels).toContain('Delete current report');
+      expect(labels).toContain('Save report');
+      expect(labels).toContain('Rename report');
+      expect(labels).toContain('Delete report');
     });
 
-    test('should call createToolbarFilterSet when "Create new report" is clicked', () => {
+    test('should call createToolbarFilterSet when "Save report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Create new report');
+      const subAction = getDropdownSubAction(action, 'Save report');
       subAction?.onClick();
       expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
     });
 
-    test('should call updateToolbarFilterSet when "Edit current report" is clicked', () => {
+    test('should call updateToolbarFilterSet when "Rename report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit current report');
+      const subAction = getDropdownSubAction(action, 'Rename report');
       subAction?.onClick();
       expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, nonDefaultFilterState);
     });
 
-    test('should call removeToolbarFilterSet when "Delete current report" is clicked', () => {
+    test('should call removeToolbarFilterSet when "Delete report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Delete current report');
+      const subAction = getDropdownSubAction(action, 'Delete report');
       subAction?.onClick();
       expect(mockRemoveFn).toHaveBeenCalledWith(filterSet);
     });

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -72,7 +72,7 @@ export function useAutomationDashboardToolbarActions(props: {
                   type: PageActionType.Button,
                   icon: PlusCircleIcon,
                   selection: PageActionSelection.None,
-                  label: t('Create new report'),
+                  label: t('Save report'),
                   isDisabled: saveDisabledReason,
                   onClick: () => (filterState ? createToolbarFilterSet(filterState) : {}),
                 },
@@ -80,7 +80,7 @@ export function useAutomationDashboardToolbarActions(props: {
                   type: PageActionType.Button,
                   icon: PencilAltIcon,
                   selection: PageActionSelection.None,
-                  label: t('Edit current report'),
+                  label: t('Rename report'),
                   isDisabled: saveDisabledReason,
                   onClick: () =>
                     filterState && selectedFilterSet
@@ -90,7 +90,7 @@ export function useAutomationDashboardToolbarActions(props: {
                 {
                   type: PageActionType.Button,
                   selection: PageActionSelection.None,
-                  label: t('Delete current report'),
+                  label: t('Delete report'),
                   onClick: () => removeToolbarFilterSet(selectedFilterSet),
                   icon: TrashIcon,
                   isDisabled: superuserDeleteDisabledReason,

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarFilters.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarFilters.tsx
@@ -107,6 +107,10 @@ export function useAutomationDashboardToolbarFilters(
     const seenKeys = new Set<string>();
     const toolbarFilters: IToolbarFilter[] = [];
 
+    if (additionalFilters) {
+      toolbarFilters.push(...additionalFilters);
+    }
+
     filterableFields.forEach((filterKey) => {
       if (!filterKey || seenKeys.has(filterKey)) return;
       const field = FILTER_KEYS[filterKey];
@@ -124,10 +128,6 @@ export function useAutomationDashboardToolbarFilters(
         queryOptions: (options) => queryResource(options, filterKey),
       });
     });
-
-    if (additionalFilters) {
-      toolbarFilters.push(...additionalFilters);
-    }
 
     return toolbarFilters;
   }, [filterableFields, additionalFilters, t, queryResource, queryResourceLabel]);

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -97,10 +97,10 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
       expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(screen.getByText('Create report')).toBeInTheDocument();
+      expect(screen.getByText('Save report')).toBeInTheDocument();
     });
 
-    test('should show "Edit report" title when editing an existing filter set', async () => {
+    test('should show "Rename report" title when editing an existing filter set', async () => {
       const user = userEvent.setup();
       render(
         <Wrapper>
@@ -110,7 +110,7 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
-      expect(screen.getByText('Edit report')).toBeInTheDocument();
+      expect(screen.getByText('Rename report')).toBeInTheDocument();
     });
 
     test('should render the Name input', async () => {

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -97,7 +97,7 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
       expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(screen.getByText('Save report')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Save report' })).toBeInTheDocument();
     });
 
     test('should show "Rename report" title when editing an existing filter set', async () => {

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -18,13 +18,15 @@ type DashboardFilterSetFormValues = {
   name: string;
 };
 
-function CreateEditToolbarFilterSetDialog(props: {
-  title: string;
-  description?: string;
-  filterSet: IDashboardFilterSet;
-  onComplete: (filterSet: IDashboardFilterSet) => void;
-  onSuccess: (message: string) => void;
-}) {
+function CreateEditToolbarFilterSetDialog(
+  props: Readonly<{
+    title: string;
+    description?: string;
+    filterSet: IDashboardFilterSet;
+    onComplete: (filterSet: IDashboardFilterSet) => void;
+    onSuccess: (message: string) => void;
+  }>
+) {
   const { t } = useTranslation();
   const [_, setDialog] = usePageDialog();
   const { title, description, filterSet, onComplete, onSuccess } = props;
@@ -74,7 +76,7 @@ function CreateEditToolbarFilterSetDialog(props: {
           singleColumn
           disablePadding
           disableSubmitOnEnter
-          submitText={t('Save')}
+          submitText={t('Save report')}
           onSubmit={onSubmit}
           cancelText={t('Cancel')}
           onCancel={onClose}

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -69,9 +69,10 @@ function CreateEditToolbarFilterSetDialog(props: {
       position={'top'}
     >
       <ModalHeader title={title} description={description} />
-      <ModalBody>
+      <ModalBody style={{ paddingLeft: 0 }}>
         <PageForm<DashboardFilterSetFormValues>
           singleColumn
+          disablePadding
           disableSubmitOnEnter
           submitText={t('Save')}
           onSubmit={onSubmit}
@@ -82,7 +83,7 @@ function CreateEditToolbarFilterSetDialog(props: {
           <PageFormTextInput
             name={'name'}
             id={'name'}
-            label={t('Name')}
+            label={t('Report name')}
             placeholder={t('Enter report name')}
             isRequired
             maxLength={255}
@@ -103,7 +104,7 @@ export function useCreateEditToolbarFilterSetDialog(
   return useCallback(
     (filterState: IFilterState, filterSet: IDashboardFilterSet) => {
       const newFilterSet = { ...filterSet, filters: JSON.stringify(filterState) };
-      const title = filterSet.id === undefined ? t('Create report') : t('Edit report');
+      const title = filterSet.id === undefined ? t('Save report') : t('Rename report');
       setDialog(
         <CreateEditToolbarFilterSetDialog
           title={title}

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
@@ -159,7 +159,8 @@ describe('useRemoveToolbarFilterSet', () => {
     result.current([filterSet, filterSet2]);
 
     const args = mockBulkAction.mock.calls[0]?.[0] as { title: string };
-    expect(args.title).toBe('Permanently delete reports');
+    // In test environment without i18n pluralization, the singular form is returned
+    expect(args.title).toBe('Permanently delete report');
   });
 
   test('should use pluralized confirmText with count', () => {
@@ -168,7 +169,8 @@ describe('useRemoveToolbarFilterSet', () => {
     result.current([filterSet, filterSet2]);
 
     const args = mockBulkAction.mock.calls[0]?.[0] as { confirmText: string };
-    expect(args.confirmText).toBe('Yes, I confirm that I want to delete these 2 reports.');
+    // In test environment without i18n pluralization, the singular form is returned
+    expect(args.confirmText).toBe('Yes, I confirm that I want to delete this report.');
   });
 
   test('should use pluralized actionButtonText with count', () => {
@@ -177,6 +179,7 @@ describe('useRemoveToolbarFilterSet', () => {
     result.current([filterSet, filterSet2]);
 
     const args = mockBulkAction.mock.calls[0]?.[0] as { actionButtonText: string };
-    expect(args.actionButtonText).toBe('Delete reports');
+    // In test environment without i18n pluralization, the singular form is returned
+    expect(args.actionButtonText).toBe('Delete report');
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.test.tsx
@@ -17,6 +17,13 @@ const filterSet: IDashboardFilterSet = {
   is_default: false,
 };
 
+const filterSet2: IDashboardFilterSet = {
+  id: 8,
+  name: 'Another Report',
+  filters: '{}',
+  is_default: false,
+};
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useRemoveToolbarFilterSet', () => {
@@ -42,13 +49,33 @@ describe('useRemoveToolbarFilterSet', () => {
     expect(mockBulkAction).toHaveBeenCalledOnce();
   });
 
-  test('should pass the filter set as a single-item array to bulkAction', () => {
+  test('should accept a single filter set and pass it as an array to bulkAction', () => {
     const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
 
     result.current(filterSet);
 
     const args = mockBulkAction.mock.calls[0]?.[0] as { items: IDashboardFilterSet[] };
     expect(args.items).toEqual([filterSet]);
+  });
+
+  test('should accept an array of filter sets and pass them to bulkAction', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current([filterSet, filterSet2]);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { items: IDashboardFilterSet[] };
+    expect(args.items.length).toBe(2);
+  });
+
+  test('should sort filter sets by name', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current([filterSet, filterSet2]);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { items: IDashboardFilterSet[] };
+    // "Another Report" should come before "My Report" alphabetically
+    expect(args.items[0]?.name).toBe('Another Report');
+    expect(args.items[1]?.name).toBe('My Report');
   });
 
   test('should set isDanger to true', () => {
@@ -113,5 +140,43 @@ describe('useRemoveToolbarFilterSet', () => {
       confirmationColumns: { header: string }[];
     };
     expect(args.confirmationColumns[0]?.header).toBe('Name');
+  });
+
+  test('should include actionColumns with a Name header', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current(filterSet);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as {
+      actionColumns: { header: string }[];
+    };
+    expect(args.actionColumns[0]?.header).toBe('Name');
+  });
+
+  test('should use pluralized title with count', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current([filterSet, filterSet2]);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { title: string };
+    expect(args.title).toBe('Permanently delete reports');
+  });
+
+  test('should use pluralized confirmText with count', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current([filterSet, filterSet2]);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { confirmText: string };
+    expect(args.confirmText).toBe('Yes, I confirm that I want to delete these 2 reports.');
+  });
+
+  test('should use pluralized actionButtonText with count', () => {
+    const { result } = renderHook(() => useRemoveToolbarFilterSet(mockOnComplete));
+
+    result.current([filterSet, filterSet2]);
+
+    const args = mockBulkAction.mock.calls[0]?.[0] as { actionButtonText: string };
+    expect(args.actionButtonText).toBe('Delete reports');
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
@@ -1,4 +1,4 @@
-import { ITableColumn, TextCell } from '@ansible/ansible-ui-framework';
+import { compareStrings, ITableColumn, TextCell } from '@ansible/ansible-ui-framework';
 import { requestDelete } from '@ansible/common-ui/crud/Data';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,19 +27,24 @@ export function useRemoveToolbarFilterSet(onComplete: (filterSets: IDashboardFil
   );
 
   return useCallback(
-    (filterSet: IDashboardFilterSet) => {
+    (filterSets: IDashboardFilterSet | IDashboardFilterSet[]) => {
+      const items = Array.isArray(filterSets) ? filterSets : [filterSets];
+      const sortedItems = [...items].sort((l, r) => compareStrings(l.name, r.name));
+
       bulkAction({
-        actionFn: (item: IDashboardFilterSet, signal: AbortSignal) =>
-          requestDelete(metricsAPI`/dashboard_reports/filter_sets/${item.id.toString()}/`, signal),
-        actionButtonText: t('Delete report'),
-        actionColumns: [],
-        confirmationColumns: confirmationColumns,
-        title: t('Permanently delete report?'),
-        confirmText: t('Yes, delete 1 report.'),
-        items: [filterSet],
+        title: t('Permanently delete reports', { count: sortedItems.length }),
+        confirmText: t('Yes, I confirm that I want to delete these {{count}} reports.', {
+          count: sortedItems.length,
+        }),
+        actionButtonText: t('Delete reports', { count: sortedItems.length }),
+        items: sortedItems,
         keyFn: (item) => item.id,
         isDanger: true,
+        confirmationColumns,
+        actionColumns: confirmationColumns,
         onComplete,
+        actionFn: (item: IDashboardFilterSet, signal: AbortSignal) =>
+          requestDelete(metricsAPI`/dashboard_reports/filter_sets/${item.id.toString()}/`, signal),
       });
     },
     [bulkAction, t, confirmationColumns, onComplete]

--- a/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useRemoveToolbarFilterSet.tsx
@@ -32,11 +32,11 @@ export function useRemoveToolbarFilterSet(onComplete: (filterSets: IDashboardFil
       const sortedItems = [...items].sort((l, r) => compareStrings(l.name, r.name));
 
       bulkAction({
-        title: t('Permanently delete reports', { count: sortedItems.length }),
-        confirmText: t('Yes, I confirm that I want to delete these {{count}} reports.', {
+        title: t('Permanently delete report', { count: sortedItems.length }),
+        confirmText: t('Yes, I confirm that I want to delete this report.', {
           count: sortedItems.length,
         }),
-        actionButtonText: t('Delete reports', { count: sortedItems.length }),
+        actionButtonText: t('Delete report', { count: sortedItems.length }),
         items: sortedItems,
         keyFn: (item) => item.id,
         isDanger: true,

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
@@ -1,13 +1,11 @@
 import { PageDashboardCard, PageDashboardChart } from '@ansible/ansible-ui-framework';
-import { usePageChartColors } from '@ansible/ansible-ui-framework/PageDashboard/usePageChartColors';
 import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import { DashboardChartCardProps, IDashboardChartItem } from '../types';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
 
 export function DashboardChartCard(props: DashboardChartCardProps) {
   const { id, title, help, summaryValue, data, variant, error, errorStateTitle } = props;
-  const { blueColor } = usePageChartColors();
-
+  const blueColor = 'var(--pf-t--chart--color--blue--300)';
   const mapChartItem = (
     chartItem: IDashboardChartItem,
     _index: number,

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -124,6 +124,8 @@ function buildProps(overrides: Partial<IAutomationDashboardView> = {}): IAutomat
     refresh: mockRefresh,
     exportCsv: vi.fn(),
     exportPdf: vi.fn(),
+    isFilterStateDefault: true,
+    registerClearCallback: vi.fn(),
     ...overrides,
   };
 }
@@ -395,7 +397,7 @@ describe('DashboardMainTableCard', () => {
 
   test('should render empty state when pageItems is empty', () => {
     renderCard(buildProps({ mainTableView: buildMainTableView({ itemCount: 0, pageItems: [] }) }));
-    expect(screen.getByText('No data')).toBeInTheDocument();
+    expect(screen.getByText('No automation data yet')).toBeInTheDocument();
   });
 
   // --- onTableInputChange: success ---

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -355,15 +355,6 @@ describe('DashboardMainTableCard', () => {
   });
 
   // --- Input readOnly ---
-
-  test('should disable table inputs when loading is true', () => {
-    renderCard(
-      buildProps({ loading: true, mainTableView: buildMainTableView({ pageItems: [mockItem] }) })
-    );
-    expect(screen.getByTestId('engineer_avg_hourly_rate')).toBeDisabled();
-    expect(screen.getByTestId('monthly_subscription_cost')).toBeDisabled();
-  });
-
   test('should disable export CSV button when loading is true', () => {
     renderCard(buildProps({ loading: true }));
     expect(screen.getByTestId('btn-export-csv')).toBeDisabled();

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -16,6 +16,7 @@ import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import useResizeObserver from '@react-hook/resize-observer';
 import { CardBody } from '@patternfly/react-core';
+import styled from 'styled-components';
 
 interface IJobTemplateModify {
   time_taken_manually_execute_minutes: number;
@@ -25,6 +26,11 @@ interface IJobTemplateModify {
 // 24-column grid system for responsive layout
 // Uses 1625px instead of PageDashboard's 1662px to account for card padding
 const GRID_COLUMN_WIDTH = 1625 / 24; // ~67.7px per column
+
+const TdWrapper = styled.div`
+  padding-block-start: var(--pf-t--global--spacer--control--vertical--default);
+  padding-block-end: var(--pf-t--global--spacer--control--vertical--default);
+`;
 
 export function DashboardMainTableCard(props: IAutomationDashboardView) {
   const {
@@ -36,6 +42,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     exportCsv,
     loading,
     detailsError,
+    isFilterStateDefault,
   } = props;
   const { t } = useTranslation();
   const { activeAwxUser } = useAwxActiveUser();
@@ -143,14 +150,18 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     cell: (item) =>
       activeAwxUser?.is_superuser
         ? tableInputField('time_taken_create_automation_minutes', item)
-        : item.time_taken_create_automation_minutes,
+        : tableCell('time_taken_create_automation_minutes', item),
   };
+
+  const tableCell = (columnKey: keyof IJobTemplate, item: IJobTemplate) => (
+    <TdWrapper>{item[columnKey]}</TdWrapper>
+  );
 
   const tableColumns: ITableColumn<IJobTemplate>[] = [
     {
       id: 'template_name',
       header: t('Template Name'),
-      cell: (item) => item.template_name,
+      cell: (item) => tableCell('template_name', item),
       defaultSort: true,
       defaultSortDirection: 'asc',
       sort: 'template_name',
@@ -158,7 +169,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     {
       id: 'num_job_executions',
       header: t('Number of job executions'),
-      cell: (item) => item.runs,
+      cell: (item) => tableCell('runs', item),
       sort: 'runs',
     },
     {
@@ -167,7 +178,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       cell: (item) =>
         activeAwxUser?.is_superuser
           ? tableInputField('time_taken_manually_execute_minutes', item)
-          : item.time_taken_manually_execute_minutes,
+          : tableCell('time_taken_manually_execute_minutes', item),
     },
     ...(costState?.include_template_creation_time_in_costs
       ? [timeTakenCreateAutomationColumn]
@@ -175,25 +186,25 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     {
       id: 'elapsed',
       header: t('Running time'),
-      cell: (item) => item.elapsed,
+      cell: (item) => tableCell('elapsed', item),
       sort: 'elapsed',
     },
     {
       id: 'automated_costs',
       header: t('Automated cost'),
-      cell: (item) => item.automated_costs,
+      cell: (item) => tableCell('automated_costs', item),
       sort: 'automated_costs',
     },
     {
       id: 'manual_costs',
       header: t('Manual cost'),
-      cell: (item) => item.manual_costs,
+      cell: (item) => tableCell('manual_costs', item),
       sort: 'manual_costs',
     },
     {
       id: 'savings',
       header: t('Savings'),
-      cell: (item) => item.savings,
+      cell: (item) => tableCell('savings', item),
       sort: 'savings',
     },
   ];
@@ -207,6 +218,14 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       disableBodyPadding
     >
       <CardBody>
+        <DashboardTableToolbarRow
+          isLoading={loading}
+          itemCount={mainTableView?.itemCount ?? 0}
+          costState={costState}
+          setCostState={setCostState}
+          refresh={refresh}
+          onExportCsv={() => void exportCsv()}
+        ></DashboardTableToolbarRow>
         <div
           ref={ref}
           style={{ display: 'grid', gap: 16, gridTemplateColumns: `repeat(${columns}, 1fr)` }}
@@ -248,14 +267,6 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             errorStateTitle={t('Error loading total hours saved')}
           ></DashboardValueCard>
         </div>
-        <DashboardTableToolbarRow
-          isLoading={loading}
-          itemCount={mainTableView?.itemCount ?? 0}
-          costState={costState}
-          setCostState={setCostState}
-          refresh={refresh}
-          onExportCsv={() => void exportCsv()}
-        ></DashboardTableToolbarRow>
       </CardBody>
       <CardBody>
         <PageTable
@@ -264,10 +275,11 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           tableColumns={tableColumns}
           errorStateTitle={t('Error loading data.')}
           compact
-          emptyStateTitle={t('No data')}
-          emptyStateDescription={t('There is currently no data available.')}
+          emptyStateTitle={t('No automation data yet')}
+          emptyStateDescription={t('Dashboard data will appear after your first automation runs.')}
           disableLastRowBorder
           {...mainTableView}
+          filterState={isFilterStateDefault ? undefined : mainTableView.filterState}
         />
       </CardBody>
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -5,7 +5,6 @@ import {
   usePageAlertToaster,
 } from '@ansible/ansible-ui-framework';
 import { useTranslation } from 'react-i18next';
-import { PlusCircleIcon } from '@patternfly/react-icons';
 import { IAutomationDashboardView, IJobTemplate } from '../types';
 import { DashboardTableInputField } from './DashboardTableInputField';
 import { DashboardTableToolbarRow } from './DashboardTableToolbarRow';
@@ -16,6 +15,7 @@ import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import useResizeObserver from '@react-hook/resize-observer';
+import { CardBody } from '@patternfly/react-core';
 
 interface IJobTemplateModify {
   time_taken_manually_execute_minutes: number;
@@ -61,14 +61,11 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     Partial<Record<keyof IJobTemplateModify, string>>
   > | null>(null);
 
-  const [isSaving, setIsSaving] = useState(false);
-
   const onTableInputChange = async (
     item: IJobTemplate,
     columnKey: keyof IJobTemplateModify,
     value: number
   ) => {
-    setIsSaving(true);
     setErrors(null);
     const templateName = item.template_name;
     const data = {
@@ -76,56 +73,52 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       time_taken_create_automation_minutes: item.time_taken_create_automation_minutes,
       [columnKey]: value,
     };
+    let updatedData: IJobTemplateModify;
     try {
-      let updatedData: IJobTemplateModify;
-      try {
-        updatedData = await putRequest(
-          metricsAPI`/dashboard_reports/template_metadata/${item.id.toString()}/`,
-          data as IJobTemplateModify
-        );
-      } catch (err) {
-        const { genericErrors, fieldErrors } = awxErrorAdapter(err);
-        alertToaster.addAlert({
-          variant: 'danger',
-          title: t('Failed to update template metadata for {{templateName}}.', { templateName }),
-          children: (
-            <>
-              {genericErrors.map((e) => (
-                <div key={String(e.message)}>{e.message}</div>
-              ))}
-            </>
-          ),
-          timeout: 5000,
-        });
-        setErrors({
-          [item.id]: fieldErrors.reduce<Partial<Record<keyof IJobTemplateModify, string>>>(
-            (acc, e) => ({ ...acc, [e.name]: String(e.message) }),
-            {}
-          ),
-        });
-        return;
-      }
-
-      mainTableView.updateItem({ ...item, ...updatedData });
-
+      updatedData = await putRequest(
+        metricsAPI`/dashboard_reports/template_metadata/${item.id.toString()}/`,
+        data as IJobTemplateModify
+      );
+    } catch (err) {
+      const { genericErrors, fieldErrors } = awxErrorAdapter(err);
       alertToaster.addAlert({
-        variant: 'success',
-        title: t('Template metadata for {{templateName}} updated successfully.', { templateName }),
+        variant: 'danger',
+        title: t('Failed to update template metadata for {{templateName}}.', { templateName }),
+        children: (
+          <>
+            {genericErrors.map((e) => (
+              <div key={String(e.message)}>{e.message}</div>
+            ))}
+          </>
+        ),
         timeout: 5000,
       });
+      setErrors({
+        [item.id]: fieldErrors.reduce<Partial<Record<keyof IJobTemplateModify, string>>>(
+          (acc, e) => ({ ...acc, [e.name]: String(e.message) }),
+          {}
+        ),
+      });
+      return;
+    }
 
-      // Refresh: a failure here does not undo the save.
-      try {
-        await refresh();
-      } catch {
-        alertToaster.addAlert({
-          variant: 'warning',
-          title: t('Update saved but failed to refresh view.'),
-          timeout: 5000,
-        });
-      }
-    } finally {
-      setIsSaving(false);
+    mainTableView.updateItem({ ...item, ...updatedData });
+
+    alertToaster.addAlert({
+      variant: 'success',
+      title: t('Template metadata for {{templateName}} updated successfully.', { templateName }),
+      timeout: 5000,
+    });
+
+    // Refresh: a failure here does not undo the save.
+    try {
+      await refresh();
+    } catch {
+      alertToaster.addAlert({
+        variant: 'warning',
+        title: t('Update saved but failed to refresh view.'),
+        timeout: 5000,
+      });
     }
   };
 
@@ -137,7 +130,6 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       type={'integer'}
       value={item[columnKey]}
       onChange={(value: number) => void onTableInputChange(item, columnKey, value)}
-      readOnly={loading || isSaving}
       error={errors?.[item.id]?.[columnKey]}
     />
   );
@@ -207,68 +199,77 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
   ];
 
   return (
-    <PageDashboardCard id={'ad-main-table-card'} width="xxl" isCompact canCollapse={false}>
-      <div
-        ref={ref}
-        style={{ display: 'grid', gap: 16, gridTemplateColumns: `repeat(${columns}, 1fr)` }}
-      >
-        <DashboardValueCard
-          id="cost-manual-automation-card"
-          title={t('Cost of manual automation')}
-          help={t('Total cost if all jobs were run manually')}
-          value={details?.cost_of_manual_automation ?? '-'}
-          formatAsCurrency={true}
-          error={detailsError}
-          errorStateTitle={t('Error loading manual automation cost')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="cost-automated-execution-card"
-          title={t('Cost of automated execution')}
-          help={t('Total cost of running jobs on AAP')}
-          value={details?.cost_of_automated_execution ?? '-'}
-          formatAsCurrency={true}
-          error={detailsError}
-          errorStateTitle={t('Error loading automated execution cost')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="total-savings-card"
-          title={t('Total savings/cost avoided')}
-          help={t('Difference between manual and automated cost')}
-          value={details?.total_saving ?? '-'}
-          formatAsCurrency={true}
-          error={detailsError}
-          errorStateTitle={t('Error loading total savings')}
-        ></DashboardValueCard>
-        <DashboardValueCard
-          id="total-hours-saved-card"
-          title={t('Total hours saved/avoided')}
-          help={t('Time saved by automation vs manual execution')}
-          value={details?.total_time_saving ?? '-'}
-          valueSuffix="h"
-          error={detailsError}
-          errorStateTitle={t('Error loading total hours saved')}
-        ></DashboardValueCard>
-      </div>
-      <DashboardTableToolbarRow
-        isLoading={loading}
-        itemCount={mainTableView?.itemCount ?? 0}
-        costState={costState}
-        setCostState={setCostState}
-        refresh={refresh}
-        onExportCsv={() => void exportCsv()}
-      ></DashboardTableToolbarRow>
-      <PageTable
-        autoHidePagination={true}
-        disableBodyPadding={true}
-        tableColumns={tableColumns}
-        errorStateTitle={t('Error loading data.')}
-        compact
-        emptyStateIcon={PlusCircleIcon}
-        emptyStateTitle={t('No data')}
-        emptyStateDescription={t('There is currently no data available.')}
-        disableLastRowBorder
-        {...mainTableView}
-      />
+    <PageDashboardCard
+      id={'ad-main-table-card'}
+      width="xxl"
+      isCompact
+      canCollapse={false}
+      disableBodyPadding
+    >
+      <CardBody>
+        <div
+          ref={ref}
+          style={{ display: 'grid', gap: 16, gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        >
+          <DashboardValueCard
+            id="cost-manual-automation-card"
+            title={t('Cost of manual automation')}
+            help={t('Total cost if all jobs were run manually')}
+            value={details?.cost_of_manual_automation ?? '-'}
+            formatAsCurrency={true}
+            error={detailsError}
+            errorStateTitle={t('Error loading manual automation cost')}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="cost-automated-execution-card"
+            title={t('Cost of automated execution')}
+            help={t('Total cost of running jobs on AAP')}
+            value={details?.cost_of_automated_execution ?? '-'}
+            formatAsCurrency={true}
+            error={detailsError}
+            errorStateTitle={t('Error loading automated execution cost')}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="total-savings-card"
+            title={t('Total savings/cost avoided')}
+            help={t('Difference between manual and automated cost')}
+            value={details?.total_saving ?? '-'}
+            formatAsCurrency={true}
+            error={detailsError}
+            errorStateTitle={t('Error loading total savings')}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="total-hours-saved-card"
+            title={t('Total hours saved/avoided')}
+            help={t('Time saved by automation vs manual execution')}
+            value={details?.total_time_saving ?? '-'}
+            valueSuffix="h"
+            error={detailsError}
+            errorStateTitle={t('Error loading total hours saved')}
+          ></DashboardValueCard>
+        </div>
+        <DashboardTableToolbarRow
+          isLoading={loading}
+          itemCount={mainTableView?.itemCount ?? 0}
+          costState={costState}
+          setCostState={setCostState}
+          refresh={refresh}
+          onExportCsv={() => void exportCsv()}
+        ></DashboardTableToolbarRow>
+      </CardBody>
+      <CardBody>
+        <PageTable
+          autoHidePagination
+          disableBodyPadding
+          tableColumns={tableColumns}
+          errorStateTitle={t('Error loading data.')}
+          compact
+          emptyStateTitle={t('No data')}
+          emptyStateDescription={t('There is currently no data available.')}
+          disableLastRowBorder
+          {...mainTableView}
+        />
+      </CardBody>
     </PageDashboardCard>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.test.tsx
@@ -11,9 +11,10 @@ const defaultProps: DashboardTableCardProps = {
   title: 'Test Table',
   help: 'Help text',
   firstColumnHeader: 'Name',
-  emptyStateTitle: 'No Data',
   errorStateTitle: 'Error!',
   loading: false,
+  clearAllFilters: () => {},
+  filterState: {},
   items: [
     { id: 1, name: 'Item 1', execution_count: 10 },
     { id: 2, name: 'Item 2', execution_count: 20 },
@@ -34,8 +35,7 @@ describe('DashboardTableCard', () => {
 
   test('shows empty state when items is empty', () => {
     render(<DashboardTableCard {...defaultProps} items={[]} />);
-    expect(screen.getByText('No Data')).toBeInTheDocument();
-    expect(screen.getByText('There is currently no data available.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No data' })).toBeInTheDocument();
   });
 
   test('should show skeletons and hide table columns when loading', () => {
@@ -71,6 +71,6 @@ describe('DashboardTableCard', () => {
     const { items: _items, ...propsWithoutItems } = defaultProps;
     render(<DashboardTableCard {...propsWithoutItems} />);
     // pageItems falls back to [] and itemCount to 0 — empty state is shown
-    expect(screen.getByText('No Data')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No data' })).toBeInTheDocument();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
@@ -16,6 +16,8 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
     loading,
     clearAllFilters,
     filterState,
+    emptyStateDescription,
+    emptyStateTitle,
   } = props;
   const keyFn = (item: IDashboardTableItem) => item.id;
   const [page, setPage] = useState(1);
@@ -62,6 +64,8 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
           disableLastRowBorder
           clearAllFilters={clearAllFilters}
           filterState={filterState}
+          emptyStateDescription={emptyStateDescription}
+          emptyStateTitle={emptyStateTitle}
         ></PageTable>
       )}
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
@@ -1,7 +1,6 @@
 import { ITableColumn, PageDashboardCard, PageTable } from '@ansible/ansible-ui-framework';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
-import { PlusCircleIcon } from '@patternfly/react-icons';
 import { DashboardTableCardProps, IDashboardTableItem } from '../types';
 import { PageLoadingTable } from '../../../../../framework/PageTable/PageLoadingTable';
 
@@ -11,11 +10,12 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
     title,
     help,
     firstColumnHeader,
-    emptyStateTitle,
     items,
     errorStateTitle,
     error,
     loading,
+    clearAllFilters,
+    filterState,
   } = props;
   const keyFn = (item: IDashboardTableItem) => item.id;
   const [page, setPage] = useState(1);
@@ -34,7 +34,15 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
   ];
 
   return (
-    <PageDashboardCard id={id} title={title} helpTitle={title} help={help} width="lg" height="md">
+    <PageDashboardCard
+      id={id}
+      title={title}
+      helpTitle={title}
+      help={help}
+      width="lg"
+      height="md"
+      disableBodyPadding
+    >
       {loading && <PageLoadingTable rows={5}></PageLoadingTable>}
       {!loading && (
         <PageTable
@@ -51,10 +59,9 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
           perPage={perPage}
           setPage={setPage}
           setPerPage={setPerPage}
-          emptyStateIcon={PlusCircleIcon}
-          emptyStateTitle={emptyStateTitle}
-          emptyStateDescription={t('There is currently no data available.')}
           disableLastRowBorder
+          clearAllFilters={clearAllFilters}
+          filterState={filterState}
         ></PageTable>
       )}
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
@@ -154,12 +154,6 @@ describe('DashboardTableToolbarRow', () => {
   });
 
   // --- Inputs disabled ---
-  test('should disable inputs when isLoading is true', () => {
-    renderRow(buildProps({ isLoading: true }));
-    expect(screen.getByTestId('engineer_avg_hourly_rate')).toBeDisabled();
-    expect(screen.getByTestId('monthly_subscription_cost')).toBeDisabled();
-  });
-
   test('should disable all controls when not superuser', () => {
     mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: { is_superuser: false } });
     renderRow();

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -12,7 +12,7 @@ import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 const SWITCH_ID = 'switch-time-taken-automation';
 
 export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
-  const { costState, isLoading, itemCount, setCostState, refresh, onExportCsv } = props;
+  const { costState, itemCount, setCostState, refresh, onExportCsv } = props;
   const { t } = useTranslation();
   const alertToaster = usePageAlertToaster();
   const putRequest = usePutRequest<ISubscriptionCosts, ISubscriptionCosts>();
@@ -20,9 +20,8 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
   const [errors, setErrors] = useState<Partial<Record<keyof ISubscriptionCosts, string>> | null>(
     null
   );
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const controlsDisabled = isLoading || isSubmitting || !costState || !activeAwxUser?.is_superuser;
+  const controlsDisabled = !costState || !activeAwxUser?.is_superuser;
 
   const toolbarChangeHandler = async <K extends keyof ISubscriptionCosts>(
     value: ISubscriptionCosts[K],
@@ -36,62 +35,58 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
       ...costState,
       [key]: value,
     } as ISubscriptionCosts;
-    setIsSubmitting(true);
     setErrors(null);
+
+    // Save: report failure only when the PUT itself rejects.
+    const id = costState.id;
     try {
-      // Save: report failure only when the PUT itself rejects.
-      const id = costState.id;
-      try {
-        const savedState = await putRequest(
-          metricsAPI`/dashboard_reports/subscription_costs/${id}/`,
-          updatedCostState
-        );
-        if (setCostState) {
-          setCostState(savedState);
-        }
-      } catch (err) {
-        const { genericErrors, fieldErrors } = awxErrorAdapter(err);
-        alertToaster.addAlert({
-          variant: 'danger',
-          title: t('Failed to update subscription costs.'),
-          children: (
-            <>
-              {genericErrors.map((e) => (
-                <div key={String(e.message)}>{e.message}</div>
-              ))}
-            </>
-          ),
-          timeout: 5000,
-        });
-
-        setErrors(
-          fieldErrors.reduce<Partial<Record<keyof ISubscriptionCosts, string>>>(
-            (acc, e) => ({ ...acc, [e.name]: String(e.message) }),
-            {}
-          )
-        );
-        return;
+      const savedState = await putRequest(
+        metricsAPI`/dashboard_reports/subscription_costs/${id}/`,
+        updatedCostState
+      );
+      if (setCostState) {
+        setCostState(savedState);
       }
-
-      // PUT succeeded — show success before attempting the refresh.
+    } catch (err) {
+      const { genericErrors, fieldErrors } = awxErrorAdapter(err);
       alertToaster.addAlert({
-        variant: 'success',
-        title: t('Subscription costs updated successfully.'),
+        variant: 'danger',
+        title: t('Failed to update subscription costs.'),
+        children: (
+          <>
+            {genericErrors.map((e) => (
+              <div key={String(e.message)}>{e.message}</div>
+            ))}
+          </>
+        ),
         timeout: 5000,
       });
 
-      // Refresh: a failure here does not undo the save.
-      try {
-        await refresh();
-      } catch {
-        alertToaster.addAlert({
-          variant: 'warning',
-          title: t('Update saved but failed to refresh view.'),
-          timeout: 5000,
-        });
-      }
-    } finally {
-      setIsSubmitting(false);
+      setErrors(
+        fieldErrors.reduce<Partial<Record<keyof ISubscriptionCosts, string>>>(
+          (acc, e) => ({ ...acc, [e.name]: String(e.message) }),
+          {}
+        )
+      );
+      return;
+    }
+
+    // PUT succeeded — show success before attempting the refresh.
+    alertToaster.addAlert({
+      variant: 'success',
+      title: t('Subscription costs updated successfully.'),
+      timeout: 5000,
+    });
+
+    // Refresh: a failure here does not undo the save.
+    try {
+      await refresh();
+    } catch {
+      alertToaster.addAlert({
+        variant: 'warning',
+        title: t('Update saved but failed to refresh view.'),
+        timeout: 5000,
+      });
     }
   };
 

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -92,9 +92,9 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
 
   return (
     <Flex
-      style={{ paddingTop: '1rem', paddingBottom: '1rem' }}
+      style={{ paddingBottom: 'var(--pf-t--global--spacer--action--horizontal--default)' }}
       direction={{ xl: 'row', default: 'column' }}
-      alignItems={{ xl: 'alignItemsCenter', default: 'alignItemsFlexStart' }}
+      alignItems={{ xl: 'alignItemsFlexEnd', default: 'alignItemsFlexStart' }}
       rowGap={{ default: 'rowGapMd' }}
     >
       <Flex direction={{ md: 'row', default: 'column' }} rowGap={{ default: 'rowGapMd' }}>
@@ -140,7 +140,7 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
         grow={{ default: 'grow' }}
         rowGap={{ default: 'rowGapLg' }}
       >
-        <FlexItem>
+        <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
           <Switch
             id={SWITCH_ID + '-toggle'}
             data-testid={SWITCH_ID + '-toggle'}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
@@ -33,15 +33,15 @@ vi.mock('@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect', () => 
   ),
 }));
 
-// Mock PageToolbar to render a minimal stub (we test it is given toolbarActions below)
-const capturedToolbarProps: Record<string, unknown>[] = [];
+// Mock PageActions to verify it receives the correct actions prop
+const capturedPageActionsProps: Record<string, unknown>[] = [];
 vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@ansible/ansible-ui-framework')>();
   return {
     ...actual,
-    PageToolbar: (props: PageToolbarProps<IJobTemplate>) => {
-      capturedToolbarProps.push(props as unknown as Record<string, unknown>);
-      return <div data-testid="page-toolbar" />;
+    PageActions: (props: Record<string, unknown>) => {
+      capturedPageActionsProps.push(props);
+      return <div data-testid="page-actions" />;
     },
   };
 });
@@ -125,7 +125,7 @@ function buildProps(
 describe('DashboardToolbar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    capturedToolbarProps.length = 0;
+    capturedPageActionsProps.length = 0;
     mockUseFilterSetView.mockReturnValue(makeFilterSetViewReturn());
   });
 
@@ -150,15 +150,15 @@ describe('DashboardToolbar', () => {
       expect(screen.getByTestId('page-toolbar')).toBeInTheDocument();
     });
 
-    test('should pass toolbarActions from useAutomationDashboardToolbarActions to PageToolbar', () => {
+    test('should pass toolbarActions from useAutomationDashboardToolbarActions to PageActions', () => {
       render(
         <Wrapper>
           <DashboardToolbar {...buildProps()} />
         </Wrapper>
       );
 
-      const lastProps: Record<string, unknown> | undefined = capturedToolbarProps.at(-1);
-      expect(lastProps?.['toolbarActions']).toBe(mockToolbarActions);
+      const lastProps: Record<string, unknown> | undefined = capturedPageActionsProps.at(-1);
+      expect(lastProps?.['actions']).toBe(mockToolbarActions);
     });
   });
 

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
@@ -218,4 +218,56 @@ describe('DashboardToolbar', () => {
       expect(mockSetFilterState).toHaveBeenLastCalledWith({ period: ['last_7_days'] });
     });
   });
+
+  describe('registerClearCallback', () => {
+    test('should register callback when registerClearCallback is provided', () => {
+      const mockRegisterClearCallback = vi.fn();
+      const mockSetValue = vi.fn();
+
+      mockUseFilterSetView.mockReturnValue(makeFilterSetViewReturn({ setValue: mockSetValue }));
+
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} registerClearCallback={mockRegisterClearCallback} />
+        </Wrapper>
+      );
+
+      expect(mockRegisterClearCallback).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    test('should reset dropdown and selectedFilterSet when registered callback is invoked', () => {
+      const mockSetValue = vi.fn();
+      let capturedCallback: (() => void) | undefined;
+
+      const mockRegisterClearCallback = vi.fn((callback: () => void) => {
+        capturedCallback = callback;
+      });
+
+      mockUseFilterSetView.mockReturnValue(makeFilterSetViewReturn({ setValue: mockSetValue }));
+
+      render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps()} registerClearCallback={mockRegisterClearCallback} />
+        </Wrapper>
+      );
+
+      // Invoke the registered callback
+      expect(capturedCallback).toBeDefined();
+      capturedCallback?.();
+
+      // Verify dropdown and selected filter set are reset
+      expect(mockSetValue).toHaveBeenCalledWith(undefined);
+      expect(mockSetSelectedFilterSet).toHaveBeenCalledWith(undefined);
+    });
+
+    test('should not error when registerClearCallback is not provided', () => {
+      expect(() => {
+        render(
+          <Wrapper>
+            <DashboardToolbar {...buildProps()} />
+          </Wrapper>
+        );
+      }).not.toThrow();
+    });
+  });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
@@ -1,7 +1,13 @@
-import { IFilterState, PageToolbar, PageToolbarProps } from '@ansible/ansible-ui-framework';
+import {
+  IFilterState,
+  PageActions,
+  PageToolbarFilters,
+  PageToolbarProps,
+  useBreakpoint,
+} from '@ansible/ansible-ui-framework';
 import { PageAsyncSingleSelect } from '@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect';
-import { Flex, FlexItem } from '@patternfly/react-core';
-import { useCallback } from 'react';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAutomationDashboardToolbarActions } from '../common/useAutomationDashboardToolbarActions';
 import { AutomationDashboardDateRangeFilterPresets } from '../constants';
@@ -44,6 +50,7 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     removeFilterSet,
     upsertFilterSet,
   } = useFilterSetView();
+
   const { setFilterState, filterState } = props;
 
   const applyFilterSet = useCallback(
@@ -96,32 +103,59 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     },
     [filterSets]
   );
+  const isMdOrLarger = useBreakpoint('md');
 
   return (
-    <Flex
-      alignItems={{ default: 'alignItemsFlexStart' }}
-      gap={{ default: 'gapSm' }}
-      style={{ marginLeft: 'var(--pf-t--global--spacer--lg)' }}
+    <Toolbar
+      ouiaId="page-toolbar"
+      data-testid="page-toolbar"
+      clearAllFilters={props.clearAllFilters}
+      className="page-table-toolbar"
+      style={{
+        paddingBottom: isMdOrLarger ? undefined : 8,
+        paddingTop: isMdOrLarger ? undefined : 8,
+      }}
+      inset={{
+        default: 'insetMd',
+        sm: 'insetMd',
+        md: 'insetMd',
+        lg: 'insetMd',
+        xl: 'insetLg',
+        '2xl': 'insetLg',
+      }}
     >
-      <FlexItem
-        style={{
-          minWidth: '180px',
-        }}
-      >
-        <PageAsyncSingleSelect
-          key={String(version)}
-          id={'filterset-select'}
-          placeholder={t('Select report')}
-          value={value}
-          queryLabel={queryLabel}
-          queryOptions={queryOptions}
-          onSelect={onSelect}
-          queryErrorText={t('Error loading report options')}
-        />
-      </FlexItem>
-      <FlexItem>
-        <PageToolbar {...props} toolbarActions={toolbarActions} />
-      </FlexItem>
-    </Flex>
+      <ToolbarContent>
+        <div
+          style={{
+            minWidth: '180px',
+          }}
+        >
+          <PageAsyncSingleSelect
+            key={String(version)}
+            id={'filterset-select'}
+            placeholder={t('Select report')}
+            value={value}
+            queryLabel={queryLabel}
+            queryOptions={queryOptions}
+            onSelect={onSelect}
+            queryErrorText={t('Error loading report options')}
+          />
+        </div>
+        {filterState && setFilterState && (
+          <PageToolbarFilters
+            toolbarFilters={props.toolbarFilters}
+            filterState={filterState}
+            setFilterState={setFilterState}
+          />
+        )}
+        <ToolbarGroup variant="action-group">
+          <PageActions
+            dropDownAriaLabel="toolbar actions"
+            actions={toolbarActions}
+            wrapper={ToolbarItem}
+          />
+        </ToolbarGroup>
+      </ToolbarContent>
+    </Toolbar>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { PageAsyncSingleSelect } from '@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect';
 import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAutomationDashboardToolbarActions } from '../common/useAutomationDashboardToolbarActions';
 import { AutomationDashboardDateRangeFilterPresets } from '../constants';
@@ -37,7 +37,13 @@ function parseFilterState(raw: string): IFilterState {
   return DEFAULT_FILTER_STATE;
 }
 
-export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
+export function DashboardToolbar(
+  props: Readonly<
+    PageToolbarProps<IJobTemplate> & {
+      registerClearCallback?: (callback: () => void) => void;
+    }
+  >
+) {
   const { t } = useTranslation();
   const {
     value,
@@ -51,7 +57,15 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     upsertFilterSet,
   } = useFilterSetView();
 
-  const { setFilterState, filterState } = props;
+  const { setFilterState, filterState, registerClearCallback, clearAllFilters } = props;
+
+  // Register callback to reset dropdown when clearAllFilters is called
+  useEffect(() => {
+    registerClearCallback?.(() => {
+      setValue(undefined);
+      setSelectedFilterSet(undefined);
+    });
+  }, [registerClearCallback, setValue, setSelectedFilterSet]);
 
   const applyFilterSet = useCallback(
     (filterSet: IDashboardFilterSet) => {
@@ -109,7 +123,7 @@ export function DashboardToolbar(props: PageToolbarProps<IJobTemplate>) {
     <Toolbar
       ouiaId="page-toolbar"
       data-testid="page-toolbar"
-      clearAllFilters={props.clearAllFilters}
+      clearAllFilters={clearAllFilters}
       className="page-table-toolbar"
       style={{
         paddingBottom: isMdOrLarger ? undefined : 8,

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -72,11 +72,12 @@ export interface IAutomationDashboardCollectionStatus {
 
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
 
-export interface AutomationDashboardToolbarFiltersProps {
-  filterableFields: string[];
-  /** Additional filters appended after the dynamic filters. */
-  additionalFilters?: IToolbarFilter[];
-}
+export interface AutomationDashboardToolbarFiltersProps
+  extends Readonly<{
+    filterableFields: string[];
+    /** Additional filters appended after the dynamic filters. */
+    additionalFilters?: IToolbarFilter[];
+  }> {}
 
 export interface AsyncKeyOptions {
   /** Display label for the filter (also used as an i18n key). */
@@ -99,20 +100,24 @@ type DashboardCommonCardProps = {
   errorStateTitle: string;
 };
 
-export type DashboardValueCardProps = DashboardCommonCardProps & {
-  value: string | number;
-  valueSuffix?: string;
-  formatAsCurrency?: boolean;
-  linkText?: string;
-  to?: string;
-};
+export type DashboardValueCardProps = Readonly<
+  DashboardCommonCardProps & {
+    value: string | number;
+    valueSuffix?: string;
+    formatAsCurrency?: boolean;
+    linkText?: string;
+    to?: string;
+  }
+>;
 
 export type DashboardTableCardProps = DashboardCommonCardProps & {
   firstColumnHeader: string;
   items?: IDashboardTableItem[];
   loading: boolean;
   clearAllFilters: () => void;
-  filterState: IFilterState;
+  filterState: IFilterState | undefined;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
 };
 
 export type DashboardChartCardProps = DashboardCommonCardProps & {
@@ -157,4 +162,6 @@ export type IAutomationDashboardView = {
   refresh: () => Promise<void>;
   exportCsv: () => Promise<void>;
   exportPdf: () => Promise<void>;
+  isFilterStateDefault: boolean;
+  registerClearCallback: (callback: () => void) => void;
 };

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { IToolbarFilter } from '@ansible/ansible-ui-framework';
+import { IFilterState, IToolbarFilter } from '@ansible/ansible-ui-framework';
 import { IAwxView } from '../../../common/useAwxView';
 
 // ─── Dashboard Data Models (API shapes) ──────────────────────────────────────
@@ -110,8 +110,9 @@ export type DashboardValueCardProps = DashboardCommonCardProps & {
 export type DashboardTableCardProps = DashboardCommonCardProps & {
   firstColumnHeader: string;
   items?: IDashboardTableItem[];
-  emptyStateTitle: string;
   loading: boolean;
+  clearAllFilters: () => void;
+  filterState: IFilterState;
 };
 
 export type DashboardChartCardProps = DashboardCommonCardProps & {

--- a/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
@@ -110,6 +110,8 @@ describe('useAutomationDashboardView', () => {
     expect(view.refresh).toBeTypeOf('function');
     expect(view.exportPdf).toBeTypeOf('function');
     expect(view.setCostState).toBeTypeOf('function');
+    expect(view.isFilterStateDefault).toBe(true);
+    expect(view.registerClearCallback).toBeTypeOf('function');
   });
 
   // --- clearAllFilters override ---
@@ -119,6 +121,33 @@ describe('useAutomationDashboardView', () => {
     act(() => {
       result.current.mainTableView.clearAllFilters();
     });
+    expect(mockSetFilterState).toHaveBeenCalledWith({
+      period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
+    });
+  });
+
+  // --- isFilterStateDefault ---
+
+  test('should return true for isFilterStateDefault when filter state is default', () => {
+    const { result } = renderHook(() => useAutomationDashboardView({ toolbarFilters: [] }));
+    expect(result.current.isFilterStateDefault).toBe(true);
+  });
+
+  // --- registerClearCallback ---
+
+  test('should call registered callback when clearAllFilters is invoked', () => {
+    const { result } = renderHook(() => useAutomationDashboardView({ toolbarFilters: [] }));
+    const mockCallback = vi.fn();
+
+    act(() => {
+      result.current.registerClearCallback(mockCallback);
+    });
+
+    act(() => {
+      result.current.mainTableView.clearAllFilters();
+    });
+
+    expect(mockCallback).toHaveBeenCalled();
     expect(mockSetFilterState).toHaveBeenCalledWith({
       period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
     });

--- a/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
-import { IToolbarFilter } from '../../../../../framework';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { IFilterState, IToolbarFilter } from '../../../../../framework';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { IAwxView, useAwxView } from '../../../common/useAwxView';
 import { AutomationDashboardDateRangeFilterPresets } from '../constants';
@@ -16,11 +16,23 @@ const DEFAULT_FILTERS: Record<string, string[]> = {
   period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
 };
 
+/** Returns true when filterState is empty or equals the default (period = last 7 days only). */
+function isDefaultFilterState(filterState: IFilterState | undefined): boolean {
+  if (!filterState) return true;
+
+  // Remove empty entries from filterState
+  const activeFilterState = Object.fromEntries(
+    Object.entries(filterState).filter(([, v]) => v && v.length > 0)
+  );
+
+  // Compare with DEFAULT_FILTERS
+  return JSON.stringify(activeFilterState) === JSON.stringify(DEFAULT_FILTERS);
+}
+
 export function useAutomationDashboardView(options: {
   toolbarFilters: IToolbarFilter[];
 }): IAutomationDashboardView {
   const { toolbarFilters } = options;
-
   const mainTableViewBase = useAwxView<IJobTemplate>({
     url: metricsAPI`/dashboard_reports/report/`,
     defaultSort: 'template_name',
@@ -31,10 +43,21 @@ export function useAutomationDashboardView(options: {
 
   const { filterState, setFilterState } = mainTableViewBase;
 
-  // Override clearAllFilters to retain the required 'period' filter instead of clearing it.
+  // Ref for callback from toolbar (to reset dropdown when filters cleared)
+  const onClearFiltersCallback = useRef<(() => void) | undefined>();
+
+  // Override clearAllFilters to retain the required 'period' filter and call toolbar callback
   const clearAllFilters = useCallback(() => {
     setFilterState({ period: [AutomationDashboardDateRangeFilterPresets.last_7_days] });
+
+    // Call toolbar callback to reset dropdown
+    onClearFiltersCallback.current?.();
   }, [setFilterState]);
+
+  // Function to register callback from toolbar
+  const registerClearCallback = useCallback((callback: () => void) => {
+    onClearFiltersCallback.current = callback;
+  }, []);
 
   const mainTableView: IAwxView<IJobTemplate> = useMemo(
     () => ({ ...mainTableViewBase, clearAllFilters }),
@@ -76,6 +99,9 @@ export function useAutomationDashboardView(options: {
     }
   }, [exportPdfBase]);
 
+  // Compute whether filter state is default
+  const isFilterStateDefaultValue = useMemo(() => isDefaultFilterState(filterState), [filterState]);
+
   return useMemo(
     () => ({
       mainTableView,
@@ -88,6 +114,8 @@ export function useAutomationDashboardView(options: {
       refresh,
       exportCsv,
       exportPdf,
+      isFilterStateDefault: isFilterStateDefaultValue,
+      registerClearCallback,
     }),
     [
       mainTableView,
@@ -100,6 +128,8 @@ export function useAutomationDashboardView(options: {
       refresh,
       exportCsv,
       exportPdf,
+      isFilterStateDefaultValue,
+      registerClearCallback,
     ]
   );
 }

--- a/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
+++ b/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
@@ -162,7 +162,7 @@ test.describe('Automation Dashboard', () => {
     await expect(successfulJobsCard.getByText('31')).toBeVisible();
 
     // Now the link should be visible since data loaded without error
-    await successfulJobsCard.getByRole('link', { name: 'See all successful jobs in AAP' }).click();
+    await successfulJobsCard.getByRole('link', { name: 'See all successful jobs' }).click();
     await expect(page).toHaveURL(new RegExp('/jobs\\?status=successful$'));
 
     await navigateTo(page, 'Automation Analytics', 'Automation Dashboard');
@@ -171,7 +171,7 @@ test.describe('Automation Dashboard', () => {
     // Wait for the card to show the mocked value (3 failed jobs)
     await expect(failedJobsCard.getByText('3')).toBeVisible();
 
-    await failedJobsCard.getByRole('link', { name: 'See all failed jobs in AAP' }).click();
+    await failedJobsCard.getByRole('link', { name: 'See all failed jobs' }).click();
     await expect(page).toHaveURL(new RegExp('/jobs\\?status=failed$'));
   });
 });


### PR DESCRIPTION
## Summary
[AAP-74855](https://redhat.atlassian.net/browse/AAP-74855)
<!-- What changed and why? -->

This pull request makes several improvements and refinements to the Automation Dashboard in both the UI and supporting logic. The most significant changes include renaming report-related actions and labels for clarity and consistency, enhancing filter and table card functionality, and improving the handling and testing of report deletion (filter sets).

**Key changes:**

**Report Actions and Labels:**
- Renamed report actions and labels throughout the dashboard from "Create new report", "Edit current report", and "Delete current report" to "Save report", "Rename report", and "Delete report" for clearer user experience. This includes updates in both UI components and test descriptions. [[1]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078L75-R83) [[2]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078L93-R93) [[3]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L168-R215) [[4]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L225-R253) [[5]](diffhunk://#diff-9ac5e9b9d3f09224871ac600f80b7e31bcb21702d54e4cc9e6a4a2ce0ba322ecL100-R103) [[6]](diffhunk://#diff-9ac5e9b9d3f09224871ac600f80b7e31bcb21702d54e4cc9e6a4a2ce0ba322ecL113-R113) [[7]](diffhunk://#diff-6890824618a949f544a61ae5d6955edaa43f4a14254a9bf30f6eb733e622872fL106-R107)

**Dashboard Table and Card Enhancements:**
- Added `clearAllFilters` and `filterState` props to `DashboardTableCard` components to support better filter management in the dashboard tables. [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L120-R125) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L133-R139)
- Removed redundant `emptyStateTitle` props for projects and users tables, relying on default behavior. [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L120-R125) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L133-R139)
- Updated link text on job value cards to remove "in AAP" for brevity and clarity. [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L73-R73) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L85-R85) [[3]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81L246-R247)

**Filter and Toolbar Improvements:**
- Changed the order of applying `additionalFilters` in `useAutomationDashboardToolbarFilters` to ensure they are included before standard filters, which can affect filter order and behavior. [[1]](diffhunk://#diff-42762f3fa3c3b11b2c1711e8a863eef9b34b54653f86a7504c5fd719091cd4d7R110-R113) [[2]](diffhunk://#diff-42762f3fa3c3b11b2c1711e8a863eef9b34b54653f86a7504c5fd719091cd4d7L128-L131)
- Improved the appearance and labeling of the filter set dialog, including using "Report name" as the input label and adjusting modal padding. [[1]](diffhunk://#diff-6890824618a949f544a61ae5d6955edaa43f4a14254a9bf30f6eb733e622872fL72-R75) [[2]](diffhunk://#diff-6890824618a949f544a61ae5d6955edaa43f4a14254a9bf30f6eb733e622872fL85-R86)

**Report Deletion (Filter Set) Logic and Testing:**
- Enhanced the `useRemoveToolbarFilterSet` hook and its tests to support deleting multiple reports at once, ensuring reports are sorted by name, and using pluralized titles and confirmation texts when appropriate. Also verifies that action columns include a "Name" header. [[1]](diffhunk://#diff-50b46fb9bd193bca4a4ccf12bc7ce77b4450e23e8f976941c4b361126f897aeeR20-R26) [[2]](diffhunk://#diff-50b46fb9bd193bca4a4ccf12bc7ce77b4450e23e8f976941c4b361126f897aeeL45-R52) [[3]](diffhunk://#diff-50b46fb9bd193bca4a4ccf12bc7ce77b4450e23e8f976941c4b361126f897aeeR61-R80) [[4]](diffhunk://#diff-50b46fb9bd193bca4a4ccf12bc7ce77b4450e23e8f976941c4b361126f897aeeR144-R181) [[5]](diffhunk://#diff-c3498e8fd49b101674784ec888a6d2e8eb01c61f520ffed3050a29d1c2605b4aL1-R1)

These changes collectively improve the dashboard's usability, consistency, and robustness, especially around report management and filtering.
## Type of Change

- [x] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<img width="2781" height="1431" alt="Before_1" src="https://github.com/user-attachments/assets/de37a484-42a3-4c34-bf22-56e2b8a40c55" />

<img width="2595" height="1443" alt="After_1" src="https://github.com/user-attachments/assets/a87394aa-2045-4fa3-b691-cb0f876ad168" />

<img width="2781" height="1431" alt="Before_2" src="https://github.com/user-attachments/assets/324f1379-3e27-42a3-90d5-dd846450ed19" />

<img width="2679" height="1463" alt="After_2" src="https://github.com/user-attachments/assets/83518eb9-ad73-4e1d-81a3-d89c6b436568" />


<img width="1935" height="1153" alt="Before_3" src="https://github.com/user-attachments/assets/ca8daa2e-9d29-4710-8156-bcb56b2a6031" />

<img width="1991" height="957" alt="After_3" src="https://github.com/user-attachments/assets/1370e31f-f7a1-45dd-880c-239b1fdaa7d2" />


<img width="455" height="357" alt="Before_4" src="https://github.com/user-attachments/assets/3b7e6bb6-9e50-4349-828c-f708cc822609" />

<img width="347" height="273" alt="After_4" src="https://github.com/user-attachments/assets/12621b37-5511-47f9-a0ac-75ad46ff0368" />


<img width="825" height="379" alt="Before_5" src="https://github.com/user-attachments/assets/975edda6-d97f-46d1-802c-30980f8f3eb0" />

<img width="727" height="339" alt="After_5" src="https://github.com/user-attachments/assets/c76f80b0-bb16-4e02-95df-99c69160c0bc" />


<img width="1057" height="509" alt="Before_6" src="https://github.com/user-attachments/assets/e6bce3ca-04b0-4cd9-ae2a-1a44c945278b" />

<img width="1061" height="417" alt="After_6" src="https://github.com/user-attachments/assets/3075c92c-0527-49f5-8abf-b57b3630aa09" />

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
