### PR TITLE
Correct UNTIL timezone calculation

### DIFF
--- a/frontend/awx/views/schedules/components/RuleForm.test.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuleFields, ScheduleFormWizard } from '../types';
 import { RuleForm, pad } from './RuleForm';
 
@@ -314,6 +314,10 @@ describe('RuleForm', () => {
   });
 
   describe('until handling', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('should set UNTIL in UTC and append Z suffix when both until date and time are provided', async () => {
       // Arrange
       const user = userEvent.setup();
@@ -330,11 +334,11 @@ describe('RuleForm', () => {
       // Act
       await user.click(screen.getByTestId('add-rule-button'));
 
-      // Assert: UNTIL is in UTC with the RFC5545 required Z suffix
+      // Assert: UNTIL is converted to UTC (10:00 EDT = 14:00 UTC) with Z suffix
       expect(setIsOpen).toHaveBeenCalledWith(false);
       await waitFor(() => {
         const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
-        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+        expect(rulesContent).toContain('UNTIL=20250601T140000Z');
       });
     });
 
@@ -352,16 +356,18 @@ describe('RuleForm', () => {
       // Act
       await user.click(screen.getByTestId('add-rule-button'));
 
-      // Assert: UNTIL derived from midnight in schedule timezone, with Z suffix
+      // Assert: midnight EDT (UTC-4) = 04:00 UTC with Z suffix
       expect(setIsOpen).toHaveBeenCalledWith(false);
       await waitFor(() => {
         const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
-        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+        expect(rulesContent).toContain('UNTIL=20250601T040000Z');
       });
     });
 
     it("should use tomorrow's date in the schedule timezone when only until time is provided", async () => {
       // Arrange
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2025-05-31T00:00:00Z'));
       const user = userEvent.setup();
       const setIsOpen = vi.fn();
       render(
@@ -374,11 +380,11 @@ describe('RuleForm', () => {
       // Act
       await user.click(screen.getByTestId('add-rule-button'));
 
-      // Assert: UNTIL derived from tomorrow in schedule timezone, with Z suffix
+      // Assert: 2025-05-31 10:00 EDT (UTC-4) = 14:00 UTC with Z suffix
       expect(setIsOpen).toHaveBeenCalledWith(false);
       await waitFor(() => {
         const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
-        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+        expect(rulesContent).toContain('UNTIL=20250531T140000Z');
       });
     });
   });

--- a/frontend/awx/views/schedules/components/RuleForm.test.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.test.tsx
@@ -3,26 +3,44 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FormProvider, useForm } from 'react-hook-form';
-import { describe, expect, it, vi } from 'vitest';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuleFields, ScheduleFormWizard } from '../types';
-import { RuleForm } from './RuleForm';
+import { RuleForm, pad } from './RuleForm';
+
+const mockUsePageWizard = vi.hoisted(() => vi.fn());
 
 vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
-  usePageWizard: () => ({
-    activeStep: { id: 'rules' },
-    wizardData: {
-      timezone: 'America/New_York',
-      startDateTime: { date: '2025-01-15', time: '10:00' },
-    } as ScheduleFormWizard,
-  }),
+  usePageWizard: mockUsePageWizard,
 }));
 
 vi.mock('../hooks/useGet24HourTime', () => ({
   useGet24HourTime: () => () => ({ hour: 10, minute: 0 }),
 }));
 
