### PR TITLE
Stabilize tests - deduping interval

### DIFF
--- a/framework/PageApp/PageApp.tsx
+++ b/framework/PageApp/PageApp.tsx
@@ -23,9 +23,6 @@ export function PageApp(props: {
    */
   basename?: string;
 
-  /** The default refresh interval for the page in seconds. */
-  defaultRefreshInterval: number;
-
   banner?: ReactNode;
 
   contextSwitcher?: ReactNode;

--- a/framework/PageFramework.test.tsx
+++ b/framework/PageFramework.test.tsx
@@ -20,7 +20,7 @@ Object.defineProperty(globalThis, 'matchMedia', {
 describe('PageFramework', () => {
   test('should render children', () => {
     render(
-      <PageFramework defaultRefreshInterval={30}>
+      <PageFramework>
         <div data-testid="child">Hello</div>
       </PageFramework>
     );
@@ -29,7 +29,7 @@ describe('PageFramework', () => {
 
   test('should pass disableThemeManagement to PageSettingsProvider', () => {
     render(
-      <PageFramework defaultRefreshInterval={30} disableThemeManagement>
+      <PageFramework disableThemeManagement>
         <div data-testid="child">Hello</div>
       </PageFramework>
     );

--- a/framework/PageFramework.tsx
+++ b/framework/PageFramework.tsx
@@ -15,19 +15,10 @@ import { FrameworkTranslationsProvider } from './useFrameworkTranslations';
  * @example
  * <PageFramework>...</PageFramework>
  */
-export function PageFramework(props: {
-  children: ReactNode;
-  defaultRefreshInterval: number;
-  defaultDedupingInterval?: number;
-  disableThemeManagement?: boolean;
-}) {
+export function PageFramework(props: { children: ReactNode; disableThemeManagement?: boolean }) {
   return (
     <FrameworkTranslationsProvider>
-      <PageSettingsProvider
-        defaultRefreshInterval={props.defaultRefreshInterval}
-        defaultDedupingInterval={props.defaultDedupingInterval}
-        disableThemeManagement={props.disableThemeManagement}
-      >
+      <PageSettingsProvider disableThemeManagement={props.disableThemeManagement}>
         <PageNavigationRoutesProvider>
           <PageDialogProvider>
             <PageAlertToasterProvider>

--- a/framework/PageSettings/PageSettingsProvider.test.tsx
+++ b/framework/PageSettings/PageSettingsProvider.test.tsx
@@ -46,13 +46,13 @@ describe('PageSettingsProvider', () => {
   describe('Settings Management', () => {
     test('should initialize with default settings when localStorage is empty', () => {
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
 
       expect(result.current).toEqual({
-        refreshInterval: 30,
+        refreshInterval: 60,
         theme: 'system',
         tableLayout: 'comfortable',
         formColumns: 'multiple',
@@ -72,7 +72,7 @@ describe('PageSettingsProvider', () => {
       localStorage.setItem('user-preferences', JSON.stringify(savedSettings));
 
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
@@ -93,13 +93,13 @@ describe('PageSettingsProvider', () => {
       localStorage.setItem('user-preferences', 'invalid-json');
 
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={15}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
 
       // Should use defaults when localStorage has invalid JSON
-      expect(result.current.refreshInterval).toBe(15);
+      expect(result.current.refreshInterval).toBe(60);
       expect(result.current.theme).toBe('system');
     });
 
@@ -122,7 +122,7 @@ describe('PageSettingsProvider', () => {
       }
 
       const { getByTestId } = render(
-        <PageSettingsProvider defaultRefreshInterval={30}>
+        <PageSettingsProvider>
           <PageSettingsContext.Consumer>
             {([_settings, setSettings]) => {
               setSettingsFunc = setSettings;
@@ -133,7 +133,7 @@ describe('PageSettingsProvider', () => {
       );
 
       // Initial state
-      expect(getByTestId('refresh-interval')).toHaveTextContent('30');
+      expect(getByTestId('refresh-interval')).toHaveTextContent('60');
 
       // Update settings
       getByTestId('update-button').click();
@@ -165,7 +165,7 @@ describe('PageSettingsProvider', () => {
       }));
 
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
@@ -192,7 +192,7 @@ describe('PageSettingsProvider', () => {
       }));
 
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
@@ -209,7 +209,7 @@ describe('PageSettingsProvider', () => {
       localStorage.setItem('user-preferences', JSON.stringify({ theme: 'light' }));
 
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => usePageSettings(), { wrapper });
@@ -221,9 +221,7 @@ describe('PageSettingsProvider', () => {
     });
 
     const disabledThemeWrapper = ({ children }: { children: ReactNode }) => (
-      <PageSettingsProvider defaultRefreshInterval={30} disableThemeManagement>
-        {children}
-      </PageSettingsProvider>
+      <PageSettingsProvider disableThemeManagement>{children}</PageSettingsProvider>
     );
 
     test('should not modify document theme class when disableThemeManagement is true and theme is dark', async () => {
@@ -279,17 +277,17 @@ describe('PageSettingsProvider', () => {
       };
 
       const { getByTestId } = render(
-        <PageSettingsProvider defaultRefreshInterval={30}>
+        <PageSettingsProvider>
           <TestComponent />
         </PageSettingsProvider>
       );
 
-      expect(getByTestId('interval')).toHaveTextContent('30');
+      expect(getByTestId('interval')).toHaveTextContent('60');
     });
 
     test('should disable revalidateOnFocus globally', () => {
       const wrapper = ({ children }: { children: ReactNode }) => (
-        <PageSettingsProvider defaultRefreshInterval={30}>{children}</PageSettingsProvider>
+        <PageSettingsProvider>{children}</PageSettingsProvider>
       );
 
       const { result } = renderHook(() => useSWRConfig(), { wrapper });
@@ -306,7 +304,7 @@ describe('PageSettingsProvider', () => {
       };
 
       const { getByTestId } = render(
-        <PageSettingsProvider defaultRefreshInterval={30}>
+        <PageSettingsProvider>
           <TestComponent />
         </PageSettingsProvider>
       );

--- a/framework/PageSettings/PageSettingsProvider.tsx
+++ b/framework/PageSettings/PageSettingsProvider.tsx
@@ -11,6 +11,18 @@ import {
 import { SWRConfig } from 'swr';
 import { isRequestError } from '@ansible/common-ui/crud/RequestError';
 
+/** Default SWR refresh interval in milliseconds. Overridden by __SWR_REFRESH_INTERVAL__ in tests. */
+export const SWR_REFRESH_INTERVAL_MS =
+  ((globalThis as unknown as Record<string, number>).__SWR_REFRESH_INTERVAL__ as
+    | number
+    | undefined) ?? 60000;
+
+/** Default SWR deduping interval in milliseconds. Overridden by __SWR_DEDUPING_INTERVAL__ in tests. */
+export const SWR_DEDUPING_INTERVAL_MS =
+  ((globalThis as unknown as Record<string, number>).__SWR_DEDUPING_INTERVAL__ as
+    | number
+    | undefined) ?? 2000;
+
 // Exported for testing
 export function createSWRErrorRetryHandler() {
   return (
@@ -61,8 +73,6 @@ export function usePageSettings() {
 
 export function PageSettingsProvider(props: {
   children?: ReactNode;
-  defaultRefreshInterval: number;
-  defaultDedupingInterval?: number;
   disableThemeManagement?: boolean;
 }) {
   const [settings, setSettingsState] = useState<IPageSettings>(() => {
@@ -77,7 +87,7 @@ export function PageSettingsProvider(props: {
     }
     // defaults
     settings = {
-      refreshInterval: props.defaultRefreshInterval,
+      refreshInterval: SWR_REFRESH_INTERVAL_MS / 1000,
       theme: 'system',
       tableLayout: 'comfortable',
       formColumns: 'multiple',
@@ -119,18 +129,8 @@ export function PageSettingsProvider(props: {
   return (
     <SWRConfig
       value={{
-        dedupingInterval:
-          //  default to 2000ms if no deduping interval is set
-          // __SWR_DEDUPING_INTERVAL__ is used only in testing to force short interval
-          props.defaultDedupingInterval ??
-          ((globalThis as unknown as Record<string, number>).__SWR_DEDUPING_INTERVAL__ as
-            | number
-            | undefined) ??
-          2000,
-        refreshInterval:
-          ((globalThis as unknown as Record<string, number>).__SWR_REFRESH_INTERVAL__ as
-            | number
-            | undefined) ?? (settings.refreshInterval ? settings.refreshInterval * 1000 : 0),
+        dedupingInterval: SWR_DEDUPING_INTERVAL_MS,
+        refreshInterval: settings.refreshInterval ? settings.refreshInterval * 1000 : 0,
         revalidateOnFocus: false,
         onErrorRetry: swrErrorRetryHandler,
       }}

--- a/framework/PageSettings/PageSettingsProvider.tsx
+++ b/framework/PageSettings/PageSettingsProvider.tsx
@@ -127,7 +127,10 @@ export function PageSettingsProvider(props: {
             | number
             | undefined) ??
           2000,
-        refreshInterval: settings.refreshInterval ? settings.refreshInterval * 1000 : 0,
+        refreshInterval:
+          ((globalThis as unknown as Record<string, number>).__SWR_REFRESH_INTERVAL__ as
+            | number
+            | undefined) ?? (settings.refreshInterval ? settings.refreshInterval * 1000 : 0),
         revalidateOnFocus: false,
         onErrorRetry: swrErrorRetryHandler,
       }}

--- a/frontend/awx/main/AwxApp.tsx
+++ b/frontend/awx/main/AwxApp.tsx
@@ -9,7 +9,6 @@ export function AwxApp() {
       masthead={<AwxMasthead />}
       navigation={navigation}
       basename={process.env.ROUTE_PREFIX}
-      defaultRefreshInterval={30}
     />
   );
 }

--- a/frontend/awx/main/AwxMain.test.tsx
+++ b/frontend/awx/main/AwxMain.test.tsx
@@ -4,7 +4,7 @@ import AwxMain from './AwxMain';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageFramework: (props: Record<string, unknown>) => (
-    <div data-testid="page-framework" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-framework">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('@ansible/common-ui/i18n', () => ({}));
@@ -13,8 +13,8 @@ vi.mock('./AwxApp', () => ({
 }));
 
 describe('AwxMain', () => {
-  it('should configure PageFramework with a 30 second refresh interval', () => {
+  it('should render PageFramework with AwxApp', () => {
     const { getByTestId } = render(<AwxMain />);
-    expect(getByTestId('page-framework').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-framework')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/main/AwxMain.tsx
+++ b/frontend/awx/main/AwxMain.tsx
@@ -13,7 +13,7 @@ import { AwxLogin } from './AwxLogin';
 export default function AwxMain() {
   return (
     <BrowserRouter>
-      <PageFramework defaultRefreshInterval={30}>
+      <PageFramework>
         <AwxActiveUserProvider>
           <AwxLogin>
             <AwxApp />

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -50,7 +50,10 @@ export function useGetJob(id?: string, type?: string) {
     workflow: 'workflow_jobs',
   };
   const path = type ? apiPaths[type] : 'jobs';
-  const defaultInterval = (settings.refreshInterval ?? 10) * 1000;
+  // override refresh interval in testing environment
+  const globalOverride = (globalThis as unknown as Record<string, number>)
+    .__SWR_REFRESH_INTERVAL__ as number | undefined;
+  const defaultInterval = globalOverride ?? (settings.refreshInterval ?? 10) * 1000;
   const refreshInterval = useCallback(
     (latestData: Job | undefined) => (latestData?.finished ? 0 : defaultInterval),
     [defaultInterval]

--- a/frontend/awx/views/jobs/JobPage.tsx
+++ b/frontend/awx/views/jobs/JobPage.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { LoadingPage, PageLayout, usePageSettings } from '@ansible/ansible-ui-framework';
+import {
+  LoadingPage,
+  PageLayout,
+  SWR_REFRESH_INTERVAL_MS,
+  usePageSettings,
+} from '@ansible/ansible-ui-framework';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { useCallback } from 'react';
@@ -50,10 +55,7 @@ export function useGetJob(id?: string, type?: string) {
     workflow: 'workflow_jobs',
   };
   const path = type ? apiPaths[type] : 'jobs';
-  // override refresh interval in testing environment
-  const globalOverride = (globalThis as unknown as Record<string, number>)
-    .__SWR_REFRESH_INTERVAL__ as number | undefined;
-  const defaultInterval = globalOverride ?? (settings.refreshInterval ?? 10) * 1000;
+  const defaultInterval = (settings.refreshInterval ?? SWR_REFRESH_INTERVAL_MS / 1000) * 1000;
   const refreshInterval = useCallback(
     (latestData: Job | undefined) => (latestData?.finished ? 0 : defaultInterval),
     [defaultInterval]

--- a/frontend/awx/views/jobs/useGetJob.test.tsx
+++ b/frontend/awx/views/jobs/useGetJob.test.tsx
@@ -66,7 +66,7 @@ describe('useGetJob', () => {
     };
 
     const runningJob = { status: 'running' } as Job;
-    expect(swrConfig.refreshInterval(runningJob)).toBe(10000);
+    expect(swrConfig.refreshInterval(runningJob)).toBe(60000);
   });
 
   it('should continue polling when no data is available yet', () => {
@@ -76,6 +76,6 @@ describe('useGetJob', () => {
       refreshInterval: (data: Job | undefined) => number;
     };
 
-    expect(swrConfig.refreshInterval(undefined)).toBe(10000);
+    expect(swrConfig.refreshInterval(undefined)).toBe(60000);
   });
 });

--- a/frontend/eda/main/EdaApp.test.tsx
+++ b/frontend/eda/main/EdaApp.test.tsx
@@ -5,7 +5,7 @@ import { EdaApp } from './EdaApp';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageApp: (props: Record<string, unknown>) => (
-    <div data-testid="page-app" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-app">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('./useEdaNavigation', () => ({
@@ -13,12 +13,12 @@ vi.mock('./useEdaNavigation', () => ({
 }));
 
 describe('EdaApp', () => {
-  it('should configure PageApp with a 30 second refresh interval', () => {
+  it('should render PageApp', () => {
     const { getByTestId } = render(
       <MemoryRouter>
         <EdaApp />
       </MemoryRouter>
     );
-    expect(getByTestId('page-app').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-app')).toBeInTheDocument();
   });
 });

--- a/frontend/eda/main/EdaApp.tsx
+++ b/frontend/eda/main/EdaApp.tsx
@@ -9,7 +9,6 @@ export function EdaApp() {
       masthead={<EdaMasthead />}
       navigation={navigation}
       basename={process.env.ROUTE_PREFIX}
-      defaultRefreshInterval={30}
     />
   );
 }

--- a/frontend/eda/main/EdaMain.test.tsx
+++ b/frontend/eda/main/EdaMain.test.tsx
@@ -4,7 +4,7 @@ import EdaMain from './EdaMain';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageFramework: (props: Record<string, unknown>) => (
-    <div data-testid="page-framework" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-framework">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('@ansible/common-ui/i18n', () => ({}));
@@ -13,8 +13,8 @@ vi.mock('./EdaApp', () => ({
 }));
 
 describe('EdaMain', () => {
-  it('should configure PageFramework with a 30 second refresh interval', () => {
+  it('should render PageFramework with EdaApp', () => {
     const { getByTestId } = render(<EdaMain />);
-    expect(getByTestId('page-framework').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-framework')).toBeInTheDocument();
   });
 });

--- a/frontend/eda/main/EdaMain.tsx
+++ b/frontend/eda/main/EdaMain.tsx
@@ -12,7 +12,7 @@ import { EdaLogin } from './EdaLogin';
 export default function EdaMain() {
   return (
     <BrowserRouter>
-      <PageFramework defaultRefreshInterval={30}>
+      <PageFramework>
         <EdaActiveUserProvider>
           <EdaLogin>
             <EdaApp />

--- a/frontend/hub/insights/HubRoot.tsx
+++ b/frontend/hub/insights/HubRoot.tsx
@@ -44,7 +44,7 @@ function HubRoot() {
 
   // Note: No BrowserRouter here - Chrome provides the router context
   return (
-    <PageFramework defaultRefreshInterval={30} disableThemeManagement>
+    <PageFramework disableThemeManagement>
       <HubActiveUserProvider>
         <HubContextProvider>
           <HubInsightsApp />

--- a/frontend/hub/main/HubApp.test.tsx
+++ b/frontend/hub/main/HubApp.test.tsx
@@ -5,7 +5,7 @@ import { HubApp } from './HubApp';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageApp: (props: Record<string, unknown>) => (
-    <div data-testid="page-app" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-app">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('./useHubNavigation', () => ({
@@ -13,12 +13,12 @@ vi.mock('./useHubNavigation', () => ({
 }));
 
 describe('HubApp', () => {
-  it('should configure PageApp with a 30 second refresh interval', () => {
+  it('should render PageApp', () => {
     const { getByTestId } = render(
       <MemoryRouter>
         <HubApp />
       </MemoryRouter>
     );
-    expect(getByTestId('page-app').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-app')).toBeInTheDocument();
   });
 });

--- a/frontend/hub/main/HubApp.tsx
+++ b/frontend/hub/main/HubApp.tsx
@@ -9,7 +9,6 @@ export function HubApp() {
       masthead={<HubMasthead />}
       navigation={navigation}
       basename={process.env.ROUTE_PREFIX}
-      defaultRefreshInterval={30}
     />
   );
 }

--- a/frontend/hub/main/HubMain.test.tsx
+++ b/frontend/hub/main/HubMain.test.tsx
@@ -4,7 +4,7 @@ import HubMain from './HubMain';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageFramework: (props: Record<string, unknown>) => (
-    <div data-testid="page-framework" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-framework">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('@ansible/common-ui/i18n', () => ({}));
@@ -13,8 +13,8 @@ vi.mock('./HubApp', () => ({
 }));
 
 describe('HubMain', () => {
-  it('should configure PageFramework with a 30 second refresh interval', () => {
+  it('should render PageFramework with HubApp', () => {
     const { getByTestId } = render(<HubMain />);
-    expect(getByTestId('page-framework').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-framework')).toBeInTheDocument();
   });
 });

--- a/frontend/hub/main/HubMain.tsx
+++ b/frontend/hub/main/HubMain.tsx
@@ -12,7 +12,7 @@ import { HubLogin } from './HubLogin';
 export default function HubMain() {
   return (
     <BrowserRouter>
-      <PageFramework defaultRefreshInterval={30}>
+      <PageFramework>
         <HubActiveUserProvider>
           <HubLogin>
             <HubApp />

--- a/platform/main/PlatformApp.tsx
+++ b/platform/main/PlatformApp.tsx
@@ -163,7 +163,6 @@ export function PlatformApp() {
         masthead={<PlatformMasthead />}
         navigation={navigation}
         basename={process.env.ROUTE_PREFIX ?? '/'}
-        defaultRefreshInterval={30}
         banner={
           <>
             {controllerDownBanner}

--- a/platform/main/PlatformMain.test.tsx
+++ b/platform/main/PlatformMain.test.tsx
@@ -4,7 +4,7 @@ import PlatformMain from './PlatformMain';
 
 vi.mock('@ansible/ansible-ui-framework', () => ({
   PageFramework: (props: Record<string, unknown>) => (
-    <div data-testid="page-framework" data-refresh-interval={props.defaultRefreshInterval} />
+    <div data-testid="page-framework">{props.children as React.ReactNode}</div>
   ),
 }));
 vi.mock('@ansible/common-ui/i18n', () => ({}));
@@ -13,8 +13,8 @@ vi.mock('./PlatformApp', () => ({
 }));
 
 describe('PlatformMain', () => {
-  it('should configure PageFramework with a 30 second refresh interval', () => {
+  it('should render PageFramework with PlatformApp', () => {
     const { getByTestId } = render(<PlatformMain />);
-    expect(getByTestId('page-framework').dataset.refreshInterval).toBe('30');
+    expect(getByTestId('page-framework')).toBeInTheDocument();
   });
 });

--- a/platform/main/PlatformMain.tsx
+++ b/platform/main/PlatformMain.tsx
@@ -42,7 +42,7 @@ export default function PlatformMain() {
           </Bullseye>
         }
       >
-        <PageFramework defaultRefreshInterval={30}>
+        <PageFramework>
           <PlatformActiveUserProvider>
             <AwxActiveUserProvider>
               <HubActiveUserProvider>

--- a/playwright/commands/setup.ts
+++ b/playwright/commands/setup.ts
@@ -10,6 +10,7 @@ export function setupBefore(options?: { path?: string }) {
   return async ({ page }: { page: Page }) => {
     await page.addInitScript(() => {
       (window as unknown as Record<string, unknown>).__SWR_DEDUPING_INTERVAL__ = 0;
+      (window as unknown as Record<string, unknown>).__SWR_REFRESH_INTERVAL__ = 5000;
     });
     // Only enable coverage if not explicitly skipped
     if (existsSync('coverage') && process.env.SKIP_COVERAGE !== 'true') {


### PR DESCRIPTION
## Summary

Follow-up to #3275 

Some playwright tests were timing out when running jobs due to the longer refresh interval. This refactors deduping interval and refresh interval and shortens them in a testing environment. Also extended refresh interval to 60s.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
