### PR TITLE
fix(jobs): stop polling on job output page once job is complete

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
@@ -1,0 +1,115 @@
+import { render } from '@testing-library/react';
+import { SWRConfiguration } from 'swr';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { Job } from '../../../interfaces/Job';
+import { JobEvent } from '../../../interfaces/JobEvent';
+import { JobStatusBar } from './JobStatusBar';
+
+const mockUseGet = vi.fn(
+  (
+    _url: string | undefined,
+    _query?: Record<string, string | number | boolean>,
+    _swrConfiguration?: SWRConfiguration
+  ) => ({
+    data: {
+      count: 0,
+      results: [],
+      next: null,
+      previous: null,
+    } as AwxItemsResponse<JobEvent>,
+    refresh: vi.fn(),
+    isLoading: false,
+    error: undefined,
+  })
+);
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: (
+    url: string | undefined,
+    query?: Record<string, string | number | boolean>,
+    swrConfiguration?: SWRConfiguration
+  ) => mockUseGet(url, query, swrConfiguration),
+}));
+
+function renderJobStatusBar(job: Job) {
+  return render(
+    <MemoryRouter>
+      <JobStatusBar job={job} />
+    </MemoryRouter>
+  );
+}
+
+const baseJob = {
+  id: 1,
+  type: 'job',
+  name: 'Test Job',
+  elapsed: '10',
+  host_status_counts: {},
+  playbook_counts: { play_count: 1, task_count: 2 },
+} as unknown as Job;
+
+describe('JobStatusBar polling', () => {
+  beforeEach(() => {
+    mockUseGet.mockClear();
+  });
+
+  it('should stop polling when job is finished', () => {
+    const finishedJob = {
+      ...baseJob,
+      status: 'successful',
+      started: '2023-06-06T18:22:42Z',
+      finished: '2023-06-06T18:23:02Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(finishedJob);
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: AwxItemsResponse<JobEvent>) => number;
+    };
+
+    expect(swrConfig.refreshInterval({ count: 0, results: [] } as AwxItemsResponse<JobEvent>)).toBe(
+      0
+    );
+  });
+
+  it('should poll at 5000ms when job is running and playbook has not started', () => {
+    const runningJob = {
+      ...baseJob,
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(runningJob);
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: AwxItemsResponse<JobEvent>) => number;
+    };
+
+    expect(swrConfig.refreshInterval({ count: 0, results: [] } as AwxItemsResponse<JobEvent>)).toBe(
+      5000
+    );
+  });
+
+  it('should stop polling when playbook_on_start event is received and job is running', () => {
+    const runningJob = {
+      ...baseJob,
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(runningJob);
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: AwxItemsResponse<JobEvent>) => number;
+    };
+
+    const eventData = {
+      count: 1,
+      results: [{ event: 'playbook_on_start' }],
+    } as AwxItemsResponse<JobEvent>;
+
+    expect(swrConfig.refreshInterval(eventData)).toBe(0);
+  });
+});

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
@@ -56,6 +56,7 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
     },
     {
       refreshInterval: (latestData: AwxItemsResponse<JobEvent>) => {
+        if (job.finished) return 0;
         if (latestData?.results.length) {
           const latestEvent = latestData.results[0];
           if (latestEvent.event === 'playbook_on_start') {

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
@@ -18,7 +18,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ProjectDiagramIcon } from '@patternfly/react-icons';
 import { DateTime, Duration } from 'luxon';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Job } from '../../../interfaces/Job';
@@ -47,6 +47,21 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
 
   const eventsSlug = job.type === 'job' ? 'job_events' : 'events';
 
+  const jobFinished = job.finished;
+  const refreshInterval = useCallback(
+    (latestData: AwxItemsResponse<JobEvent>) => {
+      if (jobFinished) return 0;
+      if (latestData?.results.length) {
+        const latestEvent = latestData.results[0];
+        if (latestEvent.event === 'playbook_on_start') {
+          return 0;
+        }
+      }
+      return 5000;
+    },
+    [jobFinished]
+  );
+
   const { data: jobEvents } = useGet<AwxItemsResponse<JobEvent>>(
     awxAPI`/${job.type}s/${job.id.toString()}/${eventsSlug}/`,
     {
@@ -54,18 +69,7 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
       counter: 1,
       count_disabled: 1,
     },
-    {
-      refreshInterval: (latestData: AwxItemsResponse<JobEvent>) => {
-        if (job.finished) return 0;
-        if (latestData?.results.length) {
-          const latestEvent = latestData.results[0];
-          if (latestEvent.event === 'playbook_on_start') {
-            return 0;
-          }
-        }
-        return 5000;
-      },
-    }
+    { refreshInterval }
   );
 
   const event = jobEvents?.results[0]?.event;

--- a/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { SWRConfiguration } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Job } from '../../../interfaces/Job';
+import { useJobOutputChildrenSummary } from './useJobOutputChildrenSummary';
+
+const mockUseGet = vi.fn(
+  (
+    _url: string | undefined,
+    _query?: Record<string, string | number | boolean>,
+    _swrConfiguration?: SWRConfiguration
+  ) => ({
+    data: undefined,
+    refresh: vi.fn(),
+    isLoading: false,
+    error: undefined,
+  })
+);
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: (
+    url: string | undefined,
+    query?: Record<string, string | number | boolean>,
+    swrConfiguration?: SWRConfiguration
+  ) => mockUseGet(url, query, swrConfiguration),
+}));
+
+describe('useJobOutputChildrenSummary', () => {
+  beforeEach(() => {
+    mockUseGet.mockClear();
+  });
+
+  it('should stop polling when job status is not running', () => {
+    const finishedJob = { id: 1, type: 'job', status: 'successful' } as Job;
+    renderHook(() => useJobOutputChildrenSummary(finishedJob, false));
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as SWRConfiguration;
+    expect(swrConfig).toEqual({ refreshInterval: 0 });
+  });
+
+  it('should continue polling when job is running', () => {
+    const runningJob = { id: 1, type: 'job', status: 'running' } as Job;
+    renderHook(() => useJobOutputChildrenSummary(runningJob, false));
+
+    const swrConfig = mockUseGet.mock.calls[0][2];
+    expect(swrConfig).toBeUndefined();
+  });
+
+  it('should stop polling for failed jobs', () => {
+    const failedJob = { id: 1, type: 'job', status: 'failed' } as Job;
+    renderHook(() => useJobOutputChildrenSummary(failedJob, false));
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as SWRConfiguration;
+    expect(swrConfig).toEqual({ refreshInterval: 0 });
+  });
+
+  it('should continue polling for pending jobs', () => {
+    const pendingJob = { id: 1, type: 'job', status: 'pending' } as Job;
+    renderHook(() => useJobOutputChildrenSummary(pendingJob, false));
+
+    const swrConfig = mockUseGet.mock.calls[0][2];
+    expect(swrConfig).toBeUndefined();
+  });
+});

