### PR TITLE
perf(awx): reduce unnecessary job list refetches on WS status changes

### DIFF
--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -3,11 +3,23 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { jobsFixture } from './jobs.fixture';
 import { Jobs } from './Jobs';
 import { getWsAction } from './JobsList';
+
+let capturedOnMessage: ((message: unknown) => void) | undefined;
+
+vi.mock('../../common/useAwxWebSocket', () => ({
+  useAwxWebSocketSubscription: (
+    _events: Record<string, string[]>,
+    onMessage: (message: unknown) => void
+  ) => {
+    capturedOnMessage = onMessage;
+    return { sendMessage: vi.fn(), lastMessage: null, readyState: 1 };
+  },
+}));
 
 const server = setupServer(
   http.options(awxAPI`/unified_jobs/`, () => {
@@ -64,7 +76,10 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  capturedOnMessage = undefined;
+});
 afterAll(() => server.close());
 
 describe('JobsList Component Tests', () => {
@@ -399,4 +414,102 @@ describe('getWsAction', () => {
       )
     ).toEqual({ type: 'refresh' });
   });
+});
+
+describe('JobsList WebSocket handler integration', () => {
+  async function renderAndWaitForJobs() {
+    render(
+      <MemoryRouter>
+        <Jobs />
+      </MemoryRouter>
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByText('491')).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+    expect(capturedOnMessage).toBeDefined();
+  }
+
+  test('should call full list refresh on pending status', async () => {
+    let listFetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'pending',
+      unified_job_id: 999,
+    });
+
+    await waitFor(() => {
+      expect(listFetchCount).toBeGreaterThan(initialCount);
+    });
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should fetch individual job on intermediate status for on-page job', async () => {
+    let detailFetchId: string | undefined;
+    server.use(
+      http.get('*/unified_jobs/:id/', ({ params }) => {
+        detailFetchId = params['id'] as string;
+        return HttpResponse.json({ ...jobsFixture.results[1], status: 'running' });
+      })
+    );
+
+    await renderAndWaitForJobs();
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'running',
+      unified_job_id: 492,
+    });
+
+    await waitFor(() => {
+      expect(detailFetchId).toBe('492');
+    });
+  }, 15000);
+
+  test('should skip for intermediate status when job is not on page', async () => {
+    let detailFetched = false;
+    let listFetchCount = 0;
+    server.use(
+      http.get('*/unified_jobs/:id/', () => {
+        detailFetched = true;
+        return HttpResponse.json({});
+      })
+    );
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialListCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'running',
+      unified_job_id: 9999,
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(detailFetched).toBe(false);
+    expect(listFetchCount).toBe(initialListCount);
+
+    server.events.removeAllListeners();
+  }, 15000);
 });

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -460,7 +460,7 @@ describe('JobsList WebSocket handler integration', () => {
   test('should fetch individual job on intermediate status for on-page job', async () => {
     let detailFetchId: string | undefined;
     server.use(
-      http.get('*/unified_jobs/:id/', ({ params }) => {
+      http.get('*/jobs/:id/', ({ params }) => {
         detailFetchId = params['id'] as string;
         return HttpResponse.json({ ...jobsFixture.results[1], status: 'running' });
       })
@@ -483,7 +483,7 @@ describe('JobsList WebSocket handler integration', () => {
   test('should skip for intermediate status when job is not on page', async () => {
     let detailFetched = false;
     server.use(
-      http.get('*/unified_jobs/:id/', () => {
+      http.get('*/jobs/:id/', () => {
         detailFetched = true;
         return HttpResponse.json({});
       })

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -3,22 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { jobsFixture } from './jobs.fixture';
 import { Jobs } from './Jobs';
-
-let capturedOnMessage: ((message: unknown) => void) | undefined;
-
-vi.mock('../../common/useAwxWebSocket', () => ({
-  useAwxWebSocketSubscription: (
-    _events: Record<string, string[]>,
-    onMessage: (message: unknown) => void
-  ) => {
-    capturedOnMessage = onMessage;
-    return { sendMessage: vi.fn(), lastMessage: null, readyState: 1 };
-  },
-}));
+import { getWsAction } from './JobsList';
 
 const server = setupServer(
   http.options(awxAPI`/unified_jobs/`, () => {
@@ -75,10 +64,7 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => {
-  server.resetHandlers();
-  capturedOnMessage = undefined;
-});
+afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('JobsList Component Tests', () => {
@@ -306,216 +292,111 @@ describe('JobsList Component Tests', () => {
   }, 15000);
 });
 
-describe('JobsList WebSocket Handler', () => {
-  async function renderAndWaitForJobs() {
-    render(
-      <MemoryRouter>
-        <Jobs />
-      </MemoryRouter>
-    );
-    await waitFor(
-      () => {
-        expect(screen.getByText('491')).toBeInTheDocument();
-      },
-      { timeout: 10000 }
-    );
-    expect(capturedOnMessage).toBeDefined();
-  }
+describe('getWsAction', () => {
+  const pageItemIds = [491, 492, 489, 488];
 
-  test('should trigger full list refresh on pending status', async () => {
-    let listFetchCount = 0;
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
+  test('should return refresh for pending status', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'pending', unified_job_id: 999 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'refresh' });
+  });
 
-    await renderAndWaitForJobs();
-    const initialCount = listFetchCount;
+  test('should return refresh for new status', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'new', unified_job_id: 999 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'refresh' });
+  });
 
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'job',
-      status: 'pending',
-      unified_job_id: 999,
-    });
+  test('should return refresh for each final status', () => {
+    for (const status of ['successful', 'failed', 'error', 'canceled']) {
+      expect(
+        getWsAction({ group_name: 'jobs', type: 'job', status, unified_job_id: 492 }, pageItemIds)
+      ).toEqual({ type: 'refresh' });
+    }
+  });
 
-    await waitFor(() => {
-      expect(listFetchCount).toBeGreaterThan(initialCount);
-    });
+  test('should return fetch for intermediate status when job is on page', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'running', unified_job_id: 492 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'fetch', jobId: 492 });
+  });
 
-    server.events.removeAllListeners();
-  }, 15000);
+  test('should return fetch for waiting status when job is on page', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'waiting', unified_job_id: 491 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'fetch', jobId: 491 });
+  });
 
-  test('should trigger full list refresh on final status', async () => {
-    let listFetchCount = 0;
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
+  test('should return skip for intermediate status when job is not on page', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'running', unified_job_id: 9999 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'skip' });
+  });
 
-    await renderAndWaitForJobs();
-    const initialCount = listFetchCount;
+  test('should return refresh when status is missing', () => {
+    expect(
+      getWsAction({ group_name: 'jobs', type: 'job', unified_job_id: 492 }, pageItemIds)
+    ).toEqual({ type: 'refresh' });
+  });
 
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'job',
-      status: 'successful',
-      unified_job_id: 492,
-    });
+  test('should return refresh when unified_job_id is missing', () => {
+    expect(
+      getWsAction({ group_name: 'jobs', type: 'job', status: 'running' }, pageItemIds)
+    ).toEqual({ type: 'refresh' });
+  });
 
-    await waitFor(() => {
-      expect(listFetchCount).toBeGreaterThan(initialCount);
-    });
+  test('should return skip for non-job group_name', () => {
+    expect(
+      getWsAction(
+        { group_name: 'inventories', type: 'job', status: 'pending', unified_job_id: 492 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'skip' });
+  });
 
-    server.events.removeAllListeners();
-  }, 15000);
+  test('should return skip for unrecognized type', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'inventory_update', status: 'running', unified_job_id: 492 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'skip' });
+  });
 
