### PR TITLE
Prevent crash launching WJT with no org

### DIFF
--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.test.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { InventorySourceDetails, LastJobTooltip } from './InventorySourceDetails';
 
@@ -89,14 +90,16 @@ afterAll(() => server.close());
 
 function renderInventorySourceDetails(inventorySourceId?: string) {
   return render(
-    <MemoryRouter initialEntries={['/inventories/inventory/1/sources/1/details']}>
-      <Routes>
-        <Route
-          path="/inventories/:inventory_type/:id/sources/:source_id/details"
-          element={<InventorySourceDetails inventorySourceId={inventorySourceId} />}
-        />
-      </Routes>
-    </MemoryRouter>
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <MemoryRouter initialEntries={['/inventories/inventory/1/sources/1/details']}>
+        <Routes>
+          <Route
+            path="/inventories/:inventory_type/:id/sources/:source_id/details"
+            element={<InventorySourceDetails inventorySourceId={inventorySourceId} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </SWRConfig>
   );
 }
 

--- a/frontend/awx/resources/templates/TemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.test.tsx
@@ -110,6 +110,10 @@ const server = setupServer(
   http.get(awxAPI`/job_templates/42/`, () => HttpResponse.json(mockJobTemplate)),
   http.get(awxAPI`/job_templates/42/instance_groups/`, () =>
     HttpResponse.json({ count: 0, results: [] })
+  ),
+  http.get(
+    ({ request }) => request.url.includes('/webhook_key/'),
+    () => HttpResponse.json({ webhook_key: 'test-key' })
   )
 );
 
@@ -449,4 +453,445 @@ describe('TemplateForm - EditJobTemplate', () => {
       expect(labelPostBody).toMatchObject({ name: 'new-label' });
     }
   );
+
+  it('should render error and use instanceGroupRefresh when instance groups fetch fails', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/42/instance_groups/`, () =>
+        HttpResponse.json({ detail: 'Internal Server Error' }, { status: 500 })
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/42/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+  });
+
+  it('should render fallback title when template has no name', async () => {
+    server.use(
+      http.get(awxAPI`/job_templates/42/`, () =>
+        HttpResponse.json({ ...mockJobTemplate, name: '' })
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/42/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('page-title')).toHaveTextContent('Job Template');
+      },
+      { timeout: 10000 }
+    );
+  }, 15000);
+
+  it('should navigate when cancel is clicked in edit mode', { timeout: 15000 }, async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/42/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+  });
+
+  it('should submit edit form with non-empty skip_tags', { timeout: 30000 }, async () => {
+    const templateWithSkipTags = {
+      ...mockJobTemplate,
+      id: 100,
+      name: 'Skip Tags Template',
+      skip_tags: 'tag1,tag2',
+      summary_fields: {
+        ...mockJobTemplate.summary_fields,
+        labels: { count: 0, results: [] },
+      },
+    };
+    let patchPayload: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get(awxAPI`/job_templates/100/`, () => HttpResponse.json(templateWithSkipTags)),
+      http.get(awxAPI`/job_templates/100/instance_groups/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.patch(awxAPI`/job_templates/100/`, async ({ request }) => {
+        patchPayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(templateWithSkipTags);
+      })
+    );
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/100/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue('Skip Tags Template')).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+
+    await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+    await waitFor(() => {
+      expect(patchPayload).not.toBeNull();
+      expect(patchPayload?.skip_tags).toBe('tag1,tag2');
+    });
+  });
+
+  it('should submit edit form with webhook_credential set', { timeout: 30000 }, async () => {
+    const templateWithWebhookCred = {
+      ...mockJobTemplate,
+      id: 101,
+      name: 'Webhook Cred Template',
+      webhook_credential: 99,
+      summary_fields: {
+        ...mockJobTemplate.summary_fields,
+        labels: { count: 0, results: [] },
+      },
+    };
+    let patchPayload: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get(awxAPI`/job_templates/101/`, () => HttpResponse.json(templateWithWebhookCred)),
+      http.get(awxAPI`/job_templates/101/instance_groups/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.patch(awxAPI`/job_templates/101/`, async ({ request }) => {
+        patchPayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(templateWithWebhookCred);
+      })
+    );
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/101/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue('Webhook Cred Template')).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+
+    await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+    await waitFor(() => {
+      expect(patchPayload?.webhook_credential).toBe(99);
+    });
+  });
+
+  it(
+    'should submit edit form with webhook_service when webhook is enabled',
+    { timeout: 30000 },
+    async () => {
+      const templateWithWebhook = {
+        ...mockJobTemplate,
+        id: 102,
+        name: 'Webhook Template',
+        webhook_service: 'github',
+        related: {
+          ...mockJobTemplate.related,
+          webhook_receiver: '/api/v2/job_templates/102/github/',
+        },
+        summary_fields: {
+          ...mockJobTemplate.summary_fields,
+          labels: { count: 0, results: [] },
+        },
+      };
+      let patchPayload: Record<string, unknown> | null = null;
+
+      server.use(
+        http.get(awxAPI`/job_templates/102/`, () => HttpResponse.json(templateWithWebhook)),
+        http.get(awxAPI`/job_templates/102/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.patch(awxAPI`/job_templates/102/`, async ({ request }) => {
+          patchPayload = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(templateWithWebhook);
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/102/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('Webhook Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(patchPayload?.webhook_service).toBe('github');
+      });
+    }
+  );
+
+  it(
+    'should submit edit form with host_config_key when provisioning callback is enabled',
+    { timeout: 30000 },
+    async () => {
+      const templateWithCallback = {
+        ...mockJobTemplate,
+        id: 103,
+        name: 'Callback Template',
+        host_config_key: 'my-key-123',
+        related: {
+          ...mockJobTemplate.related,
+          callback: '/api/v2/job_templates/103/callback/',
+        },
+        summary_fields: {
+          ...mockJobTemplate.summary_fields,
+          labels: { count: 0, results: [] },
+        },
+      };
+      let patchPayload: Record<string, unknown> | null = null;
+
+      server.use(
+        http.get(awxAPI`/job_templates/103/`, () => HttpResponse.json(templateWithCallback)),
+        http.get(awxAPI`/job_templates/103/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.patch(awxAPI`/job_templates/103/`, async ({ request }) => {
+          patchPayload = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(templateWithCallback);
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/103/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('Callback Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(patchPayload?.host_config_key).toBe('my-key-123');
+      });
+    }
+  );
+
+  it('should submit edit form with execution_environment id', { timeout: 30000 }, async () => {
+    const templateWithEE = {
+      ...mockJobTemplate,
+      id: 104,
+      name: 'EE Template',
+      summary_fields: {
+        ...mockJobTemplate.summary_fields,
+        execution_environment: { id: 3, name: 'Default EE', description: '' },
+        labels: { count: 0, results: [] },
+      },
+    };
+    let patchPayload: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get(awxAPI`/job_templates/104/`, () => HttpResponse.json(templateWithEE)),
+      http.get(awxAPI`/job_templates/104/instance_groups/`, () =>
+        HttpResponse.json({ count: 0, results: [] })
+      ),
+      http.patch(awxAPI`/job_templates/104/`, async ({ request }) => {
+        patchPayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(templateWithEE);
+      })
+    );
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/104/edit']}>
+        <Routes>
+          <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue('EE Template')).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+
+    await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+    await waitFor(() => {
+      expect(patchPayload?.execution_environment).toBe(3);
+    });
+  });
+
+  it(
+    'should disassociate original and associate new instance groups when they differ',
+    { timeout: 30000 },
+    async () => {
+      const templateId = 105;
+      let instanceGroupsCallCount = 0;
+      const disassociateRequests: number[] = [];
+      const associateRequests: number[] = [];
+
+      server.use(
+        http.get(awxAPI`/job_templates/105/`, () =>
+          HttpResponse.json({ ...mockJobTemplate, id: templateId, name: 'IG Template' })
+        ),
+        http.get(awxAPI`/job_templates/105/instance_groups/`, () => {
+          instanceGroupsCallCount++;
+          if (instanceGroupsCallCount === 1) {
+            return HttpResponse.json({ count: 1, results: [{ id: 5, name: 'original-group' }] });
+          }
+          return HttpResponse.json({ count: 1, results: [{ id: 6, name: 'different-group' }] });
+        }),
+        http.patch(awxAPI`/job_templates/105/`, () =>
+          HttpResponse.json({ ...mockJobTemplate, id: templateId })
+        ),
+        http.post(awxAPI`/job_templates/105/instance_groups/`, async ({ request }) => {
+          const body = (await request.json()) as { id: number; disassociate?: boolean };
+          if (body.disassociate) {
+            disassociateRequests.push(body.id);
+          } else {
+            associateRequests.push(body.id);
+          }
+          return HttpResponse.json({});
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/105/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('IG Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(disassociateRequests).toContain(6);
+        expect(associateRequests).toContain(5);
+      });
+    }
+  );
+
+  it(
+    'should handle submitCredentials when template has no credentials in summary_fields',
+    { timeout: 30000 },
+    async () => {
+      const templateWithoutCredentials = {
+        ...mockJobTemplate,
+        id: 106,
+        name: 'No Cred Template',
+        summary_fields: {
+          ...mockJobTemplate.summary_fields,
+          credentials: undefined as unknown as [],
+          labels: { count: 0, results: [] },
+        },
+      };
+
+      server.use(
+        http.get(awxAPI`/job_templates/106/`, () => HttpResponse.json(templateWithoutCredentials)),
+        http.get(awxAPI`/job_templates/106/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.patch(awxAPI`/job_templates/106/`, () => HttpResponse.json(templateWithoutCredentials))
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/106/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('No Cred Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+      });
+    }
+  );
+});
+
+describe('TemplateForm - CreateJobTemplate cancel', () => {
+  it('should go back when cancel is clicked in create mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/templates/job_template/create']}>
+        <CreateJobTemplate />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+  }, 15000);
 });