-function TestWrapper({ children }: { children: React.ReactNode }) {
+const defaultWizardData = {
+  activeStep: { id: 'rules' },
+  wizardData: {
+    timezone: 'America/New_York',
+    startDateTime: { date: '2025-01-15', time: '10:00' },
+  } as ScheduleFormWizard,
+};
+
+function FormSpy() {
+  const rules = useWatch({ name: 'rules' }) as RuleFields['rules'];
+  const exceptions = useWatch({ name: 'exceptions' }) as RuleFields['exceptions'];
+  return (
+    <>
+      <pre data-testid="form-rules">{JSON.stringify(rules)}</pre>
+      <pre data-testid="form-exceptions">{JSON.stringify(exceptions)}</pre>
+    </>
+  );
+}
+
+function TestWrapper({
+  children,
+  defaultValues,
+}: Readonly<{ children: React.ReactNode; defaultValues?: Partial<RuleFields> }>) {
   const methods = useForm<RuleFields>({
     defaultValues: {
       freq: 2,
@@ -31,13 +49,34 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
       rules: [],
       exceptions: [],
       endType: 'never',
+      until: null,
+      ...defaultValues,
     },
   });
   return <FormProvider {...methods}>{children}</FormProvider>;
 }
 
+describe('pad', () => {
+  it('should pad single-digit numbers with a leading zero', () => {
+    expect(pad(5)).toBe('05');
+  });
+
+  it('should return double-digit numbers unchanged', () => {
+    expect(pad(10)).toBe(10);
+  });
+
+  it('should return strings unchanged', () => {
+    // The runtime guard handles string inputs despite the number type signature
+    expect(pad('abc' as unknown as number)).toBe('abc');
+  });
+});
+
 describe('RuleForm', () => {
   const ruleFormTitle = 'Define rules';
+
+  beforeEach(() => {
+    mockUsePageWizard.mockReturnValue(defaultWizardData);
+  });
 
   it('should render Frequency label', () => {
     render(
@@ -77,35 +116,342 @@ describe('RuleForm', () => {
       </TestWrapper>
     );
 
-    // Find the Occurrences label
     const occurrencesLabel = screen.getByText('Occurrences');
     expect(occurrencesLabel).toBeInTheDocument();
 
-    // Find the help button that's near the Occurrences label
-    // In the DOM, the help button is rendered after the label within the same form group
     const occurrencesFormGroup = occurrencesLabel.closest('.pf-v6-c-form__group');
     const helpButton = occurrencesFormGroup?.querySelector('button[type="button"]');
 
     expect(helpButton).toBeInTheDocument();
 
-    // Click the help icon to open the popover
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     await user.click(helpButton!);
 
-    // Wait for popover to appear and verify new user-friendly text is present
     await waitFor(() => {
       expect(
         screen.getByText(/Filter which occurrences to include within each recurrence interval/i)
       ).toBeInTheDocument();
     });
 
-    // Verify it explains positive and negative numbers
     expect(
       screen.getByText(/Use positive numbers \(1, 2, 3\.\.\.\) to select from the beginning/i)
     ).toBeInTheDocument();
 
-    // Verify the old confusing text is NOT present
     expect(screen.queryByText(/iCalendar RFC/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/bysetpos field/i)).not.toBeInTheDocument();
+  });
+
+  describe('conditional rendering', () => {
+    it('should show Count input when endType is count', () => {
+      render(
+        <TestWrapper defaultValues={{ endType: 'count' }}>
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={() => {}} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByRole('spinbutton', { name: 'Count' })).toBeInTheDocument();
+    });
+
+    it('should show Until date picker when endType is until', () => {
+      render(
+        <TestWrapper defaultValues={{ endType: 'until' }}>
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={() => {}} />
+        </TestWrapper>
+      );
+
+      // Both the dropdown toggle (selected value) and the date picker field label render "Until".
+      // Verify the form label specifically, which only renders when the date picker is shown.
+      const untilElements = screen.getAllByText('Until');
+      expect(untilElements.some((el) => el.classList.contains('pf-v6-c-form__label-text'))).toBe(
+        true
+      );
+    });
+
+    it('should not show Count or Until fields when endType is never', () => {
+      render(
+        <TestWrapper defaultValues={{ endType: 'never' }}>
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={() => {}} />
+        </TestWrapper>
+      );
+
+      expect(screen.queryByRole('spinbutton', { name: 'Count' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Save button', () => {
+    it('should show the Save rule button for a new rule', () => {
+      render(
+        <TestWrapper>
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={() => {}} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('add-rule-button')).toBeInTheDocument();
+    });
+
+    it('should add a new rule and close the form when saving', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper>
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('add-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
+        expect(JSON.parse(rulesContent)).toHaveLength(1);
+      });
+    });
+
+    it('should show the Update rule button when editing an existing rule', () => {
+      render(
+        <TestWrapper>
+          <RuleForm title={ruleFormTitle} isOpen={1} setIsOpen={() => {}} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByTestId('update-rule-button')).toBeInTheDocument();
+    });
+
+    it('should close the form when updating an existing rule', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper>
+          <RuleForm title={ruleFormTitle} isOpen={1} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('update-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('should find and replace an existing rule by id when updating in the rules step', async () => {
+      // Arrange — pre-populate the rules array so the findIndex callback actually executes
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      const existingRule = { id: 1, rule: 'RRULE:FREQ=DAILY' };
+      render(
+        <TestWrapper defaultValues={{ rules: [existingRule] }}>
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={1} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('update-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('should find and replace an existing exception by id when updating in the exceptions step', async () => {
+      // Arrange — pre-populate exceptions so the findIndex callback actually executes
+      mockUsePageWizard.mockReturnValue({
+        activeStep: { id: 'exceptions' },
+        wizardData: {
+          timezone: 'America/New_York',
+          startDateTime: { date: '2025-01-15', time: '10:00' },
+        } as ScheduleFormWizard,
+      });
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      const existingException = { id: 1, rule: 'RRULE:FREQ=DAILY' };
+      render(
+        <TestWrapper defaultValues={{ exceptions: [existingException] }}>
+          <FormSpy />
+          <RuleForm title="Define exceptions" isOpen={1} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('update-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('should add a new exception and close the form when in the exceptions step', async () => {
+      // Arrange
+      mockUsePageWizard.mockReturnValue({
+        activeStep: { id: 'exceptions' },
+        wizardData: {
+          timezone: 'America/New_York',
+          startDateTime: { date: '2025-01-15', time: '10:00' },
+        } as ScheduleFormWizard,
+      });
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper>
+          <FormSpy />
+          <RuleForm title="Define exceptions" isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('add-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const exceptionsContent = screen.getByTestId('form-exceptions').textContent ?? '';
+        expect(JSON.parse(exceptionsContent)).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('until handling', () => {
+    it('should set UNTIL in UTC and append Z suffix when both until date and time are provided', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper
+          defaultValues={{ endType: 'until', until: { date: '2025-06-01', time: '2:00 PM' } }}
+        >
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('add-rule-button'));
+
+      // Assert: UNTIL is in UTC with the RFC5545 required Z suffix
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
+        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+      });
+    });
+
+    it('should use midnight in the schedule timezone when only until date is provided', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper defaultValues={{ endType: 'until', until: { date: '2025-06-01', time: '' } }}>
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('add-rule-button'));
+
+      // Assert: UNTIL derived from midnight in schedule timezone, with Z suffix
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
+        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+      });
+    });
+
+    it("should use tomorrow's date in the schedule timezone when only until time is provided", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper defaultValues={{ endType: 'until', until: { date: '', time: '2:00 PM' } }}>
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('add-rule-button'));
+
+      // Assert: UNTIL derived from tomorrow in schedule timezone, with Z suffix
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
+        expect(rulesContent).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+      });
+    });
+  });
+
+  describe('Discard button', () => {
+    it('should close the form without saving when discarding', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      render(
+        <TestWrapper>
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('discard-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('should preserve the existing rules array when discarding from the rules step', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      const existingRules = [{ id: 1, rule: 'RRULE:FREQ=DAILY' }];
+      render(
+        <TestWrapper defaultValues={{ rules: existingRules }}>
+          <FormSpy />
+          <RuleForm title={ruleFormTitle} isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('discard-rule-button'));
+
+      // Assert: discard resets the form, keeping the existing rules intact
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const rulesContent = screen.getByTestId('form-rules').textContent ?? '';
+        expect(JSON.parse(rulesContent)).toEqual(existingRules);
+      });
+    });
+
+    it('should preserve the existing exceptions array when discarding from the exceptions step', async () => {
+      // Arrange
+      mockUsePageWizard.mockReturnValue({
+        activeStep: { id: 'exceptions' },
+        wizardData: {
+          timezone: 'America/New_York',
+          startDateTime: { date: '2025-01-15', time: '10:00' },
+        } as ScheduleFormWizard,
+      });
+      const user = userEvent.setup();
+      const setIsOpen = vi.fn();
+      const existingExceptions = [{ id: 1, rule: 'RRULE:FREQ=DAILY' }];
+      render(
+        <TestWrapper defaultValues={{ exceptions: existingExceptions }}>
+          <FormSpy />
+          <RuleForm title="Define exceptions" isOpen={false} setIsOpen={setIsOpen} />
+        </TestWrapper>
+      );
+
+      // Act
+      await user.click(screen.getByTestId('discard-rule-button'));
+
+      // Assert
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+      await waitFor(() => {
+        const exceptionsContent = screen.getByTestId('form-exceptions').textContent ?? '';
+        expect(JSON.parse(exceptionsContent)).toEqual(existingExceptions);
+      });
+    });
   });
 });

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -106,7 +106,8 @@ export function RuleForm(
       }
     }
 
-    const itemId = ruleId ? ruleId : isRulesStep ? rules.length + 1 : exceptions.length + 1;
+    const newItemId = isRulesStep ? rules.length + 1 : exceptions.length + 1;
+    const itemId = ruleId || newItemId;
     const ruleObject = {
       rule: ensureUntilZSuffix(RRule.optionsToString({ ...rule.origOptions })),
       id: itemId,

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -106,11 +106,7 @@ export function RuleForm(
       }
     }
 
-    const itemId = ruleId
-      ? ruleId
-      : isRulesStep
-        ? rules.length + 1 || 1
-        : exceptions.length + 1 || 1;
+    const itemId = ruleId ? ruleId : isRulesStep ? rules.length + 1 : exceptions.length + 1;
     const ruleObject = {
       rule: ensureUntilZSuffix(RRule.optionsToString({ ...rule.origOptions })),
       id: itemId,

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -11,6 +11,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { RRule, datetime } from 'rrule';
 import {
+  ensureUntilZSuffix,
   useGetFrequencyOptions,
   useGetMonthOptions,
   useGetWeekdayOptions,
@@ -110,15 +111,10 @@ export function RuleForm(
       : isRulesStep
         ? rules.length + 1 || 1
         : exceptions.length + 1 || 1;
-    let ruleString = RRule.optionsToString({ ...rule.origOptions });
-
-    // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
-    // The rrule library doesn't add the Z suffix automatically, so we add it manually
-    if (ruleString.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
-      ruleString = ruleString.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
-    }
-
-    const ruleObject = { rule: ruleString, id: itemId };
+    const ruleObject = {
+      rule: ensureUntilZSuffix(RRule.optionsToString({ ...rule.origOptions })),
+      id: itemId,
+    };
     const index = isRulesStep
       ? rules.findIndex((r) => r.id === ruleId)
       : exceptions.findIndex((r) => r.id === ruleId);

--- a/frontend/awx/views/schedules/components/RuleForm.tsx
+++ b/frontend/awx/views/schedules/components/RuleForm.tsx
@@ -74,25 +74,28 @@ export function RuleForm(
       const untilTime = until?.time;
       const untilDate = until?.date;
       if (untilDate && untilTime) {
-        const utcDate = DateTime.fromISO(`${untilDate}`).set(get24Hour(untilTime)).toUTC();
+        const utcDate = DateTime.fromISO(`${untilDate}`, { zone: timezone })
+          .set(get24Hour(untilTime))
+          .toUTC();
         const { year, month, day, hour, minute } = utcDate;
         rule.origOptions.until = datetime(year, month, day, hour, minute);
       } else {
         if (untilDate) {
           // This block is used when the user enters a date, but no time.
-          // We use the date given, and the current time based on the timezone given
-          // in the first step, or default to America/New_York.
+          // We use midnight in the schedule's timezone, not browser timezone.
 
-          const utcDate = DateTime.fromISO(`${untilDate}`).toUTC();
+          const utcDate = DateTime.fromISO(`${untilDate}`, { zone: timezone })
+            .startOf('day')
+            .toUTC();
           const { year, day, month, hour, minute } = utcDate;
           rule.origOptions.until = datetime(year, month, day, hour, minute);
         }
         if (untilTime) {
           // This block is used when the user enters a time, but no date.
-          // We use the time given, and the tomorrow's date based on the timezone given
-          // in the first step, or default to America/New_York.
+          // We use tomorrow's date in the schedule's timezone, not browser timezone.
 
           const { year, day, month, hour, minute } = DateTime.now()
+            .setZone(timezone)
             .plus({ days: 1 })
             .set(get24Hour(untilTime))
             .toUTC();
@@ -107,7 +110,15 @@ export function RuleForm(
       : isRulesStep
         ? rules.length + 1 || 1
         : exceptions.length + 1 || 1;
-    const ruleObject = { rule: RRule.optionsToString({ ...rule.origOptions }), id: itemId };
+    let ruleString = RRule.optionsToString({ ...rule.origOptions });
+
+    // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
+    // The rrule library doesn't add the Z suffix automatically, so we add it manually
+    if (ruleString.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
+      ruleString = ruleString.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
+    }
+
+    const ruleObject = { rule: ruleString, id: itemId };
     const index = isRulesStep
       ? rules.findIndex((r) => r.id === ruleId)
       : exceptions.findIndex((r) => r.id === ruleId);

--- a/frontend/awx/views/schedules/hooks/ruleHelpers.test.tsx
+++ b/frontend/awx/views/schedules/hooks/ruleHelpers.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { LaunchConfiguration } from '../../../interfaces/LaunchConfiguration';
 import type { PromptFormValues } from '../../../resources/templates/WorkflowVisualizer/types';
 import {
+  ensureUntilZSuffix,
   mungePromptData,
   mungeSurveyAndExtraVarsData,
   normalizeOptions,
@@ -186,6 +187,39 @@ describe('useGetMonthOptions', () => {
     expect(result.current).toHaveLength(12);
     expect(result.current[0]).toEqual({ value: 1, label: 'January' });
     expect(result.current[11]).toEqual({ value: 12, label: 'December' });
+  });
+});
+
+describe('ensureUntilZSuffix', () => {
+  it('should return empty string unchanged', () => {
+    expect(ensureUntilZSuffix('')).toBe('');
+  });
+
+  it('should return string with no UNTIL unchanged', () => {
+    const input = 'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;COUNT=5';
+    expect(ensureUntilZSuffix(input)).toBe(input);
+  });
+
+  it('should append Z to UNTIL without Z suffix', () => {
+    const input =
+      'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;UNTIL=20250201T120000';
+    const expected =
+      'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;UNTIL=20250201T120000Z';
+    expect(ensureUntilZSuffix(input)).toBe(expected);
+  });
+
+  it('should not double-append Z when UNTIL already has Z suffix', () => {
+    const input =
+      'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;UNTIL=20250201T120000Z';
+    expect(ensureUntilZSuffix(input)).toBe(input);
+  });
+
+  it('should fix all UNTIL clauses in a multi-rule string', () => {
+    const input =
+      'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;UNTIL=20250201T120000 RRULE:FREQ=DAILY;UNTIL=20250301T120000';
+    const expected =
+      'DTSTART;TZID=America/New_York:20250101T120000 RRULE:FREQ=WEEKLY;UNTIL=20250201T120000Z RRULE:FREQ=DAILY;UNTIL=20250301T120000Z';
+    expect(ensureUntilZSuffix(input)).toBe(expected);
   });
 });
 

--- a/frontend/awx/views/schedules/hooks/ruleHelpers.tsx
+++ b/frontend/awx/views/schedules/hooks/ruleHelpers.tsx
@@ -191,6 +191,10 @@ export function mungeSurveyAndExtraVarsData(
   return { ...extraData, ...parseVariableField(extra_vars) };
 }
 
+export function ensureUntilZSuffix(ruleStr: string): string {
+  return ruleStr.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/g, 'UNTIL=$1Z');
+}
+
 export const normalizeOptions = (options: Partial<Options>) => {
   // compiled from https://github.com/jkbrzt/rrule/blob/master/src/types.ts#L59
   const propertiesToNormalize = [

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
@@ -216,4 +216,69 @@ describe('useProcessSchedule', () => {
     const response = await result.current(payload);
     expect(response.schedule).toBeDefined();
   });
+
+  it('should append Z to UNTIL date when DTSTART has TZID', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/templates/:id/schedules/create', '/templates/10/schedules/create'),
+    });
+
+    // DTSTART with TZID + UNTIL: the rrule library strips the Z suffix on serialization
+    const tzidRule =
+      'DTSTART;TZID=America/New_York:20230101T000000\nRRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20231231T050000Z';
+
+    const payload = makePayload('job_template', {
+      rules: [{ id: 1, rule: tzidRule }],
+    });
+
+    await result.current(payload);
+
+    const savedRRule = (postCalls[0].body as Record<string, unknown>).rrule as string;
+    expect(savedRRule).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+  });
+
+  it('should POST to system_job_templates with empty extra_data when schedule_days_to_keep is undefined', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/templates/:id/schedules/create', '/templates/10/schedules/create'),
+    });
+
+    const payload = makePayload('system_job_template', {
+      schedule_days_to_keep: undefined as unknown as number,
+    });
+
+    const response = await result.current(payload);
+
+    expect(response.schedule).toBeDefined();
+    expect(postCalls[0].url).toContain('/system_job_templates/');
+    expect((postCalls[0].body as Record<string, unknown>).extra_data).toEqual({});
+  });
+
+  it('should fall back to empty survey for workflow_job_template when survey is undefined', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/templates/:id/schedules/create', '/templates/10/schedules/create'),
+    });
+
+    const payload = makePayload('workflow_job_template', {
+      survey: undefined as unknown as Record<string, string | number | string[]>,
+    });
+
+    const response = await result.current(payload);
+
+    expect(response.schedule).toBeDefined();
+    expect(postCalls[0].url).toContain('/workflow_job_templates/');
+  });
+
+  it('should fall back to empty survey for job_template when survey is undefined', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/templates/:id/schedules/create', '/templates/10/schedules/create'),
+    });
+
+    const payload = makePayload('job_template', {
+      survey: undefined as unknown as Record<string, string | number | string[]>,
+    });
+
+    const response = await result.current(payload);
+
+    expect(response.schedule).toBeDefined();
+    expect(postCalls[0].url).toContain('/job_templates/');
+  });
 });

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Schedule } from '../../../interfaces/Schedule';
 import { BaseSchedulePayload, ScheduleAccessoriesPayload, ScheduleFormWizard } from '../types';
