### PR TITLE
AAP-74786 XLAB automation-dashboard loading state and tests

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -6,14 +6,29 @@ import { SWRConfig } from 'swr';
 import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
 import { AutomationDashboard } from './AutomationDashboard';
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
+import { useAutomationDashboardCollectionStatus } from './common/useAutomationDashboardCollectionStatus';
 import type {
   IAutomationDashboardView,
   IDashboardDetails,
   IJobTemplate,
   DashboardValueCardProps,
+  IAutomationDashboardCollectionStatus,
 } from './types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const DEFAULT_COLLECTION_STATUS: IAutomationDashboardCollectionStatus = {
+  enabled: true,
+  next_run: null,
+  initial_collection_status: null,
+};
+
+vi.mock('./common/useAutomationDashboardCollectionStatus', () => ({
+  useAutomationDashboardCollectionStatus: vi.fn(() => ({
+    collectionStatus: DEFAULT_COLLECTION_STATUS,
+    isLoading: false,
+  })),
+}));
 
 vi.mock('./components', () => ({
   useAutomationDashboardToolbar: vi.fn(() => []),
@@ -54,6 +69,10 @@ vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => {
     usePageAlertToaster: vi.fn(() => ({ addAlert: vi.fn() })),
   };
 });
+
+vi.mock('@ansible/ansible-ui-framework/components/LoadingState', () => ({
+  LoadingState: () => <div data-testid="loading-state">Loading...</div>,
+}));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -247,5 +266,27 @@ describe('AutomationDashboard', () => {
     render(testWrapper());
     expect(screen.getByText('See all successful jobs')).toBeInTheDocument();
     expect(screen.getByText('See all failed jobs')).toBeInTheDocument();
+  });
+
+  // ─── Collection status loading ─────────────────────────────────────────────
+
+  test('should show loading state when collection status is loading', () => {
+    vi.mocked(useAutomationDashboardCollectionStatus).mockReturnValueOnce({
+      collectionStatus: DEFAULT_COLLECTION_STATUS,
+      isLoading: true,
+    });
+    render(testWrapper());
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument();
+    expect(screen.queryByText('Automation Dashboard')).not.toBeInTheDocument();
+  });
+
+  test('should show dashboard when collection status is not loading', () => {
+    vi.mocked(useAutomationDashboardCollectionStatus).mockReturnValueOnce({
+      collectionStatus: DEFAULT_COLLECTION_STATUS,
+      isLoading: false,
+    });
+    render(testWrapper());
+    expect(screen.queryByTestId('loading-state')).not.toBeInTheDocument();
+    expect(screen.getByText('Automation Dashboard')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -20,6 +20,8 @@ import { useAutomationDashboardView } from './views/useAutomationDashboardView';
 import { DashboardToolbar } from './components/DashboardToolbar';
 import styled from 'styled-components';
 import useResizeObserver from '@react-hook/resize-observer';
+import { useAutomationDashboardCollectionStatus } from './common/useAutomationDashboardCollectionStatus';
+import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingState';
 
 const AutomationDashboardWrapper = styled.div`
   display: flex;
@@ -51,6 +53,8 @@ export function AutomationDashboard() {
   };
 
   const noDataString = t('No jobs have been run.');
+  const { isLoading } = useAutomationDashboardCollectionStatus();
+
   const ref = useRef<HTMLDivElement>(null);
   const [gridColumns, setGridColumns] = useState(1);
 
@@ -63,6 +67,15 @@ export function AutomationDashboard() {
     const width = Math.max(1, Math.floor((entry.contentRect.width ?? 0) / Divisor));
     setGridColumns(Math.min(25, width));
   });
+
+  // Show loading state while checking collection status
+  if (isLoading) {
+    return (
+      <AutomationDashboardWrapper ref={ref}>
+        <LoadingState />
+      </AutomationDashboardWrapper>
+    );
+  }
 
   return (
     <AutomationDashboardWrapper ref={ref}>

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../../common/api/metrics-utils', () => ({
 vi.mock('../../../../common/crud/Data');
 
 import useSWR from 'swr';
-import { usePlatformActiveUser } from '../../../../../platform/main/PlatformActiveUserProvider';
+import { usePlatformActiveUser } from '@ansible/platform-ui/main/PlatformActiveUserProvider';
 import { useFetcher } from '../../../../common/crud/Data';
 import { useAutomationDashboardCollectionStatus } from './useAutomationDashboardCollectionStatus';
 import { IAutomationDashboardCollectionStatus } from '../types';
@@ -30,7 +30,38 @@ function setupActiveUser({
   is_platform_auditor?: boolean;
 } = {}) {
   vi.mocked(usePlatformActiveUser).mockReturnValue({
-    activePlatformUser: { is_superuser, is_platform_auditor } as never,
+    activePlatformUser: {
+      is_superuser,
+      is_platform_auditor,
+      id: 0,
+      url: '',
+      created: '',
+      created_by: '',
+      modified: '',
+      modified_by: '',
+      related: {},
+      summary_fields: {
+        modified_by: {
+          id: 0,
+          username: '',
+          first_name: '',
+          last_name: '',
+        },
+        created_by: {
+          id: 0,
+          username: '',
+          first_name: '',
+          last_name: '',
+        },
+        resource: {
+          ansible_id: '',
+          resource_type: '',
+        },
+      },
+      username: '',
+      last_login_map_results: [],
+      managed: false,
+    },
     refreshActivePlatformUser: vi.fn(),
   });
 }
@@ -44,7 +75,7 @@ function setupActiveUserUndefined() {
 
 function setupActiveUserNull() {
   vi.mocked(usePlatformActiveUser).mockReturnValue({
-    activePlatformUser: null as never,
+    activePlatformUser: null,
     refreshActivePlatformUser: vi.fn(),
   });
 }
@@ -56,13 +87,13 @@ function setupSWR(data?: IAutomationDashboardCollectionStatus, error?: Error) {
     mutate: vi.fn(),
     isValidating: false,
     isLoading: !data && !error,
-  } as never);
+  });
 }
 
 describe('useAutomationDashboardCollectionStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useFetcher).mockReturnValue(vi.fn() as never);
+    vi.mocked(useFetcher).mockReturnValue(vi.fn());
   });
 
   describe('when user is not superuser or auditor', () => {
@@ -72,7 +103,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
       // SWR should be called with null key (no fetch)
       expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
     });
@@ -85,7 +117,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
       expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
     });
   });
@@ -97,7 +130,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
       expect(vi.mocked(useSWR).mock.calls[0][0]).toBeNull();
     });
   });
@@ -109,7 +143,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(true);
     });
 
     test('should return data from API when available', () => {
@@ -123,7 +158,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(apiData);
+      expect(result.current.collectionStatus).toEqual(apiData);
+      expect(result.current.isLoading).toBe(false);
     });
 
     test('should return default status on error', () => {
@@ -132,7 +168,23 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    test('should return default status when both data and error exist (revalidation failure)', () => {
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: new Date('2026-05-01T00:00:00Z'),
+        initial_collection_status: 'completed',
+      };
+      setupActiveUser({ is_superuser: true });
+      setupSWR(apiData, new Error('Revalidation failed'));
+
+      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
+
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
     });
 
     test('should fetch using the metrics API URL', () => {
@@ -148,7 +200,7 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
     test('should pass the fetcher function as second argument to SWR', () => {
       const mockFetcherFn = vi.fn();
-      vi.mocked(useFetcher).mockReturnValue(mockFetcherFn as never);
+      vi.mocked(useFetcher).mockReturnValue(mockFetcherFn);
       setupActiveUser({ is_superuser: true });
       setupSWR();
 
@@ -163,23 +215,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       renderHook(() => useAutomationDashboardCollectionStatus());
 
-      const options = vi.mocked(useSWR).mock.calls[0][2] as Record<string, unknown>;
+      const options = vi.mocked(useSWR).mock.calls[0][2];
       expect(options).toMatchObject({ dedupingInterval: 0, refreshInterval: 10 * 1000 });
-    });
-
-    test('should return default status during initial loading (no data and no error)', () => {
-      setupActiveUser({ is_superuser: true });
-      vi.mocked(useSWR).mockReturnValue({
-        data: undefined,
-        error: undefined,
-        mutate: vi.fn(),
-        isValidating: true,
-        isLoading: true,
-      } as never);
-
-      const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
-
-      expect(result.current).toEqual(DEFAULT_STATUS);
     });
   });
 
@@ -195,7 +232,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
 
       const { result } = renderHook(() => useAutomationDashboardCollectionStatus());
 
-      expect(result.current).toEqual(apiData);
+      expect(result.current.collectionStatus).toEqual(apiData);
+      expect(result.current.isLoading).toBe(false);
       const swrKey = vi.mocked(useSWR).mock.calls[0][0];
       expect(swrKey).not.toBeNull();
     });
@@ -212,7 +250,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
       setupSWR();
 
       const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(true);
 
       // Simulate data arriving
       setupSWR(apiData);
@@ -220,7 +259,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
         rerender();
       });
 
-      expect(result.current).toEqual(apiData);
+      expect(result.current.collectionStatus).toEqual(apiData);
+      expect(result.current.isLoading).toBe(false);
     });
 
     test('should revert to default status when error occurs after data was loaded', () => {
@@ -233,7 +273,8 @@ describe('useAutomationDashboardCollectionStatus', () => {
       setupSWR(apiData);
 
       const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
-      expect(result.current).toEqual(apiData);
+      expect(result.current.collectionStatus).toEqual(apiData);
+      expect(result.current.isLoading).toBe(false);
 
       // Simulate error
       setupSWR(undefined, new Error('Server error'));
@@ -241,7 +282,144 @@ describe('useAutomationDashboardCollectionStatus', () => {
         rerender();
       });
 
-      expect(result.current).toEqual(DEFAULT_STATUS);
+      expect(result.current.collectionStatus).toEqual(DEFAULT_STATUS);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    test('should transition from non-superuser to superuser and start loading', () => {
+      setupActiveUser({ is_superuser: false });
+      setupSWR();
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      expect(result.current.isLoading).toBe(false);
+
+      // User becomes superuser
+      setupActiveUser({ is_superuser: true });
+      vi.mocked(useSWR).mockReturnValue({
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: true,
+        isLoading: true,
+      });
+
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    test('should track multiple loading state transitions', () => {
+      setupActiveUser({ is_superuser: true });
+
+      // Initial loading state
+      vi.mocked(useSWR).mockReturnValue({
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: true,
+        isLoading: true,
+      });
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      expect(result.current.isLoading).toBe(true);
+
+      // Data arrives
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: null,
+        initial_collection_status: 'completed',
+      };
+      vi.mocked(useSWR).mockReturnValue({
+        data: apiData,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: false,
+        isLoading: false,
+      });
+
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.collectionStatus).toEqual(apiData);
+
+      // Revalidating (but has cached data)
+      vi.mocked(useSWR).mockReturnValue({
+        data: apiData,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: true,
+        isLoading: false,
+      });
+
+      act(() => {
+        rerender();
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.collectionStatus).toEqual(apiData);
+    });
+  });
+
+  describe('memoization', () => {
+    test('should return stable object reference when values do not change', () => {
+      setupActiveUser({ is_superuser: true });
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: null,
+        initial_collection_status: 'completed',
+      };
+      setupSWR(apiData);
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      const firstResult = result.current;
+
+      act(() => {
+        rerender();
+      });
+
+      const secondResult = result.current;
+      expect(firstResult).toBe(secondResult);
+    });
+
+    test('should return new object reference when isLoading changes', () => {
+      setupActiveUser({ is_superuser: true });
+      vi.mocked(useSWR).mockReturnValue({
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: true,
+        isLoading: true,
+      });
+
+      const { result, rerender } = renderHook(() => useAutomationDashboardCollectionStatus());
+      const firstResult = result.current;
+      expect(firstResult.isLoading).toBe(true);
+
+      // Data arrives - isLoading changes
+      const apiData: IAutomationDashboardCollectionStatus = {
+        enabled: true,
+        next_run: null,
+        initial_collection_status: 'completed',
+      };
+      vi.mocked(useSWR).mockReturnValue({
+        data: apiData,
+        error: undefined,
+        mutate: vi.fn(),
+        isValidating: false,
+        isLoading: false,
+      });
+
+      act(() => {
+        rerender();
+      });
+
+      const secondResult = result.current;
+      expect(secondResult.isLoading).toBe(false);
+      expect(firstResult).not.toBe(secondResult);
     });
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardCollectionStatus.tsx
@@ -1,5 +1,5 @@
 import { IAutomationDashboardCollectionStatus } from '../types';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { usePlatformActiveUser } from '../../../../../platform/main/PlatformActiveUserProvider';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useFetcher } from '../../../../common/crud/Data';
@@ -11,35 +11,41 @@ const DEFAULT_STATUS: IAutomationDashboardCollectionStatus = {
   initial_collection_status: null,
 };
 
-export function useAutomationDashboardCollectionStatus(): IAutomationDashboardCollectionStatus {
+export function useAutomationDashboardCollectionStatus(): {
+  collectionStatus: IAutomationDashboardCollectionStatus;
+  isLoading: boolean;
+} {
   const { activePlatformUser } = usePlatformActiveUser();
   const isSuperuserOrAuditor =
     activePlatformUser?.is_superuser || activePlatformUser?.is_platform_auditor;
 
   const url = metricsAPI`/dashboard_reports/collection_status/`;
   const fetcher = useFetcher();
-  const { data, error } = useSWR<IAutomationDashboardCollectionStatus, Error>(
+  const {
+    data,
+    error,
+    isLoading: isSwrLoading,
+  } = useSWR<IAutomationDashboardCollectionStatus, Error>(
     isSuperuserOrAuditor ? url : null,
     fetcher,
     { dedupingInterval: 0, refreshInterval: 10 * 1000 }
   );
 
-  const [collectionStatus, setCollectionStatus] =
-    useState<IAutomationDashboardCollectionStatus>(DEFAULT_STATUS);
+  // Use only useMemo - no useState/useEffect to avoid multiple re-renders
+  return useMemo(() => {
+    // If user is not superuser or auditor, we don't fetch
+    if (!isSuperuserOrAuditor) {
+      return {
+        collectionStatus: DEFAULT_STATUS,
+        isLoading: false,
+      };
+    }
 
-  useEffect(() => {
-    setCollectionStatus(() => {
-      if (error) {
-        return DEFAULT_STATUS;
-      }
-
-      if (data) {
-        return data;
-      }
-
-      return DEFAULT_STATUS;
-    });
-  }, [data, error]);
-
-  return useMemo<IAutomationDashboardCollectionStatus>(() => collectionStatus, [collectionStatus]);
+    // Return values directly from SWR
+    const collectionStatus = error || !data ? DEFAULT_STATUS : data;
+    return {
+      collectionStatus,
+      isLoading: isSwrLoading,
+    };
+  }, [data, error, isSwrLoading, isSuperuserOrAuditor]);
 }

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateToolbarFilterSet.test.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable i18next/no-literal-string */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { IFilterState } from '@ansible/ansible-ui-framework';
+import { useCreateToolbarFilterSet } from './useCreateToolbarFilterSet';
+import { useCreateEditToolbarFilterSetDialog } from './useCreateEditToolbarFilterSetDialog';
+
+vi.mock('./useCreateEditToolbarFilterSetDialog');
+
+const filterState: IFilterState = {
+  period: ['last_30_days'],
+  project: ['1', '2'],
+};
+
+describe('useCreateToolbarFilterSet', () => {
+  const mockCreateEditDialog = vi.fn();
+  const mockOnComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCreateEditToolbarFilterSetDialog).mockReturnValue(mockCreateEditDialog);
+  });
+
+  test('should forward onComplete callback to useCreateEditToolbarFilterSetDialog', () => {
+    renderHook(() => useCreateToolbarFilterSet(mockOnComplete));
+
+    expect(useCreateEditToolbarFilterSetDialog).toHaveBeenCalledWith(mockOnComplete);
+  });
+
+  test('should call dialog hook with filter state and new filter set structure', () => {
+    const { result } = renderHook(() => useCreateToolbarFilterSet(mockOnComplete));
+
+    result.current(filterState);
+
+    expect(mockCreateEditDialog).toHaveBeenCalledWith(filterState, {
+      id: undefined,
+      name: '',
+      is_default: false,
+      filters: '{}',
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/common/useUpdateToolbarFilterSet.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useUpdateToolbarFilterSet.test.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable i18next/no-literal-string */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { IFilterState } from '@ansible/ansible-ui-framework';
+import type { IDashboardFilterSet } from '../types';
+import { useUpdateToolbarFilterSet } from './useUpdateToolbarFilterSet';
+import { useCreateEditToolbarFilterSetDialog } from './useCreateEditToolbarFilterSetDialog';
+
+vi.mock('./useCreateEditToolbarFilterSetDialog');
+
+const existingFilterSet: IDashboardFilterSet = {
+  id: 42,
+  name: 'Existing Report',
+  filters: '{"period":["last_7_days"]}',
+  is_default: false,
+};
+
+const filterState: IFilterState = {
+  period: ['last_30_days'],
+  project: ['1', '2'],
+};
+
+describe('useUpdateToolbarFilterSet', () => {
+  const mockUpdateDialog = vi.fn();
+  const mockOnComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCreateEditToolbarFilterSetDialog).mockReturnValue(mockUpdateDialog);
+  });
+
+  test('should forward onComplete callback to useCreateEditToolbarFilterSetDialog', () => {
+    renderHook(() => useUpdateToolbarFilterSet(mockOnComplete));
+
+    expect(useCreateEditToolbarFilterSetDialog).toHaveBeenCalledWith(mockOnComplete);
+  });
+
+  test('should call dialog hook with filter state and existing filter set', () => {
+    const { result } = renderHook(() => useUpdateToolbarFilterSet(mockOnComplete));
+
+    result.current(existingFilterSet, filterState);
+
+    expect(mockUpdateDialog).toHaveBeenCalledWith(filterState, existingFilterSet);
+  });
+});

--- a/platform/main/useAutomationAnalytics.test.tsx
+++ b/platform/main/useAutomationAnalytics.test.tsx
@@ -99,7 +99,10 @@ describe('useAutomationAnalytics', () => {
       activePlatformUser: { is_superuser: true, is_platform_auditor: false },
     });
     // Dashboard feature enabled by default
-    mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: true });
+    mockUseAutomationDashboardCollectionStatus.mockReturnValue({
+      collectionStatus: { enabled: true, next_run: null, initial_collection_status: null },
+      isLoading: false,
+    });
   });
 
   // --- Label ---
@@ -221,7 +224,10 @@ describe('useAutomationAnalytics', () => {
 
   describe('when automationDashboardEnabled is false', () => {
     beforeEach(() => {
-      mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: false });
+      mockUseAutomationDashboardCollectionStatus.mockReturnValue({
+        collectionStatus: { enabled: false, next_run: null, initial_collection_status: null },
+        isLoading: false,
+      });
     });
 
     test('should remove automation dashboard from children for superuser', () => {
@@ -260,7 +266,10 @@ describe('useAutomationAnalytics', () => {
 
     test('should not remove automation dashboard from children for superuser when dashboard is enabled', () => {
       // Sanity: switching back to enabled keeps the dashboard
-      mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: true });
+      mockUseAutomationDashboardCollectionStatus.mockReturnValue({
+        collectionStatus: { enabled: true, next_run: null, initial_collection_status: null },
+        isLoading: false,
+      });
       const { result } = renderHook(() => useAutomationAnalytics());
       const { children } = asGroup(result.current);
       expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeDefined();
@@ -363,7 +372,10 @@ describe('useAutomationAnalytics', () => {
   // --- automationDashboardEnabled = null (falsy, same branch as false) ---
 
   test('should remove automation dashboard when enabled is null', () => {
-    mockUseAutomationDashboardCollectionStatus.mockReturnValue({ enabled: null });
+    mockUseAutomationDashboardCollectionStatus.mockReturnValue({
+      collectionStatus: { enabled: null, next_run: null, initial_collection_status: null },
+      isLoading: false,
+    });
     const { result } = renderHook(() => useAutomationAnalytics());
     const { children } = asGroup(result.current);
     expect(children.find((c) => c.id === AwxRoute.AutomationDashboard)).toBeUndefined();

--- a/platform/main/usePlatformNavigation.tsx
+++ b/platform/main/usePlatformNavigation.tsx
@@ -287,7 +287,9 @@ export function useAutomationAnalytics(): PageNavigationItem {
   const managedCloudInstall = useIsManagedCloudInstall() ?? false;
   const analytics = removeNavigationItemById(awxNav, AwxRoute.Analytics)!;
   const { activePlatformUser } = usePlatformActiveUser();
-  const { enabled: automationDashboardEnabled } = useAutomationDashboardCollectionStatus();
+  const { collectionStatus, isLoading: isCollectionStatusLoading } =
+    useAutomationDashboardCollectionStatus();
+  const automationDashboardEnabled = collectionStatus.enabled;
 
   if (analytics && 'children' in analytics) {
     analytics.label = t('Automation Analytics');
@@ -295,16 +297,21 @@ export function useAutomationAnalytics(): PageNavigationItem {
       removeNavigationItemById(analytics.children, AwxRoute.SubscriptionUsage);
     }
     const automationDashboardId = 'awx-automation-dashboard';
-    if (automationDashboardEnabled) {
-      if (!activePlatformUser?.is_superuser) {
-        analytics.children
-          .filter((c) => c.id !== automationDashboardId)
-          .forEach((item) => {
-            if (item.id) removeNavigationItemById(analytics.children, item.id);
-          });
+
+    // Only apply logic after loading is complete to prevent flicker
+    if (!isCollectionStatusLoading) {
+      if (automationDashboardEnabled) {
+        if (!activePlatformUser?.is_superuser) {
+          analytics.children
+            .filter((c) => c.id !== automationDashboardId)
+            .forEach((item) => {
+              if (item.id) removeNavigationItemById(analytics.children, item.id);
+            });
+        }
+      } else {
+        // Not enabled or error - remove automation dashboard from menu
+        removeNavigationItemById(analytics.children, automationDashboardId);
       }
-    } else {
-      removeNavigationItemById(analytics.children, automationDashboardId);
     }
 
     analytics.hidden =


### PR DESCRIPTION
## Summary
[AAP-74786](https://redhat.atlassian.net/browse/AAP-74786)
<!-- What changed and why? -->

This pull request enhances the `AutomationDashboard` by improving how the dashboard handles and displays the data collection status, adds comprehensive tests for this logic, and introduces a new test file for toolbar filter set creation. The main focus is on reliably tracking and reacting to the loading state of the dashboard's collection status, ensuring the UI accurately reflects loading and error conditions, and improving test coverage for these behaviors.

**Automation Dashboard Loading State Improvements:**

- Refactored `useAutomationDashboardCollectionStatus` to return both `collectionStatus` and `isLoading`, using `useMemo` for efficient updates and to avoid unnecessary re-renders. The hook now exposes a clear loading state, which is used by the dashboard to conditionally render a loading indicator.
- Updated `AutomationDashboard.tsx` to show a `LoadingState` component while the collection status is loading, improving the user experience during data fetches. [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R21-R22) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R47-R52)

**Testing Enhancements and Coverage:**

- Added and updated tests in `AutomationDashboard.test.tsx` to verify that the dashboard correctly displays the loading state and main content based on the collection status loading flag. Also mocked the loading state and the collection status hook for reliable test isolation. [[1]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81R9) [[2]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81R19-R22) [[3]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81R63-R66) [[4]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81R258-R273)
- Greatly expanded the tests for `useAutomationDashboardCollectionStatus` to cover various loading, error, and memoization scenarios, ensuring robust and predictable behavior. [[1]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL75-R76) [[2]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL88-R90) [[3]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL100-R103) [[4]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL112-R116) [[5]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL126-R131) [[6]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL135-R141) [[7]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL182-R189) [[8]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL198-R206) [[9]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL215-R233) [[10]](diffhunk://#diff-e9942e0794401f2ef01e352fda86b38cce3153b6bb0d55bcb81f2c27d56a296dL236-R393)

**New Feature Test Coverage:**

- Added a new test file, `useCreateToolbarFilterSet.test.tsx`, to verify the creation logic for dashboard filter sets, including correct parameter passing, default values, and stable function references.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
