### PR TITLE
Surface Facts and Jobs tabs for constructed inventory hosts

### DIFF
--- a/frontend/awx/resources/hosts/HostPage/HostJobs.test.tsx
+++ b/frontend/awx/resources/hosts/HostPage/HostJobs.test.tsx
@@ -7,7 +7,22 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { HostJobs } from './HostJobs';
 
+const mockRegularHost = {
+  id: 123,
+  name: 'test-host',
+  instance_id: '',
+  summary_fields: { inventory: { kind: '' } },
+};
+
+const mockConstructedHost = {
+  id: 123,
+  name: 'proxy-host',
+  instance_id: '42',
+  summary_fields: { inventory: { kind: 'constructed' } },
+};
+
 const server = setupServer(
+  http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockRegularHost)),
   http.options(awxAPI`/unified_jobs/`, () => HttpResponse.json({ actions: { GET: {} } })),
   http.options(awxAPI`/inventory_sources/`, () => HttpResponse.json({ actions: { GET: {} } })),
   http.get(awxAPI`/unified_jobs/`, () =>
@@ -37,6 +52,33 @@ describe('HostJobs', () => {
     await waitFor(
       () => {
         expect(screen.getByText('No jobs yet')).toBeInTheDocument();
+      },
+      { timeout: 15000 }
+    );
+  });
+
+  test('should use source host instance_id for constructed inventory hosts', async () => {
+    const capturedUrls: string[] = [];
+
+    server.use(
+      http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockConstructedHost)),
+      http.get(awxAPI`/unified_jobs/`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ count: 0, results: [], next: null, previous: null });
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/hosts/123/jobs']}>
+        <Routes>
+          <Route path="/hosts/:id/jobs" element={<HostJobs />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(capturedUrls.some((url) => url.includes('job__hosts=42'))).toBe(true);
       },
       { timeout: 15000 }
     );

--- a/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
+++ b/frontend/awx/resources/hosts/HostPage/HostJobs.tsx
@@ -1,12 +1,16 @@
 import { usePersistentFilters } from '@ansible/common-ui/PersistentFilters';
 import { useParams } from 'react-router-dom';
 import { JobsList } from '../../../views/jobs/JobsList';
+import { useGetHost } from '../hooks/useGetHost';
 import { useHostsJobsColumns } from '../../inventories/inventoryHostsPage/hooks/useHostsJobsColumns';
 
 export function HostJobs() {
   usePersistentFilters('inventories');
   const jobsColumns = useHostsJobsColumns();
   const { id = '' } = useParams<{ id: string }>();
-  const queryParams = { job__hosts: id, not__launch_type: 'sync' };
+  const { host } = useGetHost(id); // ponytail: SWR deduplicates — HostPage already fetched this
+  const isConstructed = host?.summary_fields?.inventory?.kind === 'constructed';
+  const effectiveHostId = isConstructed && host?.instance_id ? host.instance_id : id;
+  const queryParams = { job__hosts: effectiveHostId, not__launch_type: 'sync' };
   return <JobsList queryParams={queryParams} columns={jobsColumns} />;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.test.tsx
@@ -119,6 +119,29 @@ describe('InventoryHostFacts Component', () => {
     ).toBeInTheDocument();
   });
 
