### PR TITLE
[AAP-80791][AAP-80796] - Correct cursor pagination and value type coercion in useQueryPlatformOptions

### DIFF
--- a/platform/common/useQueryPlatformOptions.test.tsx
+++ b/platform/common/useQueryPlatformOptions.test.tsx
@@ -5,6 +5,14 @@ import { setupServer } from 'msw/node';
 import { gatewayAPI } from '../utils/gateway-api-utils';
 import { useQueryPlatformOptions } from './useQueryPlatformOptions';
 
+const multiItemResponse = {
+  count: 20,
+  results: [
+    { id: 10, username: 'testuser09' },
+    { id: 11, username: 'testuser10' },
+  ],
+};
+
 const mockResponse = {
   count: 1,
   next: null,
@@ -55,5 +63,53 @@ describe('useQueryPlatformOptions - URL Encoding', () => {
     expect(capturedUrl).toContain(
       'name__icontains=%7B%25%20for_attr_value(attribute_name)%20%25%7D'
     );
+  });
+});
+
+describe('useQueryPlatformOptions - pagination and value types', () => {
+  let capturedUrl = '';
+
+  const server = setupServer(
+    http.get(gatewayAPI`/test-endpoint/`, ({ request }) => {
+      capturedUrl = request.url;
+      return HttpResponse.json(multiItemResponse);
+    })
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterAll(() => server.close());
+  beforeEach(() => {
+    capturedUrl = '';
+    server.resetHandlers();
+  });
+
+  function setupHook() {
+    return renderHook(() =>
+      useQueryPlatformOptions<{ id: number; username: string }, 'username', 'id'>({
+        url: gatewayAPI`/test-endpoint/`,
+        labelKey: 'username',
+        valueKey: 'id',
+        orderQuery: 'order_by',
+      })
+    );
+  }
+
+  test('should use cursor pagination (username__gt) on next page load', async () => {
+    const { result } = setupHook();
+    await result.current({ next: 'testuser09', signal: new AbortController().signal });
+
+    await waitFor(() => {
+      expect(capturedUrl).toContain('username__gt=testuser09');
+      expect(capturedUrl).not.toMatch(/order_by=testuser09/);
+      expect(capturedUrl).toContain('order_by=username');
+    });
+  });
+
+  test('should return option values as strings even when valueKey holds a number', async () => {
+    const { result } = setupHook();
+    const queryResult = await result.current({ signal: new AbortController().signal });
+
+    expect(typeof queryResult.options[0].value).toBe('string');
+    expect(queryResult.options[0].value).toBe('10');
   });
 });

--- a/platform/common/useQueryPlatformOptions.tsx
+++ b/platform/common/useQueryPlatformOptions.tsx
@@ -22,7 +22,7 @@ export function useQueryPlatformOptions<
       let url = options.url;
       url += `?${options.orderQuery}=${options.labelKey as string}`;
       if (queryOptions.next) {
-        url += `&${options.orderQuery}=${queryOptions.next}`;
+        url += `&${options.labelKey as string}__gt=${encodeURIComponent(String(queryOptions.next))}`;
       }
       if (queryOptions.search) {
         url += `&${options.labelKey as string}__icontains=${encodeURIComponent(queryOptions.search)}`;
@@ -32,7 +32,7 @@ export function useQueryPlatformOptions<
       const itemOptions = itemsResponse.results.map((item) => {
         return {
           label: item[options.labelKey] as string,
-          value: item[options.valueKey] as string,
+          value: String(item[options.valueKey]),
         };
       });
       const lastItem = itemsResponse.results[itemsResponse.results.length - 1];


### PR DESCRIPTION
## Summary

Fixes two independent bugs in `useQueryPlatformOptions` that made the **User** and **Application** toolbar filter dropdowns on the API Tokens page (and any Platform page backed by this hook) unusable.

**Bug 1 — Page crash on selection:** Selecting any user from the filter dropdown crashed the entire page with `TypeError: U.includes is not a function`. The hook returned numeric IDs with a TypeScript-only `as string` cast that has no runtime effect, so the number flowed into `usePlatformView`'s `.includes(',')` call and threw. Fixed by using `String()` for a real runtime conversion.

**Bug 2 — HTTP 400 on "Load more":** Paginating the dropdown sent a malformed URL (`?order_by=username&order_by=testuser09`) that the Gateway's `OrderByBackend` rejected because duplicate `order_by` keys collapse to the last value, which is a cursor string rather than a valid field name. Fixed by using the correct Django cursor filter (`username__gt=testuser09`), matching the existing AWX pattern in `PageFormSingleSelectAwxResource`.

Both fixes are in the shared hook; all 8 call sites across 7 files are healed automatically. Two new tests cover the previously untested cursor pagination branch and the value type coercion.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

1. Seed enough users to exceed the Gateway's default page size (or use `page_size=10`).
2. Navigate to **Access → API Tokens**.
3. Open the **User** filter dropdown — first page loads without error.
4. Select any user — page should filter without crashing (fixes Bug 1).
5. Click **Load more** — next page of users loads without an "Error loading options" message (fixes Bug 2).
6. Repeat steps 3–5 for the **Application** filter dropdown.

### Screenshots

<!-- N/A — no visual changes; behavior change only. -->