-import { mungePromptData, mungeSurveyAndExtraVarsData } from './ruleHelpers';
+import { ensureUntilZSuffix, mungePromptData, mungeSurveyAndExtraVarsData } from './ruleHelpers';
 import { usePostAccessories } from './usePostScheduleAccessories';
 import { useSetRRuleItemToRuleSet } from './useSetRRuleItemToRuleSet';
 
@@ -23,13 +23,7 @@ export const useProcessSchedule = () => {
       const { resourceId, resource, prompt, survey, rules, exceptions, ...rest } = payloadData;
       const ruleset = getRuleSet(rules, exceptions);
 
-      let rrule = ruleset.toString().replaceAll('\n', ' ');
-
-      // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
-      // The rrule library strips the Z suffix when serializing, so we add it back
-      if (rrule.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
-        rrule = rrule.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
-      }
+      const rrule = ensureUntilZSuffix(ruleset.toString().replaceAll('\n', ' '));
 
       const payload = {
         ...rest,

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -23,9 +23,17 @@ export const useProcessSchedule = () => {
       const { resourceId, resource, prompt, survey, rules, exceptions, ...rest } = payloadData;
       const ruleset = getRuleSet(rules, exceptions);
 
+      let rrule = ruleset.toString().split('\n').join(' ');
+
+      // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
+      // The rrule library strips the Z suffix when serializing, so we add it back
+      if (rrule.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
+        rrule = rrule.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
+      }
+
       const payload = {
         ...rest,
-        rrule: ruleset.toString().split('\n').join(' '),
+        rrule,
       };
 
       function request(

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -23,7 +23,7 @@ export const useProcessSchedule = () => {
       const { resourceId, resource, prompt, survey, rules, exceptions, ...rest } = payloadData;
       const ruleset = getRuleSet(rules, exceptions);
 
-      let rrule = ruleset.toString().split('\n').join(' ');
+      let rrule = ruleset.toString().replaceAll('\n', ' ');
 
       // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
       // The rrule library strips the Z suffix when serializing, so we add it back

--- a/frontend/awx/views/schedules/hooks/useScheduleSteps.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useScheduleSteps.test.tsx
@@ -1,0 +1,229 @@
+import { renderHook } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { RequestError } from '@ansible/common-ui/crud/RequestError';
+import { awxAPI } from '../../../common/api/awx-utils';
+import type { LaunchConfiguration } from '../../../interfaces/LaunchConfiguration';
+import type { RuleFields, RuleListItemType, ScheduleFormWizard } from '../types';
+import { useScheduleSteps } from './useScheduleSteps';
+
+const validRuleString = 'DTSTART:20240101T000000Z\nRRULE:FREQ=DAILY;INTERVAL=1';
+const mockRule: RuleListItemType = { id: 1, rule: validRuleString };
+const askableLaunchConfig = { ask_inventory_on_launch: true } as unknown as LaunchConfiguration;
+const nonAskableLaunchConfig = { ask_inventory_on_launch: false } as unknown as LaunchConfiguration;
+
+type StepWithCallbacks = {
+  id: string;
+  hidden?: (wizardData: object) => boolean;
+  validate?: (formData: object, wizardData: object) => Promise<void> | void;
+};
+
+function getStep(
+  steps: ReturnType<ReturnType<typeof useScheduleSteps>>,
+  id: string
+): StepWithCallbacks {
+  const step = steps.find((s) => s.id === id);
+  if (!step) throw new Error(`Step '${id}' not found`);
+  return step as StepWithCallbacks;
+}
+
+const previewCalls: { body: unknown }[] = [];
+const server = setupServer(
+  http.post(awxAPI`/schedules/preview/`, async ({ request }) => {
+    previewCalls.push({ body: await request.json() });
+    return HttpResponse.json({ utc: ['2024-01-01T00:00:00Z'], local: ['2024-01-01T00:00:00Z'] });
+  })
+);
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  previewCalls.length = 0;
+});
+afterAll(() => server.close());
+
+describe('useScheduleSteps', () => {
+  it('should return a function', () => {
+    const { result } = renderHook(() => useScheduleSteps());
+    expect(typeof result.current).toBe('function');
+  });
+
+  it('should return 6 steps when called', () => {
+    const { result } = renderHook(() => useScheduleSteps());
+    expect(result.current().length).toBe(6);
+  });
+
+  it('should return steps with the correct ids in order', () => {
+    const { result } = renderHook(() => useScheduleSteps());
+    expect(result.current().map((s) => s.id)).toEqual([
+      'details',
+      'promptStep',
+      'survey',
+      'rules',
+      'exceptions',
+      'review',
+    ]);
+  });
+});
+
+describe('promptStep hidden', () => {
+  let hidden: (data: object) => boolean;
+  beforeEach(() => {
+    const { result } = renderHook(() => useScheduleSteps());
+    const step = getStep(result.current(), 'promptStep');
+    expect(step.hidden).toBeDefined();
+    hidden = step.hidden!;
+  });
+
+  it('should be hidden when wizardData is empty', () => {
+    expect(hidden({})).toBe(true);
+  });
+
+  it('should be hidden when launch_config is null', () => {
+    expect(
+      hidden({
+        schedule_type: 'job_template',
+        resource: { type: 'job_template' },
+        resourceId: 1,
+        launch_config: null,
+      })
+    ).toBe(true);
+  });
+
+  it('should be hidden when schedule_type is not a template type', () => {
+    expect(hidden({ schedule_type: 'project' })).toBe(true);
+  });
+
+  it('should be hidden when schedule_type is job_template but neither resource nor resourceId is set', () => {
+    expect(hidden({ schedule_type: 'job_template', launch_config: askableLaunchConfig })).toBe(
+      true
+    );
+  });
+
+  it('should be hidden when launch_config has no askable fields', () => {
+    expect(
+      hidden({
+        schedule_type: 'job_template',
+        resourceId: 1,
+        launch_config: nonAskableLaunchConfig,
+      })
+    ).toBe(true);
+  });
+
+  it('should be visible when schedule_type is job_template with askable field and resourceId set', () => {
+    expect(
+      hidden({ schedule_type: 'job_template', resourceId: 1, launch_config: askableLaunchConfig })
+    ).toBe(false);
+  });
+
+  it('should be visible when schedule_type is workflow_job_template with askable field', () => {
+    expect(
+      hidden({
+        schedule_type: 'workflow_job_template',
+        resourceId: 1,
+        launch_config: askableLaunchConfig,
+      })
+    ).toBe(false);
+  });
+
+  it('should be visible when resource.type is job_template with askable field and resourceId', () => {
+    expect(
+      hidden({
+        resource: { type: 'job_template' },
+        resourceId: 1,
+        launch_config: askableLaunchConfig,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('survey step hidden', () => {
+  let hidden: (data: object) => boolean;
+  beforeEach(() => {
+    const { result } = renderHook(() => useScheduleSteps());
+    const step = getStep(result.current(), 'survey');
+    expect(step.hidden).toBeDefined();
+    hidden = step.hidden!;
+  });
+
+  it('should be hidden when wizardData is empty', () => {
+    expect(hidden({})).toBe(true);
+  });
+
+  it('should be hidden when launch_config is absent', () => {
+    expect(hidden({ name: 'x' })).toBe(true);
+  });
+
+  it('should be hidden when launch_config.survey_enabled is false', () => {
+    expect(hidden({ launch_config: { survey_enabled: false } })).toBe(true);
+  });
+
+  it('should be visible when launch_config.survey_enabled is true', () => {
+    expect(hidden({ launch_config: { survey_enabled: true } })).toBe(false);
+  });
+});
+
+describe('rules step validate', () => {
+  let validate: ((formData: object, wizardData: object) => Promise<void> | void) | undefined;
+  beforeEach(() => {
+    const { result } = renderHook(() => useScheduleSteps());
+    validate = getStep(result.current(), 'rules').validate;
+    expect(validate).toBeDefined();
+  });
+
+  const emptyRules: Partial<RuleFields> = { rules: [] };
+  const noRules: Partial<RuleFields> = {};
+  const withRule: Partial<RuleFields> = { rules: [mockRule] };
+
+  it('should throw RequestError when rules is empty', () => {
+    expect(() => validate!(emptyRules as object, {})).toThrow(RequestError);
+  });
+
+  it('should throw RequestError when rules is undefined', () => {
+    expect(() => validate!(noRules as object, {})).toThrow(RequestError);
+  });
+
+  it('should not throw when rules has at least one entry', () => {
+    expect(() => validate!(withRule as object, {})).not.toThrow();
+  });
+});
+
+describe('review step validate', () => {
+  let validate: ((formData: object, wizardData: object) => Promise<void> | void) | undefined;
+  beforeEach(() => {
+    const { result } = renderHook(() => useScheduleSteps());
+    validate = getStep(result.current(), 'review').validate;
+    expect(validate).toBeDefined();
+  });
+
+  const emptyWizard: Partial<ScheduleFormWizard> = { rules: [], exceptions: [] };
+  const validWizard: Partial<ScheduleFormWizard> = { rules: [mockRule], exceptions: [] };
+
+  it('should throw RequestError when rules is empty', async () => {
+    await expect(validate!({}, emptyWizard as object)).rejects.toThrow(RequestError);
+  });
+
+  it('should throw RequestError when preview returns no future dates', async () => {
+    server.use(
+      http.post(awxAPI`/schedules/preview/`, () => HttpResponse.json({ utc: [], local: [] }))
+    );
+    await expect(validate!({}, validWizard as object)).rejects.toThrow(RequestError);
+  });
+
+  it('should resolve without error when preview returns future dates', async () => {
+    await expect(validate!({}, validWizard as object)).resolves.toBeUndefined();
+  });
+
+  it('should resolve when exceptions is undefined', async () => {
+    const wizardWithoutExceptions: Partial<ScheduleFormWizard> = { rules: [mockRule] };
+    await expect(validate!({}, wizardWithoutExceptions as object)).resolves.toBeUndefined();
+  });
+
+  it('should POST the serialized rrule string to /schedules/preview/', async () => {
+    await validate!({}, validWizard as object);
+    expect(previewCalls).toHaveLength(1);
+    const body = previewCalls[0].body as Record<string, unknown>;
+    expect(body).toHaveProperty('rrule');
+    expect(typeof body['rrule']).toBe('string');
+  });
+});

--- a/frontend/awx/views/schedules/hooks/useScheduleSteps.tsx
+++ b/frontend/awx/views/schedules/hooks/useScheduleSteps.tsx
@@ -8,6 +8,7 @@ import { WizardFormValues } from '../../../resources/templates/WorkflowVisualize
 import { shouldHideOtherStep } from '../../../resources/templates/WorkflowVisualizer/wizard/helpers';
 import { NodePromptsStep as PromptsStep } from '../../../resources/templates/WorkflowVisualizer/wizard/NodePromptsStep';
 import { RuleFields, ScheduleFormWizard } from '../types';
+import { ensureUntilZSuffix } from './ruleHelpers';
 import { ExceptionsStep } from '../wizard/ExceptionsStep';
 import { RulesStep } from '../wizard/RulesStep';
 import { ScheduleReviewStep } from '../wizard/ScheduleReviewStep';
@@ -97,7 +98,7 @@ export function useScheduleSteps() {
           const { utc, local } = await postRequest<{ utc: string[]; local: string[] }>(
             awxAPI`/schedules/preview/`,
             {
-              rrule: ruleset.toString().split('\n').join(' '),
+              rrule: ensureUntilZSuffix(ruleset.toString().replaceAll('\n', ' ')),
             }
           );
           if (!local.length && !utc.length) {

--- a/frontend/awx/views/schedules/hooks/useUpdateRules.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useUpdateRules.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RuleListItemType } from '../types';
+import { useUpdateRules } from './useUpdateRules';
+
+vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
+  usePageWizard: () => ({
+    wizardData: {
+      timezone: 'America/New_York',
+      startDateTime: { date: '2026-06-20', time: '10:00 AM' },
+    },
+  }),
+}));
+
+vi.mock('./useGet24HourTime', () => ({
+  useGet24HourTime: () => () => ({ hour: 10, minute: 0 }),
+}));
+
+describe('useUpdateRules', () => {
+  it('should add Z suffix to UNTIL when rrule library omits it during serialization', () => {
+    const { result } = renderHook(() => useUpdateRules());
+    const rules: RuleListItemType[] = [
+      {
+        id: 1,
+        rule: 'DTSTART;TZID=America/New_York:20260620T100000\nRRULE:FREQ=HOURLY;INTERVAL=1;UNTIL=20260620T200000Z',
+      },
+    ];
+
+    const updated = result.current(rules);
+
+    expect(updated[0].rule).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+    expect(updated[0].rule).not.toMatch(/UNTIL=\d{8}T\d{6}[^Z]/);
+  });
+
+  it('should return the same array reference when no rules are changed', () => {
+    const { result } = renderHook(() => useUpdateRules());
+    const rules: RuleListItemType[] = [];
+
+    const updated = result.current(rules);
+
+    expect(updated).toBe(rules);
+  });
+
+  it('should return a new array reference when rules are updated', () => {
+    const { result } = renderHook(() => useUpdateRules());
+    const rules: RuleListItemType[] = [{ id: 1, rule: 'RRULE:FREQ=HOURLY;INTERVAL=1' }];
+
+    const updated = result.current(rules);
+
+    expect(updated).not.toBe(rules);
+    expect(updated.length).toBe(1);
+  });
+
+  it('should preserve rule id when updating', () => {
+    const { result } = renderHook(() => useUpdateRules());
+    const rules: RuleListItemType[] = [{ id: 42, rule: 'RRULE:FREQ=DAILY;INTERVAL=1' }];
+
+    const updated = result.current(rules);
+
+    expect(updated[0].id).toBe(42);
+  });
+});

--- a/frontend/awx/views/schedules/hooks/useUpdateRules.tsx
+++ b/frontend/awx/views/schedules/hooks/useUpdateRules.tsx
@@ -19,14 +19,24 @@ export function useUpdateRules() {
       const { year, month, day, hour, minute } = DateTime.fromISO(`${date}`).set(getStart(time));
 
       const updatedRules = (rules || []).map(({ rule, id }) => {
-        const newRule = RRule.optionsToString({
+        let newRule = RRule.optionsToString({
           ...RRule.fromString(rule).origOptions,
           tzid: timezone,
           dtstart: datetime(year, month, day, hour, minute),
         });
+
+        // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
+        // The rrule library doesn't preserve the Z suffix when re-serializing, so we add it back
+        if (newRule.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
+          newRule = newRule.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
+        }
+
         return { rule: newRule, id };
       });
-      return updatedRules;
+
+      // Return same reference if no changes to prevent infinite render loops
+      const hasChanges = updatedRules.some((updated, index) => updated.rule !== rules[index].rule);
+      return hasChanges ? updatedRules : rules;
     },
     [getStart, wizardData]
   );

--- a/frontend/awx/views/schedules/hooks/useUpdateRules.tsx
+++ b/frontend/awx/views/schedules/hooks/useUpdateRules.tsx
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import { datetime, RRule } from 'rrule';
 import { RuleListItemType, ScheduleFormWizard } from '../types';
+import { ensureUntilZSuffix } from './ruleHelpers';
 import { useGet24HourTime } from './useGet24HourTime';
 
 export function useUpdateRules() {
@@ -19,17 +20,13 @@ export function useUpdateRules() {
       const { year, month, day, hour, minute } = DateTime.fromISO(`${date}`).set(getStart(time));
 
       const updatedRules = (rules || []).map(({ rule, id }) => {
-        let newRule = RRule.optionsToString({
-          ...RRule.fromString(rule).origOptions,
-          tzid: timezone,
-          dtstart: datetime(year, month, day, hour, minute),
-        });
-
-        // RFC5545: When DTSTART has TZID, UNTIL must be in UTC with Z suffix
-        // The rrule library doesn't preserve the Z suffix when re-serializing, so we add it back
-        if (newRule.match(/UNTIL=\d{8}T\d{6}(?!Z)/)) {
-          newRule = newRule.replace(/UNTIL=(\d{8}T\d{6})(?!Z)/, 'UNTIL=$1Z');
-        }
+        const newRule = ensureUntilZSuffix(
+          RRule.optionsToString({
+            ...RRule.fromString(rule).origOptions,
+            tzid: timezone,
+            dtstart: datetime(year, month, day, hour, minute),
+          })
+        );
 
         return { rule: newRule, id };
       });

--- a/frontend/awx/views/schedules/wizard/RulesStep.tsx
+++ b/frontend/awx/views/schedules/wizard/RulesStep.tsx
@@ -22,7 +22,9 @@ export function RulesStep() {
   const hasRules = rules?.length > 0;
   useEffect(() => {
     const updatedRules = updateRules(rules);
-    setValue('rules', updatedRules);
+    if (updatedRules !== rules) {
+      setValue('rules', updatedRules);
+    }
   }, [rules, setValue, updateRules]);
   return (
     <PageFormSection singleColumn>

--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
@@ -237,5 +237,5 @@ describe('ScheduleEditWizard', () => {
         .filter((r) => r.dataset.testid?.startsWith('row-id-'));
       expect(rows.length).toBeGreaterThan(initialRowCount);
     });
-  }, 15000);
+  });
 });

--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
@@ -237,5 +237,5 @@ describe('ScheduleEditWizard', () => {
         .filter((r) => r.dataset.testid?.startsWith('row-id-'));
       expect(rows.length).toBeGreaterThan(initialRowCount);
     });
-  });
+  }, 15000);
 });

--- a/playwright/tests/integration/automation-execution/schedules/schedule.spec.ts
+++ b/playwright/tests/integration/automation-execution/schedules/schedule.spec.ts
@@ -349,6 +349,183 @@ test.describe('Schedules - Complex Workflows', () => {
   );
 });
 
