### PR TITLE
chore(ci): skip PR risk analysis check for dependabot PRs

### DIFF
--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check-risk-analysis:
     name: Risk Analysis Required
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check risk level is selected


### PR DESCRIPTION
## Summary

Dependabot PRs are automated dependency bumps that don't use the PR template, so the risk analysis checkbox is never filled in. This causes the required "Risk Analysis Required" check to fail and block merging. This skips the job entirely when the PR author is `dependabot[bot]`.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [x] Other (please specify)

CI workflow update — skip a required check for bot-authored PRs.

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Open a Dependabot PR (or re-run the workflow on an existing one) and verify the "Risk Analysis Required" check is skipped.
- Open a human-authored PR and verify the check still runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)