### PR TITLE
test(hub): add coverage for undefined documentation_files 

### DIFF
--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
@@ -591,6 +591,45 @@ describe('CollectionDocumentation', () => {
     });
   });
 
+  test('should render gracefully when documentation_files is undefined and content_name is set', async () => {
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/content/ansible/collection_versions/');
+        },
+        () => {
+          return HttpResponse.json({
+            count: 1,
+            next: '',
+            previous: '',
+            results: [
+              {
+                docs_blob: {
+                  contents: [],
+                  collection_readme: { html: '<p>Fallback readme</p>', name: 'README.md' },
+                },
+                license: ['GPL-3.0-or-later'],
+              },
+            ],
+          });
+        }
+      )
+    );
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <TestWrapper initialPath="/collections/validated/testnamespace/testcollection/documentation/changelog">
+          <CollectionDocumentation />
+        </TestWrapper>
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      const drawer = document.querySelector('[class*="drawer"]');
+      expect(drawer).toBeTruthy();
+    });
+  });
+
   test('should render gracefully when documentation_files is undefined', async () => {
     server.use(
       http.get(


### PR DESCRIPTION
## Summary

Adds a test case for when documentation_files is undefined and content_name is set in the URL. This matches the downstream backport coverage to keep upstream and downstream in sync.

Assisted-by: Claude Code


## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
