### PR TITLE
fix(views): remove unconditional next-page prefetch from view hooks

### DIFF
--- a/frontend/awx/common/useAwxView.test.tsx
+++ b/frontend/awx/common/useAwxView.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
@@ -95,6 +95,78 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe('useAwxView', () => {
+  describe('Next-page prefetch removed (AAP-78172)', () => {
+    test('should not prefetch the next page URL from the API response', async () => {
+      const requestUrls: string[] = [];
+      server.use(
+        http.get(awxAPI`/hosts/`, ({ request }) => {
+          requestUrls.push(new URL(request.url).pathname + new URL(request.url).search);
+          return HttpResponse.json({
+            count: 40,
+            next: '/api/v2/hosts/?page=2',
+            previous: null,
+            results: mockHosts,
+          });
+        })
+      );
+
+      const { result } = renderHook(
+        () =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.pageItems).toBeDefined();
+        expect(result.current.itemCount).toBe(40);
+      });
+
+      expect(requestUrls.some((url) => url.includes('page=2'))).toBe(false);
+    });
+
+    test('should not prefetch next page when refresh is called', async () => {
+      const requestUrls: string[] = [];
+      server.use(
+        http.get(awxAPI`/hosts/`, ({ request }) => {
+          requestUrls.push(new URL(request.url).pathname + new URL(request.url).search);
+          return HttpResponse.json({
+            count: 40,
+            next: '/api/v2/hosts/?page=2',
+            previous: null,
+            results: mockHosts,
+          });
+        })
+      );
+
+      const { result } = renderHook(
+        () =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.pageItems).toBeDefined();
+      });
+
+      requestUrls.length = 0;
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      await waitFor(() => {
+        expect(requestUrls.length).toBeGreaterThan(0);
+      });
+
+      expect(requestUrls.some((url) => url.includes('page=2'))).toBe(false);
+    });
+  });
+
   describe('Error handling for pagination', () => {
     describe('Filter with pagination error recovery', () => {
       test('should reset to page 1 when filter returns 400 on page 2', async () => {

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -82,8 +82,6 @@ export function useAwxView<T extends { id: number }>(options: {
     await mutate().finally(() => {});
   }, [mutate]);
 
-  useSWR<AwxItemsResponse<T>>(data?.next, fetcher, swrOptions);
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let error: Error | undefined = response.error;
   if (error instanceof RequestError) {

--- a/frontend/eda/common/useEventDrivenView.tsx
+++ b/frontend/eda/common/useEventDrivenView.tsx
@@ -79,8 +79,6 @@ export function useEdaView<T extends { id: number | string }>(options: {
     await mutate().finally(() => {});
   }, [mutate]);
 
-  useSWR<EdaItemsResponse<T>>(data?.next, fetcher, swrOptions);
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let error: Error | undefined = response.error;
   if (error instanceof RequestError) {

--- a/frontend/hub/common/useHubView.tsx
+++ b/frontend/hub/common/useHubView.tsx
@@ -12,7 +12,6 @@ import { useFetcher } from '@ansible/common-ui/crud/Data';
 import { RequestError } from '@ansible/common-ui/crud/RequestError';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
-import { serverlessURL } from './api/hub-api-utils';
 import { url2keys } from './api/query-string';
 import { isInsightsMode } from './isInsights';
 
@@ -44,7 +43,6 @@ export type IHubView<T extends object> = IView &
 
 interface CommonResponse<T extends object> {
   count: number | undefined;
-  next: string | undefined;
   pageItems: T[] | undefined;
 }
 
@@ -55,14 +53,12 @@ function deconstruct<T extends object>(
     // HubItemsResponse
     return {
       count: data.meta.count,
-      next: data.links?.next,
       pageItems: data.data,
     };
   } else {
     // PulpItemsResponse | undefined
     return {
       count: data?.count,
-      next: data?.next,
       pageItems: data?.results,
     };
   }
@@ -144,12 +140,7 @@ export function useHubView<T extends object>({
     await mutate();
   }, [mutate]);
 
-  const { count, next, pageItems } = deconstruct<T>(data);
-
-  const nextPage = serverlessURL(next);
-  useSWR<HubItemsResponse<T> | PulpItemsResponse<T>>(nextPage, fetcher, {
-    dedupingInterval: 0,
-  });
+  const { count, pageItems } = deconstruct<T>(data);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let error: Error | undefined = response.error;


### PR DESCRIPTION
## Summary

Removes the unconditional useSWR next-page prefetch from all three list view hooks: useAwxView, useEdaView, and useHubView.

  Each hook issued a second SWR request for data?.next (the next page URL) on every render. When combined with 5-second
  WebSocket-triggered refreshes, this doubled API traffic — for example, two unified_jobs queries every 5 seconds on the jobs
  list during active periods.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.


## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).


### Manual Testing

  - Open network panel in dev tools
  - Navigate to a page with more than 1 page of resources listed
  - Confirm that the second page of resources is not pre-fetched until the pagination button to page 2 is clicked