+  test('should show error state when facts API fails', async () => {
+    server.use(
+      http.get(awxAPI`/hosts/:id/ansible_facts/`, () =>
+        HttpResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/inventories/1/hosts/1/facts']}>
+        <Routes>
+          <Route
+            path="/inventories/:id/hosts/:host_id/facts"
+            element={<InventoryHostFacts page="inventory_host" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/internal server error/i)).toBeInTheDocument();
+    });
+  });
+
   test('should render facts for standalone host page', async () => {
     render(
       <MemoryRouter initialEntries={['/hosts/123/facts']}>
@@ -140,5 +163,32 @@ describe('InventoryHostFacts Component', () => {
       // Check if facts data is present in the document
       expect(screen.getByText(/ansible_dns/i, { exact: false })).toBeInTheDocument();
     });
+  });
+
+  test('should fall back to empty string when params.id is absent for standalone host page', () => {
+    // Covers the params.id ?? '' branch on line 15 when route has no :id segment
+    render(
+      <MemoryRouter initialEntries={['/facts']}>
+        <Routes>
+          <Route path="/facts" element={<InventoryHostFacts page="host" />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  test('should fall back to empty string when params.host_id is absent for inventory host page', () => {
+    // Covers the params.host_id ?? '' branch on line 15 when route has no :host_id segment
+    render(
+      <MemoryRouter initialEntries={['/inventories/1/facts']}>
+        <Routes>
+          <Route
+            path="/inventories/:id/facts"
+            element={<InventoryHostFacts page="inventory_host" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(document.body).toBeInTheDocument();
   });
 });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.test.tsx
@@ -19,8 +19,23 @@ const mockAnsibleFacts = {
   ansible_hostname: 'test-host',
 };
 
+const mockRegularHost = {
+  id: 1,
+  name: 'test-host',
+  instance_id: '',
+  summary_fields: { inventory: { kind: '' } },
+};
+
+const mockConstructedHost = {
+  id: 1,
+  name: 'proxy-host',
+  instance_id: '999',
+  summary_fields: { inventory: { kind: 'constructed' } },
+};
+
 describe('InventoryHostFacts Component', () => {
   const server = setupServer(
+    http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockRegularHost)),
     http.get(awxAPI`/hosts/:id/ansible_facts/`, () => {
       return HttpResponse.json(mockAnsibleFacts);
     })
@@ -57,7 +72,7 @@ describe('InventoryHostFacts Component', () => {
     });
   });
 
-  test('should render empty object when no facts are available', async () => {
+  test('should render empty state when no facts are available', async () => {
     server.use(
       http.get(awxAPI`/hosts/:id/ansible_facts/`, () => {
         return HttpResponse.json({});
@@ -76,8 +91,32 @@ describe('InventoryHostFacts Component', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Facts')).toBeInTheDocument();
+      expect(screen.getByText('No facts found')).toBeInTheDocument();
     });
+  });
+
+  test('should show informational message for constructed inventory hosts', async () => {
+    server.use(http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockConstructedHost)));
+
+    render(
+      <MemoryRouter initialEntries={['/inventories/1/hosts/1/facts']}>
+        <Routes>
+          <Route
+            path="/inventories/:id/hosts/:host_id/facts"
+            element={<InventoryHostFacts page="inventory_host" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No facts available')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        'Facts for hosts in constructed and smart inventories are stored on the source inventory host.'
+      )
+    ).toBeInTheDocument();
   });
 
   test('should render facts for standalone host page', async () => {

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.tsx
@@ -13,10 +13,16 @@ export function InventoryHostFacts(props: { page: string }) {
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
 
   const hostId = props.page === 'host' ? (params.id ?? '') : (params.host_id ?? '');
-  const { host } = useGetHost(hostId); // ponytail: SWR deduplicates — parent page already fetched this
+  const { host } = useGetHost(hostId);
   const isConstructed = host?.summary_fields?.inventory?.kind === 'constructed';
 
-  const { data: facts, error, isLoading } = useGet<object>(awxAPI`/hosts/${hostId}/ansible_facts/`);
+  const hostLoaded = host !== undefined;
+  const skipFacts = hostLoaded && isConstructed;
+  const {
+    data: facts,
+    error,
+    isLoading,
+  } = useGet<object>(skipFacts ? undefined : awxAPI`/hosts/${hostId}/ansible_facts/`);
 
   if (isConstructed) {
     return (

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostFacts.tsx
@@ -1,21 +1,52 @@
 import { PageDetails } from '@ansible/ansible-ui-framework';
 import { PageDetailCodeEditor } from '@ansible/ansible-ui-framework/PageDetails/PageDetailCodeEditor';
+import { EmptyStateError } from '@ansible/ansible-ui-framework/components/EmptyStateError';
+import { EmptyStateNoData } from '@ansible/ansible-ui-framework/components/EmptyStateNoData';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { awxAPI } from '../../../common/api/awx-utils';
+import { useGetHost } from '../../hosts/hooks/useGetHost';
 
 export function InventoryHostFacts(props: { page: string }) {
   const { t } = useTranslation();
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
 
-  const { data: facts } = useGet<object>(
-    awxAPI`/hosts/${props.page === 'host' ? (params.id ?? '') : (params.host_id ?? '')}/ansible_facts/`
-  );
+  const hostId = props.page === 'host' ? (params.id ?? '') : (params.host_id ?? '');
+  const { host } = useGetHost(hostId); // ponytail: SWR deduplicates — parent page already fetched this
+  const isConstructed = host?.summary_fields?.inventory?.kind === 'constructed';
+
+  const { data: facts, error, isLoading } = useGet<object>(awxAPI`/hosts/${hostId}/ansible_facts/`);
+
+  if (isConstructed) {
+    return (
+      <EmptyStateNoData
+        title={t('No facts available')}
+        description={t(
+          'Facts for hosts in constructed and smart inventories are stored on the source inventory host.'
+        )}
+      />
+    );
+  }
+
+  if (error) {
+    return <EmptyStateError message={error.message} />;
+  }
+
+  if (!isLoading && (!facts || Object.keys(facts).length === 0)) {
+    return (
+      <EmptyStateNoData
+        title={t('No facts found')}
+        description={t(
+          'Facts are collected when a playbook with fact gathering enabled runs against this host.'
+        )}
+      />
+    );
+  }
 
   return (
     <PageDetails>
-      <PageDetailCodeEditor label={t('Facts')} value={JSON.stringify(facts) || '{}'} />
+      <PageDetailCodeEditor label={t('Facts')} value={JSON.stringify(facts) ?? '{}'} />
     </PageDetails>
   );
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.test.tsx
@@ -51,8 +51,23 @@ const mockCompletedJob = {
   },
 };
 
+const mockRegularHost = {
+  id: 123,
+  name: 'test-host',
+  instance_id: '',
+  summary_fields: { inventory: { kind: '' } },
+};
+
+const mockConstructedHost = {
+  id: 7,
+  name: 'proxy-host',
+  instance_id: '42',
+  summary_fields: { inventory: { kind: 'constructed' } },
+};
+
 describe('InventoryHostJobs Component', () => {
   const server = setupServer(
+    http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockRegularHost)),
     http.get(awxAPI`/unified_jobs/`, () => {
       return HttpResponse.json({
         count: 1,
@@ -198,6 +213,33 @@ describe('InventoryHostJobs Component', () => {
     await waitFor(
       () => {
         expect(screen.getByText(/No jobs yet/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  test('should use source host instance_id for constructed inventory hosts', async () => {
+    const capturedUrls: string[] = [];
+
+    server.use(
+      http.get(awxAPI`/hosts/:id/`, () => HttpResponse.json(mockConstructedHost)),
+      http.get(awxAPI`/unified_jobs/`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ count: 0, next: null, previous: null, results: [] });
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/inventories/1/hosts/7/jobs']}>
+        <Routes>
+          <Route path="/inventories/:id/hosts/:host_id/jobs" element={<InventoryHostJobs />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(capturedUrls.some((url) => url.includes('job__hosts=42'))).toBe(true);
       },
       { timeout: 5000 }
     );

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
@@ -8,9 +8,10 @@ export function InventoryHostJobs() {
   usePersistentFilters('inventories');
   const jobsColumns = useHostsJobsColumns();
   const { host_id = '' } = useParams<{ host_id: string }>();
-  const { host } = useGetHost(host_id); // ponytail: SWR deduplicates — InventoryHostPage already fetched this
-  const isConstructed = host?.summary_fields?.inventory?.kind === 'constructed';
-  const effectiveHostId = isConstructed && host?.instance_id ? host.instance_id : host_id;
+  const { host } = useGetHost(host_id); // SWR deduplicates — InventoryHostPage already fetched this
+  if (!host) return null;
+  const isConstructed = host.summary_fields?.inventory?.kind === 'constructed';
+  const effectiveHostId = isConstructed && host.instance_id ? host.instance_id : host_id;
   const queryParams = { job__hosts: effectiveHostId, not__launch_type: 'sync' };
   return <JobsList queryParams={queryParams} columns={jobsColumns} />;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostJobs.tsx
@@ -1,12 +1,16 @@
 import { usePersistentFilters } from '@ansible/common-ui/PersistentFilters';
 import { useParams } from 'react-router-dom';
 import { JobsList } from '../../../views/jobs/JobsList';
+import { useGetHost } from '../../hosts/hooks/useGetHost';
 import { useHostsJobsColumns } from './hooks/useHostsJobsColumns';
 
 export function InventoryHostJobs() {
   usePersistentFilters('inventories');
   const jobsColumns = useHostsJobsColumns();
   const { host_id = '' } = useParams<{ host_id: string }>();
-  const queryParams = { job__hosts: host_id, not__launch_type: 'sync' };
+  const { host } = useGetHost(host_id); // ponytail: SWR deduplicates — InventoryHostPage already fetched this
+  const isConstructed = host?.summary_fields?.inventory?.kind === 'constructed';
+  const effectiveHostId = isConstructed && host?.instance_id ? host.instance_id : host_id;
+  const queryParams = { job__hosts: effectiveHostId, not__launch_type: 'sync' };
   return <JobsList queryParams={queryParams} columns={jobsColumns} />;
 }

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.test.tsx
@@ -57,4 +57,26 @@ describe('InventoryHostPage', () => {
       { timeout: 10000 }
     );
   }, 15000);
+
+  test('should show Facts, Groups, and Jobs tabs for constructed inventory hosts', async () => {
+    render(
+      <MemoryRouter initialEntries={['/inventories/constructed_inventory/1/hosts/42/details']}>
+        <Routes>
+          <Route
+            path="/inventories/:inventory_type/:id/hosts/:host_id/*"
+            element={<InventoryHostPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('tab', { name: 'Facts' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Jobs' })).toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+  }, 15000);
 });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.test.tsx
@@ -79,4 +79,27 @@ describe('InventoryHostPage', () => {
       { timeout: 10000 }
     );
   }, 15000);
+
+  test('should show only Details tab for smart inventory hosts', async () => {
+    render(
+      <MemoryRouter initialEntries={['/inventories/smart_inventory/1/hosts/42/details']}>
+        <Routes>
+          <Route
+            path="/inventories/:inventory_type/:id/hosts/:host_id/*"
+            element={<InventoryHostPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('tab', { name: 'Details' })).toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Facts' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Groups' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: 'Jobs' })).not.toBeInTheDocument();
+      },
+      { timeout: 10000 }
+    );
+  }, 15000);
 });

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPage.tsx
@@ -38,7 +38,7 @@ export function InventoryHostPage() {
 
   let tabs: Array<{ label: string; page: string }> = [];
 
-  if (params.inventory_type === 'inventory') {
+  if (params.inventory_type === 'inventory' || params.inventory_type === 'constructed_inventory') {
     tabs = [
       { label: t('Details'), page: AwxRoute.InventoryHostDetails },
       { label: t('Facts'), page: AwxRoute.InventoryHostFacts },

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPageNavigation.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostPageNavigation.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { AwxRoute } from '../../../main/AwxRoutes';
+import { InventoryHostPage } from './InventoryHostPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@ansible/ansible-ui-framework')>()),
+  usePageNavigate: () => mockNavigate,
+}));
+
+// Capture the onDelete callback passed to useHostsActions so we can invoke it directly,
+// covering the pageNavigate lines (32-34) in InventoryHostPage without a full delete UI flow.
+let capturedOnDelete: ((host: unknown) => void) | undefined;
+
+vi.mock('../../hosts/hooks/useHostsActions', () => ({
+  useHostsActions: vi.fn().mockImplementation((onDelete: (host: unknown) => void) => {
+    capturedOnDelete = onDelete;
+    return [];
+  }),
+}));
+
+const mockHost = {
+  id: 42,
+  name: 'test-host',
+  type: 'host',
+  inventory: 1,
+  enabled: true,
+  variables: '---',
+  created: '2024-01-01T00:00:00Z',
+  modified: '2024-01-01T00:00:00Z',
+  summary_fields: {},
+};
+
+describe('InventoryHostPage — post-delete navigation', () => {
+  const server = setupServer(
+    http.get(awxAPI`/inventories/1/`, () =>
+      HttpResponse.json({ id: 1, name: 'Test Inventory', type: 'inventory' })
+    ),
+    http.get(
+      ({ request }) => request.url.includes('/hosts/') && request.url.includes('42'),
+      () => HttpResponse.json(mockHost)
+    )
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+  afterEach(() => {
+    server.resetHandlers();
+    mockNavigate.mockClear();
+  });
+  afterAll(() => server.close());
+
+  test('should navigate to inventory hosts list when onDelete callback fires', async () => {
+    capturedOnDelete = undefined;
+
+    render(
+      <MemoryRouter initialEntries={['/inventories/inventory/1/hosts/42/details']}>
+        <Routes>
+          <Route
+            path="/inventories/:inventory_type/:id/hosts/:host_id/*"
+            element={<InventoryHostPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(capturedOnDelete).toBeDefined();
+    });
+
+    capturedOnDelete!({} as never);
+
+    expect(mockNavigate).toHaveBeenCalledWith(AwxRoute.InventoryHosts, {
+      params: { inventory_type: 'inventory', id: '1' },
+    });
+  });
+});

--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-host-constructed.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-host-constructed.spec.ts
@@ -306,7 +306,7 @@ test.describe('Inventory Host - Constructed Inventory Tests', () => {
   );
 
   test(
-    'should verify edit/delete buttons and facts tab are hidden for constructed inventory hosts',
+    'should verify edit/delete buttons are hidden and Facts tab is visible for constructed inventory hosts',
     { tag: ['@not_mock'] },
     async ({ page }) => {
       test.setTimeout(4 * 60 * 1000);
@@ -389,8 +389,8 @@ test.describe('Inventory Host - Constructed Inventory Tests', () => {
         await clickTableRow({ text: host.name }, page);
         await expect(page.getByRole('heading', { name: host.name, exact: true })).toBeVisible();
 
-        // Verify Facts tab is not visible
-        await expect(page.getByRole('tab', { name: 'Facts' })).not.toBeVisible();
+        // Verify Facts tab is visible for constructed inventory hosts
+        await expect(page.getByRole('tab', { name: 'Facts' })).toBeVisible();
       } finally {
         // Cleanup using utilities
         await Inventory.api.delete(page, constructedInventory.id).catch(() => {});


### PR DESCRIPTION
## Summary

Constructed inventory hosts are database proxies in Controller — their gathered facts and job results are stored against the source host, not the proxy host record. Because of this, the Facts and Jobs tabs were intentionally suppressed for constructed inventory hosts in AAP-19501, and the Jobs tab filter was querying the wrong FK, returning empty results even where tabs were visible.

This fix re-enables the Facts and Jobs tabs for constructed inventory hosts and corrects the jobs query to use the source host ID (`instance_id`) so job history appears as expected. The Facts tab shows an informational empty state explaining that facts are stored on the source inventory host, in line with UX guidance for code-block views that cannot return live data directly.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

No backend changes required. The `instance_id` field used to resolve the source host is already present on constructed host API responses.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

1. Create a regular inventory with a host that has run a job with fact gathering enabled.
2. Create a constructed inventory and add the regular inventory as an input source.
3. Sync the constructed inventory.
4. Navigate to the constructed inventory → Hosts → click the proxy host.
5. **Facts tab** — should show "No facts available" with the message directing to the source host.
6. **Jobs tab** — should list the same jobs visible on the source host's Jobs tab.
7. Repeat steps 4–6 from the global Hosts view (`/execution/infrastructure/hosts`).

### Screenshots

<!-- Before/after screenshots recommended for the Facts and Jobs tab changes. -->