+// AAP-77222: https://issues.redhat.com/browse/AAP-77222
+test.describe('Schedules UNTIL behavior', () => {
+  test(
+    'should preserve UNTIL time when creating hourly schedule with non-UTC timezone',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      test.setTimeout(120000);
+
+      const inventoryName = await Inventory.ui.create(page);
+      const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
+
+      await navigateTo(page, 'Automation Execution', 'Schedules');
+      await page.getByRole('link', { name: 'Create schedule' }).click();
+      await expect(page.getByRole('heading', { name: 'Create schedule' })).toBeVisible();
+
+      const scheduleName = createE2EName();
+      await page.getByRole('button', { name: 'Select resource type' }).click();
+      await page.getByRole('option', { name: 'Job template', exact: true }).click();
+      await page.getByLabel('Job template *').click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(jobTemplateName);
+      await page.getByRole('option', { name: jobTemplateName }).click();
+      await page.getByRole('textbox', { name: 'Schedule name' }).fill(scheduleName);
+
+      await page.getByLabel('Time zone').click();
+      await page.getByRole('option', { name: 'America/New_York', exact: true }).click();
+
+      await page.getByRole('button', { name: 'Next' }).click();
+
+      // Rules step: set Hourly frequency and Until ending type with a specific time
+      await page.getByRole('button', { name: 'Yearly' }).click();
+      await page.getByRole('option', { name: 'Hourly', exact: true }).click();
+
+      await page.getByRole('button', { name: 'Schedule ending type' }).click();
+      await page.waitForSelector('role=listbox');
+      await page.getByRole('option', { name: 'Until Stop on a specific date' }).click();
+
+      // Set until date to 3 days from now to ensure occurrences exist
+      const untilDate = new Date();
+      untilDate.setDate(untilDate.getDate() + 3);
+      const untilDateStr = untilDate.toISOString().split('T')[0];
+
+      await page.getByRole('textbox', { name: 'Date picker' }).fill(untilDateStr);
+      await page.getByRole('textbox', { name: 'Time picker' }).fill('3:00 PM');
+
+      // Intercept the schedule creation API to capture the saved rrule
+      const scheduleResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/schedules/') &&
+          response.request().method() === 'POST' &&
+          response.status() === 201
+      );
+
+      await page.getByRole('button', { name: 'Save rule' }).click();
+      await expect(page.getByRole('heading', { name: 'Schedule Rules' })).toBeVisible();
+      await page.getByRole('button', { name: 'Next' }).click();
+      // Exceptions step
+      await page.getByRole('button', { name: 'Next' }).click();
+      // Review step
+      await expect(page.getByTestId('Review')).toBeVisible();
+      await page.getByRole('button', { name: 'Finish' }).click();
+
+      const scheduleResponse = await scheduleResponsePromise;
+      const scheduleData = (await scheduleResponse.json()) as { rrule: string };
+
+      // Verify the saved rrule has the Z suffix on UNTIL
+      expect(scheduleData.rrule).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+
+      // Verify the UNTIL time is NOT midnight UTC (the original bug behavior)
+      // 3:00 PM America/New_York = 19:00 or 20:00 UTC depending on DST
+      // It should NEVER be T000000Z (midnight UTC) or T040000Z/T050000Z (midnight Eastern)
+      const untilMatch = scheduleData.rrule.match(/UNTIL=\d{8}T(\d{6})Z/);
+      expect(untilMatch).not.toBeNull();
+      const untilTimeComponent = untilMatch![1];
+      expect(untilTimeComponent).not.toBe('000000');
+      expect(untilTimeComponent).not.toBe('040000');
+      expect(untilTimeComponent).not.toBe('050000');
+
+      // Verify on the details page
+      await expect(
+        page.getByRole('heading', { name: scheduleName, exact: true }).first()
+      ).toBeVisible({ timeout: 15000 });
+
+      // Verify the rruleset on the details page also has the Z suffix
+      await expect(page.getByTestId('rruleset')).toBeVisible();
+      const rruleText = await page.getByTestId('rruleset').textContent();
+      expect(rruleText).toMatch(/UNTIL=\d{8}T\d{6}Z/);
+      expect(rruleText).toMatch(/FREQ=HOURLY/);
+
+      // Cleanup
+      await Schedule.ui.delete(page, scheduleName);
+      await JobTemplate.ui.delete(page, jobTemplateName);
+      await Inventory.ui.delete(page, inventoryName);
+    }
+  );
+
+  test(
+    'should not show schedule occurrences beyond the UNTIL time',
+    { tag: ['@not_mock'] },
+    async ({ page }) => {
+      test.setTimeout(120000);
+
+      const inventoryName = await Inventory.ui.create(page);
+      const jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
+
+      await navigateTo(page, 'Automation Execution', 'Schedules');
+      await page.getByRole('link', { name: 'Create schedule' }).click();
+      await expect(page.getByRole('heading', { name: 'Create schedule' })).toBeVisible();
+
+      const scheduleName = createE2EName();
+      await page.getByRole('button', { name: 'Select resource type' }).click();
+      await page.getByRole('option', { name: 'Job template', exact: true }).click();
+      await page.getByLabel('Job template *').click();
+      await page.getByRole('textbox', { name: 'Search input' }).fill(jobTemplateName);
+      await page.getByRole('option', { name: jobTemplateName }).click();
+      await page.getByRole('textbox', { name: 'Schedule name' }).fill(scheduleName);
+
+      await page.getByLabel('Time zone').click();
+      await page.getByRole('option', { name: 'America/New_York', exact: true }).click();
+
+      // Set start time to 1:00 PM tomorrow to avoid past-time issues
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const startDateStr = tomorrow.toISOString().split('T')[0];
+      await page.getByRole('textbox', { name: 'Date picker' }).clear();
+      await page.getByRole('textbox', { name: 'Date picker' }).fill(startDateStr);
+      await page.getByRole('textbox', { name: 'Time picker' }).clear();
+      await page.getByRole('textbox', { name: 'Time picker' }).fill('1:00 PM');
+
+      await page.getByRole('button', { name: 'Next' }).click();
+
+      // Rules step: Hourly, ending Until at 4:00 PM same day
+      // With the fix: 3 occurrences max (2 PM, 3 PM, 4 PM)
+      // With the bug: 11 occurrences (2 PM through midnight = continuing until 00:00)
+      await page.getByRole('button', { name: 'Yearly' }).click();
+      await page.getByRole('option', { name: 'Hourly', exact: true }).click();
+
+      await page.getByRole('button', { name: 'Schedule ending type' }).click();
+      await page.waitForSelector('role=listbox');
+      await page.getByRole('option', { name: 'Until Stop on a specific date' }).click();
+
+      await page.getByRole('textbox', { name: 'Date picker' }).fill(startDateStr);
+      await page.getByRole('textbox', { name: 'Time picker' }).fill('4:00 PM');
+
+      // Intercept preview API to verify occurrences are bounded
+      const previewResponsePromise = page.waitForResponse(
+        (response) => response.url().includes('/schedules/preview/') && response.status() === 200
+      );
+
+      await page.getByRole('button', { name: 'Save rule' }).click();
+      await expect(page.getByRole('heading', { name: 'Schedule Rules' })).toBeVisible();
+
+      const previewResponse = await previewResponsePromise;
+      const previewData = (await previewResponse.json()) as { local: string[]; utc: string[] };
+
+      // Verify the preview returns occurrences
+      expect(previewData.local.length).toBeGreaterThan(0);
+
+      // Key assertion: with the bug, UNTIL defaults to midnight causing ~11 occurrences
+      // (1 PM → midnight = 11 hours of hourly runs). With the fix, UNTIL at 4 PM
+      // means at most 3-4 occurrences (2 PM, 3 PM, 4 PM, possibly including start).
+      expect(previewData.local.length).toBeLessThanOrEqual(5);
+
+      // Cleanup: finish saving and delete
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.getByRole('button', { name: 'Next' }).click();
+      await page.getByRole('button', { name: 'Finish' }).click();
+      await expect(
+        page.getByRole('heading', { name: scheduleName, exact: true }).first()
+      ).toBeVisible({ timeout: 15000 });
+
+      await Schedule.ui.delete(page, scheduleName);
+      await JobTemplate.ui.delete(page, jobTemplateName);
+      await Inventory.ui.delete(page, inventoryName);
+    }
+  );
+});
+
 test.describe('Schedules - Bulk Operations', () => {
   test('bulk deletion', { tag: ['@not_mock'] }, async ({ page }) => {
     test.setTimeout(5 * 20 * 1000);


### PR DESCRIPTION
## Summary

Fixes incorrect UNTIL value calculation in schedule wizard recurrence rules. The wizard was using the browser's timezone instead of the schedule's configured timezone, and was not adding the RFC5545-required 'Z' suffix to UTC timestamps, causing schedules to run beyond their intended end time.

For example, a user in EDT creating a schedule in PDT timezone to run hourly from 5-9 PM would see the schedule run until 5 AM (8 extra hours) because the UNTIL value was calculated in the wrong timezone and the backend double-applied the timezone offset due to the missing Z suffix.

Also fixes an infinite render loop in RulesStep caused by useUpdateRules always returning new array references.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

**Justification**: Changes affect core schedule wizard logic across multiple hooks and components (RuleForm, useUpdateRules, useProcessSchedules, RulesStep). While scoped to the AWX schedules feature, it touches the rule generation and processing pipeline used throughout the schedule creation/edit flow.

## Testing

### Test Coverage

- ✅ All 101 schedule tests pass (14 test files)
- ✅ ESLint passes
- ✅ TypeScript passes

### Manual Testing

**To verify the fix:**

1. Navigate to AWX → Resources → Templates → (select a template) → Schedules → Create Schedule
2. Configure schedule with:
   - **Timezone**: `America/Los_Angeles` (or any timezone different from your browser's)
   - **Start date/time**: Any future date at 3:00 PM
   - **Frequency**: Hourly, every 1 hour
   - **End type**: "On Date"
   - **End date**: Same day as start date
   - **End time**: 6:00 PM
3. Save the schedule
4. Verify the schedule details show:
   - **Expected**: 4 occurrences (3 PM, 4 PM, 5 PM, 6 PM in the selected timezone)
   - **Bug (before fix)**: 7+ occurrences extending into the next day
5. Check the `rrule` in the API response contains `UNTIL=<timestamp>Z` (with Z suffix)

**Cross-timezone test:**
- Repeat the above with browser timezone set to `Europe/Paris` (via DevTools)
- Should produce identical rrule and occurrence count

### Screenshots

N/A - This is a data/logic fix with no visual changes.