### PR TITLE
ci: disable spot instance usage for ui e2e tests pipeline

### DIFF
--- a/.tekton/aap-ui-e2e.yaml
+++ b/.tekton/aap-ui-e2e.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:4801a75e7c78809565a45cc2c3cec215183c83739ca1e993a5dc5b49c56528ee
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:434a81bd0d55a63923b7d916b2640aa6fd3766916d835ef4d2bd0f31ac66bc8d
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->
This PR updates the tekton pipeline bundle digest to disable using aws spot instances. To workaround the recent instability when trying to use spot instances within the pipeline.

## Type of Change
- [X] Tests

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.