--- a/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.tsx
+++ b/frontend/awx/views/jobs/JobOutput/useJobOutputChildrenSummary.tsx
@@ -1,6 +1,7 @@
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Job } from '../../../interfaces/Job';
+import { isJobRunning } from './util';
 
 export interface IJobOutputChildrenSummary {
   children_summary: { [counter: string]: { rowNumber: number; numChildren: number } };
@@ -13,7 +14,9 @@ export function useJobOutputChildrenSummary(job: Job, forceFlatMode: boolean) {
   let isFlatMode = forceFlatMode || job.type !== 'job';
 
   const response = useGet<IJobOutputChildrenSummary>(
-    awxAPI`/jobs/${job.id.toString()}/job_events/children_summary/`
+    awxAPI`/jobs/${job.id.toString()}/job_events/children_summary/`,
+    undefined,
+    isJobRunning(job.status) ? undefined : { refreshInterval: 0 }
   );
   const { data, error } = response;
 

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -2,6 +2,7 @@
 import { LoadingPage, PageLayout, usePageSettings } from '@ansible/ansible-ui-framework';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
 import { useGet } from '@ansible/common-ui/crud/useGet';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { AwxError } from '../../common/AwxError';
@@ -50,14 +51,16 @@ export function useGetJob(id?: string, type?: string) {
   };
   const path = type ? apiPaths[type] : 'jobs';
   const defaultInterval = (settings.refreshInterval ?? 10) * 1000;
+  const refreshInterval = useCallback(
+    (latestData: Job | undefined) => (latestData?.finished ? 0 : defaultInterval),
+    [defaultInterval]
+  );
   const {
     data: job,
     refresh: refreshJob,
     isLoading,
     error,
-  } = useGet<Job>(id ? awxAPI`/${path}/${id}/` : '', undefined, {
-    refreshInterval: (latestData: Job | undefined) => (latestData?.finished ? 0 : defaultInterval),
-  });
+  } = useGet<Job>(id ? awxAPI`/${path}/${id}/` : '', undefined, { refreshInterval });
 
   return { job, refreshJob, isLoading, error };
 }

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { LoadingPage, PageLayout } from '@ansible/ansible-ui-framework';
+import { LoadingPage, PageLayout, usePageSettings } from '@ansible/ansible-ui-framework';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { useTranslation } from 'react-i18next';
@@ -39,6 +39,7 @@ export function JobPage() {
 }
 
 export function useGetJob(id?: string, type?: string) {
+  const settings = usePageSettings();
   const apiPaths: { [key: string]: string } = {
     project: 'project_updates',
     inventory: 'inventory_updates',
@@ -48,12 +49,15 @@ export function useGetJob(id?: string, type?: string) {
     workflow: 'workflow_jobs',
   };
   const path = type ? apiPaths[type] : 'jobs';
+  const defaultInterval = (settings.refreshInterval ?? 10) * 1000;
   const {
     data: job,
     refresh: refreshJob,
     isLoading,
     error,
-  } = useGet<Job>(id ? awxAPI`/${path}/${id}/` : '');
+  } = useGet<Job>(id ? awxAPI`/${path}/${id}/` : '', undefined, {
+    refreshInterval: (latestData: Job | undefined) => (latestData?.finished ? 0 : defaultInterval),
+  });
 
   return { job, refreshJob, isLoading, error };
 }

