### PR TITLE
fix: add count_disabled=1 to API calls that skip pagination

### DIFF
--- a/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
+++ b/frontend/awx/access/users/UserPage/AwxUserDetails.tsx
@@ -15,7 +15,8 @@ export function AwxUserDetails() {
   const getPageUrl = useGetPageUrl();
   const { data: user } = useGetItem<AwxUser>(awxAPI`/users`, params.id);
   const itemsResponse = useGet<AwxItemsResponse<Organization>>(
-    user?.related?.organizations as string
+    user?.related?.organizations as string,
+    { count_disabled: 1 }
   );
   const organizations = useMemo<
     {

--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.tsx
@@ -30,7 +30,7 @@ export function ManagementJobPage() {
     error: isNotifAdminError,
     refresh: refreshNotifAdmin,
   } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role`
+    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
   );
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;

--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
@@ -43,6 +43,7 @@ export function ProjectPage() {
     isLoading: isNotifAdminLoading,
   } = useGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`, {
     role_level: 'notification_admin_role',
+    count_disabled: 1,
   });
   const error = isNotifAdminError || projectError;
   const getPageUrl = useGetPageUrl();

--- a/frontend/awx/resources/projects/hooks/useGetCredentialTypeIDs.tsx
+++ b/frontend/awx/resources/projects/hooks/useGetCredentialTypeIDs.tsx
@@ -9,19 +9,19 @@ import { CredentialType } from '../../../interfaces/CredentialType';
  */
 export function useGetCredentialTypeIDs() {
   const scmCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
-    awxAPI`/credential_types/?kind=scm`
+    awxAPI`/credential_types/?kind=scm&count_disabled=1`
   );
   const insightsCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
-    awxAPI`/credential_types/?name=Insights`
+    awxAPI`/credential_types/?name=Insights&count_disabled=1`
   );
   const cryptoCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
-    awxAPI`/credential_types/?kind=cryptography`
+    awxAPI`/credential_types/?kind=cryptography&count_disabled=1`
   );
   const registryCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
-    awxAPI`/credential_types/?kind=registry`
+    awxAPI`/credential_types/?kind=registry&count_disabled=1`
   );
   const galaxyCredentialTypeResponse = useGet<AwxItemsResponse<CredentialType>>(
-    awxAPI`/credential_types/?kind=galaxy`
+    awxAPI`/credential_types/?kind=galaxy&count_disabled=1`
   );
   const credentialTypeIDs: { [key: string]: number } = useMemo(() => {
     const credentialTypeIds: { [key: string]: number } = {};

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -43,7 +43,7 @@ export function TemplatePage() {
     refresh: refreshNotifAdmin,
     isLoading: isNotifAdminLoading,
   } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role`
+    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
   );
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -43,7 +43,7 @@ export function WorkflowJobTemplatePage() {
     refresh: refreshNotifAdmin,
     isLoading: isNotifAdminLoading,
   } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role`
+    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
   );
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
@@ -52,6 +52,7 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
     {
       page_size: 1,
       counter: 1,
+      count_disabled: 1,
     },
     {
       refreshInterval: (latestData: AwxItemsResponse<JobEvent>) => {


### PR DESCRIPTION
## Summary

Add `count_disabled=1` query parameter to API calls where only the `results` array is needed, not the total `count`. This skips an expensive `COUNT(*)` query on the database side, reducing API server and DB load — particularly under concurrent job execution or multiple open browser tabs.

Applied to:
- **Notification admin role checks** in `TemplatePage`, `WorkflowJobTemplatePage`, `ProjectPage`, `ManagementJobPage` — these fetch `/organizations/?role_level=notification_admin_role` solely to check `results.length > 0`
- **Credential type lookups** in `useGetCredentialTypeIDs` — 5 queries that only read `results[0]?.id`
- **Job status bar** in `JobStatusBar` — fetches a single event with `page_size=1`, only uses `results[0]`
- **User organizations** in `AwxUserDetails` — maps `results` to org name/link pairs

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

Each change adds a single query parameter (`count_disabled=1`) to an existing API URL. No logic, rendering, or control flow is altered. The AWX controller API treats `count_disabled` as an optional hint — omitting `count` from the response — so the parameter is backward-compatible and degrades gracefully if the backend version does not support it.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

1. Navigate to a Job Template detail page — verify the Notifications tab still appears for notification admins
2. Navigate to a Workflow Job Template detail page — same check
3. Navigate to a Project detail page — same check
4. Navigate to a Management Job detail page — same check
5. Open a Project create/edit form — verify credential type selectors still populate
6. Open a running job's output page — verify the status bar renders correctly
7. Open a user detail page — verify organizations list displays

### Screenshots

N/A — no visual changes. Query parameter addition only.

Assisted-by: Claude Code / Opus 4.6 (Anthropic)