### PR TITLE
fix(framework): disable SWR revalidateOnFocus globally

### DIFF
--- a/framework/PageSettings/PageSettingsProvider.test.tsx
+++ b/framework/PageSettings/PageSettingsProvider.test.tsx
@@ -2,6 +2,7 @@
 import { ReactNode } from 'react';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useSWRConfig } from 'swr';
 import {
   PageSettingsProvider,
   usePageSettings,
@@ -284,6 +285,16 @@ describe('PageSettingsProvider', () => {
       );
 
       expect(getByTestId('interval')).toHaveTextContent('30');
+    });
+
+    test('should disable revalidateOnFocus globally', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+      );
+
+      const { result } = renderHook(() => useSWRConfig(), { wrapper });
+
+      expect(result.current.revalidateOnFocus).toBe(false);
     });
 
     test('should disable refresh when interval is 0', () => {

--- a/framework/PageSettings/PageSettingsProvider.tsx
+++ b/framework/PageSettings/PageSettingsProvider.tsx
@@ -119,6 +119,7 @@ export function PageSettingsProvider(props: {
     <SWRConfig
       value={{
         refreshInterval: settings.refreshInterval ? settings.refreshInterval * 1000 : 0,
+        revalidateOnFocus: false,
         onErrorRetry: swrErrorRetryHandler,
       }}
     >


### PR DESCRIPTION
  ## Summary

  The `revalidateOnFocus` SWR flag causes the UI to refetch ALL cached data when the user
  returns to the browser tab. Since the app already uses WebSocket subscriptions and periodic
  polling for dynamic data, this adds burst API load for no benefit.

  This PR adds `revalidateOnFocus: false` to the global `SWRConfig` in `PageSettingsProvider`.
  Individual SWR hooks can still opt back in with `{ revalidateOnFocus: true }` per-request if
  needed.

  ## Type of Change

  - [x] Bug fix
  - [ ] Enhancement
  - [ ] Tests
  - [ ] Documentation
  - [ ] Other (please specify)

  ## Risk Analysis - REQUIRED

  - [x] **High** — Broad platform impact (e.g., SWR config, shared framework components,
  authentication, routing, API wrappers, build/bundler config). Changes affect multiple
  workspaces or could cause widespread regressions.
  - [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to
  multiple pages within one workspace, component library updates, test infrastructure). Limited
  blast radius but touches common code paths.
  - [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation,
  test-only changes, copy/string updates). Minimal risk of unintended side effects.

  ## Testing

  ### Ephemeral E2E Tests

  Once PR is ready and preliminary checks pass, trigger tests by posting a comment
  `/run-playwright` on this PR.

  ### Manual Testing

  1. Open the app, navigate to any data-heavy page (e.g., job list, dashboard)
  2. Open DevTools → Network tab, let initial load settle
  3. Clear the Network log
  4. Switch to a different browser tab, wait 2–3 seconds, switch back
  5. **Expected:** Zero API requests fired on tab focus return (only normal polling/WS traffic)
  6. **Before this fix:** A burst of API requests (one per active `useSWR` hook) fires
  immediately on focus

  Assisted-by: Claude Code