--- a/frontend/awx/views/jobs/useGetJob.test.tsx
+++ b/frontend/awx/views/jobs/useGetJob.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react';
+import { SWRConfiguration } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Job } from '../../interfaces/Job';
+import { useGetJob } from './JobPage';
+
+vi.mock('./JobHeader', () => ({
+  JobHeader: () => null,
+}));
+
+const mockUseGet = vi.fn(
+  (
+    _url: string | undefined,
+    _query?: Record<string, string | number | boolean>,
+    _swrConfiguration?: SWRConfiguration
+  ) => ({
+    data: undefined as Job | undefined,
+    refresh: vi.fn(),
+    isLoading: false,
+    error: undefined,
+  })
+);
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: (
+    url: string | undefined,
+    query?: Record<string, string | number | boolean>,
+    swrConfiguration?: SWRConfiguration
+  ) => mockUseGet(url, query, swrConfiguration),
+}));
+
+describe('useGetJob', () => {
+  beforeEach(() => {
+    mockUseGet.mockClear();
+  });
+
+  it('should build the correct API URL for each job type', () => {
+    renderHook(() => useGetJob('1', 'playbook'));
+    expect(mockUseGet.mock.calls[0][0]).toContain('/jobs/1/');
+
+    mockUseGet.mockClear();
+    renderHook(() => useGetJob('2', 'workflow'));
+    expect(mockUseGet.mock.calls[0][0]).toContain('/workflow_jobs/2/');
+
+    mockUseGet.mockClear();
+    renderHook(() => useGetJob('3', 'project'));
+    expect(mockUseGet.mock.calls[0][0]).toContain('/project_updates/3/');
+  });
+
+  it('should stop polling when job data has finished set', () => {
+    renderHook(() => useGetJob('1', 'playbook'));
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: Job | undefined) => number;
+    };
+
+    const finishedJob = { finished: '2023-06-06T18:23:02.484722Z' } as Job;
+    expect(swrConfig.refreshInterval(finishedJob)).toBe(0);
+  });
+
+  it('should continue polling at the configured interval when job is not finished', () => {
+    renderHook(() => useGetJob('1', 'playbook'));
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: Job | undefined) => number;
+    };
+
+    const runningJob = { status: 'running' } as Job;
+    expect(swrConfig.refreshInterval(runningJob)).toBe(10000);
+  });
+
+  it('should continue polling when no data is available yet', () => {
+    renderHook(() => useGetJob('1', 'playbook'));
+
+    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
+      refreshInterval: (data: Job | undefined) => number;
+    };
+
+    expect(swrConfig.refreshInterval(undefined)).toBe(10000);
+  });
+});


### PR DESCRIPTION
## Summary

  - `useGetJob`, `useJobOutputChildrenSummary`, and `JobStatusBar` continued polling the API after a job finished. Now each sets `refreshInterval: 0` once the job is complete
  - `useGetJob` uses SWR's function-form `refreshInterval` to check `job.finished` and respects the user-configured refresh interval while running
  - `useJobOutputChildrenSummary` and `JobStatusBar` stop polling based on `isJobRunning(job.status)` and `job.finished` respectively


## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

  - Open a completed job's Output page, confirm no recurring API requests in the Network tab
  - Run a job, observe polling while running, confirm it stops after completion

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
