### PR TITLE
feat(playwright): add @tier1 tags to Lightspeed tests

### DIFF
--- a/playwright/tests/integration/lightspeed/chatbot.spec.ts
+++ b/playwright/tests/integration/lightspeed/chatbot.spec.ts
@@ -12,29 +12,33 @@ test.describe('Chatbot', () => {
   test.afterEach(setupAfter);
   test.setTimeout(1 * 60 * 1000);
 
-  test('should display the Chatbot, add a question and hide', { tag: [] }, async ({ page }) => {
-    await Lightspeed.mock.healthStatus(page, 200, {
-      'chatbot-service': 'ok',
-      'streaming-chatbot-service': 'ok',
-    });
+  test(
+    'should display the Chatbot, add a question and hide',
+    { tag: ['@tier1'] },
+    async ({ page }) => {
+      await Lightspeed.mock.healthStatus(page, 200, {
+        'chatbot-service': 'ok',
+        'streaming-chatbot-service': 'ok',
+      });
 
-    await page.reload({ waitUntil: 'networkidle' });
-    const chatbotBadge = page.locator('[data-testid="chatbot-badge"]');
-    await expect(chatbotBadge).toBeVisible();
-    await chatbotBadge.click();
-    const chatbotIFrame = page.frameLocator('iframe[title="Ansible Chatbot IFrame"]');
-    const chatbotTextArea = chatbotIFrame.locator('textarea[aria-label="Send a message..."]');
-    await chatbotTextArea.waitFor();
-    await expect(chatbotTextArea).toBeVisible();
-    await chatbotTextArea.fill('what is ansible ?');
+      await page.reload({ waitUntil: 'networkidle' });
+      const chatbotBadge = page.locator('[data-testid="chatbot-badge"]');
+      await expect(chatbotBadge).toBeVisible();
+      await chatbotBadge.click();
+      const chatbotIFrame = page.frameLocator('iframe[title="Ansible Chatbot IFrame"]');
+      const chatbotTextArea = chatbotIFrame.locator('textarea[aria-label="Send a message..."]');
+      await chatbotTextArea.waitFor();
+      await expect(chatbotTextArea).toBeVisible();
+      await chatbotTextArea.fill('what is ansible ?');
 
-    await page.locator('[data-testid="chatbot-badge"]').click();
-    await expect(chatbotTextArea).not.toBeVisible();
-  });
+      await page.locator('[data-testid="chatbot-badge"]').click();
+      await expect(chatbotTextArea).not.toBeVisible();
+    }
+  );
 
   test(
     'should hide chatbot badge when the chatbot service is disabled',
-    { tag: [] },
+    { tag: ['@tier1'] },
     async ({ page }) => {
       await Lightspeed.mock.healthStatus(page, 200, {
         'chatbot-service': 'disabled',
@@ -49,7 +53,7 @@ test.describe('Chatbot', () => {
 
   test(
     'should hide the chatbot badge when health status request return an error',
-    { tag: [] },
+    { tag: ['@tier1'] },
     async ({ page }) => {
       await Lightspeed.mock.healthStatus(page, 200, {
         'chatbot-service': 'an error occurred',
@@ -65,7 +69,7 @@ test.describe('Chatbot', () => {
 
   test(
     'should have RAG conversation return a meaningful response',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.setTimeout(120000);
 
@@ -122,7 +126,7 @@ test.describe('Chatbot', () => {
 
   test(
     'should have MCP conversation return a meaningful response',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       const healthResponse = await page.request.get(
         `${platformUI}/api/lightspeed/v1/health/status/chatbot/`

--- a/playwright/tests/integration/lightspeed/lightspeed-oauth2.spec.ts
+++ b/playwright/tests/integration/lightspeed/lightspeed-oauth2.spec.ts
@@ -12,7 +12,7 @@ test.describe('Ansible Lightspeed oauth2', () => {
 
   test(
     'should authenticate to lightspeed via oauth2 successfully',
-    { tag: ['@not_mock'] },
+    { tag: ['@not_mock', '@tier1'] },
     async ({ page }) => {
       test.skip(!lightspeedServer, 'LIGHTSPEED_SERVER not supplied');
       test.skip(!userName, 'PLATFORM_USERNAME not supplied');


### PR DESCRIPTION
## Summary

Add `@tier1` tags to all Lightspeed Playwright tests so they are picked up by the Tier 1 PBCI pipelines.

- Tag 3 mock chatbot tests with `@tier1`
- Tag 2 live chatbot tests (RAG, MCP) with `@not_mock, @tier1`
- Tag 1 live oauth2 test with `@not_mock, @tier1`

Since Lightspeed is not integrated into aap-dev, these tests cannot run in pre-merge ephemeral environments and should remain in Tier 1 PBCI.

## Context

After the shift-left initiative applied `playwrightTags: "@tier1"` to the Tier 1 Jenkins pipelines, the Lightspeed tests were silently filtered out because they lacked the `@tier1` tag. This was confirmed by PDE (Ryan, Adriana) in [#aap-pde-pipelines](https://redhat-internal.slack.com/archives/C071ZDZN4EX).

Ref: [AAP-78642](https://redhat.atlassian.net/browse/AAP-78642)

## Type of Change

- Tests

## Risk Analysis - REQUIRED

- [ ] **High** — Broad scope (e.g., core infrastructure, auth, shared components, data migrations). High risk of cascading failures.
- [ ] **Medium** — Moderate scope (e.g., new feature, multi-page change, API integration). Some risk of side effects.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

**Rationale**: Test metadata changes only (`@tier1` tags). No functional code changes.

## Testing

No functional changes -- only tag metadata added. Tests will be verified by confirming they appear in the next Tier 1 pipeline run after merge.