-  test('should fetch individual job for intermediate status when job is on page', async () => {
-    let detailFetchId: string | undefined;
-    server.use(
-      http.get('*/unified_jobs/:id/', ({ params }) => {
-        detailFetchId = params['id'] as string;
-        return HttpResponse.json({ ...jobsFixture.results[1], status: 'running' });
-      })
-    );
+  test('should return skip for undefined message', () => {
+    expect(getWsAction(undefined, pageItemIds)).toEqual({ type: 'skip' });
+  });
 
-    await renderAndWaitForJobs();
+  test('should handle workflow_job type', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'workflow_job', status: 'running', unified_job_id: 491 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'fetch', jobId: 491 });
+  });
 
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'job',
-      status: 'running',
-      unified_job_id: 492,
-    });
-
-    await waitFor(() => {
-      expect(detailFetchId).toBe('492');
-    });
-  }, 15000);
-
-  test('should skip fetch for intermediate status when job is not on page', async () => {
-    let detailFetched = false;
-    let listFetchCount = 0;
-    server.use(
-      http.get('*/unified_jobs/:id/', () => {
-        detailFetched = true;
-        return HttpResponse.json({});
-      })
-    );
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
-
-    await renderAndWaitForJobs();
-    const initialListCount = listFetchCount;
-
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'job',
-      status: 'running',
-      unified_job_id: 9999,
-    });
-
-    // Give time for any async work to settle
-    await new Promise((r) => setTimeout(r, 500));
-
-    expect(detailFetched).toBe(false);
-    expect(listFetchCount).toBe(initialListCount);
-
-    server.events.removeAllListeners();
-  }, 15000);
-
-  test('should fall back to full refresh when status is missing', async () => {
-    let listFetchCount = 0;
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
-
-    await renderAndWaitForJobs();
-    const initialCount = listFetchCount;
-
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'job',
-      unified_job_id: 492,
-    });
-
-    await waitFor(() => {
-      expect(listFetchCount).toBeGreaterThan(initialCount);
-    });
-
-    server.events.removeAllListeners();
-  }, 15000);
-
-  test('should ignore messages with non-job group_name', async () => {
-    let detailFetched = false;
-    let listFetchCount = 0;
-    server.use(
-      http.get('*/unified_jobs/:id/', () => {
-        detailFetched = true;
-        return HttpResponse.json({});
-      })
-    );
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
-
-    await renderAndWaitForJobs();
-    const initialListCount = listFetchCount;
-
-    capturedOnMessage!({
-      group_name: 'inventories',
-      type: 'job',
-      status: 'pending',
-      unified_job_id: 492,
-    });
-
-    await new Promise((r) => setTimeout(r, 500));
-
-    expect(detailFetched).toBe(false);
-    expect(listFetchCount).toBe(initialListCount);
-
-    server.events.removeAllListeners();
-  }, 15000);
-
-  test('should ignore messages with unrecognized type', async () => {
-    let detailFetched = false;
-    let listFetchCount = 0;
-    server.use(
-      http.get('*/unified_jobs/:id/', () => {
-        detailFetched = true;
-        return HttpResponse.json({});
-      })
-    );
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
-
-    await renderAndWaitForJobs();
-    const initialListCount = listFetchCount;
-
-    capturedOnMessage!({
-      group_name: 'jobs',
-      type: 'inventory_update',
-      status: 'running',
-      unified_job_id: 492,
-    });
-
-    await new Promise((r) => setTimeout(r, 500));
-
-    expect(detailFetched).toBe(false);
-    expect(listFetchCount).toBe(initialListCount);
-
-    server.events.removeAllListeners();
-  }, 15000);
+  test('should handle project_update type', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'project_update', status: 'pending', unified_job_id: 999 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'refresh' });
+  });
 });

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -3,10 +3,22 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { jobsFixture } from './jobs.fixture';
 import { Jobs } from './Jobs';
