### PR TITLE
feat: move Automation Dashboard PDF export to UI-side print preview

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -53,8 +53,7 @@ export function AutomationDashboard() {
         controls={
           <Button
             data-testid="save-as-pdf-button"
-            // TODO: Remove `|| true` once PDF export is implemented on the BE.
-            isDisabled={loading || exporting || !view?.mainTableView?.itemCount || true}
+            isDisabled={loading || exporting || !view?.mainTableView?.itemCount}
             variant="secondary"
             onClick={() => void handleExportPdf()}
           >

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboardPrint.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboardPrint.tsx
@@ -1,0 +1,283 @@
+import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import useSWR from 'swr';
+import { metricsAPI } from '../../common/api/metrics-utils';
+import { swrOptions, useFetcher } from '../../../common/crud/Data';
+import { IDashboardDetails, IJobTemplate } from './types';
+import { DashboardValueCard } from './components/DashboardValueCard';
+import { DashboardChartCard } from './components/DashboardChartCard';
+import { DashboardTableCard } from './components/DashboardTableCard';
+import { PageDashboard } from '@ansible/ansible-ui-framework';
+
+// Injected into <head> on mount: hides the app shell chrome on the print preview page
+// (both on-screen, so the report fills the full viewport, and during printing).
+const SHELL_HIDE_STYLES = `
+  .pf-v6-c-masthead,
+  .pf-v6-c-page__sidebar,
+  .pf-v6-c-nav { display: none !important; }
+  .pf-v6-c-page__main { margin-left: 0 !important; }
+  @media print {
+    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .pf-v6-c-card { break-inside: avoid; }
+  }
+`;
+
+interface PaginatedResponse<T> {
+  count: number;
+  results: T[];
+}
+
+export function AutomationDashboardPrint() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const fetcher = useFetcher();
+  const hasPrinted = useRef(false);
+
+  // Inject shell-hiding styles and clean up on unmount.
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.textContent = SHELL_HIDE_STYLES;
+    document.head.appendChild(style);
+    return () => {
+      style.remove();
+    };
+  }, []);
+
+  const queryString = searchParams.toString();
+
+  const detailsUrl = metricsAPI`/dashboard_reports/report/details/?${queryString}`;
+  const { data: details, isLoading: detailsLoading } = useSWR<IDashboardDetails>(
+    detailsUrl,
+    fetcher,
+    swrOptions
+  );
+
+  // Fetch all templates in a single request for the print view — no pagination needed.
+  const tableParams = new URLSearchParams([...searchParams.entries()]);
+  tableParams.set('page_size', '200');
+  const tableUrl = metricsAPI`/dashboard_reports/report/?${tableParams.toString()}`;
+  const { data: tableData, isLoading: tableLoading } = useSWR<PaginatedResponse<IJobTemplate>>(
+    tableUrl,
+    fetcher,
+    swrOptions
+  );
+
+  const isReady = !detailsLoading && !tableLoading && !!details;
+
+  // Auto-trigger the browser print dialog once all data has loaded.
+  useEffect(() => {
+    if (isReady && !hasPrinted.current) {
+      hasPrinted.current = true;
+      window.addEventListener('afterprint', () => window.close(), { once: true });
+      window.print();
+    }
+  }, [isReady]);
+
+  const noDataString = t('No data available');
+  const templates = tableData?.results ?? [];
+  const period = searchParams.get('period') ?? '';
+
+  if (!isReady) {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <p>{t('Preparing report...')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '1.5rem' }}>
+      {/* Report header */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 600, margin: 0 }}>
+          {t('Automation Dashboard Report')}
+        </h1>
+        {period && (
+          <p style={{ margin: '0.25rem 0 0', color: '#6a6e73' }}>
+            {t('Period: {{period}}', { period: period.replace(/_/g, ' ') })}
+          </p>
+        )}
+      </div>
+
+      {/* KPI summary cards */}
+      <PageDashboard>
+        <DashboardValueCard
+          id="print-successful-jobs"
+          title={t('Successful jobs')}
+          value={details.total_number_of_successful_jobs ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading successful jobs')}
+        />
+        <DashboardValueCard
+          id="print-failed-jobs"
+          title={t('Failed jobs')}
+          value={details.total_number_of_failed_jobs ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading failed jobs')}
+        />
+        <DashboardValueCard
+          id="print-unique-hosts"
+          title={t('Hosts automated')}
+          value={details.total_number_of_unique_hosts ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading hosts')}
+        />
+        <DashboardValueCard
+          id="print-automation-hours"
+          title={t('Hours of automation')}
+          value={details.total_hours_of_automation ?? noDataString}
+          valueSuffix="h"
+          error={undefined}
+          errorStateTitle={t('Error loading automation hours')}
+        />
+
+        {/* Top tables */}
+        <DashboardTableCard
+          id="print-top-projects"
+          title={t('Top 5 projects')}
+          firstColumnHeader={t('Project name')}
+          emptyStateTitle={t('No projects')}
+          errorStateTitle={t('Error loading projects')}
+          items={details.top_projects}
+          error={undefined}
+          loading={false}
+        />
+        <DashboardTableCard
+          id="print-top-users"
+          title={t('Top 5 users')}
+          firstColumnHeader={t('User name')}
+          emptyStateTitle={t('No users')}
+          errorStateTitle={t('Error loading users')}
+          items={details.top_users}
+          error={undefined}
+          loading={false}
+        />
+
+        {/* Charts */}
+        <DashboardChartCard
+          id="print-host-chart"
+          title={t('Number of hosts jobs are running on')}
+          summaryValue={details.total_number_of_host_job_runs ?? 0}
+          data={details.host_chart ?? { kind: 'day', items: [] }}
+          variant="lineChart"
+          error={undefined}
+          errorStateTitle={t('Error loading host chart')}
+        />
+        <DashboardChartCard
+          id="print-job-chart"
+          title={t('Number of times jobs were run')}
+          summaryValue={details.total_number_of_job_runs ?? 0}
+          data={details.job_chart ?? { kind: 'day', items: [] }}
+          variant="barChart"
+          error={undefined}
+          errorStateTitle={t('Error loading job chart')}
+        />
+      </PageDashboard>
+
+      {/* Cost summary */}
+      <h2 style={{ fontSize: '1.1rem', fontWeight: 600, margin: '1.5rem 0 0.75rem' }}>
+        {t('Cost analysis')}
+      </h2>
+      <PageDashboard>
+        <DashboardValueCard
+          id="print-manual-cost"
+          title={t('Cost of manual automation')}
+          value={details.cost_of_manual_automation ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading manual cost')}
+        />
+        <DashboardValueCard
+          id="print-automated-cost"
+          title={t('Cost of automated execution')}
+          value={details.cost_of_automated_execution ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading automated cost')}
+        />
+        <DashboardValueCard
+          id="print-total-savings"
+          title={t('Total savings / cost avoided')}
+          value={details.total_saving ?? noDataString}
+          error={undefined}
+          errorStateTitle={t('Error loading savings')}
+        />
+        <DashboardValueCard
+          id="print-hours-saved"
+          title={t('Total hours saved / avoided')}
+          value={details.total_time_saving ?? noDataString}
+          valueSuffix="h"
+          error={undefined}
+          errorStateTitle={t('Error loading hours saved')}
+        />
+      </PageDashboard>
+
+      {/* ROI table — all rows, no pagination */}
+      {templates.length > 0 && (
+        <>
+          <h2 style={{ fontSize: '1.1rem', fontWeight: 600, margin: '1.5rem 0 0.75rem' }}>
+            {t('Job template ROI')}
+          </h2>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: '0.875rem',
+            }}
+          >
+            <thead>
+              <tr style={{ background: '#f5f5f5' }}>
+                {[
+                  t('Template name'),
+                  t('Executions'),
+                  t('Running time'),
+                  t('Manual cost'),
+                  t('Automated cost'),
+                  t('Savings'),
+                ].map((header) => (
+                  <th
+                    key={header}
+                    style={{
+                      padding: '0.5rem 0.75rem',
+                      textAlign: 'left',
+                      borderBottom: '2px solid #d2d2d2',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {templates.map((template, index) => (
+                <tr
+                  key={template.id}
+                  style={{ background: index % 2 === 0 ? '#ffffff' : '#fafafa' }}
+                >
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.template_name}
+                  </td>
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.runs}
+                  </td>
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.elapsed}
+                  </td>
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.manual_costs}
+                  </td>
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.automated_costs}
+                  </td>
+                  <td style={{ padding: '0.4rem 0.75rem', borderBottom: '1px solid #e8e8e8' }}>
+                    {template.savings}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/views/useExportPdf.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/views/useExportPdf.test.ts
@@ -1,150 +1,89 @@
 /* eslint-disable i18next/no-literal-string */
 import { act, renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, MockInstance, test, vi } from 'vitest';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { useExportPdf } from './useExportPdf';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockPostRequest, mockAddAlert, mockSvgToPng } = vi.hoisted(() => ({
-  mockPostRequest: vi.fn(),
-  mockAddAlert: vi.fn(),
-  mockSvgToPng: vi.fn(),
-}));
-
-vi.mock('../../../../common/crud/usePostRequest', () => ({
-  usePostRequest: vi.fn(() => mockPostRequest),
+const { mockGetPageUrl } = vi.hoisted(() => ({
+  mockGetPageUrl: vi.fn(() => '/awx/analytics/automation-dashboard/print'),
 }));
 
 vi.mock('../../../../../framework', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../../framework')>();
-  return { ...actual, usePageAlertToaster: vi.fn(() => ({ addAlert: mockAddAlert })) };
+  return { ...actual, useGetPageUrl: vi.fn(() => mockGetPageUrl) };
 });
 
-vi.mock('../utils/svgToPng', () => ({
-  svgToPng: mockSvgToPng,
+vi.mock('../../../main/AwxRoutes', () => ({
+  AwxRoute: { AutomationDashboardPrint: 'awx-automation-dashboard-print' },
 }));
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useExportPdf', () => {
-  let createObjectUrlSpy: MockInstance;
-  let revokeObjectUrlSpy: MockInstance;
-  let mockBlob: Blob;
-  let chartContainer: HTMLDivElement;
+  let openSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockBlob = new Blob(['pdf-content'], { type: 'application/pdf' });
-    mockPostRequest.mockResolvedValue(mockBlob);
-    mockSvgToPng.mockResolvedValue('data:image/png;base64,abc123');
-
-    createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
-    revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
-
-    chartContainer = document.createElement('div');
-    chartContainer.innerHTML = `
-      <div id="job-chart-card">
-        <div class="pf-v6-c-chart"><svg></svg></div>
-      </div>
-      <div id="host-chart-card">
-        <div class="pf-v6-c-chart"><svg></svg></div>
-      </div>`;
-    document.body.appendChild(chartContainer);
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    createObjectUrlSpy.mockRestore();
-    revokeObjectUrlSpy.mockRestore();
-    if (document.body.contains(chartContainer)) {
-      chartContainer.remove();
-    }
+    openSpy.mockRestore();
   });
-
-  // --- Basic ---
 
   test('should return a function', () => {
     const { result } = renderHook(() => useExportPdf([], {}, {}));
     expect(result.current).toBeTypeOf('function');
   });
 
-  // --- Success path ---
-
-  test('should POST PNG data to PDF endpoint and trigger download when SVGs are present', async () => {
+  test('should open the print route in a new tab', async () => {
     const { result } = renderHook(() => useExportPdf([], {}, {}));
 
     await act(async () => {
       await result.current();
     });
 
-    expect(mockPostRequest).toHaveBeenCalledOnce();
-    expect(mockPostRequest).toHaveBeenCalledWith(
-      expect.stringContaining('dashboard_reports/report/pdf/'),
-      { job_chart: 'data:image/png;base64,abc123', host_chart: 'data:image/png;base64,abc123' }
-    );
-    expect(createObjectUrlSpy).toHaveBeenCalledWith(mockBlob);
-
-    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:mock-url');
+    expect(openSpy).toHaveBeenCalledOnce();
+    const [url, target] = openSpy.mock.calls[0] as [string, string];
+    expect(url).toContain('/awx/analytics/automation-dashboard/print');
+    expect(target).toBe('_blank');
   });
 
-  test('should include queryParams in the PDF URL', async () => {
-    const { result } = renderHook(() => useExportPdf([], {}, { period: 'last_7_days' }));
+  test('should include queryParams in the print URL', async () => {
+    const { result } = renderHook(() => useExportPdf([], {}, { tz: 'Europe/Dublin' }));
 
     await act(async () => {
       await result.current();
     });
 
-    const [url] = mockPostRequest.mock.calls[0] as [string, unknown];
-    expect(url).toContain('period=last_7_days');
+    const [url] = openSpy.mock.calls[0] as [string];
+    expect(url).toContain('tz=Europe%2FDublin');
   });
 
-  // --- Null SVG branch ---
+  test('should include filter state in the print URL', async () => {
+    const toolbarFilters = [
+      { key: 'period', label: 'Period', type: 'select', query: 'period', options: [] },
+    ] as Parameters<typeof useExportPdf>[0];
+    const filterState = { period: ['last_30_days'] };
 
-  test('should pass null to svgToPng when chart elements are absent from DOM', async () => {
-    chartContainer.remove();
+    const { result } = renderHook(() => useExportPdf(toolbarFilters, filterState, {}));
 
+    await act(async () => {
+      await result.current();
+    });
+
+    const [url] = openSpy.mock.calls[0] as [string];
+    expect(url).toContain('period=last_30_days');
+  });
+
+  test('should return a resolved promise', async () => {
     const { result } = renderHook(() => useExportPdf([], {}, {}));
 
-    await act(async () => {
-      await result.current();
-    });
-
-    expect(mockSvgToPng).toHaveBeenCalledWith(null);
-  });
-
-  // --- Error path ---
-
-  test('should show danger alert with error message when postRequest throws an Error', async () => {
-    mockPostRequest.mockRejectedValue(new Error('PDF generation failed'));
-    const { result } = renderHook(() => useExportPdf([], {}, {}));
-
-    await act(async () => {
-      await result.current();
-    });
-
-    expect(mockAddAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variant: 'danger',
-        title: 'Failed to export PDF.',
-        children: 'PDF generation failed',
+    await expect(
+      act(async () => {
+        await result.current();
       })
-    );
-  });
-
-  test('should show danger alert with children: undefined when thrown value is not an Error', async () => {
-    mockPostRequest.mockRejectedValue('string error');
-    const { result } = renderHook(() => useExportPdf([], {}, {}));
-
-    await act(async () => {
-      await result.current();
-    });
-
-    expect(mockAddAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variant: 'danger',
-        children: undefined,
-      })
-    );
+    ).resolves.toBeUndefined();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/views/useExportPdf.ts
+++ b/frontend/awx/analytics/automation-dashboard/views/useExportPdf.ts
@@ -1,68 +1,33 @@
 import { useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
   filtersToSearchObj,
   IFilterState,
   IToolbarFilter,
   paramsToSearchObj,
   QueryParams,
-  usePageAlertToaster,
+  useGetPageUrl,
 } from '../../../../../framework';
-import { metricsAPI } from '../../../common/api/metrics-utils';
-import { usePostRequest } from '../../../../common/crud/usePostRequest';
-import { svgToPng } from '../utils/svgToPng';
-import { downloadBlobFile } from '../../../../../framework/utils/download-file';
-
-interface PdfRequestBody {
-  job_chart: string | null;
-  host_chart: string | null;
-}
+import { AwxRoute } from '../../../main/AwxRoutes';
 
 /**
- * Returns a stable async callback that captures the current chart SVGs as PNGs,
- * POSTs them to the PDF endpoint and triggers a file download.
+ * Returns a stable callback that opens the dashboard print preview in a new tab.
+ * The print preview fetches fresh data using the current filter state, then
+ * auto-triggers window.print() so the user can save the report as PDF.
  */
 export function useExportPdf(
   toolbarFilters: IToolbarFilter[],
   filterState: IFilterState,
   queryParams: QueryParams
 ): () => Promise<void> {
-  const postRequest = usePostRequest<PdfRequestBody, Blob>();
-  const alertToaster = usePageAlertToaster();
-  const { t } = useTranslation();
+  const getPageUrl = useGetPageUrl();
 
-  const downloadPdf = useCallback(
-    async (url: string) => {
-      const jobsChartSvg =
-        document.querySelector('#job-chart-card .pf-v6-c-chart')?.querySelector('svg') ?? null;
-      const hostChartSvg =
-        document.querySelector('#host-chart-card .pf-v6-c-chart')?.querySelector('svg') ?? null;
-
-      try {
-        const [jobsChartPng, hostChartPng] = await Promise.all([
-          svgToPng(jobsChartSvg),
-          svgToPng(hostChartSvg),
-        ]);
-        const blob = await postRequest(url, { job_chart: jobsChartPng, host_chart: hostChartPng });
-        downloadBlobFile('AAP_Automation_Dashboard_Report', 'pdf', blob);
-      } catch (err) {
-        alertToaster.addAlert({
-          variant: 'danger',
-          title: t('Failed to export PDF.'),
-          children: err instanceof Error ? err.message : undefined,
-          timeout: 5000,
-        });
-      }
-    },
-    [alertToaster, postRequest, t]
-  );
-
-  return useCallback(async () => {
+  return useCallback(() => {
     const params = new URLSearchParams([
       ...paramsToSearchObj(queryParams),
       ...filtersToSearchObj(toolbarFilters, filterState),
     ]);
-    const url = metricsAPI`/dashboard_reports/report/pdf/?${params.toString()}`;
-    await downloadPdf(url);
-  }, [toolbarFilters, filterState, queryParams, downloadPdf]);
+    const printPath = getPageUrl(AwxRoute.AutomationDashboardPrint);
+    window.open(`${printPath}?${params.toString()}`, '_blank');
+    return Promise.resolve();
+  }, [toolbarFilters, filterState, queryParams, getPageUrl]);
 }

--- a/frontend/awx/main/AwxRoutes.tsx
+++ b/frontend/awx/main/AwxRoutes.tsx
@@ -283,6 +283,7 @@ export enum AwxRoute {
   HostMetrics = 'awx-host-metrics',
   SubscriptionUsage = 'awx-subscription-usage',
   AutomationDashboard = 'awx-automation-dashboard',
+  AutomationDashboardPrint = 'awx-automation-dashboard-print',
   // Settings
   Settings = 'awx-settings',
   SettingsPreferences = 'awx-settings-preferences',

--- a/frontend/awx/main/useAwxNavigation.tsx
+++ b/frontend/awx/main/useAwxNavigation.tsx
@@ -39,6 +39,7 @@ import { useAwxTemplateRoutes } from './routes/useAwxTemplateRoutes';
 import { useAwxUsersRoutes } from './routes/useAwxUsersRoutes';
 import { useAwxWorkflowApprovalRoutes } from './routes/useAwxWorkflowApprovalRoutes';
 import { AutomationDashboard } from '../analytics/automation-dashboard/AutomationDashboard';
+import { AutomationDashboardPrint } from '../analytics/automation-dashboard/AutomationDashboardPrint';
 
 export function useAwxNavigation() {
   const { t } = useTranslation();
@@ -110,6 +111,11 @@ export function useAwxNavigation() {
           label: t('Automation Dashboard'),
           path: 'automation-dashboard',
           element: <AutomationDashboard />,
+        },
+        {
+          id: AwxRoute.AutomationDashboardPrint,
+          path: 'automation-dashboard/print',
+          element: <AutomationDashboardPrint />,
         },
         {
           id: AwxRoute.AutomationCalculator,


### PR DESCRIPTION
## Summary

- Replaces the planned backend HTML/PDF export endpoint (metrics-service PR #268) with a client-side print preview that the browser renders natively — no new backend dependency needed
- Adds `AutomationDashboardPrint` route at `analytics/automation-dashboard/print` that fetches report data using URL search params, then auto-triggers `window.print()` once ready
- Reuses existing `DashboardValueCard`, `DashboardChartCard`, `DashboardTableCard` components; ROI table fetches all rows (`page_size=200`) with no pagination
- Replaces `useExportPdf` POST-to-backend approach with `window.open()` to the print route, passing current filter state as query params
- Enables the "Save as PDF" button (removes `|| true` guard)
- App shell chrome (sidebar, masthead) is hidden via injected CSS during the print preview; `afterprint` listener closes the tab automatically

## How it works

1. User clicks **Save as PDF** on the Automation Dashboard
2. A new tab opens at `automation-dashboard/print?<current-filters>`
3. Print page fetches details + all job templates, renders a clean report using existing card components
4. `window.print()` fires automatically once data loads → browser print dialog
5. User saves as PDF; tab closes via `afterprint`

## Files changed

| File | Change |
|---|---|
| `AutomationDashboardPrint.tsx` | New — print preview component |
| `AutomationDashboard.tsx` | Remove `\|\| true` guard; enable Save as PDF button |
| `views/useExportPdf.ts` | Replace backend POST with `window.open()` |
| `views/useExportPdf.test.ts` | Rewrite tests for new `window.open` contract |
| `AwxRoutes.tsx` | Add `AutomationDashboardPrint` enum value |
| `useAwxNavigation.tsx` | Register print route at `automation-dashboard/print` |

## Test plan

- [ ] "Save as PDF" button is enabled when dashboard has data
- [ ] Clicking opens a new tab at `automation-dashboard/print?<filters>`
- [ ] Print preview shows KPI cards, charts, top projects/users, cost analysis, and ROI table
- [ ] `window.print()` fires automatically after data loads
- [ ] Tab closes after print dialog is dismissed
- [ ] Filters (period, label, org, project, template) carry through to the print view
- [ ] `useExportPdf` unit tests pass

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.