### PR TITLE
feat(ci): add PAC push template for nightly e2e coverage

### DIFF
--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:798289ba7c25c9cae4bdd77ee877555975096553e679b183b2dbaa6367e0421c
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:4afdef375da79c740cd490b4fe97300950555dc27c74b2d83edc5be35ff85a83
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:4afdef375da79c740cd490b4fe97300950555dc27c74b2d83edc5be35ff85a83
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:01918cca6f6e1bb0c4599333842334551ec505b7a648f1c3ca3576ce928dd0ab
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:8f3c23307284bd59cf439b73b08797b96b67dd43bb14f020fab5f3785cbafe05
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:c70964859c2504e78eca36842c0dcedef5bd69e0e07fb27068dba2330c16f1ef
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:01918cca6f6e1bb0c4599333842334551ec505b7a648f1c3ca3576ce928dd0ab
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:efdb343736c4720cb61ead039c6f79d6a68fe0080aacf487a7d402edf83ef14b
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: aap-ui-e2e-coverage-push
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/{{repo_owner}}/{{repo_name}}?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
+    pipelinesascode.tekton.dev/target-namespace: ansible-ci-tenant
+  labels:
+    appstudio.openshift.io/application: '{{repo_owner}}'
+    appstudio.openshift.io/component: '{{repo_owner}}-{{repo_name}}'
+    pipelines.appstudio.openshift.io/type: build
+spec:
+  timeouts:
+    pipeline: "8h"
+    tasks: "7h"
+    finally: "1h"
+  pipelineRef:
+    resolver: bundles
+    params:
+      - name: name
+        value: aap-ui-tests
+      - name: bundle
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:4801a75e7c78809565a45cc2c3cec215183c83739ca1e993a5dc5b49c56528ee
+      - name: kind
+        value: pipeline
+      - name: secret
+        value: quay-aap-ci-viewer
+
+  taskRunTemplate:
+    serviceAccountName: konflux-integration-runner
+
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: pipeline-pr-number
+      value: ''
+    - name: pipeline-github-org
+      value: '{{repo_owner}}'
+    - name: pipeline-github-repo
+      value: '{{repo_name}}'
+    - name: pipeline-target-branch
+      value: '{{target_branch}}'
+    - name: pipeline-sender
+      value: '{{sender}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: playwright-coverage-enabled
+      value: "true"
+
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     # TODO: restore push trigger before merging
     # pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
-    pipelinesascode.tekton.dev/on-comment: "^/run-playwright$"
+    pipelinesascode.tekton.dev/on-comment: "^/run-coverage$"
     pipelinesascode.tekton.dev/target-namespace: ansible-ci-tenant
   labels:
     appstudio.openshift.io/application: '{{repo_owner}}'

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:daeac69e29d164ac4ad70967addfd0ee79b6a900302590657057932444255921
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:15cc22ea74eeca9cdb369bc361c8d0906de06f20d74f1bc466bad12ecd645d1e
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:efdb343736c4720cb61ead039c6f79d6a68fe0080aacf487a7d402edf83ef14b
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:8f3c23307284bd59cf439b73b08797b96b67dd43bb14f020fab5f3785cbafe05
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -9,9 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    # TODO: restore push trigger before merging
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
-    pipelinesascode.tekton.dev/on-comment: "^/run-coverage$"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
     pipelinesascode.tekton.dev/target-namespace: ansible-ci-tenant
   labels:
     appstudio.openshift.io/application: '{{repo_owner}}'
@@ -28,7 +26,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:c70964859c2504e78eca36842c0dcedef5bd69e0e07fb27068dba2330c16f1ef
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:4801a75e7c78809565a45cc2c3cec215183c83739ca1e993a5dc5b49c56528ee
       - name: kind
         value: pipeline
       - name: secret
@@ -41,7 +39,7 @@ spec:
     - name: git-url
       value: '{{source_url}}'
     - name: pipeline-pr-number
-      value: '{{pull_request_number}}'
+      value: ''
     - name: pipeline-github-org
       value: '{{repo_owner}}'
     - name: pipeline-github-repo

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -63,7 +63,7 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 5Gi
+              storage: 50Gi
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -26,7 +26,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:4801a75e7c78809565a45cc2c3cec215183c83739ca1e993a5dc5b49c56528ee
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:21d749e0ac1be16393b072222a2ce40b9d03ccc2158170c6694612516667ab0a
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
+    # TODO: restore push trigger before merging
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "devel"
+    pipelinesascode.tekton.dev/on-comment: "^/run-playwright$"
     pipelinesascode.tekton.dev/target-namespace: ansible-ci-tenant
   labels:
     appstudio.openshift.io/application: '{{repo_owner}}'
@@ -26,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:4801a75e7c78809565a45cc2c3cec215183c83739ca1e993a5dc5b49c56528ee
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:0e73b89b7e445198dfa072cb59d4607f7b67ba17d4225a848f14266fd9adfb0e
       - name: kind
         value: pipeline
       - name: secret
@@ -39,7 +41,7 @@ spec:
     - name: git-url
       value: '{{source_url}}'
     - name: pipeline-pr-number
-      value: ''
+      value: '{{pull_request_number}}'
     - name: pipeline-github-org
       value: '{{repo_owner}}'
     - name: pipeline-github-repo

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:0e73b89b7e445198dfa072cb59d4607f7b67ba17d4225a848f14266fd9adfb0e
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:daeac69e29d164ac4ad70967addfd0ee79b6a900302590657057932444255921
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -28,7 +28,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:15cc22ea74eeca9cdb369bc361c8d0906de06f20d74f1bc466bad12ecd645d1e
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:AAP-72998@sha256:798289ba7c25c9cae4bdd77ee877555975096553e679b183b2dbaa6367e0421c
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

- Add a PAC PipelineRun template (`.tekton/aap-ui-e2e-coverage-push.yaml`) triggered on push to `devel` that runs the `aap-ui-tests` pipeline with `playwright-coverage-enabled: "true"`.
- This template is what the nightly CronJob (to be set up in `konflux-release-data` via ArgoCD) will trigger to collect Playwright e2e coverage and upload to Codecov.

Jira: [AAP-72998](https://redhat.atlassian.net/browse/AAP-72998)

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

CI/CD pipeline configuration for nightly e2e coverage uploads.

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

- [aap-konflux-pipelines#1482](https://github.com/ansible-automation-platform/aap-konflux-pipelines/pull/1482) — pipeline `merge-and-upload-coverage` task (should merge first)
- Nightly CronJob will be set up separately in `konflux-release-data` via ArgoCD

## Testing

### Manual Testing

- [x] Verified PAC template is valid YAML and follows existing `.tekton/` patterns
- [ ] After pipeline PR merges, manual test run with `playwright-coverage-enabled: "true"` to validate storage and Codecov upload
- [ ] After CronJob is set up, verify nightly trigger and coverage appears on [Codecov](https://app.codecov.io/github/ansible/ansible-ui)