+
+let capturedOnMessage: ((message: unknown) => void) | undefined;
+
+vi.mock('../../common/useAwxWebSocket', () => ({
+  useAwxWebSocketSubscription: (
+    _events: Record<string, string[]>,
+    onMessage: (message: unknown) => void
+  ) => {
+    capturedOnMessage = onMessage;
+    return { sendMessage: vi.fn(), lastMessage: null, readyState: 1 };
+  },
+}));
 
 const server = setupServer(
   http.options(awxAPI`/unified_jobs/`, () => {
@@ -63,7 +75,10 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  capturedOnMessage = undefined;
+});
 afterAll(() => server.close());
 
 describe('JobsList Component Tests', () => {
@@ -288,5 +303,219 @@ describe('JobsList Component Tests', () => {
       },
       { timeout: 10000 }
     );
+  }, 15000);
+});
+
+describe('JobsList WebSocket Handler', () => {
+  async function renderAndWaitForJobs() {
+    render(
+      <MemoryRouter>
+        <Jobs />
+      </MemoryRouter>
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByText('491')).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+    expect(capturedOnMessage).toBeDefined();
+  }
+
+  test('should trigger full list refresh on pending status', async () => {
+    let listFetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'pending',
+      unified_job_id: 999,
+    });
+
+    await waitFor(() => {
+      expect(listFetchCount).toBeGreaterThan(initialCount);
+    });
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should trigger full list refresh on final status', async () => {
+    let listFetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'successful',
+      unified_job_id: 492,
+    });
+
+    await waitFor(() => {
+      expect(listFetchCount).toBeGreaterThan(initialCount);
+    });
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should fetch individual job for intermediate status when job is on page', async () => {
+    let detailFetchId: string | undefined;
+    server.use(
+      http.get('*/unified_jobs/:id/', ({ params }) => {
+        detailFetchId = params['id'] as string;
+        return HttpResponse.json({ ...jobsFixture.results[1], status: 'running' });
+      })
+    );
+
+    await renderAndWaitForJobs();
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'running',
+      unified_job_id: 492,
+    });
+
+    await waitFor(() => {
+      expect(detailFetchId).toBe('492');
+    });
+  }, 15000);
+
+  test('should skip fetch for intermediate status when job is not on page', async () => {
+    let detailFetched = false;
+    let listFetchCount = 0;
+    server.use(
+      http.get('*/unified_jobs/:id/', () => {
+        detailFetched = true;
+        return HttpResponse.json({});
+      })
+    );
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialListCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'running',
+      unified_job_id: 9999,
+    });
+
+    // Give time for any async work to settle
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(detailFetched).toBe(false);
+    expect(listFetchCount).toBe(initialListCount);
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should fall back to full refresh when status is missing', async () => {
+    let listFetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      unified_job_id: 492,
+    });
+
+    await waitFor(() => {
+      expect(listFetchCount).toBeGreaterThan(initialCount);
+    });
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should ignore messages with non-job group_name', async () => {
+    let detailFetched = false;
+    let listFetchCount = 0;
+    server.use(
+      http.get('*/unified_jobs/:id/', () => {
+        detailFetched = true;
+        return HttpResponse.json({});
+      })
+    );
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialListCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'inventories',
+      type: 'job',
+      status: 'pending',
+      unified_job_id: 492,
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(detailFetched).toBe(false);
+    expect(listFetchCount).toBe(initialListCount);
+
+    server.events.removeAllListeners();
+  }, 15000);
+
+  test('should ignore messages with unrecognized type', async () => {
+    let detailFetched = false;
+    let listFetchCount = 0;
+    server.use(
+      http.get('*/unified_jobs/:id/', () => {
+        detailFetched = true;
+        return HttpResponse.json({});
+      })
+    );
+    server.events.on('request:match', ({ request }) => {
+      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
+        listFetchCount++;
+      }
+    });
+
+    await renderAndWaitForJobs();
+    const initialListCount = listFetchCount;
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'inventory_update',
+      status: 'running',
+      unified_job_id: 492,
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(detailFetched).toBe(false);
+    expect(listFetchCount).toBe(initialListCount);
+
+    server.events.removeAllListeners();
   }, 15000);
 });

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -482,21 +482,14 @@ describe('JobsList WebSocket handler integration', () => {
 
   test('should skip for intermediate status when job is not on page', async () => {
     let detailFetched = false;
-    let listFetchCount = 0;
     server.use(
       http.get('*/unified_jobs/:id/', () => {
         detailFetched = true;
         return HttpResponse.json({});
       })
     );
-    server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
-      }
-    });
 
     await renderAndWaitForJobs();
-    const initialListCount = listFetchCount;
 
     capturedOnMessage!({
       group_name: 'jobs',
@@ -508,8 +501,5 @@ describe('JobsList WebSocket handler integration', () => {
     await new Promise((r) => setTimeout(r, 500));
 
     expect(detailFetched).toBe(false);
-    expect(listFetchCount).toBe(initialListCount);
-
-    server.events.removeAllListeners();
   }, 15000);
 });

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -16,7 +16,7 @@ import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
 
 type QueryParams = { [key: string]: string };
 
-type WebSocketMessage = {
+export type WebSocketMessage = {
   group_name?: string;
   type?: string;
   status?: string;
@@ -25,6 +25,33 @@ type WebSocketMessage = {
 
 const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
 const NEW_JOB_STATUSES = new Set(['new', 'pending']);
+
+export type WsAction = { type: 'refresh' } | { type: 'fetch'; jobId: number } | { type: 'skip' };
+
+export function getWsAction(
+  message: WebSocketMessage | undefined,
+  pageItemIds: number[]
+): WsAction {
+  if (message?.group_name !== 'jobs') return { type: 'skip' };
+
+  switch (message?.type) {
+    case 'job':
+    case 'workflow_job':
+    case 'project_update':
+      break;
+    default:
+      return { type: 'skip' };
+  }
+
+  const status = message?.status;
+  const jobId = message?.unified_job_id;
+
+  if (!status || !jobId) return { type: 'refresh' };
+  if (NEW_JOB_STATUSES.has(status) || FINAL_STATUSES.has(status)) return { type: 'refresh' };
+
+  if (pageItemIds.includes(jobId)) return { type: 'fetch', jobId };
+  return { type: 'skip' };
+}
 
 export function JobsList(props: {
   queryParams?: QueryParams;
@@ -63,37 +90,22 @@ export function JobsList(props: {
 
   const handleWebSocketMessage = useCallback(
     (message?: WebSocketMessage) => {
-      if (message?.group_name !== 'jobs') return;
+      const pageItemIds = (pageItemsRef.current ?? []).map((item) => item.id);
+      const action = getWsAction(message, pageItemIds);
 
-      switch (message?.type) {
-        case 'job':
-        case 'workflow_job':
-        case 'project_update':
+      switch (action.type) {
+        case 'refresh':
+          throttledRefresh();
           break;
-        default:
-          return;
+        case 'fetch':
+          void requestGet<UnifiedJob>(awxAPI`/unified_jobs/${action.jobId.toString()}/`).then(
+            (updatedJob) => updateItemRef.current(updatedJob),
+            () => throttledRefresh()
+          );
+          break;
+        case 'skip':
+          break;
       }
-
-      const status = message?.status;
-      const jobId = message?.unified_job_id;
-
-      if (!status || !jobId) {
-        throttledRefresh();
-        return;
-      }
-
-      if (NEW_JOB_STATUSES.has(status) || FINAL_STATUSES.has(status)) {
-        throttledRefresh();
-        return;
-      }
-
-      const existingJob = (pageItemsRef.current ?? []).find((item) => item.id === jobId);
-      if (!existingJob) return;
-
-      void requestGet<UnifiedJob>(awxAPI`/unified_jobs/${jobId.toString()}/`).then(
-        (updatedJob) => updateItemRef.current(updatedJob),
-        () => throttledRefresh()
-      );
     },
     [throttledRefresh]
   );

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -98,12 +98,15 @@ export function JobsList(props: {
         case 'refresh':
           throttledRefresh();
           break;
-        case 'fetch':
-          void requestGet<UnifiedJob>(awxAPI`/unified_jobs/${action.jobId.toString()}/`).then(
+        case 'fetch': {
+          const item = pageItemsRef.current?.find((i) => i.id === action.jobId);
+          const url = item?.url ?? awxAPI`/unified_jobs/${action.jobId.toString()}/`;
+          requestGet<UnifiedJob>(url).then(
             (updatedJob) => updateItemRef.current(updatedJob),
             () => throttledRefresh()
           );
           break;
+        }
         case 'skip':
           break;
       }

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -83,6 +83,7 @@ export function JobsList(props: {
   );
   useEffect(() => () => throttledRefresh.cancel(), [throttledRefresh]);
 
+  // Stable refs to avoid re-render loop in WS subscription
   const pageItemsRef = useRef(pageItems);
   pageItemsRef.current = pageItems;
   const updateItemRef = useRef(updateItem);

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -1,7 +1,8 @@
 import { ITableColumn, PageTable } from '@ansible/ansible-ui-framework';
 import { usePersistentFilters } from '@ansible/common-ui/PersistentFilters';
+import { requestGet } from '@ansible/common-ui/crud/Data';
 import { CubesIcon } from '@patternfly/react-icons';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { awxAPI } from '../../common/api/awx-utils';
 import { createThrottle } from '../../common/util/createThrottle';
@@ -14,6 +15,16 @@ import { useJobToolbarActions } from '../../views/jobs/hooks/useJobToolbarAction
 import { useJobsFilters } from '../../views/jobs/hooks/useJobsFilters';
 
 type QueryParams = { [key: string]: string };
+
+type WebSocketMessage = {
+  group_name?: string;
+  type?: string;
+  status?: string;
+  unified_job_id?: number;
+};
+
+const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
+const NEW_JOB_STATUSES = new Set(['new', 'pending']);
 
 export function JobsList(props: {
   queryParams?: QueryParams;
@@ -35,7 +46,7 @@ export function JobsList(props: {
 
   usePersistentFilters('jobs');
 
-  const { refresh } = view;
+  const { refresh, updateItem, pageItems } = view;
   const throttledRefresh = useMemo(
     () =>
       createThrottle(() => {
@@ -45,19 +56,44 @@ export function JobsList(props: {
   );
   useEffect(() => () => throttledRefresh.cancel(), [throttledRefresh]);
 
+  const pageItemsRef = useRef(pageItems);
+  pageItemsRef.current = pageItems;
+  const updateItemRef = useRef(updateItem);
+  updateItemRef.current = updateItem;
+
   const handleWebSocketMessage = useCallback(
-    (message?: { group_name?: string; type?: string }) => {
-      switch (message?.group_name) {
-        case 'jobs':
-          switch (message?.type) {
-            case 'job':
-            case 'workflow_job':
-            case 'project_update':
-              throttledRefresh();
-              break;
-          }
+    (message?: WebSocketMessage) => {
+      if (message?.group_name !== 'jobs') return;
+
+      switch (message?.type) {
+        case 'job':
+        case 'workflow_job':
+        case 'project_update':
           break;
+        default:
+          return;
       }
+
+      const status = message?.status;
+      const jobId = message?.unified_job_id;
+
+      if (!status || !jobId) {
+        throttledRefresh();
+        return;
+      }
+
+      if (NEW_JOB_STATUSES.has(status) || FINAL_STATUSES.has(status)) {
+        throttledRefresh();
+        return;
+      }
+
+      const existingJob = (pageItemsRef.current ?? []).find((item) => item.id === jobId);
+      if (!existingJob) return;
+
+      void requestGet<UnifiedJob>(awxAPI`/unified_jobs/${jobId.toString()}/`).then(
+        (updatedJob) => updateItemRef.current(updatedJob),
+        () => throttledRefresh()
+      );
     },
     [throttledRefresh]
   );


### PR DESCRIPTION
## Summary

Add status-aware routing to the WebSocket handler in `JobsList.tsx` so that only structurally significant status changes trigger a full list refresh. Intermediate status updates fetch individual jobs or are skipped entirely for off-page jobs.

Builds on top of [PR #2517](https://github.com/ansible-automation-platform/aap-ui/pull/2517), which added a 5-second leading+trailing throttle. The throttle remains — this change adds smarter routing inside  the handler.

  ## Problem

The WebSocket handler in `JobsList.tsx` calls `throttledRefresh()` on every `job`, `workflow_job`, or `project_update` message regardless of status. Even with the 5-second throttle from PR #2517, every status transition still triggers a full list refetch with all active filters against the DB. On a busy system with many concurrent jobs, this produces unnecessary expensive API calls — especially for jobs not even visible on the current page.

Additionally:
  `JobsList.tsx:102` constructs the detail URL as:
`  requestGet<UnifiedJob>(awxAPI`/unified_jobs/${action.jobId.toString()}/`)`

  This endpoint does not exist in AWX's API. The fix is to use the page item's url field, which
  already contains the correct routed path (e.g., `/api/controller/v2/jobs/{id}/`).

  Recommended Fix

```
  case 'fetch': {
    const item = pageItemsRef.current?.find((i) => i.id === action.jobId);
    const url = item?.url ?? awxAPI`/unified_jobs/${action.jobId.toString()}/`;
    requestGet<UnifiedJob>(url).then(
      (updatedJob) => updateItemRef.current(updatedJob),
      () => throttledRefresh()
    );
    break;
  }

```
  Once the detail fetch returns 200 instead of 404, on-page intermediate events will update
  in-place without a full list refresh — which is where the larger performance win should come
  from. Re-capture after fixing to validate.

  ## Solution

  Categorize WebSocket `status_changed` events into three paths:

  | Status | Action | Rationale |
  |---|---|---|
  | `new`, `pending` | Throttled full list refresh | New job may appear in list |
  | `successful`, `failed`, `error`, `canceled` | Throttled full list refresh | Sort
  order, filters, finished/elapsed fields change |
  | `waiting`, `running` (intermediate) | Fetch single job via `/unified_jobs/{id}/` →
  `updateItem` if on page; skip if not | Progress update only, no structural list
  change |
  | Missing status/id | Throttled full list refresh | Defensive fallback |

  Uses `useRef` for `pageItems` and `updateItem` to keep the callback identity stable
  and avoid a re-render loop through the `useAwxWebSocketSubscription` hook.

  ## Type of Change

  - [ ] Bug fix
  - [ ] Enhancement
  - [ ] Tests
  - [ ] Documentation
  - [x] Performance improvement

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High**
- [ ] **Medium**
- [x] **Low** — The change is narrowly scoped to a single file (JobsList.tsx), only
  modifies the WebSocket message handler logic within that one component, and doesn't
  touch shared framework components, API wrappers, routing, or anything
  cross-workspace.

  ## Testing

  Tested with 50 concurrent jobs (page_size=10), using the same stress test
  methodology from PR #2517:

  1. Created a project with [websocket_stress_test.yml](https://github.com/vidyanambiar/test-playbooks/blob/test-jobs-perf/websocket_stress_test.yml)
  2. Created a job template, set `localStorage.setItem('perPage', '10')` to ensure
  pagination
  3. Opened Jobs page in Chrome, opened Network tab, cleared it
  4. Launched 50 concurrent jobs via stress test script
  5. Waited 5 minutes, exported HAR
  6. Compared before/after HAR files

  ### Test Results

  Tested with 50 concurrent jobs, page_size=10, ~5 minute capture window:

  | Metric | Before | After | Improvement |
  |---|---|---|---|
  | List endpoint requests | 65 | 55 | **15% fewer** |
  | Detail endpoint requests | 0 | 1 | — |
  | Total unified_jobs requests | 65 | 56 | **14% fewer** |
  | List avg response time | 2,373 ms | 2,145 ms | 10% faster |
  | List max response time | 7,670 ms | 5,476 ms | **29% faster** |
  | Avg blocked time | 315 ms | 91 ms | **71% less** |
  | Max blocked time | 5,626 ms | 3,416 ms | **39% less** |
  | Total time in list requests | 154.2s | 118.0s | **23% less** |
  | Sub-throttle gaps (<5s) | 40 | 29 | **28% fewer** |
  | Data transferred | 118.1 KB | 99.9 KB | 15% less |
  | List requests per minute | 12.8 | 10.9 | **15% lower** |

  ### Key takeaways

  - **Off-page jobs now cost nothing** — with page_size=10 and 50 jobs, 40 jobs on
  other pages no longer trigger any API calls for intermediate status updates
  - **Blocked time dropped 71%** — less connection slot contention from fewer list
  requests
  - **Max response time dropped 29%** — peak latency improved from reduced request
  volume
  - Existing throttle from PR #2517 continues to coalesce full-refresh events on the
  pending/final status path
  - Bulk cancel, bulk delete, and direct user actions are unaffected — they use
  `unselectItemsAndRefresh` which bypasses the WebSocket handler