### PR TITLE
fix(awx): clear stale extra_data when switching workflow node templates

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -352,6 +352,21 @@ export function useSaveVisualizer(templateId: string) {
           await processInstanceGroups(nodeId, launch_data, 'disassociate');
           await processCredentials(nodeId, launch_data, 'disassociate');
 
+          // Clear extra_data in a separate PATCH before changing the template.
+          // AWX ignores extra_data updates when unified_job_template changes in
+          // the same request because the old template's ask_variables_on_launch
+          // flag governs field writability during validation.
+          if (
+            launch_data?.original?.isTemplateChange &&
+            'extra_data' in updatedNodePayload &&
+            Object.keys(updatedNodePayload.extra_data as object).length === 0
+          ) {
+            await patchWorkflowNode(awxAPI`/workflow_job_template_nodes/${nodeId}/`, {
+              extra_data: {},
+            });
+            delete updatedNodePayload.extra_data;
+          }
+
           await patchWorkflowNode(
             awxAPI`/workflow_job_template_nodes/${nodeId}/`,
             updatedNodePayload

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/buildEffectivePrompt.ts
@@ -47,8 +47,8 @@ export function buildEffectivePrompt({
   }
 
   effectivePrompt.original = {
-    ...(launchConfig ? { launch_config: launchConfig } : {}),
     ...nodeOriginalResources,
+    ...(launchConfig ? { launch_config: launchConfig } : {}),
     ...(isTemplateChange ? { isTemplateChange: true } : {}),
   };
 


### PR DESCRIPTION
## Summary

Fixes stale `extra_data` (extra_vars) not being cleared when switching a workflow visualizer node's template to one that doesn't support prompted variables. This caused nightly CI failures across all 4 AAP 2.7 Next topologies in `workflow-visualizer-template-switch.spec.ts` (7-8/8 tests failing).

**Root causes:**

1. **`buildEffectivePrompt` spread order bug** — `nodeOriginalResources` (containing the old template's `launch_config`) was spread *after* the new template's `launchConfig`, overwriting it. This caused `useSaveVisualizer`'s `promptMapper` to reference stale `ask_*` flags, preventing valid `extra_data` writes for the new template.

2. **AWX PATCH validation constraint** — AWX ignores `extra_data` updates when `unified_job_template` changes in the same request because the old template's `ask_variables_on_launch` flag governs field writability during validation. Clearing must happen in a separate request while the old template is still in place.

**Changes:**

- `buildEffectivePrompt.ts`: Reordered spreads so `nodeOriginalResources` is applied first and the new template's `launch_config` takes precedence
- `useSaveVisualizer.tsx`: Added a separate PATCH to clear `extra_data` before the template-change PATCH when the field should be empty

## Type of Change

- [x] Bug fix
- [ ] Tests
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Manual Testing

1. Open a workflow visualizer and edit an existing node that uses a Job Template with `ask_variables_on_launch` and extra_vars set
2. Switch the node's template to a different Job Template without `ask_variables_on_launch`
3. Save the workflow
4. Re-open the node and verify `extra_data` is empty (no stale variables from old template)
5. Also verify: switching TO a template with prompts and entering new values preserves those values on save

## Test plan

- [x] Scenarios 1-10 of `workflow-visualizer-template-switch.spec.ts` pass locally (12/15 total, Scenario 11 has a pre-existing flaky credential cleanup timeout)
- [ ] Run `/run-playwright` on PR to validate against ephemeral AAP instance
- [ ] Verify nightly CI passes on next run after merge