### PR TITLE
fix(playwright): poll docs_blob API before Documentation tab navigation

### DIFF
--- a/playwright/commands/hub/collectionHelpers.ts
+++ b/playwright/commands/hub/collectionHelpers.ts
@@ -88,6 +88,45 @@ export async function verifyVersionDeleted(
 }
 
 /**
+ * Poll API until docs_blob is available for a collection version.
+ *
+ * After collection approval, Pulp indexes the docs_blob asynchronously.
+ * The Documentation tab renders a NotFound page until this completes.
+ *
+ * @param page - Playwright page object
+ * @param namespace - Collection namespace
+ * @param name - Collection name
+ * @param version - Collection version
+ * @param repository - Repository name (default: 'published')
+ * @param maxAttempts - Maximum polling attempts (default: 30)
+ */
+export async function waitForDocsBlob(
+  page: Page,
+  namespace: string,
+  name: string,
+  version: string,
+  repository: string = 'published',
+  maxAttempts: number = 30
+): Promise<void> {
+  const apiUrl = `${platformUI}/api/galaxy/v3/plugin/ansible/content/${repository}/collections/index/${namespace}/${name}/versions/${version}/docs-blob/`;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const response = await page.request.get(apiUrl);
+    if (response.ok()) {
+      const data = (await response.json()) as { docs_blob: Record<string, unknown> };
+      if (data.docs_blob && Object.keys(data.docs_blob).length > 0) {
+        return;
+      }
+    }
+    if (attempt === maxAttempts) {
+      throw new Error(
+        `docs_blob not available for ${namespace}.${name} v${version} after ${maxAttempts} attempts`
+      );
+    }
+    await page.waitForTimeout(2000);
+  }
+}
+
+/**
  * Find and select the first unchecked, enabled checkbox in a locator.
  *
  * @param checkboxes - Locator containing checkbox elements

--- a/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
+++ b/playwright/tests/integration/automation-content/collections/collection-details.spec.ts
@@ -10,6 +10,7 @@ import { clickKebabActionAndConfirm } from '@ansible/playwright/commands/hub/cli
 import {
   selectFirstAvailableCheckbox,
   verifyVersionDeleted,
+  waitForDocsBlob,
   waitForVersionsInRepository,
 } from '@ansible/playwright/commands/hub/collectionHelpers';
 import { navigateToCollectionDetails } from '@ansible/playwright/commands/hub/navigateToCollectionDetails';
@@ -700,33 +701,14 @@ test.describe('Hub Collections - Details Page', () => {
           version: uploaded.version,
         });
 
+        await waitForDocsBlob(page, namespace, name, '1.0.0');
         await navigateToCollectionDetails(page, uploaded);
 
-        // Click on the Documentation tab with retry logic for Pulp indexing delay.
-        // docs_blob may not be available immediately after collection approval,
-        // causing the tab to render a NotFound page instead of documentation content.
-        for (let attempt = 1; attempt <= 3; attempt++) {
-          await page.getByRole('tab', { name: 'Documentation' }).click();
+        await page.getByRole('tab', { name: 'Documentation' }).click();
+        await expect(page.getByPlaceholder('Find content')).toBeVisible({ timeout: 10000 });
 
-          try {
-            await expect(page.getByPlaceholder('Find content')).toBeVisible({ timeout: 10000 });
-            break;
-          } catch {
-            if (attempt === 3) {
-              const mainContent = await page.locator('main').textContent();
-              throw new Error(
-                `Documentation tab did not render after 3 attempts. Page shows: ${mainContent?.slice(0, 200)}`
-              );
-            }
-            await page.waitForTimeout(2000);
-            await page.getByTestId('collection-detail-tab').click();
-          }
-        }
-
-        // Verify documentation content renders (not an error state)
         await expect(page.getByRole('heading', { name: 'Page not found' })).not.toBeVisible();
 
-        // Verify the page does not show a generic error boundary
         const mainContent = page.locator('main');
         await expect(mainContent).not.toContainText('Error', { timeout: 10000 });
       }


### PR DESCRIPTION
## Summary

  - Fixes ~53% failure rate on the collection-details.spec.ts Documentation Tab
  test caused by Pulp's async docs_blob indexing delay after collection approval
  - Adds waitForDocsBlob() polling helper to collectionHelpers.ts (30 attempts ×
  2s = 60s max), following the existing waitForVersionsInRepository pattern
  - Replaces the flaky UI retry loop with API-level polling before navigating to
  the Documentation tab

## Type of Change

  - [x] Tests

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

