### PR TITLE
[AAP-78414] - Preserve zero default values in survey integer/float questions

### DIFF
--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
@@ -4,11 +4,14 @@ import {
   isLengthType,
   ValidateMinMaxOptions,
   TemplateSurveyForm,
+  EditTemplateSurveyForm,
+  AddTemplateSurveyForm,
 } from './TemplateSurveyForm';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { userEvent } from '@testing-library/user-event';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import type { Survey, Spec } from '../../../interfaces/Survey';
 import { awxAPI } from '../../../common/api/awx-utils';
@@ -607,6 +610,54 @@ describe('TemplateSurveyForm', () => {
       expect(screen.getByText('Maximum')).toBeInTheDocument();
       expect(screen.getByText('Default answer')).toBeInTheDocument();
     });
+
+    test('should show validation error for non-integer value in default answer', async () => {
+      const user = userEvent.setup();
+      // Use workflow_job_templates as the resourceType so the GET URL is distinct from
+      // the job_templates URL cached by the preceding tests in this describe block.
+      // This avoids the 2-second SWR dedupingInterval returning stale data.
+      //
+      // Pre-populate the default with a decimal string — avoids typing decimals into a
+      // number input (happy-dom may reject the intermediate "1." state).  The number
+      // input accepts "1.5" as a valid float, so RHF stores it as-is.  On submit,
+      // validate("1.5") fires and returns the integer error.
+      const survey: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Test Question',
+            question_description: '',
+            required: false,
+            type: 'integer',
+            variable: 'int_variable',
+            min: 0,
+            max: 100,
+            choices: '',
+            default: '1.5',
+            new_question: false,
+          },
+        ],
+      };
+
+      renderSurveyForm(server, survey, {
+        mode: 'edit',
+        questionVariable: 'int_variable',
+        resourceType: 'workflow_job_templates',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/default answer/i)).toBeInTheDocument();
+      });
+
+      // Submit without changing anything — validate('1.5') blocks submission and
+      // shows the error.  No POST mock needed because onSubmit is never reached.
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('This field must be an integer.')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('Edit Mode - Float question', () => {
@@ -769,117 +820,697 @@ describe('TemplateSurveyForm', () => {
   });
 
   describe('Integer/Float Default Value of 0 Bug Fix', () => {
-    const createSurveyWithIntegerQuestion = (
-      options: { withDefault?: boolean; defaultValue?: number | string } = {}
-    ): Survey => {
-      const { withDefault = true, defaultValue = 10 } = options;
-
-      const baseSpec: Partial<Spec> = {
-        question_name: 'Test Integer Question',
-        question_description: 'An integer question',
-        required: false,
-        type: 'integer',
-        variable: 'integer_variable',
-        min: 0,
-        max: 1024,
-        choices: '',
-        new_question: false,
-      };
-
-      if (withDefault) {
-        (baseSpec as Spec).default = defaultValue;
-      }
-
-      return {
-        name: 'Test Survey',
-        description: 'Test Survey Description',
-        spec: [baseSpec as Spec],
-      };
-    };
-
-    const createSurveyWithFloatQuestion = (
-      options: { withDefault?: boolean; defaultValue?: number | string } = {}
-    ): Survey => {
-      const { withDefault = true, defaultValue = 5.5 } = options;
-
-      const baseSpec: Partial<Spec> = {
-        question_name: 'Test Float Question',
-        question_description: 'A float question',
-        required: false,
-        type: 'float',
-        variable: 'float_variable',
-        min: 0,
-        max: 100,
-        choices: '',
-        new_question: false,
-      };
-
-      if (withDefault) {
-        (baseSpec as Spec).default = defaultValue;
-      }
-
-      return {
-        name: 'Test Survey',
-        description: 'Test Survey Description',
-        spec: [baseSpec as Spec],
-      };
-    };
-
     test('should preserve integer default value of 0', async () => {
-      const surveyWithZeroDefault = createSurveyWithIntegerQuestion({
-        withDefault: true,
-        defaultValue: 0,
-      });
+      server.use(
+        http.get(awxAPI`/job_templates/890/survey_spec/`, () =>
+          HttpResponse.json(createSurveyWithNumericQuestion({ type: 'integer', defaultValue: 0 }))
+        )
+      );
 
-      renderSurveyForm(server, surveyWithZeroDefault, {
-        mode: 'edit',
-        questionVariable: 'integer_variable',
-      });
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/890/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="int_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
 
       await waitFor(() => {
         expect(screen.getByText('Question')).toBeInTheDocument();
       });
 
-      const defaultInput = screen.getByLabelText(/default answer/i);
-      expect(defaultInput).toHaveValue(0);
+      expect(screen.getByLabelText(/default answer/i)).toHaveValue(0);
     });
 
     test('should preserve float default value of 0', async () => {
-      const surveyWithZeroDefault = createSurveyWithFloatQuestion({
-        withDefault: true,
-        defaultValue: 0,
-      });
+      server.use(
+        http.get(awxAPI`/job_templates/891/survey_spec/`, () =>
+          HttpResponse.json(createSurveyWithNumericQuestion({ type: 'float', defaultValue: 0 }))
+        )
+      );
 
-      renderSurveyForm(server, surveyWithZeroDefault, {
-        mode: 'edit',
-        questionVariable: 'float_variable',
-      });
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/891/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="int_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
 
       await waitFor(() => {
         expect(screen.getByText('Question')).toBeInTheDocument();
       });
 
-      const defaultInput = screen.getByLabelText(/default answer/i);
-      expect(defaultInput).toHaveValue(0);
+      expect(screen.getByLabelText(/default answer/i)).toHaveValue(0);
+    });
+  });
+
+  describe('Edit Mode - Answer type change', () => {
+    test('should reset min/max to defaults when answer type is changed', async () => {
+      const user = userEvent.setup();
+      const surveyWithCustomMinMax: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Test Integer Question',
+            question_description: '',
+            required: false,
+            type: 'integer',
+            variable: 'int_variable',
+            min: 5,
+            max: 500,
+            choices: '',
+            default: '',
+            new_question: false,
+          },
+        ],
+      };
+
+      renderSurveyForm(server, surveyWithCustomMinMax, {
+        mode: 'edit',
+        questionVariable: 'int_variable',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^minimum$/i)).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText(/^minimum$/i)).toHaveValue(5);
+      expect(screen.getByLabelText(/^maximum$/i)).toHaveValue(500);
+
+      // Change answer type to Float (marks the 'type' field as dirty).
+      // The toggle button's accessible name matches the current selected label ("Integer").
+      await user.click(screen.getByRole('button', { name: 'Integer' }));
+      const listbox = await screen.findByRole('listbox');
+      await user.click(within(listbox).getByText('Float'));
+
+      // isDirty branch resets min/max to their defaults
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^minimum$/i)).toHaveValue(0);
+      });
+      expect(screen.getByLabelText(/^maximum$/i)).toHaveValue(1024);
+    });
+  });
+
+  describe('Submit behavior - Edit mode', () => {
+    test('should submit successfully with valid integer default value', async () => {
+      const user = userEvent.setup();
+      const survey = createSurveyWithNumericQuestion({ type: 'integer' });
+
+      let postCalled = false;
+      server.use(
+        http.post(awxAPI`/job_templates/123/survey_spec/`, () => {
+          postCalled = true;
+          return HttpResponse.json({});
+        })
+      );
+
+      renderSurveyForm(server, survey, {
+        mode: 'edit',
+        questionVariable: 'int_variable',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/default answer/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(postCalled).toBe(true);
+      });
     });
 
-    test('should preserve float default value of 0.0', async () => {
-      const surveyWithZeroDefault = createSurveyWithFloatQuestion({
-        withDefault: true,
-        defaultValue: 0,
+    test('should show duplicate error when renaming variable to existing one', async () => {
+      const user = userEvent.setup();
+      const surveyWithTwo: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Question 1',
+            question_description: '',
+            required: false,
+            type: 'text',
+            variable: 'var1',
+            min: 0,
+            max: 1024,
+            choices: '',
+            default: '',
+            new_question: false,
+          },
+          {
+            question_name: 'Question 2',
+            question_description: '',
+            required: false,
+            type: 'text',
+            variable: 'var2',
+            min: 0,
+            max: 1024,
+            choices: '',
+            default: '',
+            new_question: false,
+          },
+        ],
+      };
+
+      renderSurveyForm(server, surveyWithTwo, {
+        mode: 'edit',
+        questionVariable: 'var1',
+        resourceType: 'workflow_job_templates',
       });
 
-      renderSurveyForm(server, surveyWithZeroDefault, {
-        mode: 'edit',
-        questionVariable: 'float_variable',
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /answer variable name/i })).toHaveValue('var1');
+      });
+
+      await user.clear(screen.getByRole('textbox', { name: /answer variable name/i }));
+      await user.type(screen.getByRole('textbox', { name: /answer variable name/i }), 'var2');
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Survey already contains a question with variable named "var2"/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should submit integer question with typed non-empty default', async () => {
+      const user = userEvent.setup();
+      const intSurvey = createSurveyWithNumericQuestion({ type: 'integer' });
+
+      let postBody: unknown;
+      server.use(
+        http.get(awxAPI`/job_templates/886/survey_spec/`, () => HttpResponse.json(intSurvey)),
+        http.post(awxAPI`/job_templates/886/survey_spec/`, async ({ request }) => {
+          postBody = await request.json();
+          return HttpResponse.json({});
+        })
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/886/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="int_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/default answer/i)).toBeInTheDocument();
+      });
+
+      const defaultInput = screen.getByLabelText(/default answer/i);
+      await user.clear(defaultInput);
+      await user.type(defaultInput, '42');
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(postBody).toBeDefined();
+      });
+    });
+
+    test('should show error message when POST request fails', async () => {
+      const user = userEvent.setup();
+      const floatSurvey = createSurveyWithNumericQuestion({ type: 'float' });
+
+      server.use(
+        http.get(awxAPI`/job_templates/888/survey_spec/`, () => HttpResponse.json(floatSurvey)),
+        http.post(awxAPI`/job_templates/888/survey_spec/`, () =>
+          HttpResponse.json({ detail: 'Server Error' }, { status: 500 })
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/888/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="int_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to create new survey question.')).toBeInTheDocument();
+      });
+    });
+
+    test('should submit float question and convert default to float', async () => {
+      const user = userEvent.setup();
+      const floatSurvey = createSurveyWithNumericQuestion({ type: 'float', defaultValue: 5 });
+
+      let postBody: unknown;
+      server.use(
+        http.post(awxAPI`/job_templates/887/survey_spec/`, async ({ request }) => {
+          postBody = await request.json();
+          return HttpResponse.json({});
+        }),
+        http.get(awxAPI`/job_templates/887/survey_spec/`, () => HttpResponse.json(floatSurvey))
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/887/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="int_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/default answer/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(postBody).toBeDefined();
+      });
+    });
+
+    test('should submit multiplechoice question with choices', async () => {
+      const user = userEvent.setup();
+      const mcSurvey = createSurveyWithMultiselectQuestion({ type: 'multiplechoice' });
+
+      let postCalled = false;
+      server.use(
+        http.post(awxAPI`/job_templates/456/survey_spec/`, () => {
+          postCalled = true;
+          return HttpResponse.json({});
+        }),
+        http.get(awxAPI`/job_templates/456/survey_spec/`, () => HttpResponse.json(mcSurvey))
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/456/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="test_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(postCalled).toBe(true);
+      });
+    });
+
+    test('should process multiplechoice question with no choices and block submit', async () => {
+      const user = userEvent.setup();
+      const emptyChoicesSurvey: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'MC Question',
+            question_description: '',
+            required: false,
+            type: 'multiplechoice',
+            variable: 'mc_variable',
+            min: 0,
+            max: 1024,
+            choices: [],
+            default: '',
+            new_question: false,
+          },
+        ],
+      };
+
+      server.use(
+        http.get(awxAPI`/job_templates/789/survey_spec/`, () =>
+          HttpResponse.json(emptyChoicesSurvey)
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/789/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="mc_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save survey question/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save survey question/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Submit behavior - Add mode', () => {
+    test('should submit new question in add mode', async () => {
+      const user = userEvent.setup();
+      const emptySurvey: Survey = { name: '', description: '', spec: [] };
+
+      let postCalled = false;
+      server.use(
+        http.post(awxAPI`/workflow_job_templates/123/survey_spec/`, () => {
+          postCalled = true;
+          return HttpResponse.json({});
+        })
+      );
+
+      renderSurveyForm(server, emptySurvey, {
+        mode: 'add',
+        resourceType: 'workflow_job_templates',
       });
 
       await waitFor(() => {
         expect(screen.getByText('Question')).toBeInTheDocument();
       });
 
-      const defaultInput = screen.getByLabelText(/default answer/i);
-      expect(defaultInput).toHaveValue(0);
+      await user.type(screen.getByRole('textbox', { name: /^question$/i }), 'New Question');
+      await user.type(
+        screen.getByRole('textbox', { name: /answer variable name/i }),
+        'new_variable'
+      );
+
+      await user.click(screen.getByRole('button', { name: /create survey question/i }));
+
+      await waitFor(() => {
+        expect(postCalled).toBe(true);
+      });
+    });
+
+    test('should show duplicate error in add mode when variable already exists', async () => {
+      const user = userEvent.setup();
+      const surveyWithExisting: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Existing Question',
+            question_description: '',
+            required: false,
+            type: 'text',
+            variable: 'existing_var',
+            min: 0,
+            max: 1024,
+            choices: '',
+            default: '',
+            new_question: false,
+          },
+        ],
+      };
+
+      renderSurveyForm(server, surveyWithExisting, {
+        mode: 'add',
+        resourceType: 'job_templates',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: /^question$/i }), 'Duplicate Question');
+      await user.type(
+        screen.getByRole('textbox', { name: /answer variable name/i }),
+        'existing_var'
+      );
+
+      await user.click(screen.getByRole('button', { name: /create survey question/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Survey already contains a question with variable named "existing_var"/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Variable validation', () => {
+    test('should show validation error for variable name with spaces', async () => {
+      const user = userEvent.setup();
+      const emptySurvey: Survey = { name: '', description: '', spec: [] };
+
+      renderSurveyForm(server, emptySurvey, {
+        mode: 'add',
+        resourceType: 'workflow_job_templates',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: /^question$/i }), 'My Question');
+      await user.type(
+        screen.getByRole('textbox', { name: /answer variable name/i }),
+        'my variable'
+      );
+
+      await user.click(screen.getByRole('button', { name: /create survey question/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('This field must not contain spaces.')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Navigation behavior', () => {
+    test('should not render form in edit mode when questionVariable is null', async () => {
+      server.use(
+        http.get(awxAPI`/job_templates/321/survey_spec/`, () =>
+          HttpResponse.json({ name: '', description: '', spec: [] })
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/321/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable={null}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole('textbox', { name: /^question$/i })).not.toBeInTheDocument();
+      });
+    });
+
+    test('should not render form when question variable is not found in survey', async () => {
+      server.use(
+        http.get(awxAPI`/job_templates/321/survey_spec/`, () =>
+          HttpResponse.json({ name: '', description: '', spec: [] })
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/321/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="job_templates"
+                  questionVariable="nonexistent_var"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole('textbox', { name: /^question$/i })).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Wrapper components', () => {
+    test('should render AddTemplateSurveyForm with add mode form', async () => {
+      server.use(
+        http.get(awxAPI`/workflow_job_templates/555/survey_spec/`, () =>
+          HttpResponse.json({ name: '', description: '', spec: [] })
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/workflow_job_template/555/survey/add']}>
+          <Routes>
+            <Route
+              path="/templates/workflow_job_template/:id/survey/:mode"
+              element={<AddTemplateSurveyForm resourceType="workflow_job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create survey question/i })).toBeInTheDocument();
+      });
+    });
+
+    test('should render EditTemplateSurveyForm reading questionVariable from URL', async () => {
+      const textSurvey = createSurveyWithTextQuestion({ withDefault: true });
+
+      server.use(
+        http.get(awxAPI`/workflow_job_templates/556/survey_spec/`, () =>
+          HttpResponse.json(textSurvey)
+        )
+      );
+
+      // useURLSearchParams reads window.location (not MemoryRouter) — set it explicitly
+      window.history.replaceState(null, '', '?question_variable=text_variable');
+
+      render(
+        <MemoryRouter initialEntries={['/templates/workflow_job_template/556/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/workflow_job_template/:id/survey/:mode"
+              element={<EditTemplateSurveyForm resourceType="workflow_job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      window.history.replaceState(null, '', '/');
+    });
+  });
+
+  describe('Choices in string format', () => {
+    test('should handle multiplechoice question where choices is a string', async () => {
+      const surveyWithStringChoices: Survey = {
+        name: 'Test Survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'String Choices Question',
+            question_description: '',
+            required: false,
+            type: 'multiplechoice',
+            variable: 'mc_str_variable',
+            min: 0,
+            max: 1024,
+            choices: 'option1\noption2',
+            default: '',
+            new_question: false,
+          },
+        ],
+      };
+
+      server.use(
+        http.get(awxAPI`/workflow_job_templates/777/survey_spec/`, () =>
+          HttpResponse.json(surveyWithStringChoices)
+        )
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/templates/workflow_job_template/777/survey/edit']}>
+          <Routes>
+            <Route
+              path="/templates/workflow_job_template/:id/survey/:mode"
+              element={
+                <TemplateSurveyForm
+                  mode="edit"
+                  resourceType="workflow_job_templates"
+                  questionVariable="mc_str_variable"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('textbox', { name: /^question$/i })).toHaveValue(
+        'String Choices Question'
+      );
     });
   });
 });

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
@@ -866,7 +866,7 @@ describe('TemplateSurveyForm', () => {
     test('should preserve float default value of 0.0', async () => {
       const surveyWithZeroDefault = createSurveyWithFloatQuestion({
         withDefault: true,
-        defaultValue: 0.0,
+        defaultValue: 0,
       });
 
       renderSurveyForm(server, surveyWithZeroDefault, {

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.test.tsx
@@ -767,4 +767,119 @@ describe('TemplateSurveyForm', () => {
       expect(screen.getByRole('button', { name: /save survey question/i })).toBeInTheDocument();
     });
   });
+
+  describe('Integer/Float Default Value of 0 Bug Fix', () => {
+    const createSurveyWithIntegerQuestion = (
+      options: { withDefault?: boolean; defaultValue?: number | string } = {}
+    ): Survey => {
+      const { withDefault = true, defaultValue = 10 } = options;
+
+      const baseSpec: Partial<Spec> = {
+        question_name: 'Test Integer Question',
+        question_description: 'An integer question',
+        required: false,
+        type: 'integer',
+        variable: 'integer_variable',
+        min: 0,
+        max: 1024,
+        choices: '',
+        new_question: false,
+      };
+
+      if (withDefault) {
+        (baseSpec as Spec).default = defaultValue;
+      }
+
+      return {
+        name: 'Test Survey',
+        description: 'Test Survey Description',
+        spec: [baseSpec as Spec],
+      };
+    };
+
+    const createSurveyWithFloatQuestion = (
+      options: { withDefault?: boolean; defaultValue?: number | string } = {}
+    ): Survey => {
+      const { withDefault = true, defaultValue = 5.5 } = options;
+
+      const baseSpec: Partial<Spec> = {
+        question_name: 'Test Float Question',
+        question_description: 'A float question',
+        required: false,
+        type: 'float',
+        variable: 'float_variable',
+        min: 0,
+        max: 100,
+        choices: '',
+        new_question: false,
+      };
+
+      if (withDefault) {
+        (baseSpec as Spec).default = defaultValue;
+      }
+
+      return {
+        name: 'Test Survey',
+        description: 'Test Survey Description',
+        spec: [baseSpec as Spec],
+      };
+    };
+
+    test('should preserve integer default value of 0', async () => {
+      const surveyWithZeroDefault = createSurveyWithIntegerQuestion({
+        withDefault: true,
+        defaultValue: 0,
+      });
+
+      renderSurveyForm(server, surveyWithZeroDefault, {
+        mode: 'edit',
+        questionVariable: 'integer_variable',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      const defaultInput = screen.getByLabelText(/default answer/i);
+      expect(defaultInput).toHaveValue(0);
+    });
+
+    test('should preserve float default value of 0', async () => {
+      const surveyWithZeroDefault = createSurveyWithFloatQuestion({
+        withDefault: true,
+        defaultValue: 0,
+      });
+
+      renderSurveyForm(server, surveyWithZeroDefault, {
+        mode: 'edit',
+        questionVariable: 'float_variable',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      const defaultInput = screen.getByLabelText(/default answer/i);
+      expect(defaultInput).toHaveValue(0);
+    });
+
+    test('should preserve float default value of 0.0', async () => {
+      const surveyWithZeroDefault = createSurveyWithFloatQuestion({
+        withDefault: true,
+        defaultValue: 0.0,
+      });
+
+      renderSurveyForm(server, surveyWithZeroDefault, {
+        mode: 'edit',
+        questionVariable: 'float_variable',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Question')).toBeInTheDocument();
+      });
+
+      const defaultInput = screen.getByLabelText(/default answer/i);
+      expect(defaultInput).toHaveValue(0);
+    });
+  });
 });

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
@@ -192,8 +192,8 @@ export function TemplateSurveyForm(props: IProps) {
     required: question ? question?.required : true,
     type: question?.type ?? 'text',
     variable: question?.variable || '',
-    min: question?.min || minDefault,
-    max: question?.max || maxDefault,
+    min: question?.min ?? minDefault,
+    max: question?.max ?? maxDefault,
     default: question?.default ?? '',
     choices: question?.choices ?? [],
     formattedChoices,
@@ -221,13 +221,16 @@ export function TemplateSurveyForm(props: IProps) {
       return;
     }
 
-    const defaultValue = newQuestion.default
-      ? newQuestion.type === 'integer'
-        ? Number(newQuestion.default)
-        : newQuestion.type === 'float'
-          ? parseFloat(newQuestion.default.toString())
-          : newQuestion?.default?.toString()
-      : '';
+    const defaultValue =
+      newQuestion.default !== null &&
+      newQuestion.default !== undefined &&
+      newQuestion.default !== ''
+        ? newQuestion.type === 'integer'
+          ? Number(newQuestion.default)
+          : newQuestion.type === 'float'
+            ? parseFloat(newQuestion.default.toString())
+            : newQuestion?.default?.toString()
+        : '';
 
     let question: Spec = {
       max: Number(newQuestion.max),

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
@@ -343,7 +343,7 @@ function TemplateSurveyInputs() {
         placeholder={t('Enter answer variable name')}
         validate={(variable: string) => {
           if (/\s/.test(variable)) {
-            return t`This field must not contain spaces.`;
+            return t('This field must not contain spaces.');
           }
           return undefined;
         }}
@@ -484,7 +484,7 @@ function SelectedAnswerType({ answer }: { answer: string }) {
             if (answer === 'integer') {
               const num = parseFloat(value);
               if (!Number.isInteger(num) && /[^0-9]/.test(value)) {
-                return t`This field must be an integer.`;
+                return t('This field must be an integer.');
               }
               return undefined;
             }


### PR DESCRIPTION
## Summary

Fixed a bug where users could not set a default value of `0` for Integer or Float survey questions through the UI. The form submission handler used JavaScript's falsy evaluation (`if (value)`) which incorrectly treated the number `0` as empty, converting it to an empty string instead of preserving the numeric value.

**Changes:**
- Replaced falsy checks with explicit `!== null && !== undefined && !== ''` checks in form submission handler
- Changed min/max initialization from logical OR (`||`) to nullish coalescing (`??`) to preserve `0` bounds
- Added 3 comprehensive unit tests to prevent regression

**Impact:** Users can now set `0` as a default value for integer/float survey questions via the UI without requiring manual API PATCH requests.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

**Justification:** Changes are isolated to survey form submission logic in `TemplateSurveyForm.tsx`. Only affects integer/float question default values. Backward compatible - all existing default values (positive, negative, empty, string) continue to work. Backend API already supports `0` values (no API changes required).

## Dependencies

None. The backend API already accepts `0` as a valid integer/float default value. This is purely a frontend UI validation fix.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

**Test Case 1: Create Integer Survey Question with Default = 0**
1. Navigate to Job Template → Survey tab
2. Click "Add" to create a new survey question
3. Fill in:
   - Question: "Retry Count"
   - Variable: `retry_count`
   - Answer Type: **Integer**
   - Default Answer: **0**
   - Min: 0, Max: 10
4. Click "Save"
5. **Expected Result:** Default shows as `0` in the survey table (not empty)
6. **Verify API:** Inspect the `survey_spec` endpoint - should show `"default": 0` (not `""`)