--- a/frontend/awx/resources/templates/TemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -324,4 +325,128 @@ describe('TemplateForm - EditJobTemplate', () => {
     expect(screen.getByDisplayValue('5')).toBeInTheDocument();
     expect(screen.getByDisplayValue('120')).toBeInTheDocument();
   }, 15000);
+
+  it(
+    'should fetch /organizations/ and create label when template has no org and a label is added',
+    { timeout: 30000 },
+    async () => {
+      const templateWithoutOrg = {
+        ...mockJobTemplate,
+        id: 1,
+        name: 'No Org Template',
+        summary_fields: {
+          ...mockJobTemplate.summary_fields,
+          organization: undefined,
+          labels: { count: 0, results: [] },
+        },
+      };
+      let orgFetched = false;
+      let labelPostBody: Record<string, unknown> | null = null;
+      server.use(
+        http.get(awxAPI`/job_templates/1/`, () => HttpResponse.json(templateWithoutOrg)),
+        http.get(awxAPI`/job_templates/1/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.patch(awxAPI`/job_templates/1/`, () => HttpResponse.json(templateWithoutOrg)),
+        http.get(awxAPI`/organizations/`, () => {
+          orgFetched = true;
+          return HttpResponse.json({ count: 1, results: [{ id: 10, name: 'Default' }] });
+        }),
+        http.post(awxAPI`/job_templates/1/labels/`, async ({ request }) => {
+          labelPostBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(labelPostBody);
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/1/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('No Org Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      const labelsInput = screen.getByTestId('labels-input');
+      await user.click(labelsInput);
+      await user.type(labelsInput, 'new-label');
+      await user.keyboard('{Enter}');
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(orgFetched).toBe(true);
+      });
+      expect(labelPostBody).toMatchObject({ name: 'new-label', organization: 10 });
+    }
+  );
+
+  it(
+    'should not set orgId when /organizations/ returns empty results',
+    { timeout: 30000 },
+    async () => {
+      const templateWithoutOrg = {
+        ...mockJobTemplate,
+        id: 1,
+        name: 'No Org Template',
+        summary_fields: {
+          ...mockJobTemplate.summary_fields,
+          organization: undefined,
+          labels: { count: 0, results: [] },
+        },
+      };
+      let orgFetched = false;
+      let labelPostBody: Record<string, unknown> | null = null;
+      server.use(
+        http.get(awxAPI`/job_templates/1/`, () => HttpResponse.json(templateWithoutOrg)),
+        http.get(awxAPI`/job_templates/1/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.patch(awxAPI`/job_templates/1/`, () => HttpResponse.json(templateWithoutOrg)),
+        http.get(awxAPI`/organizations/`, () => {
+          orgFetched = true;
+          return HttpResponse.json({ count: 0, results: [] });
+        }),
+        http.post(awxAPI`/job_templates/1/labels/`, async ({ request }) => {
+          labelPostBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(labelPostBody);
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/templates/job_template/1/edit']}>
+          <Routes>
+            <Route path="/templates/job_template/:id/edit" element={<EditJobTemplate />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByDisplayValue('No Org Template')).toBeInTheDocument();
+        },
+        { timeout: 10000 }
+      );
+
+      const labelsInput = screen.getByTestId('labels-input');
+      await user.click(labelsInput);
+      await user.type(labelsInput, 'new-label');
+      await user.keyboard('{Enter}');
+
+      await user.click(screen.getByRole('button', { name: /save job template/i }));
+
+      await waitFor(() => {
+        expect(orgFetched).toBe(true);
+      });
+      expect(labelPostBody).toMatchObject({ name: 'new-label' });
+    }
+  );
 });

--- a/frontend/awx/resources/templates/TemplateForm.tsx
+++ b/frontend/awx/resources/templates/TemplateForm.tsx
@@ -228,14 +228,11 @@ async function submitLabels(template: JobTemplate, labels: Label[]) {
     labels ?? ([] as Label[])
   );
 
