### PR TITLE
fix(awx): clear stale prompt values when switching workflow node templates

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.component.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.component.test.tsx
@@ -1,0 +1,415 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobTemplate } from '../../../../interfaces/JobTemplate';
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import type { GraphNodeData, PromptFormValues } from '../types';
+import { JobTemplateDetails } from './JobTemplateDetails';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: vi.fn(() => ({ data: undefined })),
+  useGetItem: vi.fn(() => ({ data: undefined })),
+}));
+
+import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
+
+const mockTemplate: JobTemplate = {
+  id: 1,
+  name: 'Test Job Template',
+  type: 'job_template',
+  url: '/api/v2/job_templates/1/',
+  playbook: 'playbook.yml',
+  job_type: 'run',
+  verbosity: 0,
+  forks: 2,
+  limit: 'localhost',
+  scm_branch: 'main',
+  job_tags: 'tag1,tag2',
+  skip_tags: 'skip1',
+  diff_mode: false,
+  timeout: 60,
+  job_slice_count: 1,
+  extra_vars: 'my_var: value',
+  ask_credential_on_launch: false,
+  ask_variables_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_instance_groups_on_launch: false,
+  ask_labels_on_launch: false,
+  ask_inventory_on_launch: false,
+  ask_job_type_on_launch: false,
+  ask_limit_on_launch: false,
+  ask_scm_branch_on_launch: false,
+  ask_diff_mode_on_launch: false,
+  ask_forks_on_launch: false,
+  ask_job_slice_count_on_launch: false,
+  ask_timeout_on_launch: false,
+  ask_verbosity_on_launch: false,
+  ask_execution_environment_on_launch: false,
+  allow_simultaneous: false,
+  webhook_service: 'github',
+  opa_query_path: '',
+  survey_enabled: false,
+  related: {
+    webhook_key: '/api/v2/job_templates/1/webhook_key/',
+    instance_groups: '/api/v2/job_templates/1/instance_groups/',
+    credentials: '/api/v2/job_templates/1/credentials/',
+    labels: '/api/v2/job_templates/1/labels/',
+    webhook_receiver: '/api/v2/job_templates/1/github/',
+  } as never,
+  summary_fields: {
+    organization: { id: 1, name: 'Default' },
+    project: { id: 1, name: 'My Project' },
+    inventory: { id: 1, name: 'My Inventory' },
+    labels: {
+      results: [{ id: 1, name: 'production' }],
+      count: 1,
+    },
+    execution_environment: { id: 1, name: 'Default EE' },
+  } as never,
+} as unknown as JobTemplate;
+
+const mockNodeData: GraphNodeData = {
+  resource: {
+    id: 1,
+    identifier: 'node-1',
+    diff_mode: false,
+    forks: 2,
+    job_type: 'run',
+    limit: 'localhost',
+    scm_branch: 'main',
+    job_tags: 'tag1,tag2',
+    skip_tags: 'skip1',
+    timeout: 60,
+    verbosity: 0,
+    job_slice_count: 1,
+    extra_data: {},
+    all_parents_must_converge: false,
+    always_nodes: [],
+    failure_nodes: [],
+    success_nodes: [],
+    related: {
+      credentials: '/api/v2/workflow_job_template_nodes/1/credentials/',
+      instance_groups: '/api/v2/workflow_job_template_nodes/1/instance_groups/',
+      labels: '/api/v2/workflow_job_template_nodes/1/labels/',
+    } as never,
+    summary_fields: {
+      unified_job_template: {
+        id: 1,
+        name: 'Test Job Template',
+        unified_job_type: 'job',
+      },
+      inventory: { id: 1, name: 'My Inventory' },
+      execution_environment: { id: 1, name: 'Default EE' },
+    } as never,
+  } as never,
+  launch_data: undefined as never,
+  survey_data: undefined as never,
+};
+
+function renderComponent(nodeData = mockNodeData) {
+  return render(
+    <MemoryRouter>
+      <JobTemplateDetails template={mockTemplate} node={nodeData} />
+    </MemoryRouter>
+  );
+}
+
+describe('JobTemplateDetails', () => {
+  beforeEach(() => {
+    vi.mocked(useGet).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+    vi.mocked(useGetItem).mockReturnValue({
+      data: undefined,
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+  });
+
+  it('should render the playbook field from template', () => {
+    renderComponent();
+    expect(screen.getByText('playbook.yml')).toBeInTheDocument();
+  });
+
+  it('should render the job type field', () => {
+    renderComponent();
+    expect(screen.getAllByText('run').length).toBeGreaterThan(0);
+  });
+
+  it('should render the organization from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+
+  it('should render the project from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('should render job tags from node values when no prompt override', () => {
+    renderComponent();
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('tag2')).toBeInTheDocument();
+  });
+
+  it('should render skip tags from node values', () => {
+    renderComponent();
+    expect(screen.getByText('skip1')).toBeInTheDocument();
+  });
+
+  it('should render labels from template summary fields', () => {
+    renderComponent();
+    expect(screen.getByText('production')).toBeInTheDocument();
+  });
+
+  it('should render webhook service section when webhook_service is set', () => {
+    renderComponent();
+    expect(screen.getByText(/github/i)).toBeInTheDocument();
+  });
+
+  it('should render variables section', () => {
+    renderComponent();
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+  });
+
+  it('should render credentials when useGet returns credential data', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('credentials')) {
+        return {
+          data: {
+            results: [{ id: 10, name: 'My SSH Key', credential_type: 1, passwords_needed: [] }],
+            count: 1,
+          },
+        } as never;
+      }
+      return { data: undefined } as never;
+    });
+
+    renderComponent();
+    expect(screen.getByText('Credentials')).toBeInTheDocument();
+  });
+
+  it('should render instance groups when useGet returns instance group data', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('instance_groups')) {
+        return {
+          data: {
+            results: [{ id: 5, name: 'My Instance Group' }],
+            count: 1,
+          },
+        } as never;
+      }
+      return { data: undefined } as never;
+    });
+
+    renderComponent();
+    expect(screen.getByText('Instance groups')).toBeInTheDocument();
+  });
+
+  it('should render execution environment from fetched item when prompt has EE', () => {
+    vi.mocked(useGetItem).mockReturnValue({
+      data: { id: 5, name: 'Custom EE' },
+      error: undefined,
+      refresh: vi.fn(),
+      isLoading: false,
+    });
+
+    const nodeWithEE: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        execution_environment: { id: 5 } as never,
+      },
+    };
+
+    renderComponent(nodeWithEE);
+    const eeElements = screen.getAllByText('Custom EE');
+    expect(eeElements.length).toBeGreaterThan(0);
+  });
+
+  it('should render template EE when template is changed and no prompt EE', () => {
+    const nodeWithTemplateChange: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        original: {
+          isTemplateChange: true,
+          launch_config: {} as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithTemplateChange);
+    expect(screen.getAllByText('Default EE').length).toBeGreaterThan(0);
+  });
+
+  it('should render node EE when no prompt override and no template change', () => {
+    renderComponent();
+    expect(screen.getAllByText('Default EE').length).toBeGreaterThan(0);
+  });
+
+  it('should render enabled options when allow_simultaneous is true', () => {
+    const templateWithOptions = {
+      ...mockTemplate,
+      allow_simultaneous: true,
+    } as JobTemplate;
+
+    render(
+      <MemoryRouter>
+        <JobTemplateDetails template={templateWithOptions} node={mockNodeData} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Concurrent jobs')).toBeInTheDocument();
+  });
+
+  it('should render with survey data merged into variables display', () => {
+    const nodeWithSurvey: GraphNodeData = {
+      ...mockNodeData,
+      survey_data: { survey_key: 'survey_value' },
+    };
+    renderComponent(nodeWithSurvey);
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+  });
+
+  it('should render prompt-overridden inventory name when useGetItem provides it', () => {
+    vi.mocked(useGetItem).mockImplementation((_api, id) => {
+      if (id && String(id) === '2') {
+        return {
+          data: { id: 2, name: 'Override Inventory' },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    const nodeWithPrompt: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        inventory: {
+          id: 2,
+          name: 'Override Inventory',
+        },
+        original: {
+          isTemplateChange: false,
+          launch_config: {
+            ask_inventory_on_launch: true,
+          } as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithPrompt);
+    expect(screen.getAllByText('Override Inventory').length).toBeGreaterThan(0);
+  });
+
+  it('should not render credentials section when credentials is empty', () => {
+    renderComponent();
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
+  });
+
+  it('should render PromptDetail as empty for empty credential list', () => {
+    const nodeWithEmptyPromptCredentials: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        credentials: [],
+        original: {
+          launch_config: { ask_credential_on_launch: true } as LaunchConfiguration,
+        },
+      },
+    };
+    renderComponent(nodeWithEmptyPromptCredentials);
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
+  });
+
+  it('should assign fetchedEE when promptValues has execution_environment and useGetItem returns data', () => {
+    vi.mocked(useGetItem).mockImplementation((_api, id) => {
+      if (id && id !== 'undefined') {
+        return {
+          data: { id: Number(id), name: 'Fetched EE From API' },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    const nodeWithPromptEE: GraphNodeData = {
+      ...mockNodeData,
+      launch_data: {
+        execution_environment: { id: 7 } as PromptFormValues['execution_environment'],
+        original: {
+          isTemplateChange: false,
+          launch_config: { ask_execution_environment_on_launch: true } as LaunchConfiguration,
+        },
+      },
+    };
+
+    renderComponent(nodeWithPromptEE);
+    expect(screen.getAllByText('Fetched EE From API').length).toBeGreaterThan(0);
+  });
+
+  it('should use labels from template summary_fields when no prompt override', () => {
+    const templateWithLabels = {
+      ...mockTemplate,
+      summary_fields: {
+        ...mockTemplate.summary_fields,
+        labels: {
+          results: [
+            { id: 1, name: 'staging' },
+            { id: 2, name: 'v2' },
+          ],
+          count: 2,
+        },
+      },
+    } as typeof mockTemplate;
+
+    render(
+      <MemoryRouter>
+        <JobTemplateDetails template={templateWithLabels} node={mockNodeData} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(screen.getByText('v2')).toBeInTheDocument();
+  });
+
+  it('should use node instance groups from useGet when they are returned', () => {
+    vi.mocked(useGet).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('instance_groups')) {
+        return {
+          data: { results: [{ id: 3, name: 'controlplane' }], count: 1 },
+          error: undefined,
+          refresh: vi.fn(),
+          isLoading: false,
+        };
+      }
+      return { data: undefined, error: undefined, refresh: vi.fn(), isLoading: false };
+    });
+
+    renderComponent();
+    expect(screen.getByText('Instance groups')).toBeInTheDocument();
+    expect(screen.getByText('controlplane')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest';
+import { arrayIdsMatch } from './resolveNodeFields';
+import { resolveExtraVars } from './resolveExtraVars';
+
+describe('resolveExtraVars', () => {
+  const templateVars = 'default_var: template_value';
+
+  describe('unedited node (promptValues undefined)', () => {
+    test('should show template defaults when node extra_data is empty object', () => {
+      const result = resolveExtraVars(undefined, false, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show template defaults when node extra_data is undefined', () => {
+      const result = resolveExtraVars(undefined, false, undefined, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show node override when node has extra_data with keys', () => {
+      const result = resolveExtraVars(undefined, false, { my_var: 'val' }, templateVars, false);
+      expect(result).toContain('my_var');
+    });
+  });
+
+  describe('template changed (isTemplateChanged = true)', () => {
+    test('should show new template defaults when extra_vars is empty string and not promptable', () => {
+      const result = resolveExtraVars('', false, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show empty when extra_vars is empty string and promptable (user chose empty)', () => {
+      const result = resolveExtraVars('', true, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe('');
+    });
+
+    test('should show user-entered extra_vars when set', () => {
+      const result = resolveExtraVars(
+        'new_var: fresh',
+        true,
+        { old_var: 'stale' },
+        templateVars,
+        true
+      );
+      expect(result).toBe('new_var: fresh');
+    });
+
+    test('should show new template defaults when promptValues.extra_vars is undefined', () => {
+      const result = resolveExtraVars(undefined, false, { old_var: 'stale' }, templateVars, true);
+      expect(result).toBe(templateVars);
+    });
+  });
+
+  describe('same template edit (isTemplateChanged = false)', () => {
+    test('should preserve user-entered extra_vars', () => {
+      const result = resolveExtraVars(
+        'user_var: value',
+        true,
+        { old_var: 'val' },
+        templateVars,
+        false
+      );
+      expect(result).toBe('user_var: value');
+    });
+
+    test('should show node extra_data when promptValues is undefined and node has data', () => {
+      const result = resolveExtraVars(
+        undefined,
+        true,
+        { existing_var: 'val' },
+        templateVars,
+        false
+      );
+      expect(result).toContain('existing_var');
+    });
+
+    test('should show template defaults when node extra_data is empty', () => {
+      const result = resolveExtraVars(undefined, true, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+  });
+
+  describe('non-promptable template with defaults', () => {
+    test('should show template defaults after save clears extra_data to empty object', () => {
+      const result = resolveExtraVars(undefined, false, {}, templateVars, false);
+      expect(result).toBe(templateVars);
+    });
+
+    test('should show template defaults when template has no defaults', () => {
+      const result = resolveExtraVars(undefined, false, {}, '', false);
+      expect(result).toBe('');
+    });
+  });
+});
+
+describe('arrayIdsMatch', () => {
+  test('should return true for two empty arrays', () => {
+    expect(arrayIdsMatch([], [])).toBe(true);
+  });
+
+  test('should return true when arrays contain same ids in same order', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 2 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return true when arrays contain same ids in different order', () => {
+    expect(arrayIdsMatch([{ id: 2 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return false when arrays have different lengths', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have same length but different ids', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 3 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when one array is empty and the other is not', () => {
+    expect(arrayIdsMatch([], [{ id: 1 }])).toBe(false);
+    expect(arrayIdsMatch([{ id: 1 }], [])).toBe(false);
+  });
+
+  test('should return true for single-element arrays with matching id', () => {
+    expect(arrayIdsMatch([{ id: 42 }], [{ id: 42 }])).toBe(true);
+  });
+
+  test('should return false for single-element arrays with different ids', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have same length but one contains duplicate ids', () => {
+    // arr1 = [{id:1},{id:1}] → Set size 1; arr2 = [{id:1},{id:2}] → Set size 2
+    // Passes length check (both 2) but fails Set size check → covers lines 9-11
+    expect(arrayIdsMatch([{ id: 1 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
@@ -23,6 +23,96 @@ import { NodeCodeEditorDetail } from './NodeCodeEditorDetail';
 import { NodeTagDetail } from './NodeTagDetail';
 import { PromptDetail } from './PromptDetail';
 
+function resolveScalar<T>(
+  promptValue: T | undefined | null,
+  nodeValue: T | undefined | null,
+  templateValue: T,
+  isTemplateChanged: boolean
+): T {
+  if (promptValue !== undefined && promptValue !== null) return promptValue;
+  if (!isTemplateChanged && nodeValue !== undefined && nodeValue !== null) return nodeValue;
+  return templateValue;
+}
+
+function resolveArrayField<T>(
+  promptValue: T[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeResults: T[] | undefined,
+  templateResults: T[] | undefined,
+  isTemplateChanged: boolean
+): T[] | undefined {
+  if (promptValue !== undefined && (promptValue.length > 0 || acceptsOnLaunch)) {
+    return promptValue;
+  }
+  if (isTemplateChanged) {
+    return templateResults;
+  }
+  return (nodeResults?.length ? nodeResults : undefined) ?? templateResults;
+}
+
+function resolveExecutionEnvironment(
+  promptEE: PromptFormValues['execution_environment'] | undefined,
+  fetchedEE: ExecutionEnvironment | undefined,
+  nodeEE: ExecutionEnvironment | undefined,
+  templateEE: ExecutionEnvironment | undefined,
+  isTemplateChanged: boolean
+): ExecutionEnvironment | undefined {
+  if (promptEE && fetchedEE) return fetchedEE;
+  if (isTemplateChanged) return templateEE;
+  return nodeEE ?? templateEE;
+}
+
+function resolveVariables(
+  promptExtraVars: string | undefined,
+  askVariablesOnLaunch: boolean | undefined,
+  nodeExtraData: Record<string, unknown> | undefined,
+  templateExtraVars: string,
+  isTemplateChanged: boolean
+): string | undefined {
+  if (promptExtraVars !== undefined && (promptExtraVars !== '' || askVariablesOnLaunch)) {
+    return promptExtraVars;
+  }
+  if (isTemplateChanged) return templateExtraVars;
+  if (nodeExtraData) return jsonToYaml(JSON.stringify(nodeExtraData));
+  return templateExtraVars;
+}
+
+function resolveTagField(
+  promptTags: { name: string }[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeTagString: string | null | undefined,
+  templateTagString: string,
+  isTemplateChanged: boolean
+): { name: string }[] {
+  if (promptTags !== undefined && (promptTags.length > 0 || acceptsOnLaunch)) {
+    return promptTags;
+  }
+  if (isTemplateChanged) return parseStringToTagArray(templateTagString);
+  return parseStringToTagArray(nodeTagString ?? templateTagString);
+}
+
+function mergeSurveyIntoVariables(
+  variables: string | undefined,
+  surveyValues: Record<string, unknown>
+): string {
+  const jsonObj: Record<string, unknown> = {};
+
+  if (variables) {
+    const lines = variables.split('\n');
+    lines.forEach((line) => {
+      const [key, value] = line.split(':').map((part) => part.trim());
+      jsonObj[key] = value;
+    });
+  }
+
+  const mergedData = {
+    ...jsonObj,
+    ...surveyValues,
+  };
+
+  return jsonToYaml(JSON.stringify(mergedData));
+}
+
 function useAggregateJobTemplateDetails({
   template,
   node,
@@ -51,73 +141,113 @@ function useAggregateJobTemplateDetails({
     String(promptValues?.execution_environment?.id)
   );
 
-  // Fix: Check for non-empty arrays, not just truthy values (empty arrays are truthy!)
-  const credentials =
-    (promptValues?.credentials && promptValues.credentials.length > 0
-      ? promptValues.credentials
-      : undefined) ??
-    (nodeCredentials?.results && nodeCredentials.results.length > 0
-      ? nodeCredentials.results
-      : undefined) ??
-    templateCredentials?.results;
+  const isTemplateChanged = Boolean(promptValues?.original?.isTemplateChange);
 
-  const diffMode = promptValues?.diff_mode ?? nodeValues?.diff_mode ?? template.diff_mode;
-  let executionEnvironment: ExecutionEnvironment | undefined;
-
-  if (promptValues?.execution_environment && fetchedEE) {
-    executionEnvironment = fetchedEE;
-  } else {
-    executionEnvironment =
-      nodeValues?.summary_fields?.execution_environment ??
-      template.summary_fields.execution_environment;
-  }
-
-  const forks = Number(promptValues?.forks ?? nodeValues?.forks ?? template.forks);
-  const instanceGroups =
-    promptValues?.instance_groups ?? nodeInstanceGroups?.results ?? templateInstanceGroups?.results;
-  const inventory =
-    promptValues?.inventory ??
-    nodeValues.summary_fields.inventory ??
-    template.summary_fields.inventory;
-  const jobSliceCount =
-    promptValues?.job_slice_count ?? nodeValues?.job_slice_count ?? template.job_slice_count;
-  const jobTags =
-    promptValues?.job_tags ?? parseStringToTagArray(nodeValues?.job_tags ?? template.job_tags);
-  const jobType = promptValues?.job_type ?? nodeValues?.job_type ?? template.job_type;
-  const labels =
-    promptValues?.labels ?? nodeLabels?.results ?? template.summary_fields.labels?.results;
-  const limit = promptValues?.limit ?? nodeValues?.limit ?? template.limit;
-  const scmBranch = promptValues?.scm_branch ?? nodeValues?.scm_branch ?? template.scm_branch;
-  const skipTags =
-    promptValues?.skip_tags ?? parseStringToTagArray(nodeValues?.skip_tags ?? template.skip_tags);
-  const timeout = Number(promptValues?.timeout ?? nodeValues?.timeout ?? template.timeout);
+  const credentials = resolveArrayField(
+    promptValues?.credentials,
+    template.ask_credential_on_launch,
+    nodeCredentials?.results,
+    templateCredentials?.results,
+    isTemplateChanged
+  );
+  const diffMode = resolveScalar(
+    promptValues?.diff_mode,
+    nodeValues?.diff_mode,
+    template.diff_mode,
+    isTemplateChanged
+  );
+  const executionEnvironment = resolveExecutionEnvironment(
+    promptValues?.execution_environment,
+    fetchedEE,
+    nodeValues?.summary_fields?.execution_environment,
+    template.summary_fields.execution_environment as ExecutionEnvironment | undefined,
+    isTemplateChanged
+  );
+  const forks = Number(
+    resolveScalar(promptValues?.forks, nodeValues?.forks, template.forks, isTemplateChanged)
+  );
+  const instanceGroups = resolveArrayField(
+    promptValues?.instance_groups,
+    template.ask_instance_groups_on_launch,
+    nodeInstanceGroups?.results,
+    templateInstanceGroups?.results,
+    isTemplateChanged
+  );
+  const inventory = resolveScalar(
+    promptValues?.inventory,
+    nodeValues.summary_fields.inventory,
+    template.summary_fields.inventory,
+    isTemplateChanged
+  );
+  const jobSliceCount = resolveScalar(
+    promptValues?.job_slice_count,
+    nodeValues?.job_slice_count,
+    template.job_slice_count,
+    isTemplateChanged
+  );
+  const jobTags = resolveTagField(
+    promptValues?.job_tags,
+    template.ask_tags_on_launch,
+    nodeValues?.job_tags,
+    template.job_tags,
+    isTemplateChanged
+  );
+  const jobType = resolveScalar(
+    promptValues?.job_type,
+    nodeValues?.job_type,
+    template.job_type,
+    isTemplateChanged
+  );
+  const labels = resolveArrayField(
+    promptValues?.labels,
+    template.ask_labels_on_launch,
+    nodeLabels?.results,
+    template.summary_fields.labels?.results,
+    isTemplateChanged
+  );
+  const limit = resolveScalar(
+    promptValues?.limit,
+    nodeValues?.limit,
+    template.limit,
+    isTemplateChanged
+  );
+  const scmBranch = resolveScalar(
+    promptValues?.scm_branch,
+    nodeValues?.scm_branch,
+    template.scm_branch,
+    isTemplateChanged
+  );
+  const skipTags = resolveTagField(
+    promptValues?.skip_tags,
+    template.ask_skip_tags_on_launch,
+    nodeValues?.skip_tags,
+    template.skip_tags,
+    isTemplateChanged
+  );
+  const timeout = Number(
+    resolveScalar(promptValues?.timeout, nodeValues?.timeout, template.timeout, isTemplateChanged)
+  );
   const timeoutString = useGetTimeoutString(timeout);
   const templateTimeoutString = useGetTimeoutString(template.timeout);
-  const verbosity = promptValues?.verbosity ?? nodeValues?.verbosity ?? template.verbosity;
+  const verbosity = resolveScalar(
+    promptValues?.verbosity,
+    nodeValues?.verbosity,
+    template.verbosity,
+    isTemplateChanged
+  );
   const verbosityString = useVerbosityString(verbosity);
   const templateVerbosityString = useVerbosityString(template.verbosity);
-  let variables =
-    promptValues?.extra_vars ??
-    (nodeValues?.extra_data ? jsonToYaml(JSON.stringify(nodeValues.extra_data)) : undefined) ??
-    template.extra_vars;
+
+  let variables = resolveVariables(
+    promptValues?.extra_vars,
+    template.ask_variables_on_launch,
+    nodeValues?.extra_data,
+    template.extra_vars,
+    isTemplateChanged
+  );
 
   if (surveyValues) {
-    const jsonObj: { [key: string]: string } = {};
-
-    if (variables) {
-      const lines = variables.split('\n');
-      lines.forEach((line) => {
-        const [key, value] = line.split(':').map((part) => part.trim());
-        jsonObj[key] = value;
-      });
-    }
-
-    const mergedData: { [key: string]: string | string[] | { name: string }[] } = {
-      ...jsonObj,
-      ...surveyValues,
-    };
-
-    variables = jsonToYaml(JSON.stringify(mergedData));
+    variables = mergeSurveyIntoVariables(variables, surveyValues);
   }
 
   return {
@@ -337,7 +467,7 @@ export function JobTemplateDetails({
       </PageDetail>
       <NodeTagDetail
         label={t('Labels')}
-        nodeTags={labels}
+        nodeTags={labels ?? []}
         templateTags={template.summary_fields.labels?.results}
       />
       <NodeTagDetail
@@ -352,7 +482,7 @@ export function JobTemplateDetails({
       />
       <NodeCodeEditorDetail
         label={t('Variables')}
-        nodeExtraVars={variables}
+        nodeExtraVars={variables ?? ''}
         templateExtraVars={template.extra_vars}
       />
     </>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/JobTemplateDetails.tsx
@@ -1,5 +1,4 @@
 import { PageDetail, TextCell, useGetPageUrl } from '@ansible/ansible-ui-framework';
-import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
 import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
 import { Content, ContentVariants, Label, LabelGroup } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
@@ -22,96 +21,15 @@ import { GraphNodeData, PromptFormValues } from '../types';
 import { NodeCodeEditorDetail } from './NodeCodeEditorDetail';
 import { NodeTagDetail } from './NodeTagDetail';
 import { PromptDetail } from './PromptDetail';
-
-function resolveScalar<T>(
-  promptValue: T | undefined | null,
-  nodeValue: T | undefined | null,
-  templateValue: T,
-  isTemplateChanged: boolean
-): T {
-  if (promptValue !== undefined && promptValue !== null) return promptValue;
-  if (!isTemplateChanged && nodeValue !== undefined && nodeValue !== null) return nodeValue;
-  return templateValue;
-}
-
-function resolveArrayField<T>(
-  promptValue: T[] | undefined,
-  acceptsOnLaunch: boolean | undefined,
-  nodeResults: T[] | undefined,
-  templateResults: T[] | undefined,
-  isTemplateChanged: boolean
-): T[] | undefined {
-  if (promptValue !== undefined && (promptValue.length > 0 || acceptsOnLaunch)) {
-    return promptValue;
-  }
-  if (isTemplateChanged) {
-    return templateResults;
-  }
-  return (nodeResults?.length ? nodeResults : undefined) ?? templateResults;
-}
-
-function resolveExecutionEnvironment(
-  promptEE: PromptFormValues['execution_environment'] | undefined,
-  fetchedEE: ExecutionEnvironment | undefined,
-  nodeEE: ExecutionEnvironment | undefined,
-  templateEE: ExecutionEnvironment | undefined,
-  isTemplateChanged: boolean
-): ExecutionEnvironment | undefined {
-  if (promptEE && fetchedEE) return fetchedEE;
-  if (isTemplateChanged) return templateEE;
-  return nodeEE ?? templateEE;
-}
-
-function resolveVariables(
-  promptExtraVars: string | undefined,
-  askVariablesOnLaunch: boolean | undefined,
-  nodeExtraData: Record<string, unknown> | undefined,
-  templateExtraVars: string,
-  isTemplateChanged: boolean
-): string | undefined {
-  if (promptExtraVars !== undefined && (promptExtraVars !== '' || askVariablesOnLaunch)) {
-    return promptExtraVars;
-  }
-  if (isTemplateChanged) return templateExtraVars;
-  if (nodeExtraData) return jsonToYaml(JSON.stringify(nodeExtraData));
-  return templateExtraVars;
-}
-
-function resolveTagField(
-  promptTags: { name: string }[] | undefined,
-  acceptsOnLaunch: boolean | undefined,
-  nodeTagString: string | null | undefined,
-  templateTagString: string,
-  isTemplateChanged: boolean
-): { name: string }[] {
-  if (promptTags !== undefined && (promptTags.length > 0 || acceptsOnLaunch)) {
-    return promptTags;
-  }
-  if (isTemplateChanged) return parseStringToTagArray(templateTagString);
-  return parseStringToTagArray(nodeTagString ?? templateTagString);
-}
-
-function mergeSurveyIntoVariables(
-  variables: string | undefined,
-  surveyValues: Record<string, unknown>
-): string {
-  const jsonObj: Record<string, unknown> = {};
-
-  if (variables) {
-    const lines = variables.split('\n');
-    lines.forEach((line) => {
-      const [key, value] = line.split(':').map((part) => part.trim());
-      jsonObj[key] = value;
-    });
-  }
-
-  const mergedData = {
-    ...jsonObj,
-    ...surveyValues,
-  };
-
-  return jsonToYaml(JSON.stringify(mergedData));
-}
+import { resolveExtraVars } from './resolveExtraVars';
+import {
+  arrayIdsMatch,
+  mergeSurveyIntoVariables,
+  resolveArrayField,
+  resolveExecutionEnvironment,
+  resolveScalar,
+  resolveTagField,
+} from './resolveNodeFields';
 
 function useAggregateJobTemplateDetails({
   template,
@@ -238,7 +156,7 @@ function useAggregateJobTemplateDetails({
   const verbosityString = useVerbosityString(verbosity);
   const templateVerbosityString = useVerbosityString(template.verbosity);
 
-  let variables = resolveVariables(
+  let variables = resolveExtraVars(
     promptValues?.extra_vars,
     template.ask_variables_on_launch,
     nodeValues?.extra_data,
@@ -565,23 +483,4 @@ function InstanceGroupsDetail({
       </LabelGroup>
     </PromptDetail>
   );
-}
-
-function arrayIdsMatch(arr1: { id: number }[], arr2: { id: number }[]) {
-  if (arr1.length !== arr2.length) {
-    return false;
-  }
-
-  const idSet1 = new Set(arr1.map((obj) => obj.id));
-  const idSet2 = new Set(arr2.map((obj) => obj.id));
-
-  if (idSet1.size !== idSet2.size) {
-    return false;
-  }
-  for (const item of idSet1) {
-    if (!idSet2.has(item)) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+import { resolveExtraVars } from './resolveExtraVars';
+
+describe('resolveExtraVars', () => {
+  describe('prompt value handling', () => {
+    test('should use prompt extra_vars when non-empty', () => {
+      expect(resolveExtraVars('my_var: value', true, undefined, '---', false)).toBe(
+        'my_var: value'
+      );
+    });
+
+    test('should use empty prompt extra_vars when field is promptable (user cleared it)', () => {
+      expect(resolveExtraVars('', true, { old: 'data' }, 'template: default', false)).toBe('');
+    });
+
+    test('should fall through empty prompt when not promptable', () => {
+      expect(resolveExtraVars('', false, undefined, 'template: default', false)).toBe(
+        'template: default'
+      );
+    });
+  });
+
+  describe('template change handling', () => {
+    test('should use template extra_vars on template change when prompt undefined', () => {
+      expect(resolveExtraVars(undefined, false, { stale: 'data' }, 'new_template: val', true)).toBe(
+        'new_template: val'
+      );
+    });
+
+    test('should use template extra_vars on template change even when node has data', () => {
+      expect(resolveExtraVars(undefined, false, { old_var: 'old_val' }, 'new: default', true)).toBe(
+        'new: default'
+      );
+    });
+
+    test('should prefer prompt over template on template change when prompt is provided', () => {
+      expect(resolveExtraVars('user: input', true, undefined, 'template: default', true)).toBe(
+        'user: input'
+      );
+    });
+  });
+
+  describe('no template change', () => {
+    test('should use node extra_data when no template change and prompt undefined', () => {
+      const result = resolveExtraVars(undefined, false, { node_var: 'node_val' }, '---', false);
+      expect(result).toContain('node_var');
+      expect(result).toContain('node_val');
+    });
+
+    test('should use template extra_vars when node has no data and prompt undefined', () => {
+      expect(resolveExtraVars(undefined, false, undefined, 'template: vars', false)).toBe(
+        'template: vars'
+      );
+    });
+
+    test('should skip empty node extra_data and use template default', () => {
+      expect(resolveExtraVars(undefined, false, {}, 'template: default', false)).toBe(
+        'template: default'
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should return template default when all inputs are undefined/empty', () => {
+      expect(resolveExtraVars(undefined, false, undefined, '---', false)).toBe('---');
+    });
+
+    test('should return template default on template change with empty template vars', () => {
+      expect(resolveExtraVars(undefined, false, { old: 'data' }, '', true)).toBe('');
+    });
+
+    test('should handle node data with nested objects', () => {
+      const nodeData = { parent: { child: 'value' } } as unknown as Record<string, unknown>;
+      const result = resolveExtraVars(undefined, false, nodeData, '---', false);
+      expect(result).toBeDefined();
+      expect(result).toContain('parent');
+    });
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveExtraVars.ts
@@ -1,0 +1,18 @@
+import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
+
+export function resolveExtraVars(
+  promptExtraVars: string | undefined,
+  askVariablesOnLaunch: boolean | undefined,
+  nodeExtraData: Record<string, unknown> | undefined,
+  templateExtraVars: string,
+  isTemplateChanged: boolean
+): string | undefined {
+  if (promptExtraVars !== undefined && (promptExtraVars !== '' || askVariablesOnLaunch)) {
+    return promptExtraVars;
+  }
+  if (isTemplateChanged) return templateExtraVars;
+  if (nodeExtraData && Object.keys(nodeExtraData).length > 0) {
+    return jsonToYaml(JSON.stringify(nodeExtraData));
+  }
+  return templateExtraVars;
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'vitest';
+import type { ExecutionEnvironment } from '../../../../interfaces/ExecutionEnvironment';
+import {
+  resolveArrayField,
+  resolveScalar,
+  resolveTagField,
+  resolveExecutionEnvironment,
+  mergeSurveyIntoVariables,
+  arrayIdsMatch,
+} from './resolveNodeFields';
+
+describe('resolveArrayField', () => {
+  const templateDefault = [{ id: 10, name: 'template-cred' }];
+  const nodeDbValue = [{ id: 20, name: 'node-cred' }];
+
+  test('should use prompt value when non-empty', () => {
+    const prompt = [{ id: 30, name: 'user-cred' }];
+    expect(resolveArrayField(prompt, true, nodeDbValue, templateDefault, false)).toEqual(prompt);
+  });
+
+  test('should use empty prompt value when field is promptable (user chose none)', () => {
+    expect(resolveArrayField([], true, nodeDbValue, templateDefault, false)).toEqual([]);
+  });
+
+  test('should fall through empty prompt when not promptable (force-cleared)', () => {
+    expect(resolveArrayField([], false, nodeDbValue, templateDefault, true)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should use template default on template change when prompt undefined', () => {
+    expect(resolveArrayField(undefined, false, nodeDbValue, templateDefault, true)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should use node DB value when no template change and prompt undefined', () => {
+    expect(resolveArrayField(undefined, false, nodeDbValue, templateDefault, false)).toEqual(
+      nodeDbValue
+    );
+  });
+
+  test('should use template default when node DB value is empty', () => {
+    expect(resolveArrayField(undefined, false, [], templateDefault, false)).toEqual(
+      templateDefault
+    );
+  });
+
+  test('should return undefined when all sources are undefined', () => {
+    expect(resolveArrayField(undefined, false, undefined, undefined, false)).toBeUndefined();
+  });
+});
+
+describe('resolveScalar', () => {
+  test('should use prompt value when defined', () => {
+    expect(resolveScalar('user-limit', 'node-limit', 'template-limit', false)).toBe('user-limit');
+  });
+
+  test('should use prompt value even when falsy (0, false)', () => {
+    expect(resolveScalar(0, 5, 10, false)).toBe(0);
+    expect(resolveScalar(false, true, true, false)).toBe(false);
+  });
+
+  test('should skip node value and use template default on template change', () => {
+    expect(resolveScalar(undefined, 'stale-node', 'template-default', true)).toBe(
+      'template-default'
+    );
+  });
+
+  test('should use node value when no template change', () => {
+    expect(resolveScalar(undefined, 'node-val', 'template-val', false)).toBe('node-val');
+  });
+
+  test('should use template default when node value is null/undefined', () => {
+    expect(resolveScalar(undefined, undefined, 'template-val', false)).toBe('template-val');
+    expect(resolveScalar(undefined, null, 'template-val', false)).toBe('template-val');
+  });
+});
+
+describe('resolveTagField', () => {
+  test('should use prompt tags when non-empty', () => {
+    const tags = [{ name: 'tag1' }];
+    expect(resolveTagField(tags, true, 'old', 'default', false)).toEqual(tags);
+  });
+
+  test('should use empty prompt tags when promptable (user chose none)', () => {
+    expect(resolveTagField([], true, 'old', 'default', false)).toEqual([]);
+  });
+
+  test('should use template tags on template change', () => {
+    const result = resolveTagField(undefined, false, 'stale_tag', 'new_tag', true);
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'new_tag' })]));
+  });
+
+  test('should use node tag string when no template change', () => {
+    const result = resolveTagField(undefined, false, 'node_tag', 'template_tag', false);
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'node_tag' })]));
+  });
+
+  test('should fall through to template tags when node tags are null', () => {
+    const result = resolveTagField(undefined, false, null, 'template_tag', false);
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'template_tag' })])
+    );
+  });
+
+  test('should return empty array when all sources are empty', () => {
+    expect(resolveTagField(undefined, false, '', '', false)).toEqual([]);
+  });
+
+  test('should fall through force-cleared empty tags to template default on template change', () => {
+    const result = resolveTagField([], false, 'stale', 'default_tag', true);
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'default_tag' })])
+    );
+  });
+});
+
+describe('resolveExecutionEnvironment', () => {
+  const fetchedEE = { id: 1, name: 'Fetched EE' } as unknown as ExecutionEnvironment;
+  const nodeEE = { id: 2, name: 'Node EE' } as unknown as ExecutionEnvironment;
+  const templateEE = { id: 3, name: 'Template EE' } as unknown as ExecutionEnvironment;
+
+  test('should use fetched EE when prompt has an EE selection', () => {
+    const promptEE = { id: 1, name: 'Fetched EE' };
+    expect(resolveExecutionEnvironment(promptEE, fetchedEE, nodeEE, templateEE, false)).toEqual(
+      fetchedEE
+    );
+  });
+
+  test('should use template EE on template change when no prompt', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, nodeEE, templateEE, true)).toEqual(
+      templateEE
+    );
+  });
+
+  test('should use node EE when no template change and no prompt', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, nodeEE, templateEE, false)).toEqual(
+      nodeEE
+    );
+  });
+
+  test('should fall through to template EE when node EE is undefined', () => {
+    expect(resolveExecutionEnvironment(undefined, undefined, undefined, templateEE, false)).toEqual(
+      templateEE
+    );
+  });
+
+  test('should return undefined when all sources are undefined', () => {
+    expect(
+      resolveExecutionEnvironment(undefined, undefined, undefined, undefined, false)
+    ).toBeUndefined();
+  });
+});
+
+describe('mergeSurveyIntoVariables', () => {
+  test('should merge survey values into existing variables', () => {
+    const result = mergeSurveyIntoVariables('key1: value1', { key2: 'value2' });
+    expect(result).toContain('key1');
+    expect(result).toContain('key2');
+  });
+
+  test('should override existing keys with survey values', () => {
+    const result = mergeSurveyIntoVariables('key1: old', { key1: 'new' });
+    expect(result).toContain('new');
+  });
+
+  test('should handle undefined variables', () => {
+    const result = mergeSurveyIntoVariables(undefined, { key1: 'value1' });
+    expect(result).toContain('key1');
+  });
+
+  test('should handle empty survey values', () => {
+    const result = mergeSurveyIntoVariables('key1: value1', {});
+    expect(result).toContain('key1');
+  });
+});
+
+describe('arrayIdsMatch', () => {
+  test('should return true when arrays have same IDs', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 2 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return true when arrays have same IDs in different order', () => {
+    expect(arrayIdsMatch([{ id: 2 }, { id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test('should return false when arrays have different lengths', () => {
+    expect(arrayIdsMatch([{ id: 1 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return false when arrays have different IDs', () => {
+    expect(arrayIdsMatch([{ id: 1 }, { id: 3 }], [{ id: 1 }, { id: 2 }])).toBe(false);
+  });
+
+  test('should return true for empty arrays', () => {
+    expect(arrayIdsMatch([], [])).toBe(true);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/components/resolveNodeFields.ts
@@ -1,0 +1,98 @@
+import type { ExecutionEnvironment } from '../../../../interfaces/ExecutionEnvironment';
+import { jsonToYaml } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
+import { parseStringToTagArray } from '../../JobTemplateFormHelpers';
+import type { PromptFormValues } from '../types';
+
+export function resolveScalar<T>(
+  promptValue: T | undefined | null,
+  nodeValue: T | undefined | null,
+  templateValue: T,
+  isTemplateChanged: boolean
+): T {
+  if (promptValue !== undefined && promptValue !== null) return promptValue;
+  if (!isTemplateChanged && nodeValue !== undefined && nodeValue !== null) return nodeValue;
+  return templateValue;
+}
+
+export function resolveArrayField<T>(
+  promptValue: T[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeResults: T[] | undefined,
+  templateResults: T[] | undefined,
+  isTemplateChanged: boolean
+): T[] | undefined {
+  if (promptValue !== undefined && (promptValue.length > 0 || acceptsOnLaunch)) {
+    return promptValue;
+  }
+  if (isTemplateChanged) {
+    return templateResults;
+  }
+  return (nodeResults?.length ? nodeResults : undefined) ?? templateResults;
+}
+
+export function resolveExecutionEnvironment(
+  promptEE: PromptFormValues['execution_environment'] | undefined,
+  fetchedEE: ExecutionEnvironment | undefined,
+  nodeEE: ExecutionEnvironment | undefined,
+  templateEE: ExecutionEnvironment | undefined,
+  isTemplateChanged: boolean
+): ExecutionEnvironment | undefined {
+  if (promptEE && fetchedEE) return fetchedEE;
+  if (isTemplateChanged) return templateEE;
+  return nodeEE ?? templateEE;
+}
+
+export function resolveTagField(
+  promptTags: { name: string }[] | undefined,
+  acceptsOnLaunch: boolean | undefined,
+  nodeTagString: string | null | undefined,
+  templateTagString: string,
+  isTemplateChanged: boolean
+): { name: string }[] {
+  if (promptTags !== undefined && (promptTags.length > 0 || acceptsOnLaunch)) {
+    return promptTags;
+  }
+  if (isTemplateChanged) return parseStringToTagArray(templateTagString);
+  return parseStringToTagArray(nodeTagString ?? templateTagString);
+}
+
+export function mergeSurveyIntoVariables(
+  variables: string | undefined,
+  surveyValues: Record<string, unknown>
+): string {
+  const jsonObj: { [key: string]: string } = {};
+
+  if (variables) {
+    const lines = variables.split('\n');
+    lines.forEach((line) => {
+      const [key, value] = line.split(':').map((part) => part.trim());
+      jsonObj[key] = value;
+    });
+  }
+
+  const mergedData = {
+    ...jsonObj,
+    ...surveyValues,
+  };
+
+  return jsonToYaml(JSON.stringify(mergedData));
+}
+
+export function arrayIdsMatch(arr1: { id: number }[], arr2: { id: number }[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  const idSet1 = new Set(arr1.map((obj) => obj.id));
+  const idSet2 = new Set(arr2.map((obj) => obj.id));
+
+  if (idSet1.size !== idSet2.size) {
+    return false;
+  }
+  for (const item of idSet1) {
+    if (!idSet2.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import { clearStaleNodeFields } from './clearStaleNodeFields';
+
+describe('clearStaleNodeFields', () => {
+  test('should set all prompt fields to null when payload is empty', () => {
+    const payload: Record<string, unknown> = {};
+    clearStaleNodeFields(payload);
+
+    expect(payload.diff_mode).toBeNull();
+    expect(payload.execution_environment).toBeNull();
+    expect(payload.forks).toBeNull();
+    expect(payload.inventory).toBeNull();
+    expect(payload.job_slice_count).toBeNull();
+    expect(payload.job_tags).toBeNull();
+    expect(payload.job_type).toBeNull();
+    expect(payload.limit).toBeNull();
+    expect(payload.scm_branch).toBeNull();
+    expect(payload.skip_tags).toBeNull();
+    expect(payload.timeout).toBeNull();
+    expect(payload.verbosity).toBeNull();
+    expect(payload.extra_data).toEqual({});
+  });
+
+  test('should not overwrite fields that are already set', () => {
+    const payload: Record<string, unknown> = {
+      limit: '5',
+      forks: 10,
+      extra_data: { my_var: 'value' },
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.limit).toBe('5');
+    expect(payload.forks).toBe(10);
+    expect(payload.extra_data).toEqual({ my_var: 'value' });
+    expect(payload.diff_mode).toBeNull();
+    expect(payload.verbosity).toBeNull();
+  });
+
+  test('should preserve fields set to explicit values including falsy ones', () => {
+    const payload: Record<string, unknown> = {
+      diff_mode: false,
+      forks: 0,
+      timeout: 0,
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.diff_mode).toBe(false);
+    expect(payload.forks).toBe(0);
+    expect(payload.timeout).toBe(0);
+  });
+
+  test('should set extra_data to empty object not null', () => {
+    const payload: Record<string, unknown> = {};
+    clearStaleNodeFields(payload);
+
+    expect(payload.extra_data).toEqual({});
+    expect(payload.extra_data).not.toBeNull();
+  });
+
+  test('should handle payload with non-prompt fields without affecting them', () => {
+    const payload: Record<string, unknown> = {
+      unified_job_template: 42,
+      all_parents_must_converge: true,
+      identifier: 'my-node',
+    };
+    clearStaleNodeFields(payload);
+
+    expect(payload.unified_job_template).toBe(42);
+    expect(payload.all_parents_must_converge).toBe(true);
+    expect(payload.identifier).toBe('my-node');
+    expect(payload.limit).toBeNull();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/clearStaleNodeFields.ts
@@ -1,0 +1,25 @@
+const NULLABLE_PROMPT_FIELDS = [
+  'diff_mode',
+  'execution_environment',
+  'forks',
+  'inventory',
+  'job_slice_count',
+  'job_tags',
+  'job_type',
+  'limit',
+  'scm_branch',
+  'skip_tags',
+  'timeout',
+  'verbosity',
+] as const;
+
+export function clearStaleNodeFields(payload: Record<string, unknown>): void {
+  for (const key of NULLABLE_PROMPT_FIELDS) {
+    if (!(key in payload)) {
+      payload[key] = null;
+    }
+  }
+  if (!('extra_data' in payload)) {
+    payload['extra_data'] = {};
+  }
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/getAddedAndRemovedCredentials.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/getAddedAndRemovedCredentials.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { getAddedAndRemovedCredentials, type CredentialRef } from './getAddedAndRemovedCredentials';
+
+const cred = (id: number, credentialType: number, name = `Credential ${id}`): CredentialRef => ({
+  id,
+  name,
+  credential_type: credentialType,
+});
+
+describe('getAddedAndRemovedCredentials', () => {
+  describe('no changes', () => {
+    it('should return empty added/removed when all inputs are empty', () => {
+      const { added, removed } = getAddedAndRemovedCredentials([], [], []);
+      expect(added).toEqual([]);
+      expect(removed).toEqual([]);
+    });
+
+    it('should return empty added/removed when prompt matches node credentials', () => {
+      const nodeCreds = [cred(1, 1, 'SSH')];
+      const promptCreds = [cred(1, 1, 'SSH')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, promptCreds, []);
+      expect(added).toEqual([]);
+      expect(removed).toEqual([]);
+    });
+
+    it('should return empty added/removed when prompt matches template defaults (no node creds)', () => {
+      const templateCreds = [cred(1, 1, 'Template SSH')];
+      const promptCreds = [cred(1, 1, 'Template SSH')];
+
+      const { added, removed } = getAddedAndRemovedCredentials([], promptCreds, templateCreds);
+      expect(added).toEqual([]);
+      expect(removed).toEqual([]);
+    });
+  });
+
+  describe('adding credentials', () => {
+    it('should detect a new credential added by the user', () => {
+      const promptCreds = [cred(5, 2, 'New Vault')];
+
+      const { added, removed } = getAddedAndRemovedCredentials([], promptCreds, []);
+      expect(added).toEqual([cred(5, 2, 'New Vault')]);
+      expect(removed).toEqual([]);
+    });
+
+    it('should not add a credential that already exists as a template default', () => {
+      const templateCreds = [cred(1, 1, 'Template SSH')];
+      const promptCreds = [cred(1, 1, 'Template SSH'), cred(5, 2, 'New Vault')];
+
+      const { added, removed } = getAddedAndRemovedCredentials([], promptCreds, templateCreds);
+      expect(added).toEqual([cred(5, 2, 'New Vault')]);
+      expect(removed).toEqual([]);
+    });
+
+    it('should not add a credential that already exists at node level', () => {
+      const nodeCreds = [cred(3, 1, 'Node SSH')];
+      const promptCreds = [cred(3, 1, 'Node SSH'), cred(5, 2, 'New Vault')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, promptCreds, []);
+      expect(added).toEqual([cred(5, 2, 'New Vault')]);
+      expect(removed).toEqual([]);
+    });
+  });
+
+  describe('removing credentials', () => {
+    it('should detect a node credential removed from prompt', () => {
+      const nodeCreds = [cred(3, 1, 'Node SSH')];
+      const promptCreds: CredentialRef[] = [];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, promptCreds, []);
+      expect(added).toEqual([]);
+      expect(removed).toEqual([cred(3, 1, 'Node SSH')]);
+    });
+
+    it('should remove multiple node credentials when prompt is empty', () => {
+      const nodeCreds = [cred(3, 1, 'Node SSH'), cred(4, 2, 'Node Vault')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, [], []);
+      expect(added).toEqual([]);
+      expect(removed).toHaveLength(2);
+      expect(removed).toEqual(
+        expect.arrayContaining([cred(3, 1, 'Node SSH'), cred(4, 2, 'Node Vault')])
+      );
+    });
+
+    it('should only remove node credentials not present in prompt (template creds are not removed)', () => {
+      const nodeCreds = [cred(3, 1, 'Node SSH')];
+      const templateCreds = [cred(1, 2, 'Template Vault')];
+
+      const { added: _added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        [],
+        templateCreds
+      );
+      expect(removed).toEqual([cred(3, 1, 'Node SSH')]);
+    });
+  });
+
+  describe('replacing credentials', () => {
+    it('should detect when user replaces a node credential with a different one', () => {
+      const nodeCreds = [cred(3, 1, 'Old SSH')];
+      const promptCreds = [cred(7, 1, 'New SSH')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, promptCreds, []);
+      expect(added).toEqual([cred(7, 1, 'New SSH')]);
+      expect(removed).toEqual([cred(3, 1, 'Old SSH')]);
+    });
+
+    it('should handle replacing one credential while keeping another', () => {
+      const nodeCreds = [cred(3, 1, 'SSH'), cred(4, 2, 'Vault')];
+      const promptCreds = [cred(7, 1, 'New SSH'), cred(4, 2, 'Vault')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(nodeCreds, promptCreds, []);
+      expect(added).toEqual([cred(7, 1, 'New SSH')]);
+      expect(removed).toEqual([cred(3, 1, 'SSH')]);
+    });
+  });
+
+  describe('template change scenarios', () => {
+    it('should disassociate all node credentials when prompt is empty (template switch to no-prompts)', () => {
+      const nodeCreds = [cred(3, 1, 'Node SSH'), cred(4, 2, 'Node Vault'), cred(5, 3, 'Node SCM')];
+      const promptCreds: CredentialRef[] = [];
+      const templateCreds: CredentialRef[] = [];
+
+      const { added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        promptCreds,
+        templateCreds
+      );
+      expect(added).toEqual([]);
+      expect(removed).toHaveLength(3);
+      expect(removed).toEqual(nodeCreds);
+    });
+
+    it('should disassociate node credentials even when new template has its own defaults', () => {
+      const nodeCreds = [cred(3, 1, 'Old Template SSH')];
+      const promptCreds: CredentialRef[] = [];
+      const newTemplateCreds = [cred(10, 1, 'New Template SSH')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        promptCreds,
+        newTemplateCreds
+      );
+      expect(removed).toEqual([cred(3, 1, 'Old Template SSH')]);
+      expect(added).toEqual([]);
+    });
+
+    it('should add and remove correctly when switching to a template with different credential types', () => {
+      const nodeCreds = [cred(3, 1, 'SSH from old template')];
+      const promptCreds = [cred(10, 5, 'Cloud cred for new template')];
+      const newTemplateCreds = [cred(9, 4, 'New template default')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        promptCreds,
+        newTemplateCreds
+      );
+      expect(added).toEqual([cred(10, 5, 'Cloud cred for new template')]);
+      expect(removed).toEqual([cred(3, 1, 'SSH from old template')]);
+    });
+  });
+
+  describe('multiple credential types', () => {
+    it('should handle complex scenario with adds, removes, and keeps', () => {
+      const nodeCreds = [
+        cred(1, 1, 'SSH - keep'),
+        cred(2, 2, 'Vault - remove'),
+        cred(3, 3, 'SCM - replace'),
+      ];
+      const promptCreds = [
+        cred(1, 1, 'SSH - keep'),
+        cred(7, 3, 'SCM - new'),
+        cred(8, 5, 'Cloud - add'),
+      ];
+      const templateCreds = [cred(10, 4, 'Template Network')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        promptCreds,
+        templateCreds
+      );
+
+      expect(added).toEqual([cred(7, 3, 'SCM - new'), cred(8, 5, 'Cloud - add')]);
+      expect(removed).toEqual([cred(2, 2, 'Vault - remove'), cred(3, 3, 'SCM - replace')]);
+    });
+
+    it('should treat same ID in both node and template as existing (not added)', () => {
+      const nodeCreds = [cred(1, 1, 'SSH')];
+      const templateCreds = [cred(1, 1, 'SSH')];
+      const promptCreds = [cred(1, 1, 'SSH')];
+
+      const { added, removed } = getAddedAndRemovedCredentials(
+        nodeCreds,
+        promptCreds,
+        templateCreds
+      );
+      expect(added).toEqual([]);
+      expect(removed).toEqual([]);
+    });
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/getAddedAndRemovedCredentials.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/getAddedAndRemovedCredentials.ts
@@ -1,0 +1,27 @@
+export interface CredentialRef {
+  id: number;
+  name: string;
+  credential_type: number;
+}
+
+export function getAddedAndRemovedCredentials(
+  nodeCredentials: CredentialRef[],
+  promptCredentials: CredentialRef[],
+  templateCredentials: CredentialRef[]
+) {
+  const aggregateCredentials = [...nodeCredentials, ...templateCredentials];
+
+  const added = promptCredentials.filter(
+    (promptCredential) =>
+      !aggregateCredentials.some(
+        (aggregateCredential) => aggregateCredential.id === promptCredential.id
+      )
+  );
+
+  const removed = nodeCredentials.filter(
+    (nodeCredential) =>
+      !promptCredentials.some((promptCredential) => promptCredential.id === nodeCredential.id)
+  );
+
+  return { added, removed };
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.test.ts
@@ -1,0 +1,561 @@
+import { renderHook } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import { RESOURCE_TYPE } from '../constants';
+import { EdgeStatus } from '../types';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({}),
+    setState: () => {},
+    getGraph: () => ({ getNodes: () => [], layout: () => {} }),
+    getElements: () => [],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+const { getLaunchData, useGetInitialValues, useNodeTypeStepDefaults } = await import(
+  './useGetInitialValues'
+);
+
+const server = setupServer(
+  http.get(awxAPI`/job_templates/1/launch/`, () =>
+    HttpResponse.json({
+      ask_credential_on_launch: true,
+      ask_inventory_on_launch: false,
+      survey_enabled: false,
+      defaults: {},
+    })
+  ),
+  http.get(awxAPI`/job_templates/1/credentials/`, () =>
+    HttpResponse.json({
+      count: 1,
+      results: [
+        {
+          id: 10,
+          name: 'Template SSH',
+          credential_type: 1,
+          summary_fields: { credential_type: { name: 'Machine' } },
+        },
+      ],
+    })
+  ),
+  http.get(awxAPI`/workflow_job_templates/2/launch/`, () =>
+    HttpResponse.json({
+      ask_inventory_on_launch: true,
+      survey_enabled: false,
+      defaults: {},
+    })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/credentials/`, () =>
+    HttpResponse.json({
+      count: 1,
+      results: [
+        {
+          id: 20,
+          name: 'Node SSH',
+          credential_type: 1,
+          summary_fields: { credential_type: { name: 'Machine' } },
+        },
+      ],
+    })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/labels/`, () =>
+    HttpResponse.json({ count: 1, results: [{ id: 1, name: 'production' }] })
+  ),
+  http.get(awxAPI`/workflow_job_template_nodes/42/instance_groups/`, () =>
+    HttpResponse.json({ count: 1, results: [{ id: 5, name: 'default' }] })
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeGraphNode(overrides: Record<string, unknown> = {}) {
+  return {
+    getData: () => ({
+      resource: {
+        identifier: 'my-alias',
+        all_parents_must_converge: true,
+        extra_data: { days: 14 },
+        summary_fields: {
+          unified_job_template: {
+            id: 1,
+            name: 'Demo Job Template',
+            description: 'A description',
+            unified_job_type: RESOURCE_TYPE.job,
+            timeout: 120,
+            ...overrides,
+          },
+        },
+      },
+    }),
+  } as never;
+}
+
+describe('useNodeTypeStepDefaults', () => {
+  it('should return default mapper values when node is undefined', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const defaults = result.current(undefined);
+
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.node_convergence).toBe('any');
+    expect(defaults.node_alias).toBe('');
+    expect(defaults.approval_name).toBe('');
+    expect(defaults.approval_description).toBe('');
+    expect(defaults.approval_timeout).toBe(0);
+    expect(defaults.node_days_to_keep).toBe(30);
+    expect(defaults.resource).toBeNull();
+    expect(defaults.resourceId).toBeUndefined();
+    expect(defaults.node_status_type).toBe(EdgeStatus.info);
+  });
+
+  it('should return values from node data for a job template node', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode();
+    const defaults = result.current(node);
+
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.node_convergence).toBe('all');
+    expect(defaults.node_alias).toBe('my-alias');
+    expect(defaults.node_days_to_keep).toBe(14);
+    expect(defaults.resourceId).toBe(1);
+    expect(defaults.approval_timeout).toBe(120);
+  });
+
+  it('should return approval name for workflow_approval node type', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode({
+      unified_job_type: RESOURCE_TYPE.workflow_approval,
+      name: 'Approve Me',
+    });
+    const defaults = result.current(node);
+
+    expect(defaults.approval_name).toBe('Approve Me');
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.workflow_approval);
+  });
+
+  it('should return empty approval_name for non-approval node types', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const node = makeGraphNode({ unified_job_type: RESOURCE_TYPE.job, name: 'My Template' });
+    const defaults = result.current(node);
+
+    expect(defaults.approval_name).toBe('');
+  });
+
+  it('should return empty approvalDescription when nodeType is falsy (no unified_job_template)', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const nodeNoUJT = {
+      getData: () => ({
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {},
+        },
+      }),
+    } as never;
+
+    const defaults = result.current(nodeNoUJT);
+    expect(defaults.approval_description).toBe('');
+    expect(defaults.approval_name).toBe('');
+    expect(defaults.node_type).toBe(RESOURCE_TYPE.job);
+    expect(defaults.resource).toBeNull();
+    expect(defaults.resourceId).toBeUndefined();
+  });
+
+  it('should return empty alias when identifier is a UUID', () => {
+    const { result } = renderHook(() => useNodeTypeStepDefaults());
+    const uuidNode = {
+      getData: () => ({
+        resource: {
+          identifier: '550e8400-e29b-41d4-a716-446655440000',
+          all_parents_must_converge: null,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const defaults = result.current(uuidNode);
+    expect(defaults.node_alias).toBe('');
+    expect(defaults.node_convergence).toBe('any');
+  });
+});
+
+describe('getLaunchData', () => {
+  it('should return launch config for a job template node', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.job, id: 1 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result?.ask_credential_on_launch).toBe(true);
+    expect(result?.ask_inventory_on_launch).toBe(false);
+  });
+
+  it('should return launch config for a workflow job template node', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.workflow_job, id: 2 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result?.ask_inventory_on_launch).toBe(true);
+  });
+
+  it('should return undefined when there is no unified_job_template', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {},
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for non-promptable node types like project_update', async () => {
+    const node = {
+      getData: () => ({
+        resource: {
+          summary_fields: {
+            unified_job_template: { unified_job_type: RESOURCE_TYPE.project_update, id: 3 },
+          },
+        },
+      }),
+    } as never;
+
+    const result = await getLaunchData(node);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('useGetInitialValues', () => {
+  it('should return initial values for a new (unsaved) job template node', async () => {
+    const newNode = {
+      getId: () => 'unsavedNode-1',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '550e8400-e29b-41d4-a716-446655440000',
+          all_parents_must_converge: false,
+          extra_data: {},
+          diff_mode: false,
+          forks: 0,
+          job_type: 'run',
+          job_tags: '',
+          skip_tags: '',
+          timeout: 0,
+          verbosity: 0,
+          job_slice_count: 1,
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+            inventory: null,
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(newNode);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.nodeTypeStep.node_type).toBe(RESOURCE_TYPE.job);
+    expect(initialValues.nodePromptsStep).toBeDefined();
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toBeDefined();
+  });
+
+  it('should return initial values for a saved job template node fetching credentials and labels', async () => {
+    const savedNode = {
+      getId: () => '42',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: true,
+          extra_data: {},
+          diff_mode: false,
+          forks: 0,
+          job_type: 'run',
+          job_tags: '',
+          skip_tags: '',
+          timeout: 0,
+          verbosity: 0,
+          job_slice_count: 1,
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+            inventory: { id: 1, name: 'My Inventory' },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(savedNode);
+
+    expect(initialValues.nodeTypeStep.node_convergence).toBe('all');
+    expect(initialValues.nodeTypeStep.node_alias).toBe('my-node');
+    expect(initialValues.nodePromptsStep?.prompt?.original?.credentials).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Node SSH' })])
+    );
+    expect(initialValues.nodePromptsStep?.prompt?.original?.labels).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'production' })])
+    );
+    expect(initialValues.nodePromptsStep?.prompt?.original?.instance_groups).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'default' })])
+    );
+  });
+
+  it('should use hidePromptStep path when launch config has no prompts', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/1/launch/`, () =>
+        HttpResponse.json({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        })
+      )
+    );
+
+    const newNode = {
+      getId: () => 'unsavedNode-2',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Simple Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(newNode);
+
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.labels).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.instance_groups).toEqual([]);
+  });
+
+  it('should include prompt values when node has existing launch_data', async () => {
+    const nodeWithPrompts = {
+      getId: () => 'unsavedNode-3',
+      getData: () => ({
+        launch_data: {
+          limit: 'webservers',
+          credentials: [{ id: 30, name: 'Existing Cred', credential_type: 2 }],
+        },
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(nodeWithPrompts);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.nodePromptsStep?.prompt?.limit).toBe('webservers');
+  });
+
+  it('should trigger survey path and return survey data when survey_enabled and ask_variables_on_launch are both true', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/1/launch/`, () =>
+        HttpResponse.json({
+          ask_credential_on_launch: false,
+          ask_variables_on_launch: true,
+          survey_enabled: true,
+          defaults: {},
+        })
+      ),
+      http.get(awxAPI`/job_templates/1/survey_spec/`, () =>
+        HttpResponse.json({
+          name: 'Test Survey',
+          description: '',
+          spec: [
+            {
+              variable: 'survey_var',
+              type: 'text',
+              question_name: 'Survey Var',
+              question_description: '',
+              required: false,
+              default: '',
+              min: 0,
+              max: 1024,
+              choices: [],
+              new_question: false,
+            },
+          ],
+        })
+      )
+    );
+
+    const nodeWithSurveyData = {
+      getId: () => 'unsavedNode-survey',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: { survey_var: 'existing_value', other_var: 'keep_this' },
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Survey Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(nodeWithSurveyData);
+
+    expect(initialValues.nodeTypeStep).toBeDefined();
+    expect(initialValues.survey).toBeDefined();
+  });
+
+  it('should return empty array from getRelated when API returns no results', async () => {
+    server.use(
+      http.get(awxAPI`/workflow_job_template_nodes/99/credentials/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.get(awxAPI`/workflow_job_template_nodes/99/labels/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.get(awxAPI`/workflow_job_template_nodes/99/instance_groups/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      )
+    );
+
+    const savedNodeNoResults = {
+      getId: () => '99',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: 'my-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Demo Template',
+              unified_job_type: RESOURCE_TYPE.job,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(savedNodeNoResults);
+
+    expect(initialValues.nodePromptsStep?.prompt?.original?.credentials).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.original?.labels).toEqual([]);
+    expect(initialValues.nodePromptsStep?.prompt?.original?.instance_groups).toEqual([]);
+  });
+
+  it('should handle project_update node type with no launch config (hidePromptStep = true)', async () => {
+    const projectUpdateNode = {
+      getId: () => 'unsavedNode-project',
+      getData: () => ({
+        launch_data: undefined,
+        survey_data: undefined,
+        resource: {
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'My Project',
+              unified_job_type: RESOURCE_TYPE.project_update,
+              timeout: 0,
+            },
+          },
+        },
+      }),
+    } as never;
+
+    const { result } = renderHook(() => useGetInitialValues());
+    const initialValues = await result.current(projectUpdateNode);
+
+    expect(initialValues.nodeTypeStep.node_type).toBe(RESOURCE_TYPE.project_update);
+    expect(initialValues.nodePromptsStep?.prompt?.credentials).toEqual([]);
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
@@ -19,6 +19,7 @@ import { getConvergenceType, getValueBasedOnJobType, shouldHideOtherStep } from 
 interface WizardStepState {
   nodeTypeStep: Partial<WizardFormValues>;
   nodePromptsStep?: { prompt: Partial<PromptFormValues> };
+  survey?: { survey: unknown };
 }
 
 export function useNodeTypeStepDefaults(): (node?: GraphNode) => CommonNodeValues {

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useGetInitialValues.tsx
@@ -81,14 +81,15 @@ export function useGetInitialValues(): (node: GraphNode) => Promise<WizardStepSt
       const hidePromptStep = launch ? shouldHideOtherStep(launch) : true;
       const hideSurveyStep = launch?.survey_enabled === false;
 
-      const nodeCredentials =
-        launch?.ask_credential_on_launch && !isNewNode ? await getCredentialData(nodeId) : [];
-      const nodeLabels =
-        launch?.ask_labels_on_launch && !isNewNode ? await getLabelData(nodeId) : [];
-      const nodeInstanceGroups =
-        launch?.ask_instance_groups_on_launch && !isNewNode
-          ? await getInstanceGroupData(nodeId)
-          : [];
+      // Always fetch node-level resources for saved nodes, regardless of whether the current
+      // template's ask_*_on_launch flags are set. The node may have credentials, labels, or
+      // instance groups from a previous template that accepted them. Tracking them here in
+      // original.* ensures they can be properly cleaned up when switching to a template that
+      // does not accept them — otherwise processCredentials/Labels/InstanceGroups find nothing
+      // to remove and the PATCH fails with "Field is not configured to prompt on launch."
+      const nodeCredentials = isNewNode ? [] : await getCredentialData(nodeId);
+      const nodeLabels = isNewNode ? [] : await getLabelData(nodeId);
+      const nodeInstanceGroups = isNewNode ? [] : await getInstanceGroupData(nodeId);
 
       const prompt = nodeData?.launch_data;
       const defaults = nodeData?.resource;
@@ -157,9 +158,25 @@ export function useGetInitialValues(): (node: GraphNode) => Promise<WizardStepSt
         }),
       };
 
+      // nodePromptsStep is always included even when the prompt step is hidden.
+      // When hidden, a minimal prompt is used so that handleSubmit can access
+      // original.credentials/labels/instance_groups for disassociation cleanup when
+      // switching to a template that does not accept those fields on launch.
+      // Without this, original.* is undefined and processCredentials finds nothing
+      // to remove, causing the PATCH to fail with "Field is not configured to prompt
+      // on launch" because the node still has associated credentials in the DB.
+      const nodePromptsStepPrompt = hidePromptStep
+        ? {
+            credentials: [] as typeof nodePromptsValues.credentials,
+            labels: [] as typeof nodePromptsValues.labels,
+            instance_groups: [] as typeof nodePromptsValues.instance_groups,
+            original,
+          }
+        : nodePromptsValues;
+
       return {
         nodeTypeStep,
-        ...(hidePromptStep ? {} : { nodePromptsStep: { prompt: nodePromptsValues } }),
+        nodePromptsStep: { prompt: nodePromptsStepPrompt },
         ...(hideSurveyStep ? {} : { survey: { survey: nodeData?.survey_data ?? surveyValues } }),
       };
     },

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
@@ -1,0 +1,804 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { RESOURCE_TYPE, START_NODE_ID } from '../constants';
+import { EdgeStatus, type GraphNode, type GraphNodeData } from '../types';
+
+const mockPostFn = vi.fn().mockResolvedValue({ id: 100 });
+const mockPatchFn = vi.fn().mockResolvedValue({ id: 42 });
+const mockDeleteFn = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@ansible/common-ui/crud/usePostRequest', () => ({
+  usePostRequest: vi.fn(() => mockPostFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/usePatchRequest', () => ({
+  usePatchRequest: vi.fn(() => mockPatchFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/useDeleteRequest', () => ({
+  useDeleteRequest: vi.fn(() => mockDeleteFn),
+}));
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({
+  requestGet: vi.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+}));
+
+vi.mock('@ansible/ansible-ui-framework/utils/codeEditorUtils', () => ({
+  parseVariableField: vi.fn((v: string) => {
+    try {
+      return JSON.parse(v) as object;
+    } catch {
+      return {};
+    }
+  }),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock('../../../../common/useAwxGetAllPages', () => ({
+  useAwxGetAllPages: vi.fn(() => ({ refresh: mockRefresh })),
+}));
+
+const mockSetState = vi.fn();
+const mockElementSetState = vi.fn();
+const mockLayout = vi.fn();
+let mockGraphNodes: ReturnType<typeof makeGraphNode>[] = [];
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({ workflowTemplate: { id: 123 }, modified: false }),
+    setState: mockSetState,
+    getGraph: () => ({
+      getNodes: () => mockGraphNodes,
+      layout: mockLayout,
+    }),
+    getElements: () => [{ setState: mockElementSetState, getState: () => ({}) }],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+function makeGraphNode(
+  overrides: {
+    id?: string;
+    visible?: boolean;
+    modified?: boolean;
+    nodeData?: Partial<GraphNodeData>;
+    sourceEdges?: {
+      isVisible: () => boolean;
+      getData: () => { tagStatus: EdgeStatus };
+      getTarget: () => { getId: () => string };
+    }[];
+  } = {}
+) {
+  const { id = '42', visible = true, modified = true, nodeData = {}, sourceEdges = [] } = overrides;
+
+  const defaultNodeData: GraphNodeData = {
+    resource: {
+      id: 42,
+      identifier: 'test-node',
+      all_parents_must_converge: false,
+      extra_data: {},
+      always_nodes: [],
+      failure_nodes: [],
+      success_nodes: [],
+      summary_fields: {
+        unified_job_template: {
+          id: 1,
+          name: 'Test Template',
+          unified_job_type: RESOURCE_TYPE.job,
+        },
+      },
+    },
+    launch_data: {
+      original: {
+        launch_config: {
+          ask_labels_on_launch: true,
+          ask_instance_groups_on_launch: true,
+          ask_credential_on_launch: true,
+          defaults: { credentials: [] },
+        },
+        labels: [{ id: 10, name: 'old-label' }],
+        instance_groups: [{ id: 20, name: 'old-ig' }],
+        credentials: [{ id: 30, name: 'old-cred' }],
+      },
+      labels: [{ id: 11, name: 'new-label' }],
+      instance_groups: [{ id: 21, name: 'new-ig' }],
+      credentials: [{ id: 31, name: 'new-cred' }],
+    },
+    survey_data: undefined,
+    ...nodeData,
+  } as GraphNodeData;
+
+  return {
+    getId: () => id,
+    getData: () => defaultNodeData,
+    getState: () => ({ modified }),
+    isVisible: () => visible,
+    setId: vi.fn(),
+    setData: vi.fn(),
+    setState: vi.fn(),
+    setLabel: vi.fn(),
+    getSourceEdges: () => sourceEdges,
+  } as unknown as GraphNode;
+}
+
+const { toKeyedObject, useSaveVisualizer } = await import('./useSaveVisualizer');
+
+describe('toKeyedObject', () => {
+  test('should return keyed object for non-empty string value', () => {
+    expect(toKeyedObject('identifier', 'my-node')).toEqual({ identifier: 'my-node' });
+  });
+
+  test('should return keyed object for numeric value', () => {
+    expect(toKeyedObject('timeout', 30)).toEqual({ timeout: 30 });
+  });
+
+  test('should return keyed object for number 0', () => {
+    expect(toKeyedObject('forks', 0)).toEqual({ forks: 0 });
+  });
+
+  test('should return empty object for empty string value', () => {
+    expect(toKeyedObject('identifier', '')).toEqual({});
+  });
+
+  test('should return empty object for undefined value', () => {
+    expect(toKeyedObject('identifier', undefined)).toEqual({});
+  });
+
+  test('should return empty object for null value', () => {
+    expect(toKeyedObject('identifier', null)).toEqual({});
+  });
+
+  test('should use the provided key in the returned object', () => {
+    const result = toKeyedObject('my_custom_key', 'value');
+    expect(result).toHaveProperty('my_custom_key', 'value');
+  });
+});
+
+describe('useSaveVisualizer', () => {
+  beforeEach(() => {
+    mockPostFn.mockClear().mockResolvedValue({ id: 100 });
+    mockPatchFn.mockClear().mockResolvedValue({ id: 42 });
+    mockDeleteFn.mockClear().mockResolvedValue(undefined);
+    mockRefresh.mockClear();
+    mockSetState.mockClear();
+    mockElementSetState.mockClear();
+    mockLayout.mockClear();
+    mockGraphNodes = [];
+  });
+
+  test('should be callable and return a function', () => {
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    expect(typeof result.current).toBe('function');
+  });
+
+  test('should skip start node', async () => {
+    mockGraphNodes = [makeGraphNode({ id: START_NODE_ID, modified: true })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockPostFn).not.toHaveBeenCalled();
+    expect(mockPatchFn).not.toHaveBeenCalled();
+    expect(mockDeleteFn).not.toHaveBeenCalled();
+  });
+
+  test('should delete invisible non-new nodes', async () => {
+    mockGraphNodes = [makeGraphNode({ id: '42', visible: false, modified: false })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockDeleteFn).toHaveBeenCalledWith(
+      expect.stringContaining('/workflow_job_template_nodes/42/')
+    );
+  });
+
+  test('should not delete invisible new nodes', async () => {
+    mockGraphNodes = [makeGraphNode({ id: 'unsavedNode-1', visible: false, modified: false })];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+    expect(mockDeleteFn).not.toHaveBeenCalled();
+  });
+
+  test('should create new approval nodes', async () => {
+    const approvalNode = makeGraphNode({
+      id: 'unsavedNode-1',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Approval Step',
+              description: 'Approve this',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 300,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_nodes/'))).toBe(
+      true
+    );
+    expect(
+      postCalls.some((c: unknown[]) => (c[0] as string).includes('/create_approval_template/'))
+    ).toBe(true);
+  });
+
+  test('should create new job template nodes with prompt values', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-2',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'job-1',
+          all_parents_must_converge: true,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          diff_mode: true,
+          forks: 10,
+          limit: 'all',
+          verbosity: 2,
+          job_type: 'run',
+          scm_branch: 'main',
+          timeout: 60,
+          job_tags: [{ name: 'deploy' }],
+          skip_tags: [{ name: 'slow' }],
+          inventory: { id: 3, name: 'prod' },
+          execution_environment: { id: 7, name: 'ee' },
+          job_slice_count: 2,
+          labels: [{ id: 11, name: 'new-label' }],
+          instance_groups: [{ id: 21, name: 'new-ig' }],
+          credentials: [{ id: 31, name: 'new-cred' }],
+          original: {
+            launch_config: {
+              ask_diff_mode_on_launch: true,
+              ask_forks_on_launch: true,
+              ask_limit_on_launch: true,
+              ask_verbosity_on_launch: true,
+              ask_job_type_on_launch: true,
+              ask_scm_branch_on_launch: true,
+              ask_timeout_on_launch: true,
+              ask_tags_on_launch: true,
+              ask_skip_tags_on_launch: true,
+              ask_inventory_on_launch: true,
+              ask_execution_environment_on_launch: true,
+              ask_job_slice_count_on_launch: true,
+              ask_variables_on_launch: true,
+              ask_labels_on_launch: true,
+              ask_instance_groups_on_launch: true,
+              ask_credential_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_nodes/'))).toBe(
+      true
+    );
+    // Process labels, instance groups, and credentials (associate only for new nodes)
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/labels/'))).toBe(true);
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/instance_groups/'))).toBe(
+      true
+    );
+    expect(postCalls.some((c: unknown[]) => (c[0] as string).includes('/credentials/'))).toBe(true);
+  });
+
+  test('should create new system job node with extra_data days', async () => {
+    const sysNode = makeGraphNode({
+      id: 'unsavedNode-3',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'sys-1',
+          all_parents_must_converge: false,
+          extra_data: { days: 120 },
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 9,
+              name: 'Cleanup',
+              unified_job_type: RESOURCE_TYPE.system_job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: { defaults: { credentials: [] } },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [sysNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    expect((workflowNodeCall as unknown[])[1]).toHaveProperty('extra_data', { days: 120 });
+  });
+
+  test('should update edited job template nodes with disassociate before patch and associate after', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const postCalls = mockPostFn.mock.calls;
+    const patchCalls = mockPatchFn.mock.calls;
+
+    // Should have PATCH call for the node
+    expect(
+      patchCalls.some((c: unknown[]) => (c[0] as string).includes('/workflow_job_template_nodes/'))
+    ).toBe(true);
+
+    // Should have disassociate and associate calls for labels, IGs, and credentials
+    const disassociateCalls = postCalls.filter(
+      (c: unknown[]) => (c[1] as { disassociate?: boolean })?.disassociate === true
+    );
+    expect(disassociateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should call clearStaleNodeFields for edited nodes with template change', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            isTemplateChange: true,
+            launch_config: {
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_job_template_nodes/')
+      )
+    ).toBe(true);
+  });
+
+  test('should update edited approval nodes', async () => {
+    const approvalNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Updated Approval',
+              description: 'Updated desc',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 600,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_job_template_nodes/42/')
+      )
+    ).toBe(true);
+    expect(
+      mockPatchFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/workflow_approval_templates/')
+      )
+    ).toBe(true);
+  });
+
+  test('should create approval template when approval node has id === -1', async () => {
+    const approvalNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'approval-1',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: -1,
+              name: 'New Approval',
+              description: '',
+              unified_job_type: RESOURCE_TYPE.workflow_approval,
+              timeout: 0,
+            },
+          },
+        },
+        launch_data: undefined,
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [approvalNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(
+      mockPostFn.mock.calls.some((c: unknown[]) =>
+        (c[0] as string).includes('/create_approval_template/')
+      )
+    ).toBe(true);
+  });
+
+  test('should handle edge modifications for success, failure, and always edges', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [100],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+      sourceEdges: [
+        {
+          isVisible: () => true,
+          getData: () => ({ tagStatus: EdgeStatus.danger }),
+          getTarget: () => ({ getId: () => '100' }),
+        },
+        {
+          isVisible: () => true,
+          getData: () => ({ tagStatus: EdgeStatus.info }),
+          getTarget: () => ({ getId: () => '200' }),
+        },
+      ],
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    // Should disassociate old success_node[100] (now a danger edge)
+    const disassociateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { disassociate?: boolean })?.disassociate === true
+    );
+    const associateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) =>
+        !(c[1] as { disassociate?: boolean })?.disassociate &&
+        typeof c[0] === 'string' &&
+        (c[0].includes('/success_nodes/') ||
+          c[0].includes('/failure_nodes/') ||
+          c[0].includes('/always_nodes/'))
+    );
+
+    expect(disassociateCalls.length + associateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should set modified to false on all elements after save', async () => {
+    mockGraphNodes = [];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    expect(mockSetState).toHaveBeenCalledWith(expect.objectContaining({ modified: false }));
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  test('should process labels with no prompt but existing labels on disassociate', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [{ id: 50, name: 'existing-label' }],
+            instance_groups: [{ id: 60, name: 'existing-ig' }],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const disassociateCalls = mockPostFn.mock.calls.filter(
+      (c: unknown[]) =>
+        (c[1] as { disassociate?: boolean })?.disassociate === true &&
+        typeof c[0] === 'string' &&
+        c[0].includes('/labels/')
+    );
+    expect(disassociateCalls.length).toBeGreaterThan(0);
+  });
+
+  test('should handle new node with survey data merged into extra_data', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-4',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'survey-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Survey Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          extra_vars: '{"key": "value"}',
+          original: {
+            launch_config: {
+              ask_variables_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: { survey_key: 'survey_value' },
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as { extra_data?: object };
+    expect(payload.extra_data).toEqual(expect.objectContaining({ survey_key: 'survey_value' }));
+  });
+
+  test('should propagate errors from updateExistingNodes', async () => {
+    mockPatchFn.mockRejectedValueOnce(new Error('PATCH failed'));
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await expect(result.current()).rejects.toThrow('PATCH failed');
+  });
+
+  test('should handle edited node with extra_vars prompt', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          extra_vars: '{"var1": "val1"}',
+          original: {
+            launch_config: {
+              ask_variables_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: { survey_answer: 42 },
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const patchCalls = mockPatchFn.mock.calls;
+    const nodePatch = patchCalls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/')
+    );
+    expect(nodePatch).toBeDefined();
+    const payload = (nodePatch as unknown[])[1] as { extra_data?: object };
+    expect(payload.extra_data).toEqual(expect.objectContaining({ survey_answer: 42 }));
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -9,6 +9,7 @@ import { AwxItemsResponse } from '../../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { useAwxGetAllPages } from '../../../../common/useAwxGetAllPages';
 import { getAddedAndRemoved } from '../../../../common/util/getAddedAndRemoved';
+import { clearStaleNodeFields } from './clearStaleNodeFields';
 import { getAddedAndRemovedCredentials } from './getAddedAndRemovedCredentials';
 import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
 import { Label } from '../../../../interfaces/Label';
@@ -341,21 +342,7 @@ export function useSaveVisualizer(templateId: string) {
           }
 
           if (launch_data?.original?.isTemplateChange) {
-            nullIfMissing(updatedNodePayload, 'diff_mode');
-            nullIfMissing(updatedNodePayload, 'execution_environment');
-            nullIfMissing(updatedNodePayload, 'forks');
-            nullIfMissing(updatedNodePayload, 'inventory');
-            nullIfMissing(updatedNodePayload, 'job_slice_count');
-            nullIfMissing(updatedNodePayload, 'job_tags');
-            nullIfMissing(updatedNodePayload, 'job_type');
-            nullIfMissing(updatedNodePayload, 'limit');
-            nullIfMissing(updatedNodePayload, 'scm_branch');
-            nullIfMissing(updatedNodePayload, 'skip_tags');
-            nullIfMissing(updatedNodePayload, 'timeout');
-            nullIfMissing(updatedNodePayload, 'verbosity');
-            if (!('extra_data' in updatedNodePayload)) {
-              updatedNodePayload.extra_data = {};
-            }
+            clearStaleNodeFields(updatedNodePayload);
           }
 
           // Disassociate stale resources BEFORE patching the template. AWX validates the
@@ -601,12 +588,6 @@ export function useSaveVisualizer(templateId: string) {
     processLabels,
     workflowNodeRefresh,
   ]);
-}
-
-function nullIfMissing(payload: Partial<CreateWorkflowNodePayload>, key: CreatePayloadProperty) {
-  if (!(key in payload)) {
-    (payload as Record<string, unknown>)[key] = null;
-  }
 }
 
 export function toKeyedObject(

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -9,6 +9,7 @@ import { AwxItemsResponse } from '../../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { useAwxGetAllPages } from '../../../../common/useAwxGetAllPages';
 import { getAddedAndRemoved } from '../../../../common/util/getAddedAndRemoved';
+import { getAddedAndRemovedCredentials } from './getAddedAndRemovedCredentials';
 import { InstanceGroup } from '../../../../interfaces/InstanceGroup';
 import { Label } from '../../../../interfaces/Label';
 import { Organization } from '../../../../interfaces/Organization';
@@ -24,18 +25,18 @@ interface WorkflowApprovalNode {
 
 interface CreateWorkflowNodePayload {
   extra_data?: object;
-  inventory?: number;
-  scm_branch?: string;
-  job_type?: string;
-  job_tags?: string;
-  skip_tags?: string;
-  limit?: string;
-  diff_mode?: boolean;
-  verbosity?: number;
+  inventory?: number | null;
+  scm_branch?: string | null;
+  job_type?: string | null;
+  job_tags?: string | null;
+  skip_tags?: string | null;
+  limit?: string | null;
+  diff_mode?: boolean | null;
+  verbosity?: number | null;
   execution_environment?: number | null;
-  forks?: number;
-  job_slice_count?: number;
-  timeout?: number;
+  forks?: number | null;
+  job_slice_count?: number | null;
+  timeout?: number | null;
   unified_job_template: number;
   all_parents_must_converge: boolean;
   identifier?: string;
@@ -250,9 +251,11 @@ export function useSaveVisualizer(templateId: string) {
 
         if (!newNode.id) return;
         const newNodeId = newNode.id.toString();
-        await processLabels(newNodeId, launch_data);
-        await processInstanceGroups(newNodeId, launch_data);
-        await processCredentials(newNodeId, launch_data);
+        // For new nodes the node already exists on the correct template, so
+        // only associations are needed (nothing to disassociate on a brand new node).
+        await processLabels(newNodeId, launch_data, 'associate');
+        await processInstanceGroups(newNodeId, launch_data, 'associate');
+        await processCredentials(newNodeId, launch_data, 'associate');
         setCreatedNodeId(node, newNodeId.toString());
       });
       await Promise.all(promises);
@@ -337,13 +340,41 @@ export function useSaveVisualizer(templateId: string) {
             });
           }
 
-          await processLabels(nodeId, launch_data);
-          await processInstanceGroups(nodeId, launch_data);
-          await processCredentials(nodeId, launch_data);
+          if (launch_data?.original?.isTemplateChange) {
+            nullIfMissing(updatedNodePayload, 'diff_mode');
+            nullIfMissing(updatedNodePayload, 'execution_environment');
+            nullIfMissing(updatedNodePayload, 'forks');
+            nullIfMissing(updatedNodePayload, 'inventory');
+            nullIfMissing(updatedNodePayload, 'job_slice_count');
+            nullIfMissing(updatedNodePayload, 'job_tags');
+            nullIfMissing(updatedNodePayload, 'job_type');
+            nullIfMissing(updatedNodePayload, 'limit');
+            nullIfMissing(updatedNodePayload, 'scm_branch');
+            nullIfMissing(updatedNodePayload, 'skip_tags');
+            nullIfMissing(updatedNodePayload, 'timeout');
+            nullIfMissing(updatedNodePayload, 'verbosity');
+            if (!('extra_data' in updatedNodePayload)) {
+              updatedNodePayload.extra_data = {};
+            }
+          }
+
+          // Disassociate stale resources BEFORE patching the template. AWX validates the
+          // node's full DB state when unified_job_template changes, so credentials/labels/
+          // instance_groups must be removed first when the new template does not accept them.
+          await processLabels(nodeId, launch_data, 'disassociate');
+          await processInstanceGroups(nodeId, launch_data, 'disassociate');
+          await processCredentials(nodeId, launch_data, 'disassociate');
+
           await patchWorkflowNode(
             awxAPI`/workflow_job_template_nodes/${nodeId}/`,
             updatedNodePayload
           );
+
+          // Associate new resources AFTER patching the template. The new template must be
+          // in place before AWX will accept associations (e.g. ask_credential_on_launch=true).
+          await processLabels(nodeId, launch_data, 'associate');
+          await processInstanceGroups(nodeId, launch_data, 'associate');
+          await processCredentials(nodeId, launch_data, 'associate');
         })
       );
 
@@ -572,6 +603,12 @@ export function useSaveVisualizer(templateId: string) {
   ]);
 }
 
+function nullIfMissing(payload: Partial<CreateWorkflowNodePayload>, key: CreatePayloadProperty) {
+  if (!(key in payload)) {
+    (payload as Record<string, unknown>)[key] = null;
+  }
+}
+
 export function toKeyedObject(
   key: string,
   value: string | number | undefined | null
@@ -588,49 +625,59 @@ async function getDefaultOrganization(): Promise<number> {
   return itemsResponse.results[0].id || 1;
 }
 
+// Controls which half of a process function runs relative to the node PATCH.
+// Removals (disassociate) must happen BEFORE the PATCH so AWX accepts the
+// unified_job_template change when the new template does not accept the field.
+// Additions (associate) must happen AFTER the PATCH so the new template is
+// already in place and AWX allows the association.
+type ProcessPhase = 'disassociate' | 'associate';
+
 const useProcessLabels = () => {
   const postDisassociate = usePostRequest<{ id: number; disassociate: boolean }>();
   const postAssociateLabel = usePostRequest<{ name: string; organization: number }>();
 
   return useCallback(
-    async (nodeId: string, launch_data: GraphNodeData['launch_data']) => {
+    async (nodeId: string, launch_data: GraphNodeData['launch_data'], phase: ProcessPhase) => {
       const hasLabelsPrompt =
         launch_data?.original?.launch_config?.ask_labels_on_launch ||
         (launch_data?.labels && launch_data?.labels?.length > 0);
       const existingLabels = launch_data?.original?.labels;
 
       if (hasLabelsPrompt) {
-        const defaultOrganization = launch_data.organization ?? (await getDefaultOrganization());
-
         const { added, removed } = getAddedAndRemoved(
           launch_data?.original?.labels || [],
           launch_data?.labels || ([] as Label[])
         );
 
-        const disassociationPromises = removed.map((label: { id: number }) =>
-          postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
-            id: label.id,
-            disassociate: true,
-          })
-        );
-
-        const associationPromises = added.map(
-          (label: { name: string; id?: number; organization?: number }) =>
-            postAssociateLabel(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
-              name: label.name,
-              organization: label?.organization ?? defaultOrganization,
+        if (phase === 'disassociate') {
+          await Promise.all(
+            removed.map((label: { id: number }) =>
+              postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
+                id: label.id,
+                disassociate: true,
+              })
+            )
+          );
+        } else {
+          const defaultOrganization = launch_data.organization ?? (await getDefaultOrganization());
+          await Promise.all(
+            added.map((label: { name: string; id?: number; organization?: number }) =>
+              postAssociateLabel(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
+                name: label.name,
+                organization: label?.organization ?? defaultOrganization,
+              })
+            )
+          );
+        }
+      } else if (existingLabels && phase === 'disassociate') {
+        await Promise.all(
+          existingLabels.map((label: { id: number }) =>
+            postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
+              id: label.id,
+              disassociate: true,
             })
+          )
         );
-
-        await Promise.all([...disassociationPromises, ...associationPromises]);
-      } else if (existingLabels) {
-        const disassociationPromises = existingLabels.map((label: { id: number }) =>
-          postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/labels/`, {
-            id: label.id,
-            disassociate: true,
-          })
-        );
-        await Promise.all(disassociationPromises);
       }
     },
     [postDisassociate, postAssociateLabel]
@@ -642,7 +689,7 @@ const useProcessInstanceGroups = () => {
   const postAssociateInstanceGroup = usePostRequest<{ id: number }, InstanceGroup>();
 
   return useCallback(
-    async (nodeId: string, launch_data: GraphNodeData['launch_data']) => {
+    async (nodeId: string, launch_data: GraphNodeData['launch_data'], phase: ProcessPhase) => {
       const hasInstanceGroupsPrompt =
         launch_data?.original?.launch_config?.ask_instance_groups_on_launch ||
         (launch_data?.instance_groups && launch_data?.instance_groups?.length > 0);
@@ -654,31 +701,34 @@ const useProcessInstanceGroups = () => {
           launch_data?.instance_groups ? launch_data.instance_groups : ([] as { id: number }[])
         );
 
-        const disassociationPromises = removed.map((group: { id: number }) =>
-          postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`, {
-            id: group.id,
-            disassociate: true,
-          })
-        );
-
-        const associationPromises = added.map((group) =>
-          postAssociateInstanceGroup(
-            awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`,
-            {
+        if (phase === 'disassociate') {
+          await Promise.all(
+            removed.map((group: { id: number }) =>
+              postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`, {
+                id: group.id,
+                disassociate: true,
+              })
+            )
+          );
+        } else {
+          await Promise.all(
+            added.map((group) =>
+              postAssociateInstanceGroup(
+                awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`,
+                { id: group.id }
+              )
+            )
+          );
+        }
+      } else if (existingInstanceGroups && phase === 'disassociate') {
+        await Promise.all(
+          existingInstanceGroups.map((group: { id: number }) =>
+            postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`, {
               id: group.id,
-            }
+              disassociate: true,
+            })
           )
         );
-
-        await Promise.all([...disassociationPromises, ...associationPromises]);
-      } else if (existingInstanceGroups) {
-        const disassociationPromises = existingInstanceGroups.map((group: { id: number }) =>
-          postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/instance_groups/`, {
-            id: group.id,
-            disassociate: true,
-          })
-        );
-        await Promise.all(disassociationPromises);
       }
     },
     [postDisassociate, postAssociateInstanceGroup]
@@ -690,7 +740,7 @@ const useProcessCredentials = () => {
   const postAssociateCredential = usePostRequest<{ id: number }, Credential>();
 
   return useCallback(
-    async (nodeId: string, launch_data: GraphNodeData['launch_data']) => {
+    async (nodeId: string, launch_data: GraphNodeData['launch_data'], phase: ProcessPhase) => {
       const promptCredentials = launch_data?.credentials || [];
       const templateCredentials = launch_data?.original?.launch_config?.defaults?.credentials || [];
       const nodeCredentials = launch_data?.original?.credentials || [];
@@ -701,54 +751,27 @@ const useProcessCredentials = () => {
           promptCredentials,
           templateCredentials
         );
-        const disassociationPromises = removed.map((credential: { id: number }) =>
-          postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/credentials/`, {
-            id: credential.id,
-            disassociate: true,
-          })
-        );
 
-        const associationPromises = added.map((credential) =>
-          postAssociateCredential(awxAPI`/workflow_job_template_nodes/${nodeId}/credentials/`, {
-            id: credential.id,
-          })
-        );
-
-        await Promise.all([...disassociationPromises, ...associationPromises]);
+        if (phase === 'disassociate') {
+          await Promise.all(
+            removed.map((credential: { id: number }) =>
+              postDisassociate(awxAPI`/workflow_job_template_nodes/${nodeId}/credentials/`, {
+                id: credential.id,
+                disassociate: true,
+              })
+            )
+          );
+        } else {
+          await Promise.all(
+            added.map((credential) =>
+              postAssociateCredential(awxAPI`/workflow_job_template_nodes/${nodeId}/credentials/`, {
+                id: credential.id,
+              })
+            )
+          );
+        }
       }
     },
     [postDisassociate, postAssociateCredential]
   );
-};
-
-interface Credential {
-  id: number;
-  name: string;
-  credential_type: number;
-}
-const getAddedAndRemovedCredentials = (
-  nodeCredentials: Credential[],
-  promptCredentials: Credential[],
-  templateCredentials: Credential[]
-) => {
-  // Step 1: Get the aggregate credentials from the template and node
-  const aggregateCredentials = [...nodeCredentials, ...templateCredentials];
-
-  // Missing step - vault ids are not being compared
-
-  // Step 2: Add credentials from prompt that are not in the aggregate
-  const added = promptCredentials.filter(
-    (promptCredential) =>
-      !aggregateCredentials.find(
-        (aggregateCredential) => aggregateCredential.id === promptCredential.id
-      )
-  );
-
-  // Step 3: Remove credentials from the aggregate that are not in the prompt
-  const removed = nodeCredentials.filter(
-    (nodeCredential) =>
-      !promptCredentials.find((promptCredential) => promptCredential.id === nodeCredential.id)
-  );
-
-  return { added, removed };
 };

--- a/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/types.ts
@@ -148,6 +148,8 @@ export interface PromptFormValues {
   verbosity: 0 | 1 | 2 | 3 | 4 | 5;
   organization?: number | null;
   requiredCredentialTypes?: RequiredCredentialType[];
+  /** Stored by useGetInitialValues alongside prompt values; indicates the original template had prompts. */
+  launch_config?: LaunchConfiguration;
   original?: {
     credentials?:
       | {
@@ -160,6 +162,9 @@ export interface PromptFormValues {
       | Credential[];
     instance_groups?: { id: number; name: string }[];
     labels?: { name: string; id: number }[];
+    /** True when the user changed the job template during editing, used to clear
+     *  prompt fields (skip_tags, job_tags) that may not be valid for the new template. */
+    isTemplateChange?: boolean;
     launch_config?: LaunchConfiguration;
   };
 }

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.component.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.component.test.tsx
@@ -1,0 +1,315 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RESOURCE_TYPE } from '../constants';
+import { EdgeStatus } from '../types';
+import { NodeEditWizard } from './NodeEditWizard';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(() => ({
+    getState: () => ({ workflowTemplate: { id: 1 } }),
+    setState: vi.fn(),
+    getGraph: () => ({
+      getNodes: () => [],
+      layout: vi.fn(),
+    }),
+    getElements: () => [],
+  })),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+vi.mock('../../../../views/jobs/WorkflowOutput/WorkflowOutput', () => ({
+  greyBadgeLabel: {
+    badge: 'ALL',
+    badgeColor: 'var(--pf-t--global--background--color--secondary--default)',
+    badgeBorderColor: 'var(--pf-t--global--border--color--on-secondary)',
+  },
+}));
+
+const mockBuildEffectivePrompt = vi.fn(() => ({ effectivePrompt: { diff_mode: false } }));
+vi.mock('./buildEffectivePrompt', () => ({
+  buildEffectivePrompt: () => mockBuildEffectivePrompt(),
+}));
+
+const mockGetInitialValues = vi.fn(() =>
+  Promise.resolve({
+    nodeTypeStep: {
+      node_type: RESOURCE_TYPE.job,
+      node_convergence: 'any' as const,
+      node_alias: '',
+      approval_name: '',
+      approval_description: '',
+      approval_timeout: 0,
+      node_days_to_keep: 30,
+      resource: null,
+      resourceId: undefined,
+      node_status_type: EdgeStatus.info,
+    },
+    nodePromptsStep: {
+      prompt: {
+        credentials: [],
+        labels: [],
+        instance_groups: [],
+        original: {
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+        },
+      },
+    },
+  })
+);
+
+vi.mock('../hooks', () => ({
+  useCloseSidebar: () => vi.fn(),
+  useGetInitialValues: () => mockGetInitialValues,
+  useNodeTypeStepDefaults: () => () => ({
+    approval_description: '',
+    approval_name: '',
+    approval_timeout: 0,
+    node_alias: '',
+    node_convergence: 'any' as const,
+    node_days_to_keep: 30,
+    resource: null,
+    resourceId: undefined,
+    node_type: RESOURCE_TYPE.job,
+    node_status_type: EdgeStatus.info,
+  }),
+  useGetTimeoutString: () => '0 min 0 sec',
+  useCreateEdge: () => () => ({}),
+  useDedupeOldNodes: () => vi.fn(),
+  useGetNodeTypeDetail: () => vi.fn(),
+  useRemoveGraphElements: () => vi.fn(),
+  useRemoveNode: () => vi.fn(),
+  useSaveVisualizer: () => vi.fn(),
+  useSelectedNode: () => vi.fn(),
+  useCreateConnector: () => vi.fn(),
+  useHandleCollectNodeProps: () => vi.fn(),
+  useGetPath: () => vi.fn(),
+  useTargetNodeAncestors: () => vi.fn(),
+}));
+
+const mockSetLabel = vi.fn();
+const mockSetData = vi.fn();
+const mockSetState = vi.fn();
+
+const mockNode = {
+  getId: () => '42',
+  getData: () => ({
+    resource: {
+      id: 42,
+      identifier: '550e8400-e29b-41d4-a716-446655440000',
+      all_parents_must_converge: false,
+      extra_data: {},
+      always_nodes: [],
+      failure_nodes: [],
+      success_nodes: [],
+      summary_fields: {
+        unified_job_template: {
+          id: 1,
+          name: 'Demo Template',
+          unified_job_type: RESOURCE_TYPE.job,
+        },
+      },
+    },
+  }),
+  setLabel: mockSetLabel,
+  setData: mockSetData,
+  setState: mockSetState,
+  isVisible: () => true,
+} as never;
+
+describe('NodeEditWizard', () => {
+  beforeEach(() => {
+    mockGetInitialValues.mockClear();
+    mockSetLabel.mockClear();
+    mockSetData.mockClear();
+    mockSetState.mockClear();
+  });
+
+  it('should render null initially while loading initial values', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render the wizard after initial values are fetched', async () => {
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.getByTestId('wizard-title')).toHaveTextContent('Edit step');
+  });
+
+  it('should call getInitialValues with the provided node', async () => {
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockGetInitialValues).toHaveBeenCalledWith(mockNode);
+    });
+  });
+
+  it('should render null when getInitialValues rejects (error path)', async () => {
+    mockGetInitialValues.mockRejectedValueOnce(new Error('API error'));
+
+    const { container } = render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockGetInitialValues).toHaveBeenCalled();
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should call buildEffectivePrompt and update node on submit', async () => {
+    const user = userEvent.setup();
+    mockGetInitialValues.mockResolvedValueOnce({
+      nodeTypeStep: {
+        node_type: RESOURCE_TYPE.workflow_approval,
+        node_convergence: 'any' as const,
+        node_alias: '',
+        approval_name: 'Approval',
+        approval_description: '',
+        approval_timeout: 0,
+        node_days_to_keep: 30,
+        resource: null,
+        resourceId: undefined,
+        node_status_type: EdgeStatus.info,
+      },
+      nodePromptsStep: {
+        prompt: {
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+          original: {
+            credentials: [],
+            labels: [],
+            instance_groups: [],
+          },
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    // With workflow_approval and no launch_config, prompts and survey are hidden
+    // Wizard goes: Node details → Review
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    await user.click(nextButton);
+
+    await waitFor(
+      () => {
+        const finishButton = screen.queryByRole('button', { name: 'Finish' });
+        if (finishButton) {
+          return expect(finishButton).toBeInTheDocument();
+        }
+        throw new Error('Finish button not found');
+      },
+      { timeout: 5000 }
+    );
+
+    const finishButton = screen.getByRole('button', { name: 'Finish' });
+    await user.click(finishButton);
+
+    await waitFor(
+      () => {
+        expect(mockBuildEffectivePrompt).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(mockSetData).toHaveBeenCalled();
+    expect(mockSetLabel).toHaveBeenCalled();
+  });
+
+  it('should show prompts step when initialValues has launch_config', async () => {
+    mockGetInitialValues.mockResolvedValueOnce({
+      nodeTypeStep: {
+        node_type: RESOURCE_TYPE.job,
+        node_convergence: 'any' as const,
+        node_alias: '',
+        approval_name: '',
+        approval_description: '',
+        approval_timeout: 0,
+        node_days_to_keep: 30,
+        resource: null,
+        resourceId: undefined,
+        node_status_type: EdgeStatus.info,
+      },
+      nodePromptsStep: {
+        prompt: {
+          launch_config: {
+            ask_credential_on_launch: true,
+          },
+          credentials: [],
+          labels: [],
+          instance_groups: [],
+          original: {
+            credentials: [],
+            labels: [],
+            instance_groups: [],
+          },
+        } as never,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <NodeEditWizard node={mockNode} />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('wizard-title')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.getByText('Edit step')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
@@ -15,7 +15,7 @@ import {
   replaceIdentifier,
   shouldHideOtherStep,
 } from './helpers';
-import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import { buildEffectivePrompt } from './buildEffectivePrompt';
 import { NodePromptsStep } from './NodePromptsStep';
 import { NodeReviewStep } from './NodeReviewStep';
 import { NodeTypeStep } from './NodeTypeStep';
@@ -27,30 +27,6 @@ import {
 type StepContent = Partial<WizardFormValues> | { prompt: Partial<PromptFormValues> };
 type StepName = 'nodeTypeStep' | 'nodePromptsStep';
 type WizardStep = Record<StepName, StepContent>;
-
-function clearStalePromptFields(
-  effectivePrompt: Partial<PromptFormValues>,
-  launchConfig: LaunchConfiguration | null | undefined
-) {
-  if (!launchConfig?.ask_credential_on_launch) {
-    effectivePrompt.credentials = [];
-  }
-  if (!launchConfig?.ask_labels_on_launch) {
-    effectivePrompt.labels = [];
-  }
-  if (!launchConfig?.ask_instance_groups_on_launch) {
-    effectivePrompt.instance_groups = [];
-  }
-  if (!launchConfig?.ask_skip_tags_on_launch) {
-    effectivePrompt.skip_tags = [];
-  }
-  if (!launchConfig?.ask_tags_on_launch) {
-    effectivePrompt.job_tags = [];
-  }
-  if (!launchConfig?.ask_variables_on_launch) {
-    effectivePrompt.extra_vars = '';
-  }
-}
 
 export function NodeEditWizard({ node }: { node: GraphNode }) {
   const { t } = useTranslation();
@@ -170,30 +146,15 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
       survey,
     } = formValues;
 
-    const isTemplateChange =
-      originalTemplateId !== undefined && Number(resource?.id) !== originalTemplateId;
-
-    // When the new template has no prompts, PageWizard hides the prompt step and does not
-    // include it in formValues — prompt is undefined. We still need launch_data to be set
-    // so that processCredentials/Labels/InstanceGroups can clean up any node-level resources
-    // that were associated for the old template. Without this, launch_data is undefined,
-    // processCredentials never runs, and the PATCH fails because orphaned credentials remain.
-    const effectivePrompt: Partial<PromptFormValues> = prompt ?? {};
-
-    if (resource && 'organization' in resource) {
-      effectivePrompt.organization = resource.organization ?? null;
-    }
-
-    if (isTemplateChange) {
-      clearStalePromptFields(effectivePrompt, launch_config);
-    }
-
-    // Always build original so save-time cleanup has what it needs.
-    effectivePrompt.original = {
-      ...(launch_config ? { launch_config } : {}),
-      ...nodeOriginalResources,
-      ...(isTemplateChange ? { isTemplateChange: true } : {}),
-    };
+    const { effectivePrompt } = buildEffectivePrompt({
+      originalTemplateId,
+      newResourceId: resource?.id ? Number(resource.id) : undefined,
+      prompt,
+      launchConfig: launch_config,
+      nodeOriginalResources,
+      resourceOrganization:
+        resource && 'organization' in resource ? (resource.organization ?? null) : undefined,
+    });
 
     const nodeName = getValueBasedOnJobType(node_type, resource?.name || '', approval_name);
     const nodeIdentifier = replaceIdentifier(nodeData.resource.identifier, node_alias);

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeEditWizard.tsx
@@ -15,6 +15,7 @@ import {
   replaceIdentifier,
   shouldHideOtherStep,
 } from './helpers';
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
 import { NodePromptsStep } from './NodePromptsStep';
 import { NodeReviewStep } from './NodeReviewStep';
 import { NodeTypeStep } from './NodeTypeStep';
@@ -26,6 +27,30 @@ import {
 type StepContent = Partial<WizardFormValues> | { prompt: Partial<PromptFormValues> };
 type StepName = 'nodeTypeStep' | 'nodePromptsStep';
 type WizardStep = Record<StepName, StepContent>;
+
+function clearStalePromptFields(
+  effectivePrompt: Partial<PromptFormValues>,
+  launchConfig: LaunchConfiguration | null | undefined
+) {
+  if (!launchConfig?.ask_credential_on_launch) {
+    effectivePrompt.credentials = [];
+  }
+  if (!launchConfig?.ask_labels_on_launch) {
+    effectivePrompt.labels = [];
+  }
+  if (!launchConfig?.ask_instance_groups_on_launch) {
+    effectivePrompt.instance_groups = [];
+  }
+  if (!launchConfig?.ask_skip_tags_on_launch) {
+    effectivePrompt.skip_tags = [];
+  }
+  if (!launchConfig?.ask_tags_on_launch) {
+    effectivePrompt.job_tags = [];
+  }
+  if (!launchConfig?.ask_variables_on_launch) {
+    effectivePrompt.extra_vars = '';
+  }
+}
 
 export function NodeEditWizard({ node }: { node: GraphNode }) {
   const { t } = useTranslation();
@@ -88,14 +113,23 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
         ) {
           return shouldHideOtherStep(launch_config);
         }
-        if ('nodePromptsStep' in initialValues) {
+        // nodePromptsStep is always present in initialValues (it carries original
+        // node resources for save cleanup). Only show the step if the original
+        // template actually had prompts, which is indicated by launch_config being
+        // stored in the initial prompt values.
+        if (initialValues.nodePromptsStep?.prompt?.launch_config) {
           return false;
         }
         return true;
       },
       validate: (wizardData: Partial<WizardFormValues>) => {
+        // Prefer the live wizard data's requiredCredentialTypes so that validation reflects
+        // the currently selected template, not the template that was loaded when the wizard
+        // was first opened (which is stale if the user switched templates mid-edit).
         const requiredCredentialTypes =
-          initialValues?.nodePromptsStep?.prompt?.requiredCredentialTypes || [];
+          wizardData.prompt?.requiredCredentialTypes ||
+          initialValues?.nodePromptsStep?.prompt?.requiredCredentialTypes ||
+          [];
         validateRequiredCredentialTypes(t, wizardData, requiredCredentialTypes);
       },
     },
@@ -120,6 +154,7 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
   const handleSubmit = async (formValues: WizardFormValues) => {
     const nodeData = node.getData() as { resource: WorkflowNode };
     const nodeOriginalResources = initialValues?.nodePromptsStep?.prompt?.original;
+    const originalTemplateId = nodeData.resource.summary_fields?.unified_job_template?.id;
 
     const {
       approval_name,
@@ -135,24 +170,30 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
       survey,
     } = formValues;
 
-    const promptValues = prompt;
+    const isTemplateChange =
+      originalTemplateId !== undefined && Number(resource?.id) !== originalTemplateId;
 
-    if (promptValues) {
-      if (resource && 'organization' in resource) {
-        promptValues.organization = resource.organization ?? null;
-      }
-      if (launch_config) {
-        promptValues.original = {
-          launch_config,
-        };
-      }
-      if (nodeOriginalResources) {
-        promptValues.original = {
-          ...promptValues.original,
-          ...nodeOriginalResources,
-        };
-      }
+    // When the new template has no prompts, PageWizard hides the prompt step and does not
+    // include it in formValues — prompt is undefined. We still need launch_data to be set
+    // so that processCredentials/Labels/InstanceGroups can clean up any node-level resources
+    // that were associated for the old template. Without this, launch_data is undefined,
+    // processCredentials never runs, and the PATCH fails because orphaned credentials remain.
+    const effectivePrompt: Partial<PromptFormValues> = prompt ?? {};
+
+    if (resource && 'organization' in resource) {
+      effectivePrompt.organization = resource.organization ?? null;
     }
+
+    if (isTemplateChange) {
+      clearStalePromptFields(effectivePrompt, launch_config);
+    }
+
+    // Always build original so save-time cleanup has what it needs.
+    effectivePrompt.original = {
+      ...(launch_config ? { launch_config } : {}),
+      ...nodeOriginalResources,
+      ...(isTemplateChange ? { isTemplateChange: true } : {}),
+    };
 
     const nodeName = getValueBasedOnJobType(node_type, resource?.name || '', approval_name);
     const nodeIdentifier = replaceIdentifier(nodeData.resource.identifier, node_alias);
@@ -180,7 +221,7 @@ export function NodeEditWizard({ node }: { node: GraphNode }) {
           },
         },
       },
-      launch_data: promptValues,
+      launch_data: effectivePrompt,
       survey_data: survey,
     };
 

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
@@ -1,0 +1,502 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RESOURCE_TYPE } from '../constants';
+import type { WizardFormValues } from '../types';
+import { NodeTypeStep } from './NodeTypeStep';
+
+vi.mock('@patternfly/react-topology', () => ({
+  Edge: {},
+  EdgeModel: {},
+  ElementModel: {},
+  GraphElement: {},
+  Node: {},
+  NodeModel: {},
+  NodeStatus: { danger: 'danger', success: 'success', info: 'info', default: 'default' },
+  WithSelectionProps: {},
+  useVisualizationController: vi.fn(),
+  action: vi.fn((fn: () => void) => fn),
+  observer: (component: unknown) => component,
+  TopologySideBar: () => null,
+  NodeShape: { circle: 'circle' },
+  EdgeTerminalType: { directional: 'directional' },
+}));
+
+const mockSetWizardData = vi.hoisted(() => vi.fn());
+const mockStepState = {
+  nodePromptsStep: {
+    prompt: {
+      credentials: [],
+      labels: [],
+      instance_groups: [],
+      skip_tags: [],
+      job_tags: [],
+      extra_vars: '',
+      inventory: null,
+    },
+  },
+};
+const mockSetStepData = vi.hoisted(() =>
+  vi.fn((updater: unknown) => {
+    if (typeof updater === 'function') {
+      (updater as (prev: typeof mockStepState) => typeof mockStepState)(mockStepState);
+    }
+  })
+);
+
+vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
+  usePageWizard: () => ({
+    setWizardData: mockSetWizardData,
+    setStepData: mockSetStepData,
+    wizardData: {},
+    stepData: {},
+    activeStep: { id: 'nodeTypeStep' },
+  }),
+}));
+
+vi.mock('../../../../common/useAwxConfig', () => ({
+  useAwxConfig: vi.fn(() => null),
+}));
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: vi.fn(() => ({ data: undefined })),
+  useGetItem: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock('@ansible/hub-ui/common/ExternalLink', () => ({
+  ExternalLink: ({ children }: Readonly<{ children: React.ReactNode }>) => <span>{children}</span>,
+}));
+
+vi.mock('@ansible/common-ui/utils/useGetDocsUrl', () => ({
+  useGetDocsUrl: vi.fn(() => 'https://docs.example.com'),
+}));
+
+const mockRequestGet = vi.hoisted(() =>
+  vi.fn((url: string): Promise<Record<string, unknown>> => {
+    if (url.includes('/launch/')) {
+      return Promise.resolve({
+        ask_credential_on_launch: true,
+        ask_inventory_on_launch: true,
+        ask_variables_on_launch: false,
+        survey_enabled: false,
+        defaults: { credentials: [], inventory: null },
+      });
+    }
+    if (url.includes('/credentials/')) {
+      return Promise.resolve({
+        count: 1,
+        results: [
+          {
+            id: 10,
+            name: 'SSH Key',
+            credential_type: 1,
+            summary_fields: { credential_type: { name: 'Machine' } },
+          },
+        ],
+      });
+    }
+    return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+  })
+);
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({
+  requestGet: mockRequestGet,
+}));
+
+function TestWrapper({ defaultValues }: Readonly<{ defaultValues: Partial<WizardFormValues> }>) {
+  const methods = useForm<WizardFormValues>({ defaultValues });
+  return (
+    <MemoryRouter>
+      <FormProvider {...methods}>
+        <NodeTypeStep />
+      </FormProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('NodeTypeStep', () => {
+  beforeEach(() => {
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+    mockRequestGet.mockClear();
+  });
+
+  it('should call setWizardData with launch_config when a job template resourceId is set', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 1,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result).toHaveProperty('resourceId', 1);
+    } else {
+      expect(wizardDataArg).toBeDefined();
+    }
+  });
+
+  it('should call setStepData with prompt values when launch config has prompts', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 1,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetStepData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it('should call setWizardData with null launch_config when template has no promptable fields', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      return Promise.resolve({ id: 2, name: 'Simple Template', type: 'job_template' });
+    });
+
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: 2,
+        }}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result.launch_config).toBeNull();
+    }
+  });
+
+  it('should early-return and not call setWizardData when resourceId is undefined', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+          resourceId: undefined,
+        }}
+      />
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(mockSetWizardData).not.toHaveBeenCalled();
+  });
+
+  it('should not call setLaunchToWizardData for workflow_approval node type', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_approval,
+          resourceId: undefined,
+        }}
+      />
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(mockRequestGet).not.toHaveBeenCalled();
+  });
+
+  it('should reset prompt step data when template changes (isTemplateChange = true)', async () => {
+    // Use a controlled wrapper that can change resourceId via setValue to trigger isTemplateChange
+    function ControlledWrapper() {
+      const [nextId, setNextId] = useState<number | undefined>(undefined);
+      const methods = useForm<WizardFormValues>({
+        defaultValues: { node_type: RESOURCE_TYPE.job, resourceId: 1 },
+      });
+
+      useEffect(() => {
+        if (nextId !== undefined) {
+          methods.setValue('resourceId', nextId);
+        }
+      }, [nextId, methods]);
+
+      return (
+        <MemoryRouter>
+          <FormProvider {...methods}>
+            <NodeTypeStep />
+            <button onClick={() => setNextId(2)}>Switch</button>
+          </FormProvider>
+        </MemoryRouter>
+      );
+    }
+
+    const { getByRole } = render(<ControlledWrapper />);
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+
+    act(() => {
+      getByRole('button', { name: 'Switch' }).click();
+    });
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    expect(mockSetStepData).toHaveBeenCalled();
+  });
+
+  it('should clear prompt step state when switching to a template with no promptable fields (else-if isTemplateChange path)', async () => {
+    // Override mock: template 1 has prompts, template 3 has NO prompts
+    // When switching from 1→3 with isTemplateChange=true and shouldShowPromptStep=false,
+    // lines 238-254 (the else-if isTemplateChange cleanup path) should be covered.
+    // fetchResource builds URLs with a trailing slash, producing double slashes like
+    // /job_templates//3/launch/. Match resource ID suffix to handle both /3/ and //3/ patterns.
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('3/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_variables_on_launch: false,
+          ask_labels_on_launch: false,
+          ask_instance_groups_on_launch: false,
+          ask_tags_on_launch: false,
+          ask_skip_tags_on_launch: false,
+          ask_diff_mode_on_launch: false,
+          ask_limit_on_launch: false,
+          ask_verbosity_on_launch: false,
+          ask_scm_branch_on_launch: false,
+          ask_forks_on_launch: false,
+          ask_job_slice_count_on_launch: false,
+          ask_timeout_on_launch: false,
+          ask_execution_environment_on_launch: false,
+          ask_job_type_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      if (url.includes('3/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      // fetchResource for template 3: endsWith //3 or /3 (must come AFTER launch/ and credentials/ checks)
+      if (url.endsWith('//3') || url.endsWith('/3')) {
+        return Promise.resolve({ id: 3, name: 'No-Prompts Template', type: 'job_template' });
+      }
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: true,
+          ask_inventory_on_launch: true,
+          ask_variables_on_launch: false,
+          survey_enabled: false,
+          defaults: { credentials: [], inventory: null },
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({
+          count: 1,
+          results: [
+            {
+              id: 10,
+              name: 'SSH',
+              credential_type: 1,
+              summary_fields: { credential_type: { name: 'Machine' } },
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+    });
+
+    function ControlledWrapper() {
+      const [nextId, setNextId] = useState<number | undefined>(undefined);
+      const methods = useForm<WizardFormValues>({
+        defaultValues: { node_type: RESOURCE_TYPE.job, resourceId: 1 },
+      });
+
+      useEffect(() => {
+        if (nextId !== undefined) {
+          methods.setValue('resourceId', nextId);
+        }
+      }, [nextId, methods]);
+
+      return (
+        <MemoryRouter>
+          <FormProvider {...methods}>
+            <NodeTypeStep />
+            <button onClick={() => setNextId(3)}>Switch to no-prompts</button>
+          </FormProvider>
+        </MemoryRouter>
+      );
+    }
+
+    const { getByRole } = render(<ControlledWrapper />);
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+
+    act(() => {
+      getByRole('button', { name: 'Switch to no-prompts' }).click();
+    });
+
+    await waitFor(
+      () => {
+        expect(mockSetWizardData).toHaveBeenCalled();
+      },
+      { timeout: 5000 }
+    );
+    expect(mockSetStepData).toHaveBeenCalled();
+
+    const wizardDataArg: unknown = mockSetWizardData.mock.calls[0][0];
+    if (typeof wizardDataArg === 'function') {
+      const result = (wizardDataArg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        {}
+      );
+      expect(result.launch_config).toBeNull();
+    }
+  });
+
+  it('should handle workflow_job template type and fetch launch config', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/workflow_job_templates/10/launch/')) {
+        return Promise.resolve({
+          ask_inventory_on_launch: true,
+          ask_credential_on_launch: false,
+          survey_enabled: false,
+          defaults: {},
+        });
+      }
+      return Promise.resolve({ id: 10, name: 'WF Template', type: 'workflow_job_template' });
+    });
+
+    render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_job,
+          resourceId: 10,
+        }}
+      />
+    );
+
+    await waitFor(() => expect(mockSetWizardData).toHaveBeenCalled(), { timeout: 5000 });
+    expect(mockRequestGet).toHaveBeenCalledWith(
+      expect.stringContaining('/workflow_job_templates/10/launch/')
+    );
+  });
+
+  it('should render the node type selector form elements', () => {
+    const { container } = render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.job,
+        }}
+      />
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});
+
+function TestWrapperWithSourceNode({
+  defaultValues,
+  hasSourceNode = false,
+}: Readonly<{ defaultValues: Partial<WizardFormValues>; hasSourceNode?: boolean }>) {
+  const methods = useForm<WizardFormValues>({ defaultValues });
+  return (
+    <MemoryRouter>
+      <FormProvider {...methods}>
+        <NodeTypeStep hasSourceNode={hasSourceNode} />
+      </FormProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('NodeTypeStep sub-components', () => {
+  beforeEach(() => {
+    mockSetWizardData.mockClear();
+    mockSetStepData.mockClear();
+    mockRequestGet.mockClear();
+  });
+
+  it('should render NodeStatusType when hasSourceNode is true', () => {
+    const { getByTestId } = render(
+      <TestWrapperWithSourceNode defaultValues={{ node_type: RESOURCE_TYPE.job }} hasSourceNode />
+    );
+    expect(getByTestId('node-status-type')).toBeInTheDocument();
+  });
+
+  it('should not render NodeStatusType when hasSourceNode is false', () => {
+    const { queryByTestId } = render(
+      <TestWrapperWithSourceNode
+        defaultValues={{ node_type: RESOURCE_TYPE.job }}
+        hasSourceNode={false}
+      />
+    );
+    expect(queryByTestId('node-status-type')).not.toBeInTheDocument();
+  });
+
+  it('should render convergence input', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-convergence')).toBeInTheDocument();
+  });
+
+  it('should render alias input', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-alias')).toBeInTheDocument();
+  });
+
+  it('should render approval form fields for workflow_approval node type', () => {
+    const { getByTestId } = render(
+      <TestWrapper
+        defaultValues={{
+          node_type: RESOURCE_TYPE.workflow_approval,
+          approval_timeout: 90,
+        }}
+      />
+    );
+    expect(getByTestId('approval_timeout_minutes')).toBeInTheDocument();
+    expect(getByTestId('approval_timeout_seconds')).toBeInTheDocument();
+  });
+
+  it('should render node type select', () => {
+    const { getByTestId } = render(
+      <TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job }} />
+    );
+    expect(getByTestId('node-type')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
@@ -14,7 +14,7 @@ import {
   InputGroupText,
   TextInput,
 } from '@patternfly/react-core';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Controller, FieldPath, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { PageFormManagementJobsSelect } from '../../../../administration/management-jobs/components/PageFormManagementJobsSelect';
@@ -40,6 +40,11 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
   const { defaultValues } = formState;
 
   const { setWizardData, setStepData } = usePageWizard<WizardFormValues>();
+
+  // Tracks the last resourceId the effect actually processed, so we can distinguish
+  // "initial load of the existing node's template" (no change needed) from
+  // "user switched to a different template" (credentials must be reset).
+  const prevResourceIdRef = useRef<WizardFormValues['resourceId']>(undefined);
 
   // Register form fields
   register('node_type');
@@ -73,6 +78,14 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
   }, [nodeType, getFieldState, setValue, reset, setWizardData, setStepData, getValues]);
 
   useEffect(() => {
+    // Compute synchronously before any async work so the value is stable for this effect run.
+    // A defined prev that differs from the current resourceId means the user explicitly switched
+    // to a different template — credentials must be reset. On initial mount, prev is undefined,
+    // meaning we preserve whatever stepDefaults already loaded for the existing node.
+    const isTemplateChange =
+      prevResourceIdRef.current !== undefined && prevResourceIdRef.current !== resourceId;
+    prevResourceIdRef.current = resourceId;
+
     // Once we finish AAP-34015 fetchResource could probably be removed.
     const fetchResource = async () => {
       const nodeResourceUrl = getResourceURL(nodeType);
@@ -93,6 +106,34 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
         launchConfigResults = await requestGet<LaunchConfiguration>(
           awxAPI`/job_templates/${resourceId.toString()}/launch/`
         );
+
+        // Early step-data reset: clear prompt credentials as soon as the launch config is
+        // known, BEFORE the credentials fetch. Because PageWizardBody re-creates the Prompts
+        // form (key={activeStep.id}) from stepData when the user navigates to that step,
+        // this ensures the credential picker initialises with [] even if the user navigates
+        // to Prompts before the credentials fetch completes.
+        if (isTemplateChange) {
+          setStepData((prev) => {
+            if (!prev?.nodePromptsStep) return prev;
+            return {
+              ...prev,
+              nodePromptsStep: {
+                ...prev.nodePromptsStep,
+                prompt: {
+                  ...(prev.nodePromptsStep.prompt as object),
+                  credentials: [],
+                  labels: [],
+                  instance_groups: [],
+                  skip_tags: [],
+                  job_tags: [],
+                  extra_vars: '',
+                  inventory: null,
+                },
+              },
+            };
+          });
+        }
+
         // Fetch template credentials to determine required credential types
         const templateCredentialsResponse = await requestGet<AwxItemsResponse<Credential>>(
           awxAPI`/job_templates/${resourceId.toString()}/credentials/`
@@ -115,32 +156,29 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
 
       const shouldShowPromptStep = !shouldHideOtherStep(launchConfigResults);
       const shouldShowSurveyStep = launchConfigResults.survey_enabled;
+
+      // Always update wizard-level data so launch_config reflects the currently selected template.
+      // This prevents stale prompt flags from a previously selected template being used on save.
+      setWizardData((prev) => ({
+        ...prev,
+        launch_config: shouldShowPromptStep || shouldShowSurveyStep ? launchConfigResults : null,
+        resourceId,
+        resource: nodeResource,
+      }));
+
       if (shouldShowPromptStep || shouldShowSurveyStep) {
-        setWizardData((prev) => ({
-          ...prev,
-          launch_config: shouldShowPromptStep || shouldShowSurveyStep ? launchConfigResults : null,
-          resourceId,
-          resource: nodeResource,
-        }));
         setStepData((prev) => {
           const prompts = prev.nodePromptsStep?.prompt;
 
-          return {
-            ...prev,
-            nodePromptsStep: {
-              launch_config: launchConfigResults,
-              resourceId,
-              resource: nodeResource,
-              prompt: {
-                ...launchConfigValue,
+          // When the template has not changed (initial load or same-template re-render),
+          // preserve any user-entered prompt values from the existing step state so they
+          // survive the effect re-run. When the template HAS changed, all prompt fields
+          // must start from the new template's defaults — stale values from a different
+          // template's playbook are meaningless and can cause incorrect job runs or API errors.
+          const preservedPromptOverrides = isTemplateChange
+            ? {}
+            : {
                 inventory: prompts?.inventory ?? launchConfigValue.inventory,
-                credentials: getAggregateCredentials(
-                  [], // no node credentials for new nodes
-                  prompts?.credentials ?? [],
-                  launchConfigValue?.credentials ?? []
-                ),
-                skip_tags: [...(prompts?.skip_tags || []), ...(launchConfigValue?.skip_tags || [])],
-                job_tags: [...(prompts?.job_tags || []), ...(launchConfigValue?.job_tags ?? [])],
                 execution_environment: prompts?.execution_environment
                   ? {
                       id: prompts?.execution_environment?.id ?? prompts?.execution_environment,
@@ -151,6 +189,8 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
                   prompts?.extra_vars && prompts.extra_vars !== ''
                     ? prompts.extra_vars
                     : (launchConfigValue?.extra_vars ?? ''),
+                skip_tags: [...(prompts?.skip_tags || []), ...(launchConfigValue?.skip_tags || [])],
+                job_tags: [...(prompts?.job_tags || []), ...(launchConfigValue?.job_tags ?? [])],
                 instance_groups: [
                   ...(prompts?.instance_groups ?? []),
                   ...(launchConfigValue?.instance_groups ?? []),
@@ -163,11 +203,51 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
                 job_slice_count: prompts?.job_slice_count ?? launchConfigValue?.job_slice_count,
                 timeout: prompts?.timeout ?? launchConfigValue?.timeout,
                 job_type: prompts?.job_type ?? launchConfigValue?.job_type,
-                // Add required credential types for job templates
+              };
+
+          const newCredentials = getAggregateCredentials(
+            [],
+            isTemplateChange ? [] : (prompts?.credentials ?? []),
+            launchConfigValue?.credentials ?? []
+          );
+
+          return {
+            ...prev,
+            nodePromptsStep: {
+              launch_config: launchConfigResults,
+              resourceId,
+              resource: nodeResource,
+              prompt: {
+                ...launchConfigValue,
+                ...preservedPromptOverrides,
+                credentials: newCredentials,
                 requiredCredentialTypes: templateCredentials.map((cred) => ({
                   id: cred.credential_type,
                   name: cred.summary_fields.credential_type.name,
                 })),
+              },
+            },
+          };
+        });
+      } else if (isTemplateChange) {
+        // The user switched to a template that has no promptable fields. Clear the entire
+        // previous prompt step state so stale values from the old template are not submitted.
+        // processCredentials, processLabels, and processInstanceGroups all check for non-empty
+        // arrays independently of ask_*_on_launch flags, so any leftover values would be sent.
+        // On initial load (isTemplateChange=false) there is nothing stale to clear.
+        setStepData((prev) => {
+          if (!prev?.nodePromptsStep) return prev;
+          return {
+            ...prev,
+            nodePromptsStep: {
+              launch_config: launchConfigResults,
+              resourceId,
+              resource: nodeResource,
+              prompt: {
+                credentials: [],
+                labels: [],
+                instance_groups: [],
+                requiredCredentialTypes: [],
               },
             },
           };

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'vitest';
+import { buildEffectivePrompt } from './buildEffectivePrompt';
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+
+const baseLaunchConfig = {
+  ask_credential_on_launch: false,
+  ask_labels_on_launch: false,
+  ask_instance_groups_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_variables_on_launch: false,
+} as LaunchConfiguration;
+
+describe('buildEffectivePrompt', () => {
+  describe('template change detection', () => {
+    test('should detect template change when IDs differ', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(true);
+    });
+
+    test('should not detect template change when IDs match', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(false);
+    });
+
+    test('should not detect template change when original ID is undefined', () => {
+      const { isTemplateChange } = buildEffectivePrompt({
+        originalTemplateId: undefined,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(isTemplateChange).toBe(false);
+    });
+  });
+
+  describe('force-clearing on template change', () => {
+    test('should clear all fields when new template has no prompts', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: {
+          credentials: [{ id: 1, name: 'old', credential_type: 1, passwords_needed: [] }],
+        },
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toEqual([]);
+      expect(effectivePrompt.labels).toEqual([]);
+      expect(effectivePrompt.instance_groups).toEqual([]);
+      expect(effectivePrompt.skip_tags).toEqual([]);
+      expect(effectivePrompt.job_tags).toEqual([]);
+      expect(effectivePrompt.extra_vars).toBe('');
+    });
+
+    test('should preserve credentials when new template accepts them', () => {
+      const creds = [{ id: 1, name: 'cred', credential_type: 1, passwords_needed: [] as string[] }];
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: { credentials: creds },
+        launchConfig: { ...baseLaunchConfig, ask_credential_on_launch: true },
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toEqual(creds);
+    });
+
+    test('should preserve extra_vars when new template accepts them', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: { extra_vars: 'my_var: value' },
+        launchConfig: { ...baseLaunchConfig, ask_variables_on_launch: true },
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.extra_vars).toBe('my_var: value');
+    });
+
+    test('should not clear fields when template does not change', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: {
+          credentials: [{ id: 1, name: 'cred', credential_type: 1, passwords_needed: [] }],
+        },
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toHaveLength(1);
+    });
+  });
+
+  describe('original object construction', () => {
+    test('should include isTemplateChange flag when template changed', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 2,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: {
+          credentials: [{ id: 5, name: 'old', credential_type: 1 }],
+        },
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.isTemplateChange).toBe(true);
+      expect(effectivePrompt.original?.credentials).toEqual([
+        { id: 5, name: 'old', credential_type: 1 },
+      ]);
+    });
+
+    test('should not include isTemplateChange when template did not change', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.isTemplateChange).toBeUndefined();
+    });
+
+    test('should include launch_config in original when provided', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: baseLaunchConfig,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.original?.launch_config).toBe(baseLaunchConfig);
+    });
+  });
+
+  describe('prompt fallback', () => {
+    test('should use empty object when prompt is undefined', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: undefined,
+        nodeOriginalResources: undefined,
+        resourceOrganization: undefined,
+      });
+      expect(effectivePrompt.credentials).toBeUndefined();
+    });
+
+    test('should set organization from resource', () => {
+      const { effectivePrompt } = buildEffectivePrompt({
+        originalTemplateId: 1,
+        newResourceId: 1,
+        prompt: undefined,
+        launchConfig: undefined,
+        nodeOriginalResources: undefined,
+        resourceOrganization: 42,
+      });
+      expect(effectivePrompt.organization).toBe(42);
+    });
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
@@ -1,0 +1,56 @@
+import type { LaunchConfiguration } from '../../../../interfaces/LaunchConfiguration';
+import type { PromptFormValues } from '../types';
+
+export interface BuildEffectivePromptParams {
+  originalTemplateId: number | undefined;
+  newResourceId: number | undefined;
+  prompt: Partial<PromptFormValues> | undefined;
+  launchConfig: LaunchConfiguration | null | undefined;
+  nodeOriginalResources: PromptFormValues['original'];
+  resourceOrganization: number | null | undefined;
+}
+
+function clearUnpromptedFields(
+  effectivePrompt: Partial<PromptFormValues>,
+  launchConfig: LaunchConfiguration | null | undefined
+): void {
+  if (!launchConfig?.ask_credential_on_launch) effectivePrompt.credentials = [];
+  if (!launchConfig?.ask_labels_on_launch) effectivePrompt.labels = [];
+  if (!launchConfig?.ask_instance_groups_on_launch) effectivePrompt.instance_groups = [];
+  if (!launchConfig?.ask_skip_tags_on_launch) effectivePrompt.skip_tags = [];
+  if (!launchConfig?.ask_tags_on_launch) effectivePrompt.job_tags = [];
+  if (!launchConfig?.ask_variables_on_launch) effectivePrompt.extra_vars = '';
+}
+
+export function buildEffectivePrompt({
+  originalTemplateId,
+  newResourceId,
+  prompt,
+  launchConfig,
+  nodeOriginalResources,
+  resourceOrganization,
+}: Readonly<BuildEffectivePromptParams>): {
+  isTemplateChange: boolean;
+  effectivePrompt: Partial<PromptFormValues>;
+} {
+  const isTemplateChange =
+    originalTemplateId !== undefined && Number(newResourceId) !== originalTemplateId;
+
+  const effectivePrompt: Partial<PromptFormValues> = prompt ?? {};
+
+  if (resourceOrganization !== undefined) {
+    effectivePrompt.organization = resourceOrganization;
+  }
+
+  if (isTemplateChange) {
+    clearUnpromptedFields(effectivePrompt, launchConfig);
+  }
+
+  effectivePrompt.original = {
+    ...(launchConfig ? { launch_config: launchConfig } : {}),
+    ...nodeOriginalResources,
+    ...(isTemplateChange ? { isTemplateChange: true } : {}),
+  };
+
+  return { isTemplateChange, effectivePrompt };
+}

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/getAggregateCredentials.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/getAggregateCredentials.test.ts
@@ -237,6 +237,65 @@ describe('getAggregateCredentials', () => {
     });
   });
 
+  describe('template change behavior', () => {
+    it('should return only new template defaults when prompt credentials are cleared on template switch', () => {
+      const newTemplateCredentials = [
+        createMockCredential(20, 1, 'New Template SSH'),
+        createMockCredential(21, 3, 'New Template SCM'),
+      ];
+
+      const result = getAggregateCredentials([], [], newTemplateCredentials);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([
+        expect.objectContaining({ id: 20, name: 'New Template SSH', credential_type: 1 }),
+        expect.objectContaining({ id: 21, name: 'New Template SCM', credential_type: 3 }),
+      ]);
+    });
+
+    it('should preserve prompt values on initial load (no template change)', () => {
+      const templateCredentials = [createMockCredential(1, 1, 'Template SSH')];
+      const existingPromptCredentials = [
+        createMockCredential(5, 1, 'User SSH Override'),
+        createMockCredential(6, 2, 'User Vault'),
+      ];
+
+      const result = getAggregateCredentials([], existingPromptCredentials, templateCredentials);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 5, name: 'User SSH Override', credential_type: 1 }),
+          expect.objectContaining({ id: 6, name: 'User Vault', credential_type: 2 }),
+        ])
+      );
+    });
+
+    it('should discard stale node credentials when both node and prompt are cleared on template switch', () => {
+      const staleNodeCredentials = [
+        createMockCredential(3, 1, 'Old Node SSH'),
+        createMockCredential(4, 2, 'Old Node Vault'),
+      ];
+      const newTemplateCredentials = [createMockCredential(20, 3, 'New Template SCM')];
+
+      const result = getAggregateCredentials(staleNodeCredentials, [], newTemplateCredentials);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 3, credential_type: 1 }),
+          expect.objectContaining({ id: 4, credential_type: 2 }),
+          expect.objectContaining({ id: 20, credential_type: 3 }),
+        ])
+      );
+    });
+
+    it('should produce clean state when called with all empty arrays (template switch to no-prompts template)', () => {
+      const result = getAggregateCredentials([], [], []);
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('real-world scenarios', () => {
     it('should handle the original bug scenario: same credential ID in template and user selection', () => {
       // This represents the bug scenario where user selected the same credential that was already

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/helpers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'vitest';
+import { awxAPI } from '../../../../common/api/awx-utils';
+import type { Survey } from '../../../../interfaces/Survey';
+import { getConvergenceType, getResourceURL, processSurvey } from './helpers';
+
+describe('getConvergenceType', () => {
+  test('should return "all" when convergence is true', () => {
+    expect(getConvergenceType(true)).toBe('all');
+  });
+
+  test('should return "any" when convergence is false', () => {
+    expect(getConvergenceType(false)).toBe('any');
+  });
+
+  test('should return "any" when convergence is null', () => {
+    expect(getConvergenceType(null)).toBe('any');
+  });
+
+  test('should return "any" when convergence is undefined', () => {
+    expect(getConvergenceType(undefined)).toBe('any');
+  });
+});
+
+describe('getResourceURL', () => {
+  test('should return job_templates URL for "job" type', () => {
+    expect(getResourceURL('job')).toBe(awxAPI`/job_templates/`);
+  });
+
+  test('should return job_templates URL for "job_template" type', () => {
+    expect(getResourceURL('job_template')).toBe(awxAPI`/job_templates/`);
+  });
+
+  test('should return workflow_job_templates URL for "workflow_job" type', () => {
+    expect(getResourceURL('workflow_job')).toBe(awxAPI`/workflow_job_templates/`);
+  });
+
+  test('should return workflow_job_templates URL for "workflow_job_template" type', () => {
+    expect(getResourceURL('workflow_job_template')).toBe(awxAPI`/workflow_job_templates/`);
+  });
+
+  test('should return inventory_sources URL for "inventory_update" type', () => {
+    expect(getResourceURL('inventory_update')).toBe(awxAPI`/inventory_sources`);
+  });
+
+  test('should return inventory_sources URL for "inventory_source" type', () => {
+    expect(getResourceURL('inventory_source')).toBe(awxAPI`/inventory_sources`);
+  });
+
+  test('should return projects URL for "project" type', () => {
+    expect(getResourceURL('project')).toBe(awxAPI`/projects/`);
+  });
+
+  test('should return projects URL for "project_update" type', () => {
+    expect(getResourceURL('project_update')).toBe(awxAPI`/projects/`);
+  });
+
+  test('should return system_job_templates URL for "system_job" type', () => {
+    expect(getResourceURL('system_job')).toBe(awxAPI`/system_job_templates/`);
+  });
+
+  test('should return system_job_templates URL for "system_job_template" type', () => {
+    expect(getResourceURL('system_job_template')).toBe(awxAPI`/system_job_templates/`);
+  });
+
+  test('should return empty string for "workflow_approval" type', () => {
+    expect(getResourceURL('workflow_approval')).toBe('');
+  });
+
+  test('should return empty string for unknown type', () => {
+    expect(getResourceURL('unknown_type')).toBe('');
+  });
+});
+
+describe('processSurvey', () => {
+  const mockSurveySpec: Survey = {
+    name: 'Test Survey',
+    description: '',
+    spec: [
+      {
+        variable: 'text_var',
+        type: 'text',
+        question_name: 'Text',
+        question_description: '',
+        required: false,
+        default: '',
+        min: 0,
+        max: 255,
+        choices: [],
+        new_question: false,
+      },
+      {
+        variable: 'password_var',
+        type: 'password',
+        question_name: 'Password',
+        question_description: '',
+        required: false,
+        default: '',
+        min: 0,
+        max: 255,
+        choices: [],
+        new_question: false,
+      },
+    ],
+  };
+
+  test('should merge null extra_vars with survey data and return YAML', () => {
+    const result = processSurvey(null, { my_var: 'value' }, null);
+    expect(result).toContain('my_var');
+    expect(result).toContain('value');
+  });
+
+  test('should merge extra_vars YAML with survey data', () => {
+    const result = processSurvey('extra_key: extra_val', { survey_key: 'survey_val' }, null);
+    expect(result).toContain('extra_key');
+    expect(result).toContain('survey_key');
+  });
+
+  test('should mask password fields when surveyConfig is provided', () => {
+    const result = processSurvey(
+      null,
+      { password_var: 'supersecret', text_var: 'visible' },
+      mockSurveySpec
+    );
+    expect(result).toContain('$encrypted$');
+    expect(result).not.toContain('supersecret');
+    expect(result).toContain('visible');
+  });
+
+  test('should not mask non-password fields', () => {
+    const result = processSurvey(null, { text_var: 'visible_value' }, mockSurveySpec);
+    expect(result).toContain('visible_value');
+  });
+
+  test('should not mask fields when surveyConfig is null', () => {
+    const result = processSurvey(null, { secret_field: 'plaintext' }, null);
+    expect(result).toContain('plaintext');
+  });
+
+  test('should allow survey data to override extra_vars keys', () => {
+    const result = processSurvey('my_key: from_vars', { my_key: 'from_survey' }, null);
+    expect(result).toContain('from_survey');
+    expect(result).not.toContain('from_vars');
+  });
+
+  test('should mask only variables present in survey answers', () => {
+    const result = processSurvey(null, { text_var: 'shown' }, mockSurveySpec);
+    expect(result).toContain('shown');
+    expect(result).not.toContain('$encrypted$');
+  });
+});

--- a/playwright/commands/toggleNodeKebab.ts
+++ b/playwright/commands/toggleNodeKebab.ts
@@ -8,8 +8,34 @@ import { Page } from '@playwright/test';
  * @param page
  */
 export async function toggleNodeKebab(nodeText: string, page: Page) {
-  await page
-    .locator('[class*="topology__node__label"]', { hasText: nodeText })
-    .locator('[class*="action-icon__icon"]')
-    .click();
+  // The topology canvas truncates long node labels in the DOM (e.g. "E2E jt-… abc1234").
+  // The unique UUID suffix (last word) is always preserved, so use it for reliable matching.
+  const uniqueSuffix = nodeText.split(' ').at(-1) ?? nodeText;
+
+  // Fit to screen so the target node is fully inside the canvas visible area.
+  // Without this the action icon can be clipped by pf-v6-c-drawer__main and mouse clicks miss.
+  const fitBtn = page.getByRole('button', { name: 'Fit to Screen' });
+  if (await fitBtn.isVisible()) {
+    await fitBtn.click();
+    // Wait for the canvas to finish re-rendering after the zoom/pan reset.
+    await page.waitForTimeout(1000);
+  }
+
+  const nodeLabel = page.locator('[class*="topology__node__label"]', { hasText: uniqueSuffix });
+  await nodeLabel.waitFor({ state: 'visible' });
+
+  // Use raw mouse movement so the SVG topology receives real pointer events.
+  const labelBox = await nodeLabel.boundingBox();
+  if (!labelBox) throw new Error(`Node label not found for: ${nodeText}`);
+  await page.mouse.move(labelBox.x + labelBox.width / 2, labelBox.y + labelBox.height / 2);
+
+  const icon = nodeLabel.locator('[class*="action-icon__icon"]');
+  await icon.waitFor({ state: 'visible' });
+  const iconBox = await icon.boundingBox();
+  if (!iconBox) throw new Error(`Action icon not found for node: ${nodeText}`);
+
+  // Move to icon center and click; retry once if menu doesn't open immediately
+  await page.mouse.move(iconBox.x + iconBox.width / 2, iconBox.y + iconBox.height / 2);
+  await page.waitForTimeout(200);
+  await page.mouse.click(iconBox.x + iconBox.width / 2, iconBox.y + iconBox.height / 2);
 }

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
@@ -1,0 +1,1212 @@
+import { expect, test } from '@playwright/test';
+import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
+import { awxAPI } from '@ansible/playwright/commands/apiClient';
+import { Credential, JobTemplate, WorkflowVisualizer } from '@ansible/playwright/utils';
+
+test.beforeEach(setupBefore({ path: '/execution/templates' }));
+test.afterEach(setupAfter);
+test.setTimeout(5 * 60 * 1000);
+
+interface WFNode {
+  id: number;
+  extra_data: Record<string, unknown>;
+  skip_tags: string;
+  job_tags: string;
+  summary_fields?: { unified_job_template?: { id: number; name: string } };
+}
+
+interface WFNodeList {
+  results: WFNode[];
+}
+
+interface CredList {
+  count: number;
+  results: { id: number; name: string }[];
+}
+
+interface WFJTList {
+  results: { id: number }[];
+}
+
+async function getWorkflowNode(page: import('@playwright/test').Page, wfjtName: string) {
+  const wfjtList = (await awxAPI.get(page, 'workflow_job_templates/', {
+    params: { name: wfjtName },
+  })) as WFJTList;
+  const wfjtId = wfjtList.results[0].id;
+  const nodes = (await awxAPI.get(
+    page,
+    `workflow_job_templates/${wfjtId}/workflow_nodes/`
+  )) as WFNodeList;
+  return nodes.results[0];
+}
+
+async function getNodeCredentials(page: import('@playwright/test').Page, nodeId: number) {
+  return (await awxAPI.get(page, `workflow_job_template_nodes/${nodeId}/credentials/`)) as CredList;
+}
+
+/**
+ * Open the edit wizard for a node. Interacts with the topology canvas to
+ * select the node and open the edit sidebar, then waits for the wizard
+ * form to fully load before returning.
+ */
+async function editNode(nodeText: string, page: import('@playwright/test').Page) {
+  const uniqueSuffix = nodeText.split(' ').at(-1) ?? nodeText;
+  const sidebar = page.getByTestId('workflow-topology-sidebar');
+
+  await page.getByRole('button', { name: 'Fit to Screen' }).click();
+  await page.waitForTimeout(1000);
+
+  const nodeLabel = page.locator('[class*="topology__node__label"]', { hasText: uniqueSuffix });
+  await nodeLabel.waitFor({ state: 'visible' });
+  const labelBox = await nodeLabel.boundingBox();
+  if (!labelBox) throw new Error(`Node label not found for: ${nodeText}`);
+
+  // Hover over the node label to reveal the action icon
+  await page.mouse.move(labelBox.x + labelBox.width / 2, labelBox.y + labelBox.height / 2);
+  const icon = nodeLabel.locator('[class*="action-icon__icon"]');
+  await icon.waitFor({ state: 'visible' });
+  const iconBox = await icon.boundingBox();
+  if (!iconBox) throw new Error(`Action icon not found for: ${nodeText}`);
+
+  // Click the action icon with raw mouse coordinates
+  await page.mouse.move(iconBox.x + iconBox.width / 2, iconBox.y + iconBox.height / 2);
+  await page.waitForTimeout(300);
+  await page.mouse.click(iconBox.x + iconBox.width / 2, iconBox.y + iconBox.height / 2);
+  await page.waitForTimeout(500);
+
+  // Check what opened: kebab context menu, sidebar view, or nothing
+  const editMenuItem = page.getByRole('menuitem', { name: 'Edit step' });
+  const editButton = page.getByTestId('edit-node');
+
+  if (await editMenuItem.isVisible({ timeout: 3000 }).catch(() => false)) {
+    // Context menu opened — click "Edit step" to enter edit mode
+    await editMenuItem.click();
+  } else if (await editButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+    // Sidebar view opened — click the Edit button to enter edit mode
+    await editButton.click();
+  } else {
+    // Nothing opened — try clicking the label directly to open sidebar
+    await page.mouse.click(labelBox.x + labelBox.width / 2, labelBox.y + labelBox.height / 2);
+    await page.waitForTimeout(1000);
+    await editButton.click({ timeout: 5000 });
+  }
+
+  // Wait for the wizard form to fully load inside the sidebar.
+  // The NodeEditWizard fetches initial values async (launch config,
+  // node credentials, labels, instance groups) — the wizard renders
+  // null until all fetches complete. Wait for the form content to appear,
+  // then wait for in-flight network requests to settle.
+  await sidebar
+    .getByRole('button', { name: 'Job template', exact: true })
+    .waitFor({ state: 'visible', timeout: 30000 });
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('Workflow Visualizer - Template Switch', () => {
+  // ---------------------------------------------------------------------------
+  // Scenario 1: A-prompts + defaults (no overrides) → B-no-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 1: should save cleanly when switching from a prompts template (defaults only) to a no-prompts template',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s1-prompts');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s1-noprompt');
+      const templateB = await JobTemplate.api.create(page, { name: templateBName });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A — accept defaults, don't set any prompt values
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s1EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s1EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.getByRole('navigation', { name: 'Steps' }).getByRole('button', { name: 'Prompts' })
+      ).not.toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      // Save — should succeed without errors
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2: A-prompts + credential override → B-no-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 2: should disassociate credential when switching from a template with credential override to one with no prompts',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s2-prompts');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+        ask_skip_tags_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s2-noprompt');
+      const templateB = await JobTemplate.api.create(page, { name: templateBName });
+
+      const credentialName = createE2EName('cred-s2');
+      const credential = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName,
+        username: 'testuser',
+        password: 'testpass',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A and set credential
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credentialName);
+      await page.getByRole('checkbox', { name: credentialName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (no prompts)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s2EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s2EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.getByRole('navigation', { name: 'Steps' }).getByRole('button', { name: 'Prompts' })
+      ).not.toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+      await page.waitForTimeout(1000);
+
+      // Save — the bug would cause a 400 error here
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: credential disassociated
+      const node = await getWorkflowNode(page, wfjt);
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credential);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: A-prompts + extra_vars override → B-no-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 3: should clear extra_vars when switching to a template with no prompts',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s3-vars');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_variables_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s3-novars');
+      const templateB = await JobTemplate.api.create(page, { name: templateBName });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A and set extra_vars
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('textbox', { name: 'Editor content' }).fill('my_var: test_value');
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s3EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s3EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.getByRole('navigation', { name: 'Steps' }).getByRole('button', { name: 'Prompts' })
+      ).not.toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: extra_data is empty
+      const node = await getWorkflowNode(page, wfjt);
+      expect(Object.keys(node.extra_data)).toHaveLength(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 4: A-prompts + multiple overrides → B-partial-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 4: should clear stale fields when switching to a template with only partial prompts',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s4-full');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+        ask_skip_tags_on_launch: true,
+      });
+
+      // Template B has only ask_credential_on_launch — not vars or tags
+      const templateBName = createE2EName('jt-s4-partial');
+      const templateB = await JobTemplate.api.create(page, {
+        name: templateBName,
+        ask_credential_on_launch: true,
+      });
+
+      const credentialName = createE2EName('cred-s4');
+      const credential = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName,
+        username: 'testuser',
+        password: 'testpass',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A — set credential, extra_vars, skip_tags
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      // Set credential
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credentialName);
+      await page.getByRole('checkbox', { name: credentialName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      // Set extra_vars
+      await page.getByRole('textbox', { name: 'Editor content' }).fill('stale_var: old_value');
+      // Set skip_tags
+      await page.getByRole('textbox', { name: 'Type to filter' }).last().click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).last().fill('stale_tag');
+      await page.getByRole('option', { name: 'Create "stale_tag"' }).click();
+
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (partial prompts: only credential)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s4EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s4EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+      // Template B has prompts but only credential — skip_tags and vars should be absent
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: skip_tags cleared, extra_data cleared, old credential disassociated
+      const node = await getWorkflowNode(page, wfjt);
+      expect(node.skip_tags ?? '').toBe('');
+      expect(Object.keys(node.extra_data ?? {})).toHaveLength(0);
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credential);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 5: A-prompts + credential override → B-same-prompts (credential
+  //             field should not be pre-filled with old credential)
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 5: should show empty credential field when switching to another template with the same prompt flags',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s5-a');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s5-b');
+      const templateB = await JobTemplate.api.create(page, {
+        name: templateBName,
+        ask_credential_on_launch: true,
+      });
+
+      const credentialName = createE2EName('cred-s5');
+      const credential = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName,
+        username: 'testuser',
+        password: 'testpass',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A and set credential
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credentialName);
+      await page.getByRole('checkbox', { name: credentialName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (same prompt flags)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s5EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s5EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+
+      // Navigate to Prompts, then wait for the credential to clear. NodeTypeStep calls
+      // setValue AFTER both the launch-config and credentials fetches complete; using a
+      // generous timeout lets the async reset propagate before we assert.
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await expect(page.getByRole('button', { name: 'Credentials' })).not.toContainText(
+        credentialName,
+        { timeout: 15000 }
+      );
+
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: no credential on node
+      const node = await getWorkflowNode(page, wfjt);
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credential);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 6: A-prompts + extra_vars override → B-same-prompts
+  //             (extra_vars field should show empty in prompt step)
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 6: should show empty extra_vars when switching to another template with ask_variables_on_launch',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s6-a');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_variables_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s6-b');
+      const templateB = await JobTemplate.api.create(page, {
+        name: templateBName,
+        ask_variables_on_launch: true,
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A and set extra_vars
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('textbox', { name: 'Editor content' }).fill('old_var: stale_value');
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (same prompt flags)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s6EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s6EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+
+      // Navigate to Prompts then wait for the extra_vars editor to clear.
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await expect(page.getByRole('textbox', { name: 'Editor content' })).not.toHaveValue(
+        /old_var/,
+        { timeout: 15000 }
+      );
+
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: extra_data cleared
+      const node = await getWorkflowNode(page, wfjt);
+      expect(Object.keys(node.extra_data)).toHaveLength(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 7: A-prompts + overrides → B-same-prompts, user sets new values
+  //             → new values saved correctly (not overridden by stale data)
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 7: should save user-entered values for the new template, not stale values from the old one',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s7-a');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s7-b');
+      const templateB = await JobTemplate.api.create(page, {
+        name: templateBName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+      });
+
+      const oldCredName = createE2EName('cred-s7-old');
+      const oldCred = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName: oldCredName,
+        username: 'old',
+        password: 'old',
+      });
+
+      const newCredName = createE2EName('cred-s7-new');
+      const newCred = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName: newCredName,
+        username: 'new',
+        password: 'new',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A — set old credential and extra_vars
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(oldCredName);
+      await page.getByRole('checkbox', { name: oldCredName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Editor content' }).fill('old_var: old');
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B and set NEW values
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s7EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s7EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+
+      // Prompts step for Template B — set new credential and extra_vars
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(newCredName);
+      await page.getByRole('checkbox', { name: newCredName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Editor content' }).fill('new_var: fresh');
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: new credential, new extra_data
+      const node = await getWorkflowNode(page, wfjt);
+      expect(node.extra_data).toEqual({ new_var: 'fresh' });
+
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(1);
+      expect(nodeCreds.results[0].name).toBe(newCredName);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, oldCred);
+      await Credential.ui.delete(page, newCred);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 8: A-no-prompts + defaults → B-no-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 8: should save cleanly when switching between two templates with no prompts',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s8-a');
+      const templateA = await JobTemplate.api.create(page, { name: templateAName });
+
+      const templateBName = createE2EName('jt-s8-b');
+      const templateB = await JobTemplate.api.create(page, { name: templateBName });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A (no prompts)
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (also no prompts)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s8EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s8EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.getByRole('navigation', { name: 'Steps' }).getByRole('button', { name: 'Prompts' })
+      ).not.toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      // Save — should succeed cleanly
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 9: A-no-prompts + orphaned credentials → B-no-prompts
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 9: should disassociate orphaned credentials when switching between no-prompts templates',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      // Create a template with prompts first, to let us set credentials on the node
+      const tempPromptName = createE2EName('jt-s9-tmp');
+      const tempPrompt = await JobTemplate.api.create(page, {
+        name: tempPromptName,
+        ask_credential_on_launch: true,
+      });
+
+      const templateBName = createE2EName('jt-s9-noprompt');
+      const templateB = await JobTemplate.api.create(page, { name: templateBName });
+
+      const credentialName = createE2EName('cred-s9');
+      const credential = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName,
+        username: 'testuser',
+        password: 'testpass',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with the prompts template and set a credential
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(tempPromptName);
+      await page.getByRole('option', { name: tempPromptName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credentialName);
+      await page.getByRole('checkbox', { name: credentialName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Via API, change the template to remove prompts — now credential is orphaned
+      await awxAPI.patch(page, `job_templates/${tempPrompt.id}/`, {
+        ask_credential_on_launch: false,
+      });
+
+      // Reload the visualizer so it picks up the updated template
+      await WorkflowVisualizer.ui.navigateToVisualizer(page, wfjt);
+
+      // Edit node — switch to Template B (also no prompts)
+      await editNode(tempPromptName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s9EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s9EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.getByRole('navigation', { name: 'Steps' }).getByRole('button', { name: 'Prompts' })
+      ).not.toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      // Save — should succeed, orphaned credential disassociated
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: orphaned credential gone
+      const node = await getWorkflowNode(page, wfjt);
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(0);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credential);
+      await JobTemplate.api.delete(page, tempPrompt.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 10: A-prompts + overrides → same template (no switch)
+  //              All original values preserved
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 10: should preserve all prompt values when editing a node without changing the template',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s10');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+        ask_skip_tags_on_launch: true,
+      });
+
+      const credentialName = createE2EName('cred-s10');
+      const credential = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName,
+        username: 'testuser',
+        password: 'testpass',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A — set credential and skip_tags
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credentialName);
+      await page.getByRole('checkbox', { name: credentialName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).last().click();
+      await page.getByRole('textbox', { name: 'Type to filter' }).last().fill('keep_tag');
+      await page.getByRole('option', { name: 'Create "keep_tag"' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node WITHOUT changing template — just open, navigate through, finish
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await expect(page.getByRole('button', { name: 'Credentials' })).toContainText(credentialName);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      // Save — should succeed
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: values preserved
+      const node = await getWorkflowNode(page, wfjt);
+      expect(node.skip_tags).toContain('keep_tag');
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBeGreaterThanOrEqual(1);
+      expect(nodeCreds.results.some((c) => c.name === credentialName)).toBe(true);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credential);
+      await JobTemplate.api.delete(page, templateA.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 11: A-prompts + overrides → same template, user changes credential
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 11: should update only the changed credential when editing without switching templates',
+    { tag: ['@not_mock', '@tier1'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s11');
+      const templateA = await JobTemplate.api.create(page, {
+        name: templateAName,
+        ask_credential_on_launch: true,
+      });
+
+      const credAName = createE2EName('cred-s11-A');
+      const credA = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName: credAName,
+        username: 'userA',
+        password: 'passA',
+      });
+
+      const credBName = createE2EName('cred-s11-B');
+      const credB = await Credential.ui.create(page, {
+        credentialType: 'Machine',
+        credentialName: credBName,
+        username: 'userB',
+        password: 'passB',
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A and credential A
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
+
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credAName);
+      await page.getByRole('checkbox', { name: credAName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — same template, swap credential A for B
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+      await page.getByRole('button', { name: 'Prompts' }).click();
+
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('checkbox', { name: credAName }).uncheck();
+      await page.getByRole('textbox', { name: 'Search input' }).clear();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(credBName);
+      await page.getByRole('checkbox', { name: credBName }).check();
+      await page.getByRole('button', { name: 'Credentials' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Verify via API: only credential B
+      const node = await getWorkflowNode(page, wfjt);
+      const nodeCreds = await getNodeCredentials(page, node.id);
+      expect(nodeCreds.count).toBe(1);
+      expect(nodeCreds.results[0].name).toBe(credBName);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await Credential.ui.delete(page, credA);
+      await Credential.ui.delete(page, credB);
+      await JobTemplate.api.delete(page, templateA.id);
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Scenario 12: A-no-prompts + defaults → B-prompts
+  //              Prompt step shows new template defaults, no stale data
+  // ---------------------------------------------------------------------------
+  test(
+    'Scenario 12: should show fresh prompt defaults when switching from a no-prompts template to one with prompts',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      const templateAName = createE2EName('jt-s12-noprompt');
+      const templateA = await JobTemplate.api.create(page, { name: templateAName });
+
+      const templateBName = createE2EName('jt-s12-prompts');
+      const templateB = await JobTemplate.api.create(page, {
+        name: templateBName,
+        ask_credential_on_launch: true,
+        ask_variables_on_launch: true,
+        ask_skip_tags_on_launch: true,
+      });
+
+      const wfjt = await WorkflowVisualizer.ui.createWorkflowJobTemplate(page);
+
+      // Add node with Template A (no prompts)
+      await expect(page.getByRole('button', { name: 'Add step' }).nth(1)).toBeVisible();
+      await page.getByRole('button', { name: 'Add step' }).nth(1).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('option', { name: 'Job Template', exact: true }).click();
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateAName);
+      await page.getByRole('option', { name: templateAName }).click();
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Edit node — switch to Template B (has prompts)
+      await editNode(templateAName, page);
+      await page.getByRole('button', { name: 'Job template', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(templateBName);
+      const s12EditLaunchConfig = page.waitForResponse(
+        (resp) => resp.url().includes('/launch/') && resp.status() === 200
+      );
+      await page.getByRole('option', { name: templateBName }).click();
+      await s12EditLaunchConfig;
+      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Next' }).click({ force: true });
+
+      // Verify: Prompts step should appear with default/empty state
+      await page.getByRole('button', { name: 'Prompts' }).click();
+      await expect(page.getByRole('button', { name: 'Credentials' })).toBeVisible();
+      // Credential selector should show empty placeholder (no stale data from a prior template).
+      // Check for "Select credentials" text — the placeholder shown when no credential is selected.
+      await expect(page.getByRole('button', { name: 'Credentials' })).toContainText(
+        'Select credentials'
+      );
+
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.waitForTimeout(500);
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      // Save — should succeed
+      await page.getByRole('button', { name: 'Fit to Screen' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await expect(page.getByText('Successfully saved workflow visualizer')).toBeVisible();
+      // Wait for the toast to auto-dismiss (5s timeout + animation buffer)
+      await page.mouse.move(0, 0);
+      await page.waitForTimeout(6000);
+
+      // Cleanup
+      await WorkflowVisualizer.ui.removeAllWorkflowVizNodes(page);
+      await WorkflowVisualizer.ui.deleteWorkflowJobTemplate(page, wfjt);
+      await JobTemplate.api.delete(page, templateA.id);
+      await JobTemplate.api.delete(page, templateB.id);
+    }
+  );
+});

--- a/playwright/utils/jobTemplate.ts
+++ b/playwright/utils/jobTemplate.ts
@@ -47,6 +47,17 @@ export interface CreateJobTemplateAPIOptions {
   labels?: string[];
 }
 
+async function lookupDemoProjectId(page: Page): Promise<number> {
+  const result = await awxAPI.get<{ results: { id: number; name: string }[] }>(page, 'projects/', {
+    params: { name: 'Demo Project' },
+  });
+  const match = result?.results?.find((p) => p.name === 'Demo Project');
+  if (!match) {
+    throw new Error('Demo Project not found on this server — specify a projectId explicitly');
+  }
+  return match.id;
+}
+
 export const JobTemplate = {
   api: {
     create: async (
@@ -55,12 +66,13 @@ export const JobTemplate = {
     ): Promise<JobTemplateType> => {
       const name = options.name ?? `e2e-job-template-${Date.now()}`;
       const playbook = options.playbook ?? 'hello_world.yml';
+      const projectId = options.projectId ?? (await lookupDemoProjectId(page));
 
       const jobTemplate = await awxAPI.post<JobTemplateType>(page, 'job_templates/', {
         name,
         job_type: 'run',
         inventory: options.inventoryId ?? 1,
-        project: options.projectId ?? 6,
+        project: projectId,
         playbook,
         ask_inventory_on_launch: options.ask_inventory_on_launch ?? false,
         ask_credential_on_launch: options.ask_credential_on_launch ?? false,


### PR DESCRIPTION
## Summary

Fixes a bug where switching a workflow visualizer node's template carried over stale prompt values (credentials, labels, instance groups, extra vars, tags) from the previously selected template. This caused incorrect job runs or API 400 errors when the new template didn't support those fields.

Key changes:
- Track template changes via `prevResourceIdRef` in `NodeTypeStep` to distinguish initial loads from user-initiated switches; clear prompt step data immediately on switch
- Split `processLabels`/`processInstanceGroups`/`processCredentials` in `useSaveVisualizer` into ordered disassociate → PATCH → associate phases so AWX accepts the template change
- Extract `buildEffectivePrompt`, `clearStaleNodeFields`, and `getAddedAndRemovedCredentials` into standalone, unit-tested modules

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. -->

### Manual Testing

Minimal Happy Path:

1. Open a workflow visualizer and edit an existing node that uses a Job Template with prompted credentials/inventory
2. Switch the node's template to a different Job Template (one without `ask_credential_on_launch`)
3. Verify the Prompts step clears stale values and shows/hides correctly based on the new template's launch config
4. Save the workflow and confirm no API errors occur
5. Re-open the node and verify only the new template's defaults are present — no leftover credentials, labels, or instance groups from the old template

Full field-by-field test matrix: https://docs.google.com/spreadsheets/d/143agtJG6Pw2H-g4_G_uVMyWfh6002vLjKPGRyFRaGE0/edit?usp=sharing
