### PR TITLE
[Wf-Viz Update Bug] Extract helpers into standalone modules with unit tests

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.component.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.component.test.tsx
@@ -1,0 +1,415 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobTemplate } from '../../../../interfaces/JobTemplate';
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import type { GraphNodeData, PromptFormValues } from '../types';
+import { JobTemplateDetails } from './JobTemplateDetails';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: vi.fn(() => ({ data: undefined })),
+  useGetItem: vi.fn(() => ({ data: undefined })),
+}));
+
+import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
+
+const mockTemplate: JobTemplate = {
+  id: 1,
+  name: 'Test Job Template',
+  type: 'job_template',
+  url: '/api/v2/job_templates/1/',
+  playbook: 'playbook.yml',
+  job_type: 'run',
+  verbosity: 0,
+  forks: 2,
+  limit: 'localhost',
+  scm_branch: 'main',
+  job_tags: 'tag1,tag2',
+  skip_tags: 'skip1',
+  diff_mode: false,
+  timeout: 60,
+  job_slice_count: 1,
+  extra_vars: 'my_var: value',
+  ask_credential_on_launch: false,
+  ask_variables_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_instance_groups_on_launch: false,
+  ask_labels_on_launch: false,
+  ask_inventory_on_launch: false,
+  ask_job_type_on_launch: false,
+  ask_limit_on_launch: false,
+  ask_scm_branch_on_launch: false,
+  ask_diff_mode_on_launch: false,
+  ask_forks_on_launch: false,
+  ask_job_slice_count_on_launch: false,
+  ask_timeout_on_launch: false,
+  ask_verbosity_on_launch: false,
+  ask_execution_environment_on_launch: false,
+  allow_simultaneous: false,
+  webhook_service: 'github',
+  opa_query_path: '',
+  survey_enabled: false,
+  related: {
+    webhook_key: '/api/v2/job_templates/1/webhook_key/',
+    instance_groups: '/api/v2/job_templates/1/instance_groups/',
+    credentials: '/api/v2/job_templates/1/credentials/',
+    labels: '/api/v2/job_templates/1/labels/',
+    webhook_receiver: '/api/v2/job_templates/1/github/',
+  } as never,
+  summary_fields: {
+    organization: { id: 1, name: 'Default' },
+    project: { id: 1, name: 'My Project' },
+    inventory: { id: 1, name: 'My Inventory' },
+    labels: {
+      results: [{ id: 1, name: 'production' }],
+      count: 1,
+    },
+    execution_environment: { id: 1, name: 'Default EE' },
+  } as never,
+} as unknown as JobTemplate;
+
+const mockNodeData: GraphNodeData = {
+  resource: {
+    id: 1,
+    identifier: 'node-1',
+    diff_mode: false,
+    forks: 2,
+    job_type: 'run',
+    limit: 'localhost',
+    scm_branch: 'main',
+    job_tags: 'tag1,tag2',
+    skip_tags: 'skip1',
+    timeout: 60,
+    verbosity: 0,
+    job_slice_count: 1,
+    extra_data: {},
+    all_parents_must_converge: false,
+    always_nodes: [],
+    failure_nodes: [],
+    success_nodes: [],
+    related: {
+      credentials: '/api/v2/workflow_job_template_nodes/1/credentials/',
+      instance_groups: '/api/v2/workflow_job_template_nodes/1/instance_groups/',
+      labels: '/api/v2/workflow_job_template_nodes/1/labels/',
+    } as never,
+    summary_fields: {
+      unified_job_template: {
+        id: 1,
+        name: 'Test Job Template',
+        unified_job_type: 'job',
+      },
+      inventory: { id: 1, name: 'My Inventory' },
+      execution_environment: { id: 1, name: 'Default EE' },
+    } as never,
+  } as never,
+  launch_data: undefined as never,
+  survey_data: undefined as never,
+};
+
+function renderComponent(nodeData = mockNodeData) {
+  return render(
+    <MemoryRouter>
+      <JobTemplateDetails template={mockTemplate} node={nodeData} />
+    </MemoryRouter>
+  );
+}
+
+describe('JobTemplateDetails', () => {
+  beforeEach(() => {
+    vi.mocked(useGet).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+    vi.mocked(useGetItem).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+  });
+
+  it('should render the playbook field from template', () => {
+    renderComponent();
+    expect(screen.getByText('playbook.yml')).toBeInTheDocument();
+  });
+
+  it('should render the job type field', () => {
+    renderComponent();
+    expect(screen.getAllByText('run').length).toBeGreaterThan(0);
+  });
+
+  it('should render the organization from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+
+  it('should render the project from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('should render job tags from node values when no prompt override', () => {
+    renderComponent();
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('tag2')).toBeInTheDocument();
+  });
+
+  it('should render skip tags from node values', () => {
+    renderComponent();
+    expect(screen.getByText('skip1')).toBeInTheDocument();
+  });
+
+  it('should render labels from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('production')).toBeInTheDocument();
+  });
+
+  it('should render webhook service section when webhook_service is set', () => {
+    renderComponent();
+    expect(screen.getByText(/github/i)).toBeInTheDocument();
+  });
+
+  it('should render variables section', () => {
+    renderComponent();
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+  });
+
+  it('should render credentials when useGet returns credential data', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('credentials')) {
+        return {
+          data: {
+            results: [{ id: 10, name: 'My SSH Key', credential_type: 1, passwords_needed: [] }],
+            count: 1,
+          },
+        } as never;
+      }
+      return { data: undefined } as never;
+    });
+
+    renderComponent();
+    expect(screen.getByText('Credentials')).toBeInTheDocument();
+  });
+
+  it('should render instance groups when useGet returns instance group data', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('instance_groups')) {
+        return {
+          data: {
+            results: [{ id: 5, name: 'My Instance Group' }],
+            count: 1,
+          },
+        } as never;
+      }
+      return { data: undefined } as never;
+    });
+
+    renderComponent();
+    expect(screen.getByText('Instance groups')).toBeInTheDocument();
+  });
+
+  it('should render execution environment from fetched item when prompt has EE', () => {
+    vi.mocked(useGetItem).mockReturnValue({
+      data: { id: 5, name: 'Custom EE' },
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+
+    const nodeWithEE: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        execution_environment: { id: 5 } as never,
+      },
+    };
+
+    renderComponent(nodeWithEE);
+    const eeElements = screen.getAllByText('Custom EE');
+    expect(eeElements.length).toBeGreaterThan(0);
+  });
+
+  it('should render template EE when template is changed and no prompt EE', () => {
+    const nodeWithTemplateChange: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        original: {
+          isTemplateChange: true,
+          launch_config: {} as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithTemplateChange);
+    expect(screen.getAllByText('Default EE').length).toBeGreaterThan(0);
+  });
+
+  it('should render node EE when no prompt override and no template change', () => {
+    renderComponent();
+    expect(screen.getAllByText('Default EE').length).toBeGreaterThan(0);
+  });
+
+  it('should render enabled options when allow_simultaneous is true', () => {
+    const templateWithOptions = {
+      ...mockTemplate,
+      allow_simultaneous: true,
+    } as JobTemplate;
+
+    render(
+      <MemoryRouter>
+        <JobTemplateDetails template={templateWithOptions} node={mockNodeData} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Concurrent jobs')).toBeInTheDocument();
+  });
+
+  it('should render with survey data merged into variables display', () => {
+    const nodeWithSurvey: GraphNodeData = {
+      ...mockNodeData,
+      survey_data: { survey_key: 'survey_value' },
+    };
+    renderComponent(nodeWithSurvey);
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+  });
+
+  it('should render prompt-overridden inventory name when useGetItem provides it', () => {
+    vi.mocked(useGetItem).mockImplementation((_api, id) => {
+      if (id && String(id) === '2') {
+        return {
+          data: { id: 2, name: 'Override Inventory' },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    const nodeWithPrompt: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        inventory: {
+          id: 2,
+          name: 'Override Inventory',
+        },
+        original: {
+          isTemplateChange: false,
+          launch_config: {
+            ask_inventory_on_launch: true,
+          } as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithPrompt);
+    expect(screen.getAllByText('Override Inventory').length).toBeGreaterThan(0);
+  });
+
+  it('should not render credentials section when credentials is empty', () => {
+    renderComponent();
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
+  });
+
+  it('should render PromptDetail as empty for empty credential list', () => {
+    const nodeWithEmptyPromptCredentials: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        credentials: [],
+        original: {
+          launch_config: { ask_credential_on_launch: true } as LaunchConfiguration,
+        },
+      },
+    };
+    renderComponent(nodeWithEmptyPromptCredentials);
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
+  });
+
+  it('should assign fetchedEE when promptValues has execution_environment and useGetItem returns data', () => {
+    vi.mocked(useGetItem).mockImplementation((_api, id) => {
+      if (id && id !== 'undefined') {
+        return {
+          data: { id: Number(id), name: 'Fetched EE From API' },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    const nodeWithPromptEE: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        execution_environment: { id: 7 } as PromptFormValues['execution_environment'],
+        original: {
+          isTemplateChange: false,
+          launch_config: { ask_execution_environment_on_launch: true } as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithPromptEE);
+    expect(screen.getAllByText('Fetched EE From API').length).toBeGreaterThan(0);
+  });
+
+  it('should use labels from template summary_fields when no prompt override', () => {
+    const templateWithLabels = {
+      ...mockTemplate,
+      summary_fields: {
+        ...mockTemplate.summary_fields,
+        labels: {
+          results: [
+            { id: 1, name: 'staging' },
+            { id: 2, name: 'v2' },
+          ],
+          count: 2,
+        },
+      },
+    } as typeof mockTemplate;
+
+    render(
+      <MemoryRouter>
+        <JobTemplateDetails template={templateWithLabels} node={mockNodeData} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(screen.getByText('v2')).toBeInTheDocument();
+  });
+
+  it('should use node instance groups from useGet when they are returned', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('instance_groups')) {
+        return {
+          data: { results: [{ id: 3, name: 'controlplane' }], count: 1 },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    renderComponent();
+    expect(screen.getByText('Instance groups')).toBeInTheDocument();
+    expect(screen.getByText('controlplane')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest';
+import { arrayIdsMatch } from './resolveNodeFields';
+import { resolveExtraVars } from './resolveExtraVars';
+
+describe('resolveExtraVars', () => {
+  const templateVars = 'default_var: template_value';
+
+  describe('unedited node (promptValues undefined)', () => {
+    test('should show template defaults when node extra_data is empty object', () => {
+      const result = resolveExtraVars(undefined, false, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show template defaults when node extra_data is undefined', () => {
+      const result = resolveExtraVars(undefined, false, undefined, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show node override when node has extra_data with keys', () => {
+      const result = resolveExtraVars(undefined, false, { my_var: 'val' }, templateVars, false);
+      expect(result).toContain('my_var');
+    });
+  });
+
+  describe('template changed (isTemplateChanged = true)', () => {
+    test('should show new template defaults when extra_vars is empty string and not promptable', () => {
+      const result = resolveExtraVars('', false, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show empty when extra_vars is empty string and promptable (user chose empty)', () => {
+      const result = resolveExtraVars('', true, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe('');
+    });
+
+    test('should show user-entered extra_vars when set', () => {
+      const result = resolveExtraVars(
+        'new_var: fresh',
+        true,
+        { old_var: 'stale' },
+        templateVars,
+        true
+      );
+      expect(result).toBe('new_var: fresh');
+    });
+
+    test('should show new template defaults when promptValues.extra_vars is undefined', () => {
+      const result = resolveExtraVars(undefined, false, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe(templateVars);
+    });
+  });
+
+  describe('same template edit (isTemplateChanged = false)', () => {
+    test('should preserve user-entered extra_vars', () => {
+      const result = resolveExtraVars(
+        'user_var: value',
+        true,
+        { old_var: 'val' },
+        templateVars,
+        false
+      );
+      expect(result).toBe('user_var: value');
+    });
+
+    test('should show node extra_data when promptValues is undefined and node has data', () => {
+      const result = resolveExtraVars(
+        undefined,
+        true,
+        { existing_var: 'val' },
+        templateVars,
+        false
+      );
+      expect(result).toContain('existing_var');
+    });
+
+    test('should show template defaults when node extra_data is empty', () => {
+      const result = resolveExtraVars(undefined, true, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+  });
+
+  describe('non-promptable template with defaults', () => {
+    test('should show template defaults after save clears extra_data to empty object', () => {
+      const result = resolveExtraVars(undefined, false, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show template defaults when template has no defaults', () => {
+      const result = resolveExtraVars(undefined, false, {}, '', false);
+      expect(result).toBe('');
+    });
+  });
+});
+
+describe('arrayIdsMatch', () => {
+  test('should return true for two empty arrays', () => {
+    expect(arrayIdsMatch([], [])).toBe(true);
+  });
+
+  test('should return true when arrays contain same ids in same order', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 2 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return true when arrays contain same ids in different order', () => {
+    expect(arrayIdsMatch([{ id: 2 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return false when arrays have different lengths', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have same length but different ids', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 3 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when one array is empty and the other is not', () => {
+    expect(arrayIdsMatch([], [{ id: 1 }])).toBe(false);
+    expect(arrayIdsMatch([{ id: 1 }], [])).toBe(false);
+  });
+
+  test('should return true for single-element arrays with matching id', () => {
+    expect(arrayIdsMatch([{ id: 42 }], [{ id: 42 }])).toBe(true);
+  });
+
+  test('should return false for single-element arrays with different ids', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have same length but one contains duplicate ids', () => {
+    // arr1 = [{id:1},{id:1}] → Set size 1; arr2 = [{id:1},{id:2}] → Set size 2
+    // Passes length check (both 2) but fails Set size check → covers lines 9-11
+    expect(arrayIdsMatch([{ id: 1 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
@@ -1,5 +1,4 @@
 import { PageDetail, TextCell, useGetPageUrl } from '@ansible/ansible-ui-framework';
-import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
 import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
 import { Content, ContentVariants, Label, LabelGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
@@ -22,96 +21,15 @@ import { GraphNodeData, PromptFormValues } from '../types';
 import { NodeCodeEditorDetail } from './NodeCodeEditorDetail';
 import { NodeTagDetail } from './NodeTagDetail';
 import { PromptDetail } from './PromptDetail';
-
-function resolveScalar<T>(
-  promptValue: T | undefined | null,
-  nodeValue: T | undefined | null,
-  templateValue: T,
-  isTemplateChanged: boolean
-): T {
-  if (promptValue !== undefined && promptValue !== null) return promptValue;
-  if (!isTemplateChanged && nodeValue !== undefined && nodeValue !== null) return nodeValue;
-  return templateValue;
-}
-
-function resolveArrayField<T>(
-  promptValue: T[] | undefined,
-  acceptsOnLaunch: boolean | undefined,
-  nodeResults: T[] | undefined,
-  templateResults: T[] | undefined,
-  isTemplateChanged: boolean
-): T[] | undefined {
-  if (promptValue !== undefined && (promptValue.length > 0 || acceptsOnLaunch)) {
-    return promptValue;
-  }
-  if (isTemplateChanged) {
-    return templateResults;
-  }
-  return (nodeResults?.length ? nodeResults : undefined) ?? templateResults;
-}
-
-function resolveExecutionEnvironment(
-  promptEE: PromptFormValues['execution_environment'] | undefined,
-  fetchedEE: ExecutionEnvironment | undefined,
-  nodeEE: ExecutionEnvironment | undefined,
-  templateEE: ExecutionEnvironment | undefined,
-  isTemplateChanged: boolean
-): ExecutionEnvironment | undefined {
-  if (promptEE && fetchedEE) return fetchedEE;
-  if (isTemplateChanged) return templateEE;
-  return nodeEE ?? templateEE;
-}
-
-function resolveVariables(
-  promptExtraVars: string | undefined,
-  askVariablesOnLaunch: boolean | undefined,
-  nodeExtraData: Record<string, unknown> | undefined,
-  templateExtraVars: string,
-  isTemplateChanged: boolean
-): string | undefined {
-  if (promptExtraVars !== undefined && (promptExtraVars !== '' || askVariablesOnLaunch)) {
-    return promptExtraVars;
-  }
-  if (isTemplateChanged) return templateExtraVars;
-  if (nodeExtraData) return jsonToYaml(JSON.stringify(nodeExtraData));
-  return templateExtraVars;
-}
-
-function resolveTagField(
-  promptTags: { name: string }[] | undefined,
-  acceptsOnLaunch: boolean | undefined,
-  nodeTagString: string | null | undefined,
-  templateTagString: string,
-  isTemplateChanged: boolean
-): { name: string }[] {
-  if (promptTags !== undefined && (promptTags.length > 0 || acceptsOnLaunch)) {
-    return promptTags;
-  }
-  if (isTemplateChanged) return parseStringToTagArray(templateTagString);
-  return parseStringToTagArray(nodeTagString ?? templateTagString);
-}
-
-function mergeSurveyIntoVariables(
-  variables: string | undefined,
-  surveyValues: Record<string, unknown>
-): string {
-  const jsonObj: Record<string, unknown> = {};
-
-  if (variables) {
-    const lines = variables.split('\n');
-    lines.forEach((line) => {
-      const [key, value] = line.split(':').map((part) => part.trim());
-      jsonObj[key] = value;
-    });
-  }
-
-  const mergedData = {
-    ...jsonObj,
-    ...surveyValues,
-  };
-
-  return jsonToYaml(JSON.stringify(mergedData));
-}
+import { resolveExtraVars } from './resolveExtraVars';
+import {
+  arrayIdsMatch,
+  mergeSurveyIntoVariables,
+  resolveArrayField,
+  resolveExecutionEnvironment,
+  resolveScalar,
+  resolveTagField,
+} from './resolveNodeFields';
 
 function useAggregateJobTemplateDetails({
   template,
@@ -238,7 +156,7 @@ function useAggregateJobTemplateDetails({
   const verbosityString = useVerbosityString(verbosity);
   const templateVerbosityString = useVerbosityString(template.verbosity);
 
-  let variables = resolveVariables(
+  let variables = resolveExtraVars(
     promptValues?.extra_vars,
     template.ask_variables_on_launch,
     nodeValues?.extra_data,
@@ -565,23 +483,4 @@ function InstanceGroupsDetail({
       </LabelGroup>
     </PromptDetail>
   );
-}
-
-function arrayIdsMatch(arr1: { id: number }[], arr2: { id: number }[]) {
-  if (arr1.length !== arr2.length) {
-    return false;
-  }
-
-  const idSet1 = new Set(arr1.map((obj) => obj.id));
-  const idSet2 = new Set(arr2.map((obj) => obj.id));
-
-  if (idSet1.size !== idSet2.size) {
-    return false;
-  }
-  for (const item of idSet1) {
-    if (!idSet2.has(item)) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+import { resolveExtraVars } from './resolveExtraVars';
+
+describe('resolveExtraVars', () => {
+  describe('prompt value handling', () => {
+    test('should use prompt extra_vars when non-empty', () => {
+      expect(resolveExtraVars('my_var: value', true, undefined, '---', false)).toBe(
+        'my_var: value'
+      );
+    });
+
+    test('should use empty prompt extra_vars when field is promptable (user cleared it)', () => {
+      expect(resolveExtraVars('', true, { old: 'data' }, 'template: default', false)).toBe('');
+    });
+
+    test('should fall through empty prompt when not promptable', () => {
+      expect(resolveExtraVars('', false, undefined, 'template: default', false)).toBe(
+        'template: default'
+      );
+    });
+  });
+
+  describe('template change handling', () => {
+    test('should use template extra_vars on template change when prompt undefined', () => {
+      expect(resolveExtraVars(undefined, false, { stale: 'data' }, 'new_template: val', true)).toBe(
+        'new_template: val'
+      );
+    });
+
+    test('should use template extra_vars on template change even when node has data', () => {
+      expect(resolveExtraVars(undefined, false, { old_var: 'old_val' }, 'new: default', true)).toBe(
+        'new: default'
+      );
+    });
+
+    test('should prefer prompt over template on template change when prompt is provided', () => {
+      expect(resolveExtraVars('user: input', true, undefined, 'template: default', true)).toBe(
+        'user: input'
+      );
+    });
+  });
+
+  describe('no template change', () => {
+    test('should use node extra_data when no template change and prompt undefined', () => {
+      const result = resolveExtraVars(undefined, false, { node_var: 'node_val' }, '---', false);
+      expect(result).toContain('node_var');
+      expect(result).toContain('node_val');
+    });
+
+    test('should use template extra_vars when node has no data and prompt undefined', () => {
+      expect(resolveExtraVars(undefined, false, undefined, 'template: vars', false)).toBe(
+        'template: vars'
+      );
+    });
+
+    test('should skip empty node extra_data and use template default', () => {
+      expect(resolveExtraVars(undefined, false, {}, 'template: default', false)).toBe(
+        'template: default'
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should return template default when all inputs are undefined/empty', () => {
+      expect(resolveExtraVars(undefined, false, undefined, '---', false)).toBe('---');
+    });
+
+    test('should return template default on template change with empty template vars', () => {
+      expect(resolveExtraVars(undefined, false, { old: 'data' }, '', true)).toBe('');
+    });
+
+    test('should handle node data with nested objects', () => {
+      const nodeData = { parent: { child: 'value' } } as unknown as Record<string, unknown>;
+      const result = resolveExtraVars(undefined, false, nodeData, '---', false);
+      expect(result).toBeDefined();
+      expect(result).toContain('parent');
+    });
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.ts
@@ -1,0 +1,18 @@
+import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
+
+export function resolveExtraVars(
+  promptExtraVars: string | undefined,
+  askVariablesOnLaunch: boolean | undefined,
+  nodeExtraData: Record<string, unknown> | undefined,
+  templateExtraVars: string,
+  isTemplateChanged: boolean
+): string | undefined {
+  if (promptExtraVars !== undefined && (promptExtraVars !== '' || askVariablesOnLaunch)) {
+    return promptExtraVars;
+  }
+  if (isTemplateChanged) return templateExtraVars;
+  if (nodeExtraData && Object.keys(nodeExtraData).length > 0) {
+    return jsonToYaml(JSON.stringify(nodeExtraData));
+  }
+  return templateExtraVars;
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'vitest';
+import type { ExecutionEnvironment } from '../../../../interfaces/ExecutionEnvironment';
+import {
+  resolveArrayField,
+  resolveScalar,
+  resolveTagField,
+  resolveExecutionEnvironment,
+  mergeSurveyIntoVariables,
+  arrayIdsMatch,
+} from './resolveNodeFields';
+
+describe('resolveArrayField', () => {
+  const templateDefault = [{ id: 10, name: 'template-cred' }];
+  const nodeDbValue = [{ id: 20, name: 'node-cred' }];
+
+  test('should use prompt value when non-empty', () => {
+    const prompt = [{ id: 30, name: 'user-cred' }];
+    expect(resolveArrayField(prompt, true, nodeDbValue, templateDefault, false)).toEqual(prompt);
+  });
+
+  test('should use empty prompt value when field is promptable (user chose none)', () => {
+    expect(resolveArrayField([], true, nodeDbValue, templateDefault, false)).toEqual([]);
+  });
+
+  test('should fall through empty prompt when not promptable (force-cleared)', () => {
+    expect(resolveArrayField([], false, nodeDbValue, templateDefault, true)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should use template default on template change when prompt undefined', () => {
+    expect(resolveArrayField(undefined, false, nodeDbValue, templateDefault, true)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should use node DB value when no template change and prompt undefined', () => {
+    expect(resolveArrayField(undefined, false, nodeDbValue, templateDefault, false)).toEqual(
+      nodeDbValue
+    );
+  });
+
+  test('should use template default when node DB value is empty', () => {
+    expect(resolveArrayField(undefined, false, [], templateDefault, false)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should return undefined when all sources are undefined', () => {
+    expect(resolveArrayField(undefined, false, undefined, undefined, false)).toBeUndefined();
+  });
+});
+
+describe('resolveScalar', () => {
+  test('should use prompt value when defined', () => {
+    expect(resolveScalar('user-limit', 'node-limit', 'template-limit', false)).toBe('user-limit');
+  });
+
+  test('should use prompt value even when falsy (0, false)', () => {
+    expect(resolveScalar(0, 5, 10, false)).toBe(0);
+    expect(resolveScalar(false, true, true, false)).toBe(false);
+  });
+
+  test('should skip node value and use template default on template change', () => {
+    expect(resolveScalar(undefined, 'stale-node', 'template-default', true)).toBe(
+      'template-default'
+    );
+  });
+
+  test('should use node value when no template change', () => {
+    expect(resolveScalar(undefined, 'node-val', 'template-val', false)).toBe('node-val');
+  });
+
+  test('should use template default when node value is null/undefined', () => {
+    expect(resolveScalar(undefined, undefined, 'template-val', false)).toBe('template-val');
+    expect(resolveScalar(undefined, null, 'template-val', false)).toBe('template-val');
+  });
+});
+
+describe('resolveTagField', () => {
+  test('should use prompt tags when non-empty', () => {
+    const tags = [{ name: 'tag1' }];
+    expect(resolveTagField(tags, true, 'old', 'default', false)).toEqual(tags);
+  });
+
+  test('should use empty prompt tags when promptable (user chose none)', () => {
+    expect(resolveTagField([], true, 'old', 'default', false)).toEqual([]);
+  });
+
+  test('should use template tags on template change', () => {
+    const result = resolveTagField(undefined, false, 'stale_tag', 'new_tag', true);
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'new_tag' })]));
+  });
+
+  test('should use node tag string when no template change', () => {
+    const result = resolveTagField(undefined, false, 'node_tag', 'template_tag', false);
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'node_tag' })]));
+  });
+
+  test('should fall through to template tags when node tags are null', () => {
+    const result = resolveTagField(undefined, false, null, 'template_tag', false);
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'template_tag' })])
+    );
+  });
+
+  test('should return empty array when all sources are empty', () => {
+    expect(resolveTagField(undefined, false, '', '', false)).toEqual([]);
+  });
+
+  test('should fall through force-cleared empty tags to template default on template change', () => {
+    const result = resolveTagField([], false, 'stale', 'default_tag', true);
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'default_tag' })])
+    );
+  });
+});
+
+describe('resolveExecutionEnvironment', () => {
+  const fetchedEE = { id: 1, name: 'Fetched EE' } as unknown as ExecutionEnvironment;
+  const nodeEE = { id: 2, name: 'Node EE' } as unknown as ExecutionEnvironment;
+  const templateEE = { id: 3, name: 'Template EE' } as unknown as ExecutionEnvironment;
+
+  test('should use fetched EE when prompt has an EE selection', () => {
+    const promptEE = { id: 1, name: 'Fetched EE' };
+    expect(resolveExecutionEnvironment(promptEE, fetchedEE, nodeEE, templateEE, false)).toEqual(
+      fetchedEE
+    );
+  });
+
+  test('should use template EE on template change when no prompt', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, nodeEE, templateEE, true)).toEqual(
+      templateEE
+    );
+  });
+
+  test('should use node EE when no template change and no prompt', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, nodeEE, templateEE, false)).toEqual(
+      nodeEE
+    );
+  });
+
+  test('should fall through to template EE when node EE is undefined', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, undefined, templateEE, false)).toEqual(
+      templateEE
+    );
+  });
+
+  test('should return undefined when all sources are undefined', () => {
+    expect(
+      resolveExecutionEnvironment(undefined, undefined, undefined, undefined, false)
+    ).toBeUndefined();
+  });
+});
+
+describe('mergeSurveyIntoVariables', () => {
+  test('should merge survey values into existing variables', () => {
+    const result = mergeSurveyIntoVariables('key1: value1', { key2: 'value2' });
+    expect(result).toContain('key1');
+    expect(result).toContain('key2');
+  });
+
+  test('should override existing keys with survey values', () => {
+    const result = mergeSurveyIntoVariables('key1: old', { key1: 'new' });
+    expect(result).toContain('new');
+  });
+
+  test('should handle undefined variables', () => {
+    const result = mergeSurveyIntoVariables(undefined, { key1: 'value1' });
+    expect(result).toContain('key1');
+  });
+
+  test('should handle empty survey values', () => {
+    const result = mergeSurveyIntoVariables('key1: value1', {});
+    expect(result).toContain('key1');
+  });
+});
+
+describe('arrayIdsMatch', () => {
+  test('should return true when arrays have same IDs', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 2 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return true when arrays have same IDs in different order', () => {
+    expect(arrayIdsMatch([{ id: 2 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return false when arrays have different lengths', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have different IDs', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 3 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return true for empty arrays', () => {
+    expect(arrayIdsMatch([], [])).toBe(true);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.ts
@@ -1,0 +1,98 @@
+import type { ExecutionEnvironment } from '../../../../interfaces/ExecutionEnvironment';
+import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
+import { parseStringToTagArray } from '../../JobTemplateFormHelpers';
+import type { PromptFormValues } from '../types';
+
+export function resolveScalar<T>(
+  promptValue: T | undefined | null,
+  nodeValue: T | undefined | null,
+  templateValue: T,
+  isTemplateChanged: boolean
+): T {
+  if (promptValue !== undefined && promptValue !== null) return promptValue;
+  if (!isTemplateChanged && nodeValue !== undefined && nodeValue !== null) return nodeValue;
+  return templateValue;
+}
+
+export function resolveArrayField<T>(
+  promptValue: T[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeResults: T[] | undefined,
+  templateResults: T[] | undefined,
+  isTemplateChanged: boolean
+): T[] | undefined {
+  if (promptValue !== undefined && (promptValue.length > 0 || acceptsOnLaunch)) {
+    return promptValue;
+  }
+  if (isTemplateChanged) {
+    return templateResults;
+  }
+  return (nodeResults?.length ? nodeResults : undefined) ?? templateResults;
+}
+
+export function resolveExecutionEnvironment(
+  promptEE: PromptFormValues['execution_environment'] | undefined,
+  fetchedEE: ExecutionEnvironment | undefined,
+  nodeEE: ExecutionEnvironment | undefined,
+  templateEE: ExecutionEnvironment | undefined,
+  isTemplateChanged: boolean
+): ExecutionEnvironment | undefined {
+  if (promptEE && fetchedEE) return fetchedEE;
+  if (isTemplateChanged) return templateEE;
+  return nodeEE ?? templateEE;
+}
+
+export function resolveTagField(
+  promptTags: { name: string }[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeTagString: string | null | undefined,
+  templateTagString: string,
+  isTemplateChanged: boolean
+): { name: string }[] {
+  if (promptTags !== undefined && (promptTags.length > 0 || acceptsOnLaunch)) {
+    return promptTags;
+  }
+  if (isTemplateChanged) return parseStringToTagArray(templateTagString);
+  return parseStringToTagArray(nodeTagString ?? templateTagString);
+}
+
+export function mergeSurveyIntoVariables(
+  variables: string | undefined,
+  surveyValues: Record<string, unknown>
+): string {
+  const jsonObj: { [key: string]: string } = {};
+
+  if (variables) {
+    const lines = variables.split('\n');
+    lines.forEach((line) => {
+      const [key, value] = line.split(':').map((part) => part.trim());
+      jsonObj[key] = value;
+    });
+  }
+
+  const mergedData = {
+    ...jsonObj,
+    ...surveyValues,
+  };
+
+  return jsonToYaml(JSON.stringify(mergedData));
+}
+
+export function arrayIdsMatch(arr1: { id: number }[], arr2: { id: number }[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  const idSet1 = new Set(arr1.map((obj) => obj.id));
+  const idSet2 = new Set(arr2.map((obj) => obj.id));
+
+  if (idSet1.size !== idSet2.size) {
+    return false;
+  }
+  for (const item of idSet1) {
+    if (!idSet2.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import { clearStaleNodeFields } from './clearStaleNodeFields';
+
+describe('clearStaleNodeFields', () => {
+  test('should set all prompt fields to null when payload is empty', () => {
+    const payload: Record<string, unknown> = {};
+    clearStaleNodeFields(payload);
+
+    expect(payload.diff_mode).toBeNull();
+    expect(payload.execution_environment).toBeNull();
+    expect(payload.forks).toBeNull();
+    expect(payload.inventory).toBeNull();
+    expect(payload.job_slice_count).toBeNull();
+    expect(payload.job_tags).toBeNull();
+    expect(payload.job_type).toBeNull();
+    expect(payload.limit).toBeNull();
+    expect(payload.scm_branch).toBeNull();
+    expect(payload.skip_tags).toBeNull();
+    expect(payload.timeout).toBeNull();
+    expect(payload.verbosity).toBeNull();
+    expect(payload.extra_data).toEqual({});
+  });
+
+  test('should not overwrite fields that are already set', () => {
+    const payload: Record<string, unknown> = {
+      limit: '5',
+      forks: 10,
+      extra_data: { my_var: 'value' },
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.limit).toBe('5');
+    expect(payload.forks).toBe(10);
+    expect(payload.extra_data).toEqual({ my_var: 'value' });
+    expect(payload.diff_mode).toBeNull();
+    expect(payload.verbosity).toBeNull();
+  });
+
+  test('should preserve fields set to explicit values including falsy ones', () => {
+    const payload: Record<string, unknown> = {
+      diff_mode: false,
+      forks: 0,
+      timeout: 0,
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.diff_mode).toBe(false);
+    expect(payload.forks).toBe(0);
+    expect(payload.timeout).toBe(0);
+  });
+
+  test('should set extra_data to empty object not null', () => {
+    const payload: Record<string, unknown> = {};
+    clearStaleNodeFields(payload);
+
+    expect(payload.extra_data).toEqual({});
+    expect(payload.extra_data).not.toBeNull();
+  });
+
+  test('should handle payload with non-prompt fields without affecting them', () => {
+    const payload: Record<string, unknown> = {
+      unified_job_template: 42,
+      all_parents_must_converge: true,
+      identifier: 'my-node',
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.unified_job_template).toBe(42);
+    expect(payload.all_parents_must_converge).toBe(true);
+    expect(payload.identifier).toBe('my-node');
+    expect(payload.limit).toBeNull();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.ts
@@ -1,0 +1,25 @@
+const NULLABLE_PROMPT_FIELDS = [
+  'diff_mode',
+  'execution_environment',
+  'forks',
+  'inventory',
+  'job_slice_count',
+  'job_tags',
+  'job_type',
+  'limit',
+  'scm_branch',
+  'skip_tags',
+  'timeout',
+  'verbosity',
+] as const;
+
+export function clearStaleNodeFields(payload: Record<string, unknown>): void {
+  for (const key of NULLABLE_PROMPT_FIELDS) {
+    if (!(key in payload)) {
+      payload[key] = null;
+    }
+  }
+  if (!('extra_data' in payload)) {
+    payload['extra_data'] = {};
+  }
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.test.ts
@@ -1,0 +1,561 @@
+import { renderHook } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { RESOURCE_TYPE } from '../constants';
+import { EdgeStatus } from '../types';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({}),
+    setState: () => {},
+    getGraph: () => ({ getNodes: () => [], layout: () => {} }),
+    getElements: () => [],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+const { getLaunchData, useGetInitialValues, useNodeTypeStepDefaults } = await import(
+  './useGetInitialValues'
+);
+
+const server = setupServer(
+  http.get(awxAPI`/job_templates/1/launch/`, () =>
+    HttpResponse.json({
+      ask_credential_on_launch: true,
+      ask_inventory_on_launch: false,
+      survey_enabled: false,
+      defaults: {},
+    })
+  ),
+  http.get(awxAPI`/job_templates/1/credentials/`, () =>
+    HttpResponse.json({
+      count: 1,
+      results: [
+        {
+          id: 10,
+          name: 'Template SSH',
+          credential_type: 1,
+          summary_fields: { credential_type: { name: 'Machine' } },
+        },
+      ],
+    })
+  ),
+  http.get(awxAPI`/workflow_job_templates/2/launch/`, () =>
+    HttpResponse.json({
+      ask_inventory_on_launch: true,
+      survey_enabled: false,
+      defaults: {},
+    })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/credentials/`, () =>
+    HttpResponse.json({
+      count: 1,
+      results: [
+        {
+          id: 20,
+          name: 'Node SSH',
+          credential_type: 1,
+          summary_fields: { credential_type: { name: 'Machine' } },
+        },
+      ],
+    })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/labels/`, () =>
+    HttpResponse.json({ count: 1, results: [{ id: 1, name: 'production' }] })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/instance_groups/`, () =>
+    HttpResponse.json({ count: 1, results: [{ id: 5, name: 'default' }] })
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeGraphNode(overrides: Record<string, unknown> = {}) {
+  return {
+    getData: () => ({
+      resource: {
+        identifier: 'my-alias',
+        all_parents_must_converge: true,
+        extra_data: { days: 14 },
+        summary_fields: {
+          unified_job_template: {
+            id: 1,
+            name: 'Demo Job Template',
+            description: 'A description',
+            unified_job_type: RESOURCE_TYPE.job,
+            timeout: 120,
+            ...overrides,
+          },
+        },
+      },
+    }),
+  } as never;
+}
+
+describe('useNodeTypeStepDefaults', () => {
+  it('should return default mapper values when node is undefined', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const defaults = result.current(undefined);
+
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.node_convergence).toBe('any');
+    expect(defaults.node_alias).toBe('');
+    expect(defaults.approval_name).toBe('');
+    expect(defaults.approval_description).toBe('');
+    expect(defaults.approval_timeout).toBe(0);
+    expect(defaults.node_days_to_keep).toBe(30);
+    expect(defaults.resource).toBeNull();
+    expect(defaults.resourceId).toBeUndefined();
+    expect(defaults.node_status_type).toBe(EdgeStatus.info);
+  });
+
+  it('should return values from node data for a job template node', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode();
+    const defaults = result.current(node);
+
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.node_convergence).toBe('all');
+    expect(defaults.node_alias).toBe('my-alias');
+    expect(defaults.node_days_to_keep).toBe(14);
+    expect(defaults.resourceId).toBe(1);
+    expect(defaults.approval_timeout).toBe(120);
+  });
+
+  it('should return approval name for workflow_approval node type', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode({
+      unified_job_type: RESOURCE_TYPE.workflow_approval,
+      name: 'Approve Me',
+    });
+    const defaults = result.current(node);
+
+    expect(defaults.approval_name).toBe('Approve Me');
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.workflow_approval);
+  });
+
+  it('should return empty approval_name for non-approval node types', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode({ unified_job_type: RESOURCE_TYPE.job, name: 'My Template' });
+    const defaults = result.current(node);
+
+    expect(defaults.approval_name).toBe('');
+  });
+
+  it('should return empty approvalDescription when nodeType is falsy (no unified_job_template)', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const nodeNoUJT = {
+      getData: () => ({
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {},
+        },
+      }),
+    } as never;
+
+    const defaults = result.current(nodeNoUJT);
+    expect(defaults.approval_description).toBe('');
+    expect(defaults.approval_name).toBe('');
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.resource).toBeNull();
+    expect(defaults.resourceId).toBeUndefined();
+  });
+
+  it('should return empty alias when identifier is a UUID', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const uuidNode = {
+      getData: () => ({
+        resource: {
+          identifier: '550e8400-e29b-41d4-a716-446655440000',
+          all_parents_must_converge: null,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const defaults = result.current(uuidNode);
+    expect(defaults.node_alias).toBe('');
+    expect(defaults.node_convergence).toBe('any');
+  });
+});
+
+describe('getLaunchData', () => {
+  it('should return launch config for a job template node', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.job, id: 1 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result?.ask_credential_on_launch).toBe(true);
+    expect(result?.ask_inventory_on_launch).toBe(false);
+  });
+
+  it('should return launch config for a workflow job template node', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.workflow_job, id: 2 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result?.ask_inventory_on_launch).toBe(true);
+  });
+
+  it('should return undefined when there is no unified_job_template', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {},
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for non-promptable node types like project_update', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.project_update, id: 3 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('useGetInitialValues', () => {
+  it('should return initial values for a new (unsaved) job template node', async () => {
+    const newNode = {
+      getId: () => 'unsavedNode-1',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '550e8400-e29b-41d4-a716-446655440000',
+          all_parents_must_converge: false,
+          extra_data: {},
+          diff_mode: false,
+          forks: 0,
+          job_type: 'run',
+          job_tags: '',
+          skip_tags: '',
+          timeout: 0,
+          verbosity: 0,
+          job_slice_count: 1,
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+            inventory: null,
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(newNode);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.nodeTypeStep.node_type).toBe(RESOURCE_TYPE.job);
+    expect(initialValues.nodePromptsStep).toBeDefined();
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toBeDefined();
+  });
+
+  it('should return initial values for a saved job template node fetching credentials and labels', async () => {
+    const savedNode = {
+      getId: () => '42',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: true,
+          extra_data: {},
+          diff_mode: false,
+          forks: 0,
+          job_type: 'run',
+          job_tags: '',
+          skip_tags: '',
+          timeout: 0,
+          verbosity: 0,
+          job_slice_count: 1,
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+            inventory: { id: 1, name: 'My Inventory' },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(savedNode);
+
+    expect(initialValues.nodeTypeStep.node_convergence).toBe('all');
+    expect(initialValues.nodeTypeStep.node_alias).toBe('my-node');
+    expect(initialValues.nodePromptsStep?.prompt?.original?.credentials).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Node SSH' })])
+    );
+    expect(initialValues.nodePromptsStep?.prompt?.original?.labels).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'production' })])
+    );
+    expect(initialValues.nodePromptsStep?.prompt?.original?.instance_groups).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'default' })])
+    );
+  });
+
+  it('should use hidePromptStep path when launch config has no prompts', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/1/launch/`, () =>
+        HttpResponse.json({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        })
+      )
+    );
+
+    const newNode = {
+      getId: () => 'unsavedNode-2',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Simple Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(newNode);
+
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.labels).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.instance_groups).toEqual([]);
+  });
+
+  it('should include prompt values when node has existing launch_data', async () => {
+    const nodeWithPrompts = {
+      getId: () => 'unsavedNode-3',
+      getData: () => ({
+        launch_data: {
+          limit: 'webservers',
+          credentials: [{ id: 30, name: 'Existing Cred', credential_type: 2 }],
+        },
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(nodeWithPrompts);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.nodePromptsStep?.prompt?.limit).toBe('webservers');
+  });
+
+  it('should trigger survey path and return survey data when survey_enabled and ask_variables_on_launch are both true', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/1/launch/`, () =>
+        HttpResponse.json({
+          ask_credential_on_launch: false,
+          ask_variables_on_launch: true,
+          survey_enabled: true,
+          defaults: {},
+        })
+      ),
+      http.get(awxAPI`/job_templates/1/survey_spec/`, () =>
+        HttpResponse.json({
+          name: 'Test Survey',
+          description: '',
+          spec: [
+            {
+              variable: 'survey_var',
+              type: 'text',
+              question_name: 'Survey Var',
+              question_description: '',
+              required: false,
+              default: '',
+              min: 0,
+              max: 1024,
+              choices: [],
+              new_question: false,
+            },
+          ],
+        })
+      )
+    );
+
+    const nodeWithSurveyData = {
+      getId: () => 'unsavedNode-survey',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: { survey_var: 'existing_value', other_var: 'keep_this' },
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Survey Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(nodeWithSurveyData);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.survey).toBeDefined();
+  });
+
+  it('should return empty array from getRelated when API returns no results', async () => {
+    server.use(
+      http.get(awxAPI`/workflow_job_template_nodes/99/credentials/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.get(awxAPI`/workflow_job_template_nodes/99/labels/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.get(awxAPI`/workflow_job_template_nodes/99/instance_groups/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      )
+    );
+
+    const savedNodeNoResults = {
+      getId: () => '99',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(savedNodeNoResults);
+
+    expect(initialValues.nodePromptsStep?.prompt?.original?.credentials).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.original?.labels).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.original?.instance_groups).toEqual([]);
+  });
+
+  it('should handle project_update node type with no launch config (hidePromptStep = true)', async () => {
+    const projectUpdateNode = {
+      getId: () => 'unsavedNode-project',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'My Project',
+              unified_job_type: RESOURCE_TYPE.project_update,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(projectUpdateNode);
+
+    expect(initialValues.nodeTypeStep.node_type).toBe(RESOURCE_TYPE.project_update);
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toEqual([]);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
@@ -19,6 +19,7 @@ import { getConvergenceType, getValueBasedOnJobType, shouldHideOtherStep } from 
 interface WizardStepState {
   nodeTypeStep: Partial<WizardFormValues>;
   nodePromptsStep?: { prompt: Partial<PromptFormValues> };
+  survey?: { survey: unknown };
 }
 
 export function useNodeTypeStepDefaults(): (node?: GraphNode) => CommonNodeValues {

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
@@ -1,0 +1,804 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { RESOURCE_TYPE, START_NODE_ID } from '../constants';
+import { EdgeStatus, type GraphNode, type GraphNodeData } from '../types';
+
+const mockPostFn = vi.fn().mockResolvedValue({ id: 100 });
+const mockPatchFn = vi.fn().mockResolvedValue({ id: 42 });
+const mockDeleteFn = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@ansible/common-ui/crud/usePostRequest', () => ({
+  usePostRequest: vi.fn(() => mockPostFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/usePatchRequest', () => ({
+  usePatchRequest: vi.fn(() => mockPatchFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/useDeleteRequest', () => ({
+  useDeleteRequest: vi.fn(() => mockDeleteFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({
+  requestGet: vi.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+}));
+
+vi.mock('@ansible/ansible-ui-framework/utils/codeEditorUtils', () => ({
+  parseVariableField: vi.fn((v: string) => {
+    try {
+      return JSON.parse(v) as object;
+    } catch {
+      return {};
+    }
+  }),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock('../../../../common/useAwxGetAllPages', () => ({
+  useAwxGetAllPages: vi.fn(() => ({ refresh: mockRefresh })),
+}));
+
+const mockSetState = vi.fn();
+const mockElementSetState = vi.fn();
+const mockLayout = vi.fn();
+let mockGraphNodes: ReturnType<typeof makeGraphNode>[] = [];
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({ workflowTemplate: { id: 123 }, modified: false }),
+    setState: mockSetState,
+    getGraph: () => ({
+      getNodes: () => mockGraphNodes,
+      layout: mockLayout,
+    }),
+    getElements: () => [{ setState: mockElementSetState, getState: () => ({}) }],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+function makeGraphNode(
+  overrides: {
+    id?: string;
+    visible?: boolean;
+    modified?: boolean;
+    nodeData?: Partial<GraphNodeData>;
+    sourceEdges?: {
+      isVisible: () => boolean;
+      getData: () => { tagStatus: EdgeStatus };
+      getTarget: () => { getId: () => string };
+    }[];
+  } = {}
+) {
+  const { id = '42', visible = true, modified = true, nodeData = {}, sourceEdges = [] } = overrides;
+
+  const defaultNodeData: GraphNodeData = {
+    resource: {
+      id: 42,
+      identifier: 'test-node',
+      all_parents_must_converge: false,
+      extra_data: {},
+      always_nodes: [],
+      failure_nodes: [],
+      success_nodes: [],
+      summary_fields: {
+        unified_job_template: {
+          id: 1,
+          name: 'Test Template',
+          unified_job_type: RESOURCE_TYPE.job,
+        },
+      },
+    },
+    launch_data: {
+      original: {
+        launch_config: {
+          ask_labels_on_launch: true,
+          ask_instance_groups_on_launch: true,
+          ask_credential_on_launch: true,
+          defaults: { credentials: [] },
+        },
+        labels: [{ id: 10, name: 'old-label' }],
+        instance_groups: [{ id: 20, name: 'old-ig' }],
+        credentials: [{ id: 30, name: 'old-cred' }],
+      },
+      labels: [{ id: 11, name: 'new-label' }],
+      instance_groups: [{ id: 21, name: 'new-ig' }],
+      credentials: [{ id: 31, name: 'new-cred' }],
+    },
+    survey_data: undefined,
+    ...nodeData,
+  } as GraphNodeData;
+
+  return {
+    getId: () => id,
+    getData: () => defaultNodeData,
+    getState: () => ({ modified }),
+    isVisible: () => visible,
+    setId: vi.fn(),
+    setData: vi.fn(),
+    setState: vi.fn(),
+    setLabel: vi.fn(),
+    getSourceEdges: () => sourceEdges,
+  } as unknown as GraphNode;
+}
+
+const { toKeyedObject, useSaveVisualizer } = await import('./useSaveVisualizer');
+
+describe('toKeyedObject', () => {
+  test('should return keyed object for non-empty string value', () => {
+    expect(toKeyedObject('identifier', 'my-node')).toEqual({ identifier: 'my-node' });
+  });
+
+  test('should return keyed object for numeric value', () => {
+    expect(toKeyedObject('timeout', 30)).toEqual({ timeout: 30 });
+  });
+
+  test('should return keyed object for number 0', () => {
+    expect(toKeyedObject('forks', 0)).toEqual({ forks: 0 });
+  });
+
+  test('should return empty object for empty string value', () => {
+    expect(toKeyedObject('identifier', '')).toEqual({});
+  });
+
+  test('should return empty object for undefined value', () => {
+    expect(toKeyedObject('identifier', undefined)).toEqual({});
+  });
+
+  test('should return empty object for null value', () => {
+    expect(toKeyedObject('identifier', null)).toEqual({});
+  });
+
+  test('should use the provided key in the returned object', () => {
+    const result = toKeyedObject('my_custom_key', 'value');
+    expect(result).toHaveProperty('my_custom_key', 'value');
+  });
+});
+
+describe('useSaveVisualizer', () => {
+  beforeEach(() => {
+    mockPostFn.mockClear().mockResolvedValue({ id: 100 });
+    mockPatchFn.mockClear().mockResolvedValue({ id: 42 });
+    mockDeleteFn.mockClear().mockResolvedValue(undefined);
+    mockRefresh.mockClear();
+    mockSetState.mockClear();
+    mockElementSetState.mockClear();
+    mockLayout.mockClear();
+    mockGraphNodes = [];
+  });
+
+  test('should be callable and return a function', () => {
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    expect(typeof result.current).toBe('function');
+  });
+
+  test('should skip start node', async () => {
+    mockGraphNodes = [makeGraphNode({ id: START_NODE_ID, modified: true })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockPostFn).not.toHaveBeenCalled();
+    expect(mockPatchFn).not.toHaveBeenCalled();
+    expect(mockDeleteFn).not.toHaveBeenCalled();
+  });
+
+  test('should delete invisible non-new nodes', async () => {
+    mockGraphNodes = [makeGraphNode({ id: '42', visible: false, modified: false })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockDeleteFn).toHaveBeenCalledWith(
+      expect.stringContaining('/workflow_job_template_nodes/42/')
+    );
+  });
+
+  test('should not delete invisible new nodes', async () => {
+    mockGraphNodes = [makeGraphNode({ id: 'unsavedNode-1', visible: false, modified: false })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockDeleteFn).not.toHaveBeenCalled();
+  });
+
+  test('should create new approval nodes', async () => {
+    const approvalNode = makeGraphNode({
+      id: 'unsavedNode-1',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Approval Step',
+              description: 'Approve this',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 300,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_nodes/'))).toBe(
+      true
+    );
+    expect(
+      postCalls.some((c: unknown[]) => (c[0] as string).includes('/create_approval_template/'))
+    ).toBe(true);
+  });
+
+  test('should create new job template nodes with prompt values', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-2',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'job-1',
+          all_parents_must_converge: true,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          diff_mode: true,
+          forks: 10,
+          limit: 'all',
+          verbosity: 2,
+          job_type: 'run',
+          scm_branch: 'main',
+          timeout: 60,
+          job_tags: [{ name: 'deploy' }],
+          skip_tags: [{ name: 'slow' }],
+          inventory: { id: 3, name: 'prod' },
+          execution_environment: { id: 7, name: 'ee' },
+          job_slice_count: 2,
+          labels: [{ id: 11, name: 'new-label' }],
+          instance_groups: [{ id: 21, name: 'new-ig' }],
+          credentials: [{ id: 31, name: 'new-cred' }],
+          original: {
+            launch_config: {
+              ask_diff_mode_on_launch: true,
+              ask_forks_on_launch: true,
+              ask_limit_on_launch: true,
+              ask_verbosity_on_launch: true,
+              ask_job_type_on_launch: true,
+              ask_scm_branch_on_launch: true,
+              ask_timeout_on_launch: true,
+              ask_tags_on_launch: true,
+              ask_skip_tags_on_launch: true,
+              ask_inventory_on_launch: true,
+              ask_execution_environment_on_launch: true,
+              ask_job_slice_count_on_launch: true,
+              ask_variables_on_launch: true,
+              ask_labels_on_launch: true,
+              ask_instance_groups_on_launch: true,
+              ask_credential_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_nodes/'))).toBe(
+      true
+    );
+    // Process labels, instance groups, and credentials (associate only for new nodes)
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/labels/'))).toBe(true);
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/instance_groups/'))).toBe(
+      true
+    );
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/credentials/'))).toBe(true);
+  });
+
+  test('should create new system job node with extra_data days', async () => {
+    const sysNode = makeGraphNode({
+      id: 'unsavedNode-3',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'sys-1',
+          all_parents_must_converge: false,
+          extra_data: { days: 120 },
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 9,
+              name: 'Cleanup',
+              unified_job_type: RESOURCE_TYPE.system_job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: { defaults: { credentials: [] } },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [sysNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    expect((workflowNodeCall as unknown[])[1]).toHaveProperty('extra_data', { days: 120 });
+  });
+
+  test('should update edited job template nodes with disassociate before patch and associate after', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    const patchCalls = mockPatchFn.mock.calls;
+
+    // Should have PATCH call for the node
+    expect(
+      patchCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_job_template_nodes/'))
+    ).toBe(true);
+
+    // Should have disassociate and associate calls for labels, IGs, and credentials
+    const disassociateCalls = postCalls.filter(
+      (c: unknown[]) => (c[1] as { disassociate?: boolean })?.disassociate === true
+    );
+    expect(disassociateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should call clearStaleNodeFields for edited nodes with template change', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            isTemplateChange: true,
+            launch_config: {
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_job_template_nodes/')
+      )
+    ).toBe(true);
+  });
+
+  test('should update edited approval nodes', async () => {
+    const approvalNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Updated Approval',
+              description: 'Updated desc',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 600,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_job_template_nodes/42/')
+      )
+    ).toBe(true);
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_approval_templates/')
+      )
+    ).toBe(true);
+  });
+
+  test('should create approval template when approval node has id === -1', async () => {
+    const approvalNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: -1,
+              name: 'New Approval',
+              description: '',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 0,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPostFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/create_approval_template/')
+      )
+    ).toBe(true);
+  });
+
+  test('should handle edge modifications for success, failure, and always edges', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [100],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+      sourceEdges: [
+        {
+          isVisible: () => true,
+          getData: () => ({ tagStatus: EdgeStatus.danger }),
+          getTarget: () => ({ getId: () => '100' }),
+        },
+        {
+          isVisible: () => true,
+          getData: () => ({ tagStatus: EdgeStatus.info }),
+          getTarget: () => ({ getId: () => '200' }),
+        },
+      ],
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    // Should disassociate old success_node[100] (now a danger edge)
+    const disassociateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { disassociate?: boolean })?.disassociate === true
+    );
+    const associateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) =>
+        !(c[1] as { disassociate?: boolean })?.disassociate &&
+        typeof c[0] === 'string' &&
+        (c[0].includes('/success_nodes/') ||
+          c[0].includes('/failure_nodes/') ||
+          c[0].includes('/always_nodes/'))
+    );
+
+    expect(disassociateCalls.length + associateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should set modified to false on all elements after save', async () => {
+    mockGraphNodes = [];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(mockSetState).toHaveBeenCalledWith(expect.objectContaining({ modified: false }));
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  test('should process labels with no prompt but existing labels on disassociate', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [{ id: 50, name: 'existing-label' }],
+            instance_groups: [{ id: 60, name: 'existing-ig' }],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const disassociateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) =>
+        (c[1] as { disassociate?: boolean })?.disassociate === true &&
+        typeof c[0] === 'string' &&
+        c[0].includes('/labels/')
+    );
+    expect(disassociateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should handle new node with survey data merged into extra_data', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-4',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'survey-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Survey Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          extra_vars: '{"key": "value"}',
+          original: {
+            launch_config: {
+              ask_variables_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: { survey_key: 'survey_value' },
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as { extra_data?: object };
+    expect(payload.extra_data).toEqual(expect.objectContaining({ survey_key: 'survey_value' }));
+  });
+
+  test('should propagate errors from updateExistingNodes', async () => {
+    mockPatchFn.mockRejectedValueOnce(new Error('PATCH failed'));
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await expect(result.current()).rejects.toThrow('PATCH failed');
+  });
+
+  test('should handle edited node with extra_vars prompt', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          extra_vars: '{"var1": "val1"}',
+          original: {
+            launch_config: {
+              ask_variables_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: { survey_answer: 42 },
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const patchCalls = mockPatchFn.mock.calls;
+    const nodePatch = patchCalls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/')
+    );
+    expect(nodePatch).toBeDefined();
+    const payload = (nodePatch as unknown[])[1] as { extra_data?: object };
+    expect(payload.extra_data).toEqual(expect.objectContaining({ survey_answer: 42 }));
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -9,6 +9,7 @@ import { AwxItemsResponse } from '../../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { useAwxGetAllPages } from '../../../../common/useAwxGetAllPages';
 import { getAddedAndRemoved } from '../../../../common/util/getAddedAndRemoved';
+import { clearStaleNodeFields } from './clearStaleNodeFields';
 import { getAddedAndRemovedCredentials } from './getAddedAndRemovedCredentials';
 import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
 import { Label } from '../../../../interfaces/Label';
@@ -341,21 +342,7 @@ export function useSaveVisualizer(templateId: string) {
           }
 
           if (launch_data?.original?.isTemplateChange) {
-            nullIfMissing(updatedNodePayload, 'diff_mode');
-            nullIfMissing(updatedNodePayload, 'execution_environment');
-            nullIfMissing(updatedNodePayload, 'forks');
-            nullIfMissing(updatedNodePayload, 'inventory');
-            nullIfMissing(updatedNodePayload, 'job_slice_count');
-            nullIfMissing(updatedNodePayload, 'job_tags');
-            nullIfMissing(updatedNodePayload, 'job_type');
-            nullIfMissing(updatedNodePayload, 'limit');
-            nullIfMissing(updatedNodePayload, 'scm_branch');
-            nullIfMissing(updatedNodePayload, 'skip_tags');
-            nullIfMissing(updatedNodePayload, 'timeout');
-            nullIfMissing(updatedNodePayload, 'verbosity');
-            if (!('extra_data' in updatedNodePayload)) {
-              updatedNodePayload.extra_data = {};
-            }
+            clearStaleNodeFields(updatedNodePayload as Record<string, unknown>);
           }
 
           // Disassociate stale resources BEFORE patching the template. AWX validates the
@@ -601,12 +588,6 @@ export function useSaveVisualizer(templateId: string) {
     processLabels,
     workflowNodeRefresh,
   ]);
-}
-
-function nullIfMissing(payload: Partial<CreateWorkflowNodePayload>, key: CreatePayloadProperty) {
-  if (!(key in payload)) {
-    (payload as Record<string, unknown>)[key] = null;
-  }
 }
 
 export function toKeyedObject(

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -342,7 +342,7 @@ export function useSaveVisualizer(templateId: string) {
           }
 
           if (launch_data?.original?.isTemplateChange) {
-            clearStaleNodeFields(updatedNodePayload as Record<string, unknown>);
+            clearStaleNodeFields(updatedNodePayload);
           }
 
           // Disassociate stale resources BEFORE patching the template. AWX validates the

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.component.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.component.test.tsx
@@ -1,0 +1,315 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RESOURCE_TYPE } from '../constants';
+import { EdgeStatus } from '../types';
+import { NodeEditWizard } from './NodeEditWizard';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({ workflowTemplate: { id: 1 } }),
+    setState: vi.fn(),
+    getGraph: () => ({
+      getNodes: () => [],
+      layout: vi.fn(),
+    }),
+    getElements: () => [],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+vi.mock('../../../../views/jobs/WorkflowOutput/WorkflowOutput', () => ({
+  greyBadgeLabel: {
+    badge: 'ALL',
+    badgeColor: 'var(--pf-t--global--background--color--secondary--default)',
+    badgeBorderColor: 'var(--pf-t--global--border--color--on-secondary)',
+  },
+}));
+
+const mockBuildEffectivePrompt = vi.fn(() => ({ effectivePrompt: { diff_mode: false } }));
+vi.mock('./buildEffectivePrompt', () => ({
+  buildEffectivePrompt: () => mockBuildEffectivePrompt(),
+}));
+
+const mockGetInitialValues = vi.fn(() =>
+  Promise.resolve({
+    nodeTypeStep: {
+      node_type: RESOURCE_TYPE.job,
+      node_convergence: 'any' as const,
+      node_alias: '',
+      approval_name: '',
+      approval_description: '',
+      approval_timeout: 0,
+      node_days_to_keep: 30,
+      resource: null,
+      resourceId: undefined,
+      node_status_type: EdgeStatus.info,
+    },
+    nodePromptsStep: {
+      prompt: {
+        credentials: [],
+        labels: [],
+        instance_groups: [],
+        original: {
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+        },
+      },
+    },
+  })
+);
+
+vi.mock('../hooks', () => ({
+  useCloseSidebar: () => vi.fn(),
+  useGetInitialValues: () => mockGetInitialValues,
+  useNodeTypeStepDefaults: () => () => ({
+    approval_description: '',
+    approval_name: '',
+    approval_timeout: 0,
+    node_alias: '',
+    node_convergence: 'any' as const,
+    node_days_to_keep: 30,
+    resource: null,
+    resourceId: undefined,
+    node_type: RESOURCE_TYPE.job,
+    node_status_type: EdgeStatus.info,
+  }),
+  useGetTimeoutString: () => '0 min 0 sec',
+  useCreateEdge: () => () => ({}),
+  useDedupeOldNodes: () => vi.fn(),
+  useGetNodeTypeDetail: () => vi.fn(),
+  useRemoveGraphElements: () => vi.fn(),
+  useRemoveNode: () => vi.fn(),
+  useSaveVisualizer: () => vi.fn(),
+  useSelectedNode: () => vi.fn(),
+  useCreateConnector: () => vi.fn(),
+  useHandleCollectNodeProps: () => vi.fn(),
+  useGetPath: () => vi.fn(),
+  useTargetNodeAncestors: () => vi.fn(),
+}));
+
+const mockSetLabel = vi.fn();
+const mockSetData = vi.fn();
+const mockSetState = vi.fn();
+
+const mockNode = {
+  getId: () => '42',
+  getData: () => ({
+    resource: {
+      id: 42,
+      identifier: '550e8400-e29b-41d4-a716-446655440000',
+      all_parents_must_converge: false,
+      extra_data: {},
+      always_nodes: [],
+      failure_nodes: [],
+      success_nodes: [],
+      summary_fields: {
+        unified_job_template: {
+          id: 1,
+          name: 'Demo Template',
+          unified_job_type: RESOURCE_TYPE.job,
+        },
+      },
+    },
+  }),
+  setLabel: mockSetLabel,
+  setData: mockSetData,
+  setState: mockSetState,
+  isVisible: () => true,
+} as never;
+
+describe('NodeEditWizard', () => {
+  beforeEach(() => {
+    mockGetInitialValues.mockClear();
+    mockSetLabel.mockClear();
+    mockSetData.mockClear();
+    mockSetState.mockClear();
+  });
+
+  it('should render null initially while loading initial values', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render the wizard after initial values are fetched', async () => {
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.getByTestId('wizard-title')).toHaveTextContent('Edit step');
+  });
+
+  it('should call getInitialValues with the provided node', async () => {
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockGetInitialValues).toHaveBeenCalledWith(mockNode);
+    });
+  });
+
+  it('should render null when getInitialValues rejects (error path)', async () => {
+    mockGetInitialValues.mockRejectedValueOnce(new Error('API error'));
+
+    const { container } = render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockGetInitialValues).toHaveBeenCalled();
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should call buildEffectivePrompt and update node on submit', async () => {
+    const user = userEvent.setup();
+    mockGetInitialValues.mockResolvedValueOnce({
+      nodeTypeStep: {
+        node_type: RESOURCE_TYPE.workflow_approval,
+        node_convergence: 'any' as const,
+        node_alias: '',
+        approval_name: 'Approval',
+        approval_description: '',
+        approval_timeout: 0,
+        node_days_to_keep: 30,
+        resource: null,
+        resourceId: undefined,
+        node_status_type: EdgeStatus.info,
+      },
+      nodePromptsStep: {
+        prompt: {
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+          original: {
+            credentials: [],
+            labels: [],
+            instance_groups: [],
+          },
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    // With workflow_approval and no launch_config, prompts and survey are hidden
+    // Wizard goes: Node details → Review
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    await user.click(nextButton);
+
+    await waitFor(
+      () => {
+        const finishButton = screen.queryByRole('button', { name: 'Finish' });
+        if (finishButton) {
+          return expect(finishButton).toBeInTheDocument();
+        }
+        throw new Error('Finish button not found');
+      },
+      { timeout: 5000 }
+    );
+
+    const finishButton = screen.getByRole('button', { name: 'Finish' });
+    await user.click(finishButton);
+
+    await waitFor(
+      () => {
+        expect(mockBuildEffectivePrompt).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(mockSetData).toHaveBeenCalled();
+    expect(mockSetLabel).toHaveBeenCalled();
+  });
+
+  it('should show prompts step when initialValues has launch_config', async () => {
+    mockGetInitialValues.mockResolvedValueOnce({
+      nodeTypeStep: {
+        node_type: RESOURCE_TYPE.job,
+        node_convergence: 'any' as const,
+        node_alias: '',
+        approval_name: '',
+        approval_description: '',
+        approval_timeout: 0,
+        node_days_to_keep: 30,
+        resource: null,
+        resourceId: undefined,
+        node_status_type: EdgeStatus.info,
+      },
+      nodePromptsStep: {
+        prompt: {
+          launch_config: {
+            ask_credential_on_launch: true,
+          },
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+          original: {
+            credentials: [],
+            labels: [],
+            instance_groups: [],
+          },
+        } as never,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.getByText('Edit step')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
@@ -15,7 +15,7 @@ import {
   replaceIdentifier,
   shouldHideOtherStep,
 } from './helpers';
-import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import { buildEffectivePrompt } from './buildEffectivePrompt';
 import { NodePromptsStep } from './NodePromptsStep';
 import { NodeReviewStep } from './NodeReviewStep';
 import { NodeTypeStep } from './NodeTypeStep';
@@ -27,30 +27,6 @@ import {
 type StepContent = Partial<WizardFormValues> | { prompt: Partial<PromptFormValues> };
 type StepName = 'nodeTypeStep' | 'nodePromptsStep';
 type WizardStep = Record<StepName, StepContent>;
-
-function clearStalePromptFields(
-  effectivePrompt: Partial<PromptFormValues>,
-  launchConfig: LaunchConfiguration | null | undefined
-) {
-  if (!launchConfig?.ask_credential_on_launch) {
-    effectivePrompt.credentials = [];
-  }
-  if (!launchConfig?.ask_labels_on_launch) {
-    effectivePrompt.labels = [];
-  }
-  if (!launchConfig?.ask_instance_groups_on_launch) {
-    effectivePrompt.instance_groups = [];
-  }
-  if (!launchConfig?.ask_skip_tags_on_launch) {
-    effectivePrompt.skip_tags = [];
-  }
-  if (!launchConfig?.ask_tags_on_launch) {
-    effectivePrompt.job_tags = [];
-  }
-  if (!launchConfig?.ask_variables_on_launch) {
-    effectivePrompt.extra_vars = '';
-  }
-}
 
 export function NodeEditWizard({ node }: { node: GraphNode }) {
   const { t } = useTranslation();
@@ -170,30 +146,15 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
       survey,
     } = formValues;
 
-    const isTemplateChange =
-      originalTemplateId !== undefined && Number(resource?.id) !== originalTemplateId;
-
-    // When the new template has no prompts, PageWizard hides the prompt step and does not
-    // include it in formValues — prompt is undefined. We still need launch_data to be set
-    // so that processCredentials/Labels/InstanceGroups can clean up any node-level resources
-    // that were associated for the old template. Without this, launch_data is undefined,
-    // processCredentials never runs, and the PATCH fails because orphaned credentials remain.
-    const effectivePrompt: Partial<PromptFormValues> = prompt ?? {};
-
-    if (resource && 'organization' in resource) {
-      effectivePrompt.organization = resource.organization ?? null;
-    }
-
-    if (isTemplateChange) {
-      clearStalePromptFields(effectivePrompt, launch_config);
-    }
-
-    // Always build original so save-time cleanup has what it needs.
-    effectivePrompt.original = {
-      ...(launch_config ? { launch_config } : {}),
-      ...nodeOriginalResources,
-      ...(isTemplateChange ? { isTemplateChange: true } : {}),
-    };
+    const { effectivePrompt } = buildEffectivePrompt({
+      originalTemplateId,
+      newResourceId: resource?.id ? Number(resource.id) : undefined,
+      prompt,
+      launchConfig: launch_config,
+      nodeOriginalResources,
+      resourceOrganization:
+        resource && 'organization' in resource ? (resource.organization ?? null) : undefined,
+    });
 
     const nodeName = getValueBasedOnJobType(node_type, resource?.name || '', approval_name);
     const nodeIdentifier = replaceIdentifier(nodeData.resource.identifier, node_alias);

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
@@ -25,7 +25,26 @@ vi.mock('@patternfly/react-topology', () => ({
 }));
 
 const mockSetWizardData = vi.hoisted(() => vi.fn());
-const mockSetStepData = vi.hoisted(() => vi.fn());
+const mockStepState = {
+  nodePromptsStep: {
+    prompt: {
+      credentials: [],
+      labels: [],
+      instance_groups: [],
+      skip_tags: [],
+      job_tags: [],
+      extra_vars: '',
+      inventory: null,
+    },
+  },
+};
+const mockSetStepData = vi.hoisted(() =>
+  vi.fn((updater: unknown) => {
+    if (typeof updater === 'function') {
+      (updater as (prev: typeof mockStepState) => typeof mockStepState)(mockStepState);
+    }
+  })
+);
 
 vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
   usePageWizard: () => ({

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
@@ -1,0 +1,483 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RESOURCE_TYPE } from '../constants';
+import type { WizardFormValues } from '../types';
+import { NodeTypeStep } from './NodeTypeStep';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+const mockSetWizardData = vi.hoisted(() => vi.fn());
+const mockSetStepData = vi.hoisted(() => vi.fn());
+
+vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
+  usePageWizard: () => ({
+    setWizardData: mockSetWizardData,
+    setStepData: mockSetStepData,
+    wizardData: {},
+    stepData: {},
+    activeStep: { id: 'nodeTypeStep' },
+  }),
+}));
+
+vi.mock('../../../../common/useAwxConfig', () => ({
+  useAwxConfig: vi.fn(() => null),
+}));
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: vi.fn(() => ({ data: undefined })),
+  useGetItem: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock('@ansible/hub-ui/common/ExternalLink', () => ({
+  ExternalLink: ({ children }: Readonly<{ children: React.ReactNode }>) => <span>{children}</span>,
+}));
+
+vi.mock('@ansible/common-ui/utils/useGetDocsUrl', () => ({
+  useGetDocsUrl: vi.fn(() => 'https://docs.example.com'),
+}));
+
+const mockRequestGet = vi.hoisted(() =>
+  vi.fn((url: string): Promise<Record<string, unknown>> => {
+    if (url.includes('/launch/')) {
+      return Promise.resolve({
+        ask_credential_on_launch: true,
+        ask_inventory_on_launch: true,
+        ask_variables_on_launch: false,
+        survey_enabled: false,
+        defaults: { credentials: [], inventory: null },
+      });
+    }
+    if (url.includes('/credentials/')) {
+      return Promise.resolve({
+        count: 1,
+        results: [
+          {
+            id: 10,
+            name: 'SSH Key',
+            credential_type: 1,
+            summary_fields: { credential_type: { name: 'Machine' } },
+          },
+        ],
+      });
+    }
+    return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+  })
+);
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({
+  requestGet: mockRequestGet,
+}));
+
+function TestWrapper({ defaultValues }: Readonly<{ defaultValues: Partial<WizardFormValues> }>) {
+  const methods = useForm<WizardFormValues>({ defaultValues });
+  return (
+    <MemoryRouter>
+      <FormProvider {...methods}>
+        <NodeTypeStep />
+      </FormProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('NodeTypeStep', () => {
+  beforeEach(() => {
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+    mockRequestGet.mockClear();
+  });
+
+  it('should call setWizardData with launch_config when a job template resourceId is set', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 1,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result).toHaveProperty('resourceId', 1);
+    } else {
+      expect(wizardDataArg).toBeDefined();
+    }
+  });
+
+  it('should call setStepData with prompt values when launch config has prompts', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 1,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetStepData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it('should call setWizardData with null launch_config when template has no promptable fields', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      return Promise.resolve({ id: 2, name: 'Simple Template', type: 'job_template' });
+    });
+
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 2,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result.launch_config).toBeNull();
+    }
+  });
+
+  it('should early-return and not call setWizardData when resourceId is undefined', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: undefined,
+        }}
+      />
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(mockSetWizardData).not.toHaveBeenCalled();
+  });
+
+  it('should not call setLaunchToWizardData for workflow_approval node type', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_approval,
+          resourceId: undefined,
+        }}
+      />
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(mockRequestGet).not.toHaveBeenCalled();
+  });
+
+  it('should reset prompt step data when template changes (isTemplateChange = true)', async () => {
+    // Use a controlled wrapper that can change resourceId via setValue to trigger isTemplateChange
+    function ControlledWrapper() {
+      const [nextId, setNextId] = useState<number | undefined>(undefined);
+      const methods = useForm<WizardFormValues>({
+        defaultValues: { node_type: RESOURCE_TYPE.job, resourceId: 1 },
+      });
+
+      useEffect(() => {
+        if (nextId !== undefined) {
+          methods.setValue('resourceId', nextId);
+        }
+      }, [nextId, methods]);
+
+      return (
+        <MemoryRouter>
+          <FormProvider {...methods}>
+            <NodeTypeStep />
+            <button onClick={() => setNextId(2)}>Switch</button>
+          </FormProvider>
+        </MemoryRouter>
+      );
+    }
+
+    const { getByRole } = render(<ControlledWrapper />);
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+
+    act(() => {
+      getByRole('button', { name: 'Switch' }).click();
+    });
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    expect(mockSetStepData).toHaveBeenCalled();
+  });
+
+  it('should clear prompt step state when switching to a template with no promptable fields (else-if isTemplateChange path)', async () => {
+    // Override mock: template 1 has prompts, template 3 has NO prompts
+    // When switching from 1→3 with isTemplateChange=true and shouldShowPromptStep=false,
+    // lines 238-254 (the else-if isTemplateChange cleanup path) should be covered.
+    // fetchResource builds URLs with a trailing slash, producing double slashes like
+    // /job_templates//3/launch/. Match resource ID suffix to handle both /3/ and //3/ patterns.
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('3/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          ask_labels_on_launch: false,
+          ask_instance_groups_on_launch: false,
+          ask_tags_on_launch: false,
+          ask_skip_tags_on_launch: false,
+          ask_diff_mode_on_launch: false,
+          ask_limit_on_launch: false,
+          ask_verbosity_on_launch: false,
+          ask_scm_branch_on_launch: false,
+          ask_forks_on_launch: false,
+          ask_job_slice_count_on_launch: false,
+          ask_timeout_on_launch: false,
+          ask_execution_environment_on_launch: false,
+          ask_job_type_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      if (url.includes('3/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      // fetchResource for template 3: endsWith //3 or /3 (must come AFTER launch/ and credentials/ checks)
+      if (url.endsWith('//3') || url.endsWith('/3')) {
+        return Promise.resolve({ id: 3, name: 'No-Prompts Template', type: 'job_template' });
+      }
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: true,
+          ask_inventory_on_launch: true,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: { credentials: [], inventory: null },
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({
+          count: 1,
+          results: [
+            {
+              id: 10,
+              name: 'SSH',
+              credential_type: 1,
+              summary_fields: { credential_type: { name: 'Machine' } },
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+    });
+
+    function ControlledWrapper() {
+      const [nextId, setNextId] = useState<number | undefined>(undefined);
+      const methods = useForm<WizardFormValues>({
+        defaultValues: { node_type: RESOURCE_TYPE.job, resourceId: 1 },
+      });
+
+      useEffect(() => {
+        if (nextId !== undefined) {
+          methods.setValue('resourceId', nextId);
+        }
+      }, [nextId, methods]);
+
+      return (
+        <MemoryRouter>
+          <FormProvider {...methods}>
+            <NodeTypeStep />
+            <button onClick={() => setNextId(3)}>Switch to no-prompts</button>
+          </FormProvider>
+        </MemoryRouter>
+      );
+    }
+
+    const { getByRole } = render(<ControlledWrapper />);
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+
+    act(() => {
+      getByRole('button', { name: 'Switch to no-prompts' }).click();
+    });
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+    expect(mockSetStepData).toHaveBeenCalled();
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result.launch_config).toBeNull();
+    }
+  });
+
+  it('should handle workflow_job template type and fetch launch config', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/workflow_job_templates/10/launch/')) {
+        return Promise.resolve({
+          ask_inventory_on_launch: true,
+          ask_credential_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      return Promise.resolve({ id: 10, name: 'WF Template', type: 'workflow_job_template' });
+    });
+
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_job,
+          resourceId: 10,
+        }}
+      />
+    );
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    expect(mockRequestGet).toHaveBeenCalledWith(
+      expect.stringContaining('/workflow_job_templates/10/launch/')
+    );
+  });
+
+  it('should render the node type selector form elements', () => {
+    const { container } = render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+        }}
+      />
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+function TestWrapperWithSourceNode({
+  defaultValues,
+  hasSourceNode = false,
+}: Readonly<{ defaultValues: Partial<WizardFormValues>; hasSourceNode?: boolean }>) {
+  const methods = useForm<WizardFormValues>({ defaultValues });
+  return (
+    <MemoryRouter>
+      <FormProvider {...methods}>
+        <NodeTypeStep hasSourceNode={hasSourceNode} />
+      </FormProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('NodeTypeStep sub-components', () => {
+  beforeEach(() => {
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+    mockRequestGet.mockClear();
+  });
+
+  it('should render NodeStatusType when hasSourceNode is true', () => {
+    const { getByTestId } = render(
+      <TestWrapperWithSourceNode defaultValues={{ node_type: RESOURCE_TYPE.job }} hasSourceNode />
+    );
+    expect(getByTestId('node-status-type')).toBeInTheDocument();
+  });
+
+  it('should not render NodeStatusType when hasSourceNode is false', () => {
+    const { queryByTestId } = render(
+      <TestWrapperWithSourceNode
+        defaultValues={{ node_type: RESOURCE_TYPE.job }}
+        hasSourceNode={false}
+      />
+    );
+    expect(queryByTestId('node-status-type')).not.toBeInTheDocument();
+  });
+
+  it('should render convergence input', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-convergence')).toBeInTheDocument();
+  });
+
+  it('should render alias input', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-alias')).toBeInTheDocument();
+  });
+
+  it('should render approval form fields for workflow_approval node type', () => {
+    const { getByTestId } = render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_approval,
+          approval_timeout: 90,
+        }}
+      />
+    );
+    expect(getByTestId('approval_timeout_minutes')).toBeInTheDocument();
+    expect(getByTestId('approval_timeout_seconds')).toBeInTheDocument();
+  });
+
+  it('should render node type select', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-type')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'vitest';
+import { buildEffectivePrompt } from './buildEffectivePrompt';
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+
+const baseLaunchConfig = {
+  ask_credential_on_launch: false,
+  ask_labels_on_launch: false,
+  ask_instance_groups_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_variables_on_launch: false,
+} as LaunchConfiguration;
+
+describe('buildEffectivePrompt', () => {
+  describe('template change detection', () => {
+    test('should detect template change when IDs differ', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(true);
+    });
+
+    test('should not detect template change when IDs match', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(false);
+    });
+
+    test('should not detect template change when original ID is undefined', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: undefined,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(false);
+    });
+  });
+
+  describe('force-clearing on template change', () => {
+    test('should clear all fields when new template has no prompts', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: {
+          credentials: [{ id: 1, name: 'old', credential_type: 1, passwords_needed: [] }],
+        },
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toEqual([]);
+      expect(effectivePrompt.labels).toEqual([]);
+      expect(effectivePrompt.instance_groups).toEqual([]);
+      expect(effectivePrompt.skip_tags).toEqual([]);
+      expect(effectivePrompt.job_tags).toEqual([]);
+      expect(effectivePrompt.extra_vars).toBe('');
+    });
+
+    test('should preserve credentials when new template accepts them', () => {
+      const creds = [{ id: 1, name: 'cred', credential_type: 1, passwords_needed: [] as string[] }];
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: { credentials: creds },
+        launchConfig: { ...baseLaunchConfig, ask_credential_on_launch: true },
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toEqual(creds);
+    });
+
+    test('should preserve extra_vars when new template accepts them', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: { extra_vars: 'my_var: value' },
+        launchConfig: { ...baseLaunchConfig, ask_variables_on_launch: true },
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.extra_vars).toBe('my_var: value');
+    });
+
+    test('should not clear fields when template does not change', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: {
+          credentials: [{ id: 1, name: 'cred', credential_type: 1, passwords_needed: [] }],
+        },
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toHaveLength(1);
+    });
+  });
+
+  describe('original object construction', () => {
+    test('should include isTemplateChange flag when template changed', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: {
+          credentials: [{ id: 5, name: 'old', credential_type: 1 }],
+        },
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.isTemplateChange).toBe(true);
+      expect(effectivePrompt.original?.credentials).toEqual([
+        { id: 5, name: 'old', credential_type: 1 },
+      ]);
+    });
+
+    test('should not include isTemplateChange when template did not change', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.isTemplateChange).toBeUndefined();
+    });
+
+    test('should include launch_config in original when provided', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.launch_config).toBe(baseLaunchConfig);
+    });
+  });
+
+  describe('prompt fallback', () => {
+    test('should use empty object when prompt is undefined', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: undefined,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toBeUndefined();
+    });
+
+    test('should set organization from resource', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: undefined,
+        nodeOriginalResources: undefined,
+        resourceOrganization: 42,
+      });
+      expect(effectivePrompt.organization).toBe(42);
+    });
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
@@ -1,0 +1,56 @@
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import type { PromptFormValues } from '../types';
+
+export interface BuildEffectivePromptParams {
+  originalTemplateId: number | undefined;
+  newResourceId: number | undefined;
+  prompt: Partial<PromptFormValues> | undefined;
+  launchConfig: LaunchConfiguration | null | undefined;
+  nodeOriginalResources: PromptFormValues['original'];
+  resourceOrganization: number | null | undefined;
+}
+
+function clearUnpromptedFields(
+  effectivePrompt: Partial<PromptFormValues>,
+  launchConfig: LaunchConfiguration | null | undefined
+): void {
+  if (!launchConfig?.ask_credential_on_launch) effectivePrompt.credentials = [];
+  if (!launchConfig?.ask_labels_on_launch) effectivePrompt.labels = [];
+  if (!launchConfig?.ask_instance_groups_on_launch) effectivePrompt.instance_groups = [];
+  if (!launchConfig?.ask_skip_tags_on_launch) effectivePrompt.skip_tags = [];
+  if (!launchConfig?.ask_tags_on_launch) effectivePrompt.job_tags = [];
+  if (!launchConfig?.ask_variables_on_launch) effectivePrompt.extra_vars = '';
+}
+
+export function buildEffectivePrompt({
+  originalTemplateId,
+  newResourceId,
+  prompt,
+  launchConfig,
+  nodeOriginalResources,
+  resourceOrganization,
+}: Readonly<BuildEffectivePromptParams>): {
+  isTemplateChange: boolean;
+  effectivePrompt: Partial<PromptFormValues>;
+} {
+  const isTemplateChange =
+    originalTemplateId !== undefined && Number(newResourceId) !== originalTemplateId;
+
+  const effectivePrompt: Partial<PromptFormValues> = prompt ?? {};
+
+  if (resourceOrganization !== undefined) {
+    effectivePrompt.organization = resourceOrganization;
+  }
+
+  if (isTemplateChange) {
+    clearUnpromptedFields(effectivePrompt, launchConfig);
+  }
+
+  effectivePrompt.original = {
+    ...(launchConfig ? { launch_config: launchConfig } : {}),
+    ...nodeOriginalResources,
+    ...(isTemplateChange ? { isTemplateChange: true } : {}),
+  };
+
+  return { isTemplateChange, effectivePrompt };
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'vitest';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import type { Survey } from '../../../../interfaces/Survey';
+import { getConvergenceType, getResourceURL, processSurvey } from './helpers';
+
+describe('getConvergenceType', () => {
+  test('should return "all" when convergence is true', () => {
+    expect(getConvergenceType(true)).toBe('all');
+  });
+
+  test('should return "any" when convergence is false', () => {
+    expect(getConvergenceType(false)).toBe('any');
+  });
+
+  test('should return "any" when convergence is null', () => {
+    expect(getConvergenceType(null)).toBe('any');
+  });
+
+  test('should return "any" when convergence is undefined', () => {
+    expect(getConvergenceType(undefined)).toBe('any');
+  });
+});
+
+describe('getResourceURL', () => {
+  test('should return job_templates URL for "job" type', () => {
+    expect(getResourceURL('job')).toBe(awxAPI`/job_templates/`);
+  });
+
+  test('should return job_templates URL for "job_template" type', () => {
+    expect(getResourceURL('job_template')).toBe(awxAPI`/job_templates/`);
+  });
+
+  test('should return workflow_job_templates URL for "workflow_job" type', () => {
+    expect(getResourceURL('workflow_job')).toBe(awxAPI`/workflow_job_templates/`);
+  });
+
+  test('should return workflow_job_templates URL for "workflow_job_template" type', () => {
+    expect(getResourceURL('workflow_job_template')).toBe(awxAPI`/workflow_job_templates/`);
+  });
+
+  test('should return inventory_sources URL for "inventory_update" type', () => {
+    expect(getResourceURL('inventory_update')).toBe(awxAPI`/inventory_sources`);
+  });
+
+  test('should return inventory_sources URL for "inventory_source" type', () => {
+    expect(getResourceURL('inventory_source')).toBe(awxAPI`/inventory_sources`);
+  });
+
+  test('should return projects URL for "project" type', () => {
+    expect(getResourceURL('project')).toBe(awxAPI`/projects/`);
+  });
+
+  test('should return projects URL for "project_update" type', () => {
+    expect(getResourceURL('project_update')).toBe(awxAPI`/projects/`);
+  });
+
+  test('should return system_job_templates URL for "system_job" type', () => {
+    expect(getResourceURL('system_job')).toBe(awxAPI`/system_job_templates/`);
+  });
+
+  test('should return system_job_templates URL for "system_job_template" type', () => {
+    expect(getResourceURL('system_job_template')).toBe(awxAPI`/system_job_templates/`);
+  });
+
+  test('should return empty string for "workflow_approval" type', () => {
+    expect(getResourceURL('workflow_approval')).toBe('');
+  });
+
+  test('should return empty string for unknown type', () => {
+    expect(getResourceURL('unknown_type')).toBe('');
+  });
+});
+
+describe('processSurvey', () => {
+  const mockSurveySpec: Survey = {
+    name: 'Test Survey',
+    description: '',
+    spec: [
+      {
+        variable: 'text_var',
+        type: 'text',
+        question_name: 'Text',
+        question_description: '',
+        required: false,
+        default: '',
+        min: 0,
+        max: 255,
+        choices: [],
+        new_question: false,
+      },
+      {
+        variable: 'password_var',
+        type: 'password',
+        question_name: 'Password',
+        question_description: '',
+        required: false,
+        default: '',
+        min: 0,
+        max: 255,
+        choices: [],
+        new_question: false,
+      },
+    ],
+  };
+
+  test('should merge null extra_vars with survey data and return YAML', () => {
+    const result = processSurvey(null, { my_var: 'value' }, null);
+    expect(result).toContain('my_var');
+    expect(result).toContain('value');
+  });
+
+  test('should merge extra_vars YAML with survey data', () => {
+    const result = processSurvey('extra_key: extra_val', { survey_key: 'survey_val' }, null);
+    expect(result).toContain('extra_key');
+    expect(result).toContain('survey_key');
+  });
+
+  test('should mask password fields when surveyConfig is provided', () => {
+    const result = processSurvey(
+      null,
+      { password_var: 'supersecret', text_var: 'visible' },
+      mockSurveySpec
+    );
+    expect(result).toContain('$encrypted$');
+    expect(result).not.toContain('supersecret');
+    expect(result).toContain('visible');
+  });
+
+  test('should not mask non-password fields', () => {
+    const result = processSurvey(null, { text_var: 'visible_value' }, mockSurveySpec);
+    expect(result).toContain('visible_value');
+  });
+
+  test('should not mask fields when surveyConfig is null', () => {
+    const result = processSurvey(null, { secret_field: 'plaintext' }, null);
+    expect(result).toContain('plaintext');
+  });
+
+  test('should allow survey data to override extra_vars keys', () => {
+    const result = processSurvey('my_key: from_vars', { my_key: 'from_survey' }, null);
+    expect(result).toContain('from_survey');
+    expect(result).not.toContain('from_vars');
+  });
+
+  test('should mask only variables present in survey answers', () => {
+    const result = processSurvey(null, { text_var: 'shown' }, mockSurveySpec);
+    expect(result).toContain('shown');
+    expect(result).not.toContain('$encrypted$');
+  });
+});


### PR DESCRIPTION
Move resolveScalar, resolveArrayField, resolveTagField, resolveExecutionEnvironment, mergeSurveyIntoVariables, and arrayIdsMatch from JobTemplateDetails.tsx into resolveNodeFields.ts. Extract resolveVariables into resolveExtraVars.ts. Move clearStalePromptFields and nullIfMissing logic into clearStaleNodeFields.ts. Extract prompt assembly from NodeEditWizard into buildEffectivePrompt.ts.

Each new module has a co-located test file covering happy-path, edge-case, and template-switch scenarios.

## Summary

<!-- What changed and why? -->

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

Full field-by-field test matrix: https://docs.google.com/spreadsheets/d/143agtJG6Pw2H-g4_G_uVMyWfh6002vLjKPGRyFRaGE0/edit?usp=sharing

Assisted-by: Claude Code / Opus 4.6 (Anthropic)