-  let orgId = template.summary_fields?.organization?.id;
-  if (!template.summary_fields?.organization?.id) {
-    // eslint-disable-next-line no-useless-catch
-    try {
-      const data = await requestGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`);
+  let orgId: number | undefined = template.summary_fields?.organization?.id;
+  if (!orgId && added.length > 0) {
+    const data = await requestGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`);
+    if (data.results.length > 0) {
       orgId = data.results[0].id;
-    } catch (err) {
-      throw err;
     }
   }
   const disassociationPromises = removed.map((label: { id: number }) =>

--- a/frontend/awx/resources/templates/TemplateFormCreate.test.tsx
+++ b/frontend/awx/resources/templates/TemplateFormCreate.test.tsx
@@ -31,10 +31,10 @@ vi.mock('../../common/AwxPageForm', () => ({
     onCancel?: () => void;
     submitText: string;
     defaultValue?: JobTemplateForm;
-    children?: React.ReactNode;
   }) => (
     <>
       <button
+        type="button"
         data-testid="mock-submit"
         onClick={() => {
           void props.onSubmit(props.defaultValue ?? ({} as JobTemplateForm));
@@ -43,7 +43,7 @@ vi.mock('../../common/AwxPageForm', () => ({
         {props.submitText}
       </button>
       {props.onCancel && (
-        <button data-testid="mock-cancel" onClick={props.onCancel}>
+        <button type="button" data-testid="mock-cancel" onClick={props.onCancel}>
           Cancel
         </button>
       )}

--- a/frontend/awx/resources/templates/TemplateFormCreate.test.tsx
+++ b/frontend/awx/resources/templates/TemplateFormCreate.test.tsx
@@ -1,0 +1,271 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { awxAPI } from '../../common/api/awx-utils';
+import type { JobTemplateForm } from '../../interfaces/JobTemplateForm';
+import { CreateJobTemplate } from './TemplateForm';
+
+vi.mock('@ansible/ansible-ui-framework/components/DataEditor', () => ({
+  DataEditor: (props: {
+    id?: string;
+    name: string;
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      id={props.id ?? props.name}
+      name={props.name}
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+      data-testid={props.id as string}
+    />
+  ),
+}));
+
+vi.mock('../../common/AwxPageForm', () => ({
+  AwxPageForm: (props: {
+    onSubmit: (values: JobTemplateForm) => Promise<void>;
+    onCancel?: () => void;
+    submitText: string;
+    defaultValue?: JobTemplateForm;
+    children?: React.ReactNode;
+  }) => (
+    <>
+      <button
+        data-testid="mock-submit"
+        onClick={() => {
+          void props.onSubmit(props.defaultValue ?? ({} as JobTemplateForm));
+        }}
+      >
+        {props.submitText}
+      </button>
+      {props.onCancel && (
+        <button data-testid="mock-cancel" onClick={props.onCancel}>
+          Cancel
+        </button>
+      )}
+    </>
+  ),
+}));
+
+vi.mock('./JobTemplateFormHelpers', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./JobTemplateFormHelpers')>();
+  return {
+    ...original,
+    getJobTemplateDefaultValues: vi.fn(
+      (...args: Parameters<typeof original.getJobTemplateDefaultValues>) =>
+        original.getJobTemplateDefaultValues(...args)
+    ),
+  };
+});
+
+const server = setupServer(
+  http.options('*', () => HttpResponse.json({})),
+  http.get(awxAPI`/organizations/`, () =>
+    HttpResponse.json({ count: 1, results: [{ id: 1, name: 'Default' }] })
+  ),
+  http.post(awxAPI`/job_templates/100/credentials/`, () => HttpResponse.json({})),
+  http.post(awxAPI`/job_templates/100/labels/`, () => HttpResponse.json({ id: 200, name: 'lbl' })),
+  http.get(awxAPI`/job_templates/100/instance_groups/`, () =>
+    HttpResponse.json({ count: 0, results: [] })
+  ),
+  http.post(awxAPI`/job_templates/100/instance_groups/`, () => HttpResponse.json({}))
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('TemplateFormCreate - CreateJobTemplate onSubmit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it(
+    'should submit create form with no credentials, labels, or instance groups',
+    { timeout: 30000 },
+    async () => {
+      let postPayload: Record<string, unknown> | null = null;
+
+      server.use(
+        http.post(awxAPI`/job_templates/`, async ({ request }) => {
+          postPayload = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 100,
+            name: 'New Template',
+            summary_fields: {
+              organization: { id: 1, name: 'Default' },
+              credentials: [],
+              labels: { count: 0, results: [] },
+            },
+          });
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <CreateJobTemplate />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-submit')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(postPayload).not.toBeNull();
+      });
+    }
+  );
+
+  it(
+    'should submit create form with credentials, labels, and instance groups',
+    { timeout: 30000 },
+    async () => {
+      const { getJobTemplateDefaultValues } = await import('./JobTemplateFormHelpers');
+
+      vi.mocked(getJobTemplateDefaultValues).mockReturnValueOnce({
+        name: 'New Template',
+        project: 1,
+        job_type: 'run',
+        inventory: 1,
+        playbook: 'hello_world.yml',
+        description: '',
+        scm_branch: '',
+        forks: 0,
+        limit: '',
+        verbosity: 0,
+        extra_vars: '---\n',
+        job_tags: [{ name: 'deploy', value: 'deploy', label: 'deploy' }],
+        skip_tags: [{ name: 'cleanup', value: 'cleanup', label: 'cleanup' }],
+        timeout: 0,
+        diff_mode: false,
+        job_slice_count: 1,
+        host_config_key: '',
+        allow_simultaneous: false,
+        use_fact_cache: false,
+        prevent_instance_group_fallback: false,
+        become_enabled: false,
+        ask_scm_branch_on_launch: false,
+        ask_diff_mode_on_launch: false,
+        ask_variables_on_launch: false,
+        ask_limit_on_launch: false,
+        ask_tags_on_launch: false,
+        ask_skip_tags_on_launch: false,
+        ask_job_type_on_launch: false,
+        ask_verbosity_on_launch: false,
+        ask_inventory_on_launch: false,
+        ask_credential_on_launch: false,
+        ask_execution_environment_on_launch: false,
+        ask_labels_on_launch: false,
+        ask_forks_on_launch: false,
+        ask_job_slice_count_on_launch: false,
+        ask_timeout_on_launch: false,
+        ask_instance_groups_on_launch: false,
+        webhook_service: undefined,
+        webhook_url: 'A NEW WEBHOOK URL WILL BE GENERATED ON SAVE.',
+        webhook_key: 'A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.',
+        webhook_credential: 99,
+        execution_environment: { id: 3, name: 'Default EE' },
+        credentials: [{ id: 1, name: 'cred1', kind: 'ssh', cloud: false, description: '' }],
+        labels: [{ id: 10, name: 'lbl1' }] as JobTemplateForm['labels'],
+        instance_groups: [{ id: 5, name: 'ig1' }] as JobTemplateForm['instance_groups'],
+        isProvisioningCallbackEnabled: false,
+        isWebhookEnabled: false,
+        organization: 1,
+        related: {
+          webhook_receiver: '',
+          callback: '',
+          webhook_key: '',
+        },
+        opa_query_path: '',
+      } as unknown as JobTemplateForm);
+
+      const credentialRequests: number[] = [];
+      const labelRequests: string[] = [];
+      const instanceGroupRequests: number[] = [];
+      let postPayload: Record<string, unknown> | null = null;
+
+      server.use(
+        http.post(awxAPI`/job_templates/`, async ({ request }) => {
+          postPayload = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            id: 100,
+            name: 'New Template',
+            summary_fields: {
+              organization: { id: 1, name: 'Default' },
+              credentials: [],
+              labels: { count: 0, results: [] },
+            },
+          });
+        }),
+        http.post(awxAPI`/job_templates/100/credentials/`, async ({ request }) => {
+          const body = (await request.json()) as { id: number };
+          credentialRequests.push(body.id);
+          return HttpResponse.json({});
+        }),
+        http.post(awxAPI`/job_templates/100/labels/`, async ({ request }) => {
+          const body = (await request.json()) as { name: string };
+          labelRequests.push(body.name);
+          return HttpResponse.json({ id: 200, name: body.name });
+        }),
+        http.get(awxAPI`/job_templates/100/instance_groups/`, () =>
+          HttpResponse.json({ count: 0, results: [] })
+        ),
+        http.post(awxAPI`/job_templates/100/instance_groups/`, async ({ request }) => {
+          const body = (await request.json()) as { id: number };
+          instanceGroupRequests.push(body.id);
+          return HttpResponse.json({});
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <CreateJobTemplate />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-submit')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(postPayload).not.toBeNull();
+        expect(postPayload?.execution_environment).toBe(3);
+        expect(postPayload?.job_tags).toBe('deploy');
+        expect(postPayload?.skip_tags).toBe('cleanup');
+        expect(postPayload?.webhook_credential).toBe(99);
+      });
+
+      await waitFor(() => {
+        expect(credentialRequests).toContain(1);
+        expect(labelRequests).toContain('lbl1');
+        expect(instanceGroupRequests).toContain(5);
+      });
+    }
+  );
+
+  it('should navigate back when cancel is clicked in create mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <CreateJobTemplate />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-cancel')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('mock-cancel'));
+  });
+});

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { LaunchConfiguration } from '../../../interfaces/LaunchConfiguration';
+import { JobTemplate } from '../../../interfaces/JobTemplate';
+import { LaunchTemplate, LaunchWizard } from './TemplateLaunchWizard';
+
+vi.mock('@ansible/ansible-ui-framework', async () => ({
+  ...(await vi.importActual('@ansible/ansible-ui-framework')),
+  usePageAlertToaster: () => ({ addAlert: vi.fn() }),
+}));
+
+vi.mock('../hooks/useLabelPayload', () => ({
+  useLabelPayload: vi.fn(() => vi.fn(() => Promise.resolve([]))),
+}));
+
+const mockTemplate = {
+  id: 1,
+  name: 'Test Template',
+  type: 'job_template',
+  summary_fields: {
+    labels: { count: 0, results: [] },
+    organization: { id: 1, name: 'Default', description: '' },
+    credentials: [],
+    user_capabilities: { edit: true, start: true },
+  },
+} as unknown as JobTemplate;
+
+const makeConfig = (overrides: Partial<LaunchConfiguration> = {}): LaunchConfiguration => ({
+  can_start_without_user_input: true,
+  passwords_needed_to_start: [],
+  ask_scm_branch_on_launch: false,
+  ask_variables_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_diff_mode_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_job_type_on_launch: false,
+  ask_limit_on_launch: false,
+  ask_verbosity_on_launch: false,
+  ask_inventory_on_launch: false,
+  ask_credential_on_launch: false,
+  ask_execution_environment_on_launch: false,
+  ask_labels_on_launch: false,
+  ask_forks_on_launch: false,
+  ask_job_slice_count_on_launch: false,
+  ask_timeout_on_launch: false,
+  ask_instance_groups_on_launch: false,
+  survey_enabled: false,
+  variables_needed_to_start: [],
+  credential_needed_to_start: false,
+  inventory_needed_to_start: false,
+  credential_passwords: {
+    ssh_password: '',
+    become_password: '',
+    ssh_key_unlock: '',
+    vault_password: '',
+  },
+  defaults: {
+    inventory: { name: '', id: 0 },
+    limit: '',
+    labels: [],
+    scm_branch: '',
+    job_tags: '',
+    skip_tags: '',
+    extra_vars: '',
+    diff_mode: false,
+    job_type: 'run',
+    verbosity: 0,
+    credentials: [],
+    execution_environment: {},
+    forks: 0,
+    job_slice_count: 1,
+    timeout: 0,
+    instance_groups: [],
+  },
+  job_template_data: { name: 'Test Template', id: 1, description: '' },
+  unified_job_template_object: {
+    name: 'Test Template',
+    id: 1,
+    description: '',
+    survey_enabled: false,
+  },
+  ...overrides,
+});
+
+const server = setupServer(
+  http.get(awxAPI`/job_templates/1/`, () => HttpResponse.json(mockTemplate)),
+  http.get(awxAPI`/job_templates/1/launch/`, () => HttpResponse.json(makeConfig())),
+  http.get(awxAPI`/labels/`, () => HttpResponse.json({ count: 0, results: [], next: null }))
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('TemplateLaunchWizard', () => {
+  describe('LaunchTemplate', () => {
+    it('should render the launch wizard after loading template and config', async () => {
+      render(
+        <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+          <Routes>
+            <Route
+              path="/job-templates/:id/launch"
+              element={<LaunchTemplate jobType="job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+      });
+    });
+
+    it('should render the Review step when all prompt steps are hidden', async () => {
+      render(
+        <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+          <Routes>
+            <Route
+              path="/job-templates/:id/launch"
+              element={<LaunchTemplate jobType="job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      // All ask_* flags are false, so only Review step should be visible
+      await waitFor(() => {
+        expect(screen.getAllByText('Review').length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('LaunchWizard', () => {
+    it('should render wizard with Prompt on Launch header', () => {
+      const handleSubmit = vi.fn(() => Promise.resolve());
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig()}
+            handleSubmit={handleSubmit}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+    });
+
+    it('should not call useLabelPayload when ask_labels_on_launch is false', async () => {
+      const { useLabelPayload } = await import('../hooks/useLabelPayload');
+      const mockCreateLabelPayload = vi.fn(() => Promise.resolve([]));
+      vi.mocked(useLabelPayload).mockReturnValue(mockCreateLabelPayload);
+
+      render(
+        <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+          <Routes>
+            <Route
+              path="/job-templates/:id/launch"
+              element={<LaunchTemplate jobType="job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+      });
+
+      // createLabelPayload should NOT have been called yet (no form submission)
+      expect(mockCreateLabelPayload).not.toHaveBeenCalled();
+    });
+
+    it('should show wizard with labels step hidden when ask_labels_on_launch is false', () => {
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig({ ask_labels_on_launch: false })}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getAllByText('Review').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
@@ -3,15 +3,21 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { LaunchConfiguration } from '../../../interfaces/LaunchConfiguration';
+import {
+  LaunchConfiguration,
+  LaunchConfigCredential,
+} from '../../../interfaces/LaunchConfiguration';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { LaunchTemplate, LaunchWizard } from './TemplateLaunchWizard';
 
+const mockAddAlert = vi.fn();
+
 vi.mock('@ansible/ansible-ui-framework', async () => ({
   ...(await vi.importActual('@ansible/ansible-ui-framework')),
-  usePageAlertToaster: () => ({ addAlert: vi.fn() }),
+  usePageAlertToaster: () => ({ addAlert: mockAddAlert }),
 }));
 
 vi.mock('../hooks/useLabelPayload', () => ({
@@ -86,6 +92,37 @@ const makeConfig = (overrides: Partial<LaunchConfiguration> = {}): LaunchConfigu
   },
   ...overrides,
 });
+
+const baseDefaults = {
+  inventory: { name: '', id: 0 as number },
+  limit: '',
+  labels: [] as { id: number; name: string }[],
+  scm_branch: '',
+  job_tags: '',
+  skip_tags: '',
+  extra_vars: '',
+  diff_mode: false,
+  job_type: 'run',
+  verbosity: 0 as const,
+  credentials: [] as LaunchConfigCredential[],
+  execution_environment: {} as Record<string, never>,
+  forks: 0,
+  job_slice_count: 1,
+  timeout: 0,
+  instance_groups: [] as [],
+};
+
+const mockWJT = {
+  id: 1,
+  name: 'Test WJT',
+  type: 'workflow_job_template',
+  summary_fields: {
+    labels: { count: 0, results: [] },
+    organization: { id: 1, name: 'Default', description: '' },
+    credentials: [],
+    user_capabilities: { edit: true, start: true },
+  },
+} as unknown as JobTemplate;
 
 const server = setupServer(
   http.get(awxAPI`/job_templates/1/`, () => HttpResponse.json(mockTemplate)),
@@ -288,5 +325,327 @@ describe('TemplateLaunchWizard', () => {
 
       expect(screen.getAllByText('Review').length).toBeGreaterThan(0);
     });
+
+    it('should render wizard with non-zero inventory id in initial values', () => {
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig({
+              defaults: { ...baseDefaults, inventory: { id: 5, name: 'Test Inv' } },
+            })}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+    });
+
+    it('should render breadcrumb for workflow_job_template type', () => {
+      const wjtTemplate = {
+        ...mockTemplate,
+        type: 'workflow_job_template' as const,
+        name: 'My WJT',
+      };
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={wjtTemplate as unknown as JobTemplate}
+            config={makeConfig()}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="workflow_job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('My WJT')).toBeInTheDocument();
+    });
+
+    it('should hide Credential Passwords step when no credentials require passwords', () => {
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig()}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.queryByTestId('wizard-nav-item-credential_passwords')).not.toBeInTheDocument();
+    });
+
+    it('should show Credential Passwords step when passwords_needed_to_start is set and credential is not asked', () => {
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig({
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: ['ssh_password'],
+            })}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('wizard-nav-item-credential_passwords')).toBeInTheDocument();
+    });
+
+    it('should show Credential Passwords step when a default credential has ASK inputs', () => {
+      const credWithAsk: LaunchConfigCredential = {
+        id: 1,
+        name: 'SSH Cred',
+        credential_type: 1,
+        passwords_needed: [],
+        inputs: { password: 'ASK' },
+      };
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig({
+              ask_credential_on_launch: true,
+              defaults: { ...baseDefaults, credentials: [credWithAsk] },
+            })}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('wizard-nav-item-credential_passwords')).toBeInTheDocument();
+    });
+
+    it('should show Credential Passwords step when a default credential has passwords_needed', () => {
+      const credWithPasswordsNeeded: LaunchConfigCredential = {
+        id: 2,
+        name: 'Key Cred',
+        credential_type: 1,
+        passwords_needed: ['ssh_password'],
+      };
+      render(
+        <MemoryRouter>
+          <LaunchWizard
+            template={mockTemplate}
+            config={makeConfig({
+              ask_credential_on_launch: true,
+              defaults: { ...baseDefaults, credentials: [credWithPasswordsNeeded] },
+            })}
+            handleSubmit={vi.fn(() => Promise.resolve())}
+            jobType="job_templates"
+          />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('wizard-nav-item-credential_passwords')).toBeInTheDocument();
+    });
+  });
+
+  describe('LaunchTemplate - additional coverage', () => {
+    it('should render AwxError when template fetch returns an error', async () => {
+      server.use(http.get(awxAPI`/job_templates/1/`, () => HttpResponse.json({}, { status: 500 })));
+      render(
+        <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+          <Routes>
+            <Route
+              path="/job-templates/:id/launch"
+              element={<LaunchTemplate jobType="job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+      });
+    });
+
+    it('should launch a workflow job template successfully', { timeout: 15000 }, async () => {
+      let wjtLaunched = false;
+      server.use(
+        http.get(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(mockWJT)),
+        http.get(awxAPI`/workflow_job_templates/1/launch/`, () => HttpResponse.json(makeConfig())),
+        http.post(awxAPI`/workflow_job_templates/1/launch/`, () => {
+          wjtLaunched = true;
+          return HttpResponse.json({ id: 200, type: 'workflow_job' });
+        })
+      );
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter initialEntries={['/workflow-job-templates/1/launch']}>
+          <Routes>
+            <Route
+              path="/workflow-job-templates/:id/launch"
+              element={<LaunchTemplate jobType="workflow_job_templates" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+      await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
+      await user.click(screen.getByTestId('wizard-next'));
+      await waitFor(() => {
+        expect(wjtLaunched).toBe(true);
+      });
+    });
+
+    it(
+      'should show failure alert when the launch POST request fails',
+      { timeout: 15000 },
+      async () => {
+        mockAddAlert.mockClear();
+        server.use(
+          http.post(awxAPI`/job_templates/1/launch/`, () => HttpResponse.json({}, { status: 500 }))
+        );
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+        await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
+        await user.click(screen.getByTestId('wizard-next'));
+        await waitFor(() => {
+          expect(mockAddAlert).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Failure to launch', variant: 'danger' })
+          );
+        });
+      }
+    );
+
+    it(
+      'should include labels in the launch payload when labelPayload is non-empty',
+      { timeout: 15000 },
+      async () => {
+        const { useLabelPayload } = await import('../hooks/useLabelPayload');
+        const mockCreateLabelPayload = vi.fn(() => Promise.resolve([1, 2]));
+        vi.mocked(useLabelPayload).mockReturnValue(mockCreateLabelPayload);
+
+        let capturedPayload: Record<string, unknown> = {};
+        server.use(
+          http.get(awxAPI`/job_templates/1/launch/`, () =>
+            HttpResponse.json(makeConfig({ ask_labels_on_launch: true }))
+          ),
+          http.post(awxAPI`/job_templates/1/launch/`, async ({ request }) => {
+            capturedPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: 100, type: 'job' });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <SWRConfig value={{ provider: () => new Map() }}>
+            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+              <Routes>
+                <Route
+                  path="/job-templates/:id/launch"
+                  element={<LaunchTemplate jobType="job_templates" />}
+                />
+              </Routes>
+            </MemoryRouter>
+          </SWRConfig>
+        );
+
+        await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByTestId('Submit')).toBeInTheDocument());
+        await user.click(screen.getByTestId('Submit'));
+        await waitFor(() => expect(screen.getByTestId('wizard-next')).toBeInTheDocument());
+        await user.click(screen.getByTestId('wizard-next'));
+
+        await waitFor(() => {
+          expect(capturedPayload.labels).toEqual([1, 2]);
+        });
+      }
+    );
+
+    it(
+      'should merge survey answers into extra_vars when survey_enabled is true',
+      { timeout: 15000 },
+      async () => {
+        let capturedPayload: Record<string, unknown> = {};
+        server.use(
+          http.get(awxAPI`/job_templates/1/launch/`, () =>
+            HttpResponse.json(makeConfig({ survey_enabled: true }))
+          ),
+          http.post(awxAPI`/job_templates/1/launch/`, async ({ request }) => {
+            capturedPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: 100, type: 'job' });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <SWRConfig value={{ provider: () => new Map() }}>
+            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+              <Routes>
+                <Route
+                  path="/job-templates/:id/launch"
+                  element={<LaunchTemplate jobType="job_templates" />}
+                />
+              </Routes>
+            </MemoryRouter>
+          </SWRConfig>
+        );
+
+        await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByTestId('Submit')).toBeInTheDocument());
+        await user.click(screen.getByTestId('Submit'));
+        await waitFor(() => expect(screen.getByTestId('wizard-next')).toBeInTheDocument());
+        await user.click(screen.getByTestId('wizard-next'));
+
+        await waitFor(() => {
+          expect(capturedPayload).toHaveProperty('extra_vars');
+        });
+      }
+    );
+
+    it(
+      'should include credential_passwords in payload when passwords_needed_to_start is set',
+      { timeout: 15000 },
+      async () => {
+        let capturedPayload: Record<string, unknown> = {};
+        server.use(
+          http.get(awxAPI`/job_templates/1/launch/`, () =>
+            HttpResponse.json(
+              makeConfig({
+                ask_credential_on_launch: false,
+                passwords_needed_to_start: ['ssh_password'],
+              })
+            )
+          ),
+          http.post(awxAPI`/job_templates/1/launch/`, async ({ request }) => {
+            capturedPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: 100, type: 'job' });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <SWRConfig value={{ provider: () => new Map() }}>
+            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+              <Routes>
+                <Route
+                  path="/job-templates/:id/launch"
+                  element={<LaunchTemplate jobType="job_templates" />}
+                />
+              </Routes>
+            </MemoryRouter>
+          </SWRConfig>
+        );
+
+        await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByTestId('launch-ssh-password')).toBeInTheDocument());
+        await user.type(screen.getByTestId('launch-ssh-password'), 'secret');
+        await user.click(screen.getByTestId('Submit'));
+        await waitFor(() => expect(screen.getByTestId('wizard-next')).toBeInTheDocument());
+        await user.click(screen.getByTestId('wizard-next'));
+
+        await waitFor(() => {
+          expect(capturedPayload.credential_passwords).toBeDefined();
+        });
+      }
+    );
   });
 });

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -132,6 +133,104 @@ describe('TemplateLaunchWizard', () => {
         expect(screen.getAllByText('Review').length).toBeGreaterThan(0);
       });
     });
+
+    it(
+      'should skip createLabelPayload and POST launch when ask_labels_on_launch is false',
+      { timeout: 15000 },
+      async () => {
+        const { useLabelPayload } = await import('../hooks/useLabelPayload');
+        const mockCreateLabelPayload = vi.fn(() => Promise.resolve([]));
+        vi.mocked(useLabelPayload).mockReturnValue(mockCreateLabelPayload);
+
+        let launchPosted = false;
+        server.use(
+          http.post(awxAPI`/job_templates/1/launch/`, () => {
+            launchPosted = true;
+            return HttpResponse.json({ id: 100, type: 'job' });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(() => {
+          expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+        });
+
+        // With all ask_* false only Review step is visible; click Finish to submit
+        await user.click(screen.getByTestId('wizard-next'));
+
+        await waitFor(() => {
+          expect(launchPosted).toBe(true);
+        });
+        expect(mockCreateLabelPayload).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      'should call createLabelPayload when ask_labels_on_launch is true',
+      { timeout: 15000 },
+      async () => {
+        const { useLabelPayload } = await import('../hooks/useLabelPayload');
+        const mockCreateLabelPayload = vi.fn(() => Promise.resolve([]));
+        vi.mocked(useLabelPayload).mockReturnValue(mockCreateLabelPayload);
+
+        let launchPosted = false;
+        server.use(
+          http.get(awxAPI`/job_templates/1/launch/`, () =>
+            HttpResponse.json(makeConfig({ ask_labels_on_launch: true }))
+          ),
+          http.post(awxAPI`/job_templates/1/launch/`, () => {
+            launchPosted = true;
+            return HttpResponse.json({ id: 100, type: 'job' });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(() => {
+          expect(screen.getByText('Prompt on Launch')).toBeInTheDocument();
+        });
+
+        // With ask_labels_on_launch: true, the Prompts step is visible first.
+        // Steps with `inputs` render PageFormSubmitButton (data-testid="Submit"),
+        // steps with `element` (Review) render a plain button (data-testid="wizard-next").
+        await waitFor(() => {
+          expect(screen.getByTestId('Submit')).toBeInTheDocument();
+        });
+        await user.click(screen.getByTestId('Submit'));
+
+        // Now on Review step — click Finish to submit
+        await waitFor(() => {
+          expect(screen.getByTestId('wizard-next')).toBeInTheDocument();
+        });
+        await user.click(screen.getByTestId('wizard-next'));
+
+        await waitFor(() => {
+          expect(launchPosted).toBe(true);
+        });
+        expect(mockCreateLabelPayload).toHaveBeenCalled();
+      }
+    );
   });
 
   describe('LaunchWizard', () => {

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -109,7 +109,9 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
       const { credential_passwords = {}, prompt = undefined, survey } = formValues;
 
       try {
-        const labelPayload = await createLabelPayload(prompt?.labels || [], template);
+        const labelPayload = config.ask_labels_on_launch
+          ? await createLabelPayload(prompt?.labels || [], template)
+          : [];
 
         let payload: Partial<LaunchPayload> = {};
         const setValue = <K extends LaunchPayloadProperty>(key: K, value?: LaunchPayload[K]) => {

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
@@ -322,5 +322,121 @@ describe('WorkflowJobTemplateForm', () => {
         expect(screen.getByText('Not Found')).toBeInTheDocument();
       });
     });
+
+    it(
+      'should fetch /organizations/ and create label when template has no org and a label is added',
+      { timeout: 15000 },
+      async () => {
+        const wjtWithoutOrg = {
+          ...mockWJT,
+          organization: null,
+          summary_fields: {
+            ...mockWJT.summary_fields,
+            organization: undefined,
+            labels: { count: 0, results: [] },
+          },
+        };
+        let orgFetched = false;
+        let labelPostBody: unknown = null;
+        server.use(
+          http.get(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
+          http.patch(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
+          http.get(awxAPI`/organizations/`, () => {
+            orgFetched = true;
+            return HttpResponse.json({ count: 1, results: [{ id: 20, name: 'Default' }] });
+          }),
+          http.post(awxAPI`/workflow_job_templates/1/labels/`, async ({ request }) => {
+            labelPostBody = await request.json();
+            return HttpResponse.json(labelPostBody);
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/workflow-job-templates/1/edit']}>
+            <Routes>
+              <Route
+                path="/workflow-job-templates/:id/edit"
+                element={<EditWorkflowJobTemplate />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId('name')).toHaveValue('Test Workflow');
+        });
+
+        const labelsInput = screen.getByTestId('labels-input');
+        await user.click(labelsInput);
+        await user.type(labelsInput, 'new-label');
+        await user.keyboard('{Enter}');
+
+        await user.click(screen.getByRole('button', { name: /save workflow job template/i }));
+
+        await waitFor(() => {
+          expect(orgFetched).toBe(true);
+        });
+        expect(labelPostBody).toMatchObject({ name: 'new-label', organization: 20 });
+      }
+    );
+
+    it(
+      'should not set orgId when /organizations/ returns empty results for WJT',
+      { timeout: 15000 },
+      async () => {
+        const wjtWithoutOrg = {
+          ...mockWJT,
+          organization: null,
+          summary_fields: {
+            ...mockWJT.summary_fields,
+            organization: undefined,
+            labels: { count: 0, results: [] },
+          },
+        };
+        let orgFetched = false;
+        let labelPostBody: unknown = null;
+        server.use(
+          http.get(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
+          http.patch(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
+          http.get(awxAPI`/organizations/`, () => {
+            orgFetched = true;
+            return HttpResponse.json({ count: 0, results: [] });
+          }),
+          http.post(awxAPI`/workflow_job_templates/1/labels/`, async ({ request }) => {
+            labelPostBody = await request.json();
+            return HttpResponse.json(labelPostBody);
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/workflow-job-templates/1/edit']}>
+            <Routes>
+              <Route
+                path="/workflow-job-templates/:id/edit"
+                element={<EditWorkflowJobTemplate />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId('name')).toHaveValue('Test Workflow');
+        });
+
+        const labelsInput = screen.getByTestId('labels-input');
+        await user.click(labelsInput);
+        await user.type(labelsInput, 'new-label');
+        await user.keyboard('{Enter}');
+
+        await user.click(screen.getByRole('button', { name: /save workflow job template/i }));
+
+        await waitFor(() => {
+          expect(orgFetched).toBe(true);
+        });
+        expect(labelPostBody).toMatchObject({ name: 'new-label' });
+      }
+    );
   });
 });

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -328,10 +329,12 @@ describe('WorkflowJobTemplateForm', () => {
       { timeout: 15000 },
       async () => {
         const wjtWithoutOrg = {
-          ...mockWJT,
+          ...mockWfjt,
+          id: 1,
+          name: 'Test Workflow',
           organization: null,
           summary_fields: {
-            ...mockWJT.summary_fields,
+            ...mockWfjt.summary_fields,
             organization: undefined,
             labels: { count: 0, results: [] },
           },
@@ -353,19 +356,22 @@ describe('WorkflowJobTemplateForm', () => {
 
         const user = userEvent.setup();
         render(
-          <MemoryRouter initialEntries={['/workflow-job-templates/1/edit']}>
+          <MemoryRouter initialEntries={['/templates/workflow_job_template/1/edit']}>
             <Routes>
               <Route
-                path="/workflow-job-templates/:id/edit"
+                path="/templates/workflow_job_template/:id/edit"
                 element={<EditWorkflowJobTemplate />}
               />
             </Routes>
           </MemoryRouter>
         );
 
-        await waitFor(() => {
-          expect(screen.getByTestId('name')).toHaveValue('Test Workflow');
-        });
+        await waitFor(
+          () => {
+            expect(screen.getByDisplayValue('Test Workflow')).toBeInTheDocument();
+          },
+          { timeout: 10000 }
+        );
 
         const labelsInput = screen.getByTestId('labels-input');
         await user.click(labelsInput);
@@ -386,10 +392,12 @@ describe('WorkflowJobTemplateForm', () => {
       { timeout: 15000 },
       async () => {
         const wjtWithoutOrg = {
-          ...mockWJT,
+          ...mockWfjt,
+          id: 1,
+          name: 'Test Workflow',
           organization: null,
           summary_fields: {
-            ...mockWJT.summary_fields,
+            ...mockWfjt.summary_fields,
             organization: undefined,
             labels: { count: 0, results: [] },
           },
@@ -411,19 +419,22 @@ describe('WorkflowJobTemplateForm', () => {
 
         const user = userEvent.setup();
         render(
-          <MemoryRouter initialEntries={['/workflow-job-templates/1/edit']}>
+          <MemoryRouter initialEntries={['/templates/workflow_job_template/1/edit']}>
             <Routes>
               <Route
-                path="/workflow-job-templates/:id/edit"
+                path="/templates/workflow_job_template/:id/edit"
                 element={<EditWorkflowJobTemplate />}
               />
             </Routes>
           </MemoryRouter>
         );
 
-        await waitFor(() => {
-          expect(screen.getByTestId('name')).toHaveValue('Test Workflow');
-        });
+        await waitFor(
+          () => {
+            expect(screen.getByDisplayValue('Test Workflow')).toBeInTheDocument();
+          },
+          { timeout: 10000 }
+        );
 
         const labelsInput = screen.getByTestId('labels-input');
         await user.click(labelsInput);

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
@@ -526,18 +526,17 @@ describe('WorkflowJobTemplateForm', () => {
 
         await waitFor(() => {
           expect(patchBody).not.toBeNull();
+          // mockWfjt has job_tags: 'deploy' and skip_tags: 'cleanup' → stringified (non-null)
+          expect(patchBody?.job_tags).toBe('deploy');
+          expect(patchBody?.skip_tags).toBe('cleanup');
+          // mockWfjt has limit: '' and scm_branch: '' → null
+          expect(patchBody?.limit).toBeNull();
+          expect(patchBody?.scm_branch).toBeNull();
+          // mockWfjt has no inventory and no webhook_credential → null
+          expect(patchBody?.inventory).toBeNull();
+          expect(patchBody?.webhook_credential).toBeNull();
+          expect(patchBody?.webhook_service).toBe('');
         });
-
-        // mockWfjt has job_tags: 'deploy' and skip_tags: 'cleanup' → stringified (non-null)
-        expect(patchBody?.job_tags).toBe('deploy');
-        expect(patchBody?.skip_tags).toBe('cleanup');
-        // mockWfjt has limit: '' and scm_branch: '' → null
-        expect(patchBody?.limit).toBeNull();
-        expect(patchBody?.scm_branch).toBeNull();
-        // mockWfjt has no inventory and no webhook_credential → null
-        expect(patchBody?.inventory).toBeNull();
-        expect(patchBody?.webhook_credential).toBeNull();
-        expect(patchBody?.webhook_service).toBe('');
       }
     );
 
@@ -586,14 +585,13 @@ describe('WorkflowJobTemplateForm', () => {
 
         await waitFor(() => {
           expect(patchBody).not.toBeNull();
+          // Empty tags → stringifyTags([]) = '' → null
+          expect(patchBody?.job_tags).toBeNull();
+          expect(patchBody?.skip_tags).toBeNull();
+          // Non-empty limit and scm_branch → passed through as-is
+          expect(patchBody?.limit).toBe('host-pattern');
+          expect(patchBody?.scm_branch).toBe('feature/test');
         });
-
-        // Empty tags → stringifyTags([]) = '' → null
-        expect(patchBody?.job_tags).toBeNull();
-        expect(patchBody?.skip_tags).toBeNull();
-        // Non-empty limit and scm_branch → passed through as-is
-        expect(patchBody?.limit).toBe('host-pattern');
-        expect(patchBody?.scm_branch).toBe('feature/test');
       }
     );
 

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
@@ -232,6 +232,47 @@ describe('WorkflowJobTemplateForm', () => {
         expect(screen.getByText('Extra variables')).toBeInTheDocument();
       });
     });
+
+    it('should POST to /workflow_job_templates/ with null for empty job_tags, skip_tags, and webhook_credential', async () => {
+      let postBody: Record<string, unknown> | null = null;
+      server.use(
+        http.post(awxAPI`/workflow_job_templates/`, async ({ request }) => {
+          postBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: 99, name: 'New Template', organization: 1 });
+        })
+      );
+
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <CreateWorkflowJobTemplate />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(/enter workflow job template name/i)
+        ).toBeInTheDocument();
+      });
+
+      await user.type(
+        screen.getByPlaceholderText(/enter workflow job template name/i),
+        'New Template'
+      );
+      await user.click(screen.getByRole('button', { name: /create workflow job template/i }));
+
+      await waitFor(() => {
+        expect(postBody).not.toBeNull();
+      });
+
+      // Default job_tags/skip_tags are [] → stringifyTags([]) = '' → null
+      expect(postBody).toMatchObject({
+        name: 'New Template',
+        job_tags: null,
+        skip_tags: null,
+        webhook_credential: null,
+      });
+    });
   });
 
   describe('EditWorkflowJobTemplate', () => {
@@ -447,6 +488,155 @@ describe('WorkflowJobTemplateForm', () => {
           expect(orgFetched).toBe(true);
         });
         expect(labelPostBody).toMatchObject({ name: 'new-label' });
+      }
+    );
+
+    it(
+      'should PATCH with non-null job_tags/skip_tags and null for empty limit and scm_branch',
+      { timeout: 15000 },
+      async () => {
+        let patchBody: Record<string, unknown> | null = null;
+        server.use(
+          http.patch(awxAPI`/workflow_job_templates/10/`, async ({ request }) => {
+            patchBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ...mockWfjt });
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/templates/workflow_job_template/10/edit']}>
+            <Routes>
+              <Route
+                path="/templates/workflow_job_template/:id/edit"
+                element={<EditWorkflowJobTemplate />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(
+          () => {
+            expect(screen.getByDisplayValue('My Workflow')).toBeInTheDocument();
+          },
+          { timeout: 10000 }
+        );
+
+        await user.click(screen.getByRole('button', { name: /save workflow job template/i }));
+
+        await waitFor(() => {
+          expect(patchBody).not.toBeNull();
+        });
+
+        // mockWfjt has job_tags: 'deploy' and skip_tags: 'cleanup' → stringified (non-null)
+        expect(patchBody?.job_tags).toBe('deploy');
+        expect(patchBody?.skip_tags).toBe('cleanup');
+        // mockWfjt has limit: '' and scm_branch: '' → null
+        expect(patchBody?.limit).toBeNull();
+        expect(patchBody?.scm_branch).toBeNull();
+        // mockWfjt has no inventory and no webhook_credential → null
+        expect(patchBody?.inventory).toBeNull();
+        expect(patchBody?.webhook_credential).toBeNull();
+        expect(patchBody?.webhook_service).toBe('');
+      }
+    );
+
+    it(
+      'should PATCH with null job_tags/skip_tags and non-null limit/scm_branch when template has those values',
+      { timeout: 15000 },
+      async () => {
+        const wfjtEmptyTagsWithLimit = {
+          ...mockWfjt,
+          job_tags: '',
+          skip_tags: '',
+          limit: 'host-pattern',
+          scm_branch: 'feature/test',
+        };
+        let patchBody: Record<string, unknown> | null = null;
+        server.use(
+          http.get(awxAPI`/workflow_job_templates/10/`, () =>
+            HttpResponse.json(wfjtEmptyTagsWithLimit)
+          ),
+          http.patch(awxAPI`/workflow_job_templates/10/`, async ({ request }) => {
+            patchBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(wfjtEmptyTagsWithLimit);
+          })
+        );
+
+        const user = userEvent.setup();
+        render(
+          <MemoryRouter initialEntries={['/templates/workflow_job_template/10/edit']}>
+            <Routes>
+              <Route
+                path="/templates/workflow_job_template/:id/edit"
+                element={<EditWorkflowJobTemplate />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(
+          () => {
+            expect(screen.getByDisplayValue('My Workflow')).toBeInTheDocument();
+          },
+          { timeout: 10000 }
+        );
+
+        await user.click(screen.getByRole('button', { name: /save workflow job template/i }));
+
+        await waitFor(() => {
+          expect(patchBody).not.toBeNull();
+        });
+
+        // Empty tags → stringifyTags([]) = '' → null
+        expect(patchBody?.job_tags).toBeNull();
+        expect(patchBody?.skip_tags).toBeNull();
+        // Non-empty limit and scm_branch → passed through as-is
+        expect(patchBody?.limit).toBe('host-pattern');
+        expect(patchBody?.scm_branch).toBe('feature/test');
+      }
+    );
+
+    it(
+      'should set isWebhookEnabled and render webhook details when webhook_receiver is present',
+      { timeout: 15000 },
+      async () => {
+        const wfjtWithWebhook = {
+          ...mockWfjt,
+          related: {
+            ...mockWfjt.related,
+            webhook_receiver: '/api/v2/workflow_job_templates/10/github/',
+          },
+        };
+        server.use(
+          http.get(awxAPI`/workflow_job_templates/10/`, () => HttpResponse.json(wfjtWithWebhook)),
+          http.get(awxAPI`/workflow_job_templates/10/webhook_key/`, () =>
+            HttpResponse.json({ webhook_key: 'test-key' })
+          )
+        );
+
+        render(
+          <MemoryRouter initialEntries={['/templates/workflow_job_template/10/edit']}>
+            <Routes>
+              <Route
+                path="/templates/workflow_job_template/:id/edit"
+                element={<EditWorkflowJobTemplate />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        await waitFor(
+          () => {
+            expect(screen.getByDisplayValue('My Workflow')).toBeInTheDocument();
+          },
+          { timeout: 10000 }
+        );
+
+        // isWebhookEnabled = true because webhook_receiver is truthy → WebhookSubForm renders
+        await waitFor(() => {
+          expect(screen.getByText('Webhook details')).toBeInTheDocument();
+        });
       }
     );
   });

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.test.tsx
@@ -337,7 +337,7 @@ describe('WorkflowJobTemplateForm', () => {
           },
         };
         let orgFetched = false;
-        let labelPostBody: unknown = null;
+        let labelPostBody: Record<string, unknown> | null = null;
         server.use(
           http.get(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
           http.patch(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
@@ -346,7 +346,7 @@ describe('WorkflowJobTemplateForm', () => {
             return HttpResponse.json({ count: 1, results: [{ id: 20, name: 'Default' }] });
           }),
           http.post(awxAPI`/workflow_job_templates/1/labels/`, async ({ request }) => {
-            labelPostBody = await request.json();
+            labelPostBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json(labelPostBody);
           })
         );
@@ -395,7 +395,7 @@ describe('WorkflowJobTemplateForm', () => {
           },
         };
         let orgFetched = false;
-        let labelPostBody: unknown = null;
+        let labelPostBody: Record<string, unknown> | null = null;
         server.use(
           http.get(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
           http.patch(awxAPI`/workflow_job_templates/1/`, () => HttpResponse.json(wjtWithoutOrg)),
@@ -404,7 +404,7 @@ describe('WorkflowJobTemplateForm', () => {
             return HttpResponse.json({ count: 0, results: [] });
           }),
           http.post(awxAPI`/workflow_job_templates/1/labels/`, async ({ request }) => {
-            labelPostBody = await request.json();
+            labelPostBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json(labelPostBody);
           })
         );

--- a/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplateForm.tsx
@@ -206,14 +206,12 @@ async function submitLabels(
     labels ?? ([] as Label[])
   );
 
-  let orgId = template?.organization;
-  if (!template.summary_fields?.organization?.id) {
-    // eslint-disable-next-line no-useless-catch
-    try {
-      const data = await requestGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`);
+  let orgId: number | undefined =
+    (template?.organization as number | undefined) ?? template.summary_fields?.organization?.id;
+  if (!orgId && added.length > 0) {
+    const data = await requestGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`);
+    if (data.results.length > 0) {
       orgId = data.results[0].id;
-    } catch (err) {
-      throw err;
     }
   }
   const disassociationPromises = removed.map((label: { id: number }) =>

--- a/frontend/awx/resources/templates/hooks/useLabelPayload.test.tsx
+++ b/frontend/awx/resources/templates/hooks/useLabelPayload.test.tsx
@@ -114,6 +114,30 @@ describe('useLabelPayload', () => {
     expect(labelIds).toContain(999);
   });
 
+  it('should throw when template has no org and no organizations are accessible', async () => {
+    server.use(
+      http.get(awxAPI`/organizations/`, () => HttpResponse.json({ count: 0, results: [] }))
+    );
+
+    const templateNoOrg = {
+      ...mockTemplate,
+      summary_fields: {
+        ...mockTemplate.summary_fields,
+        organization: undefined,
+      },
+    } as unknown as JobTemplate;
+
+    const { result } = renderHook(() => useLabelPayload());
+
+    await waitFor(() => {
+      expect(result.current).toBeInstanceOf(Function);
+    });
+
+    await expect(result.current([{ name: 'new-label' }], templateNoOrg)).rejects.toThrow(
+      'Cannot create label: this template has no organization and no organizations are accessible.'
+    );
+  });
+
   it('should handle label creation failure gracefully', async () => {
     server.use(http.post(awxAPI`/labels/`, () => HttpResponse.json({}, { status: 500 })));
 

--- a/frontend/awx/resources/templates/hooks/useLabelPayload.tsx
+++ b/frontend/awx/resources/templates/hooks/useLabelPayload.tsx
@@ -32,12 +32,6 @@ export function useLabelPayload() {
       templateLabels.forEach((label) => labelIds.add(label.id));
 
       let organizationId = template?.summary_fields?.organization?.id;
-      if (!organizationId) {
-        const { results } = await requestGet<AwxItemsResponse<Organization>>(
-          awxAPI`/organizations/`
-        );
-        organizationId = results[0].id;
-      }
 
       const labelsToCreate: Promise<Label>[] = [];
       for (const label of promptLabels) {
@@ -52,7 +46,21 @@ export function useLabelPayload() {
           continue;
         }
 
-        // Label needs to be created
+        // Label needs to be created — resolve org ID only at this point
+        if (!organizationId) {
+          const { results } = await requestGet<AwxItemsResponse<Organization>>(
+            awxAPI`/organizations/`
+          );
+          if (!results.length) {
+            throw new Error(
+              t(
+                'Cannot create label: this template has no organization and no organizations are accessible.'
+              )
+            );
+          }
+          organizationId = results[0].id;
+        }
+
         labelsToCreate.push(
           postRequest(awxAPI`/labels/`, {
             name: label.name,


### PR DESCRIPTION
## Summary

Fixes a crash that occurred when a non-superuser (team-level execute access only) launched a Workflow Job Template with no organization set, where a survey or other prompt forced the launch wizard open.

The UI threw `TypeError: can't access property "id", f[0] is undefined` instead of creating the workflow job. The backend launch API itself succeeds — this was a UI-only bug.

**Root cause:** `useLabelPayload` unconditionally called `GET /organizations/` before processing any labels and dereferenced `results[0].id` without a length guard. For users with no org membership the API returns `{ results: [] }`, causing the crash. Additionally, `TemplateLaunchWizard` was calling `createLabelPayload` unconditionally even when `ask_labels_on_launch` is false, so the org-fetch path was reached on every wizard submit regardless of whether labels were prompted.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

> Changes are isolated to the WJT/JT launch wizard and template form submit handlers. The only behavioral change for users unaffected by the bug is that `GET /organizations/` is no longer called on every wizard submit when `ask_labels_on_launch` is false.

## Testing

### Manual Testing

**Repro scenario (requires a non-superuser with team-level execute access):**

1. Log in to the AAP web UI as **admin** (`admin` / `admin`).
2. Create a **Workflow Job Template** named `NoOrgTestWJT` with **Organization** set to none (leave blank / null).
3. Open the **Workflow Visualizer**, add a single node that launches **Demo Job Template**, and save.
4. On the **Survey** tab, add one survey question (e.g. text, variable `test_var`, required) and enable the survey.
5. Create a **User** named `NoOrgUser` (User Type: normal; do not assign to any organization).
6. Create a **Team** named `DefaultTeam` in the **Default** organization.
7. Add `NoOrgUser` to team `DefaultTeam`.
8. On `NoOrgTestWJT`, open **Team Access**, add role **Workflow Job Template Execute** (or equivalent execute role) for `DefaultTeam`.
9. Log out and log in as **NoOrgUser** (`NoOrgUser123!` on the lab; Gateway login at `/api/gateway/v1/login/`).
10. Navigate to **Automation Execution → Templates**, select **NoOrgTestWJT**, and click **Launch**.
11. Complete the **Survey** step, proceed through **Review**, and submit the launch.

**Before:** UI crashes with `Failure to launch — TypeError: can't access property "id", f[0] is undefined`.

**After:** The workflow job is created successfully and the user is navigated to the job output page.

**Workaround that existed before this fix:** Assign an organization to the WJT.

### Unit Tests Added

New Vitest coverage added across four files:

- **`useLabelPayload.test.tsx`** — org fetch not called when no labels need creation; descriptive error thrown when org results are empty and a new label must be created; label created successfully when org is available.
- **`TemplateLaunchWizard.test.tsx`** — `createLabelPayload` skipped when `ask_labels_on_launch` is false; called when true.
- **`WorkflowJobTemplateForm.test.tsx`** — org fetch skipped when no labels are added; `results[0]` access guarded.
- **`TemplateForm.test.tsx`** — same as above.
