### PR TITLE
JobList - reduced network traffic

### DIFF
--- a/frontend/awx/access/credentials/hooks/useCredentialToolbarActions.test.tsx
+++ b/frontend/awx/access/credentials/hooks/useCredentialToolbarActions.test.tsx
@@ -41,6 +41,8 @@ describe('useCredentialToolbarActions', () => {
     keyFn: (item: { id: number }) => item.id,
     limitFiltersToOneOrOperation: true as const,
     updateItem: vi.fn(),
+    upsertItem: vi.fn(),
+    listUrl: '',
   };
 
   const mockPageNavigate = vi.fn();

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -135,6 +135,8 @@ const mockMainTableView: IAutomationDashboardView['mainTableView'] = {
   unselectItemsAndRefresh: vi.fn(),
   limitFiltersToOneOrOperation: true,
   updateItem: vi.fn(),
+  upsertItem: vi.fn(),
+  listUrl: '',
 } as unknown as IAutomationDashboardView['mainTableView'];
 
 const mockView: IAutomationDashboardView = {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -103,6 +103,8 @@ function buildMainTableView(overrides: Partial<MainTableView> = {}): MainTableVi
     unselectItemsAndRefresh: vi.fn(),
     limitFiltersToOneOrOperation: true,
     updateItem: vi.fn(),
+    upsertItem: vi.fn(),
+    listUrl: '',
   };
   return { ...base, ...overrides } as MainTableView;
 }

--- a/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
@@ -52,6 +52,8 @@ vi.mock('../../../common/useAwxView', () => ({
     unselectItemsAndRefresh: vi.fn(),
     limitFiltersToOneOrOperation: true,
     updateItem: vi.fn(),
+    upsertItem: vi.fn(),
+    listUrl: '',
   })),
 }));
 

--- a/frontend/awx/common/useAwxView.test.tsx
+++ b/frontend/awx/common/useAwxView.test.tsx
@@ -167,6 +167,57 @@ describe('useAwxView', () => {
     });
   });
 
+  describe('upsertItem', () => {
+    test('should update an existing item in the list', async () => {
+      const { result } = renderHook(
+        () =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.pageItems).toBeDefined();
+        expect(result.current.pageItems!.length).toBe(20);
+      });
+
+      const updatedHost = { ...result.current.pageItems![0], name: 'updated-host' };
+      act(() => {
+        result.current.upsertItem(updatedHost);
+      });
+
+      expect(result.current.pageItems![0].name).toBe('updated-host');
+      expect(result.current.pageItems!.length).toBe(20);
+    });
+
+    test('should prepend a new item to the list', async () => {
+      const { result } = renderHook(
+        () =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.pageItems).toBeDefined();
+        expect(result.current.pageItems!.length).toBe(20);
+      });
+
+      const newHost = { ...mockHosts[0], id: 9999, name: 'new-host' };
+      act(() => {
+        result.current.upsertItem(newHost);
+      });
+
+      expect(result.current.pageItems!.length).toBe(21);
+      expect(result.current.pageItems![0].id).toBe(9999);
+      expect(result.current.pageItems![0].name).toBe('new-host');
+    });
+  });
+
   describe('Error handling for pagination', () => {
     describe('Filter with pagination error recovery', () => {
       test('should reset to page 1 when filter returns 400 on page 2', async () => {

--- a/frontend/awx/common/useAwxView.test.tsx
+++ b/frontend/awx/common/useAwxView.test.tsx
@@ -4,7 +4,7 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { SWRConfig } from 'swr';
 import { awxAPI } from './api/awx-utils';
-import { useAwxView } from './useAwxView';
+import { useAwxView, compareByField } from './useAwxView';
 import { AwxHost } from '../interfaces/AwxHost';
 import { ReactNode } from 'react';
 import { ToolbarFilterType } from '@ansible/ansible-ui-framework';
@@ -340,5 +340,58 @@ describe('useAwxView', () => {
         });
       });
     });
+  });
+});
+
+describe('compareByField', () => {
+  const items = [
+    { id: 1, name: 'Demo Template', started: '2026-06-01T10:00:00Z', priority: 3 },
+    { id: 2, name: 'chatty tasks', started: '2026-06-02T10:00:00Z', priority: 1 },
+    { id: 3, name: 'Test Playbooks', started: '2026-06-01T12:00:00Z', priority: 2 },
+  ];
+
+  test('should sort strings case-insensitively ascending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'name', 'asc'));
+    expect(sorted.map((i) => i.name)).toEqual(['chatty tasks', 'Demo Template', 'Test Playbooks']);
+  });
+
+  test('should sort strings case-insensitively descending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'name', 'desc'));
+    expect(sorted.map((i) => i.name)).toEqual(['Test Playbooks', 'Demo Template', 'chatty tasks']);
+  });
+
+  test('should sort numbers ascending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'priority', 'asc'));
+    expect(sorted.map((i) => i.priority)).toEqual([1, 2, 3]);
+  });
+
+  test('should sort numbers descending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'priority', 'desc'));
+    expect(sorted.map((i) => i.priority)).toEqual([3, 2, 1]);
+  });
+
+  test('should sort date strings ascending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'started', 'asc'));
+    expect(sorted.map((i) => i.id)).toEqual([1, 3, 2]);
+  });
+
+  test('should sort date strings descending', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'started', 'desc'));
+    expect(sorted.map((i) => i.id)).toEqual([2, 3, 1]);
+  });
+
+  test('should treat null/undefined values as neutral', () => {
+    const withNulls = [
+      { id: 1, name: 'Bravo' },
+      { id: 2, name: null },
+      { id: 3, name: 'Alpha' },
+    ];
+    const sorted = [...withNulls].sort((a, b) => compareByField(a, b, 'name', 'asc'));
+    expect(sorted.map((i) => i.id)).toEqual([1, 2, 3]);
+  });
+
+  test('should default to ascending when direction is omitted', () => {
+    const sorted = [...items].sort((a, b) => compareByField(a, b, 'priority'));
+    expect(sorted.map((i) => i.priority)).toEqual([1, 2, 3]);
   });
 });

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -13,6 +13,30 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { AwxItemsResponse } from './AwxItemsResponse';
 
+export function compareByField<T>(
+  a: T,
+  b: T,
+  key: string,
+  direction: 'asc' | 'desc' = 'asc'
+): number {
+  const aVal = (a as Record<string, unknown>)[key];
+  const bVal = (b as Record<string, unknown>)[key];
+  if (aVal === null || aVal === undefined || bVal === null || bVal === undefined) return 0;
+
+  let cmp: number;
+  if (typeof aVal === 'string' && typeof bVal === 'string') {
+    cmp = aVal.localeCompare(bVal, undefined, { sensitivity: 'base' });
+  } else if (aVal < bVal) {
+    cmp = -1;
+  } else if (aVal > bVal) {
+    cmp = 1;
+  } else {
+    cmp = 0;
+  }
+
+  return direction === 'desc' ? -cmp : cmp;
+}
+
 export type IAwxView<T extends { id: number }> = IView &
   ISelected<T> & {
     itemCount: number | undefined;
@@ -22,7 +46,7 @@ export type IAwxView<T extends { id: number }> = IView &
     unselectItemsAndRefresh: (items: T[]) => void;
     limitFiltersToOneOrOperation: true;
     updateItem: (item: T) => void;
-    /** Insert or update an item in the local items state. New items are prepended. */
+    /** Insert or update an item in the local items state. New items are inserted in sort order. */
     upsertItem: (item: T) => void;
     /** The current fully-qualified list URL including query string (filters, sort, pagination). */
     listUrl: string;
@@ -140,14 +164,20 @@ export function useAwxView<T extends { id: number }>(options: {
       if (!items) return;
       const index = items.findIndex((i) => i.id === item.id);
       if (index === -1) {
-        setItems([item, ...items]);
+        const newItems = [item, ...items];
+        if (view.sort) {
+          const key = view.sort;
+          const dir = view.sortDirection ?? 'asc';
+          newItems.sort((a, b) => compareByField(a, b, key, dir));
+        }
+        setItems(newItems);
       } else {
         const newItems = [...items];
         newItems[index] = item;
         setItems(newItems);
       }
     },
-    [items]
+    [items, view.sort, view.sortDirection]
   );
 
   return useMemo(() => {

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -139,12 +139,12 @@ export function useAwxView<T extends { id: number }>(options: {
     (item: T) => {
       if (!items) return;
       const index = items.findIndex((i) => i.id === item.id);
-      if (index !== -1) {
+      if (index === -1) {
+        setItems([item, ...items]);
+      } else {
         const newItems = [...items];
         newItems[index] = item;
         setItems(newItems);
-      } else {
-        setItems([item, ...items]);
       }
     },
     [items]

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -144,7 +144,6 @@ export function useAwxView<T extends { id: number }>(options: {
         newItems[index] = item;
         setItems(newItems);
       } else {
-        // TODO: insert at end if list is inverse sorted?
         setItems([item, ...items]);
       }
     },

--- a/frontend/awx/common/useAwxView.tsx
+++ b/frontend/awx/common/useAwxView.tsx
@@ -22,6 +22,10 @@ export type IAwxView<T extends { id: number }> = IView &
     unselectItemsAndRefresh: (items: T[]) => void;
     limitFiltersToOneOrOperation: true;
     updateItem: (item: T) => void;
+    /** Insert or update an item in the local items state. New items are prepended. */
+    upsertItem: (item: T) => void;
+    /** The current fully-qualified list URL including query string (filters, sort, pagination). */
+    listUrl: string;
   };
 
 export function useAwxView<T extends { id: number }>(options: {
@@ -131,6 +135,22 @@ export function useAwxView<T extends { id: number }>(options: {
     [items]
   );
 
+  const upsertItem = useCallback(
+    (item: T) => {
+      if (!items) return;
+      const index = items.findIndex((i) => i.id === item.id);
+      if (index !== -1) {
+        const newItems = [...items];
+        newItems[index] = item;
+        setItems(newItems);
+      } else {
+        // TODO: insert at end if list is inverse sorted?
+        setItems([item, ...items]);
+      }
+    },
+    [items]
+  );
+
   return useMemo(() => {
     return {
       refresh,
@@ -143,6 +163,8 @@ export function useAwxView<T extends { id: number }>(options: {
       unselectItemsAndRefresh,
       limitFiltersToOneOrOperation: true,
       updateItem,
+      upsertItem,
+      listUrl: url,
     };
   }, [
     error,
@@ -152,6 +174,8 @@ export function useAwxView<T extends { id: number }>(options: {
     selection,
     unselectItemsAndRefresh,
     updateItem,
+    upsertItem,
+    url,
     view,
   ]);
 }

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -328,10 +328,17 @@ describe('getWsAction', () => {
     ).toEqual({ type: 'refresh' });
   });
 
-  test('should return refresh for each final status', () => {
+  test('should return fetch for each final status when job is on page', () => {
     for (const status of ['successful', 'failed', 'error', 'canceled']) {
       expect(
         getWsAction({ group_name: 'jobs', type: 'job', status, unified_job_id: 492 }, pageItemIds)
+      ).toEqual({ type: 'fetch', jobId: 492 });
+    }
+  });
+  test('should return refresh for each final status when job is not on page', () => {
+    for (const status of ['successful', 'failed', 'error', 'canceled']) {
+      expect(
+        getWsAction({ group_name: 'jobs', type: 'job', status, unified_job_id: 9999 }, pageItemIds)
       ).toEqual({ type: 'refresh' });
     }
   });
@@ -455,6 +462,29 @@ describe('JobsList WebSocket handler integration', () => {
     });
 
     server.events.removeAllListeners();
+  }, 15000);
+
+  test('should fetch individual job on final status for on-page job instead of full refresh', async () => {
+    let detailFetchId: string | undefined;
+    server.use(
+      http.get('*/jobs/:id/', ({ params }) => {
+        detailFetchId = params['id'] as string;
+        return HttpResponse.json({ ...jobsFixture.results[1], status: 'successful' });
+      })
+    );
+
+    await renderAndWaitForJobs();
+
+    capturedOnMessage!({
+      group_name: 'jobs',
+      type: 'job',
+      status: 'successful',
+      unified_job_id: 492,
+    });
+
+    await waitFor(() => {
+      expect(detailFetchId).toBe('492');
+    });
   }, 15000);
 
   test('should fetch individual job on intermediate status for on-page job', async () => {

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -310,22 +310,22 @@ describe('JobsList Component Tests', () => {
 describe('getWsAction', () => {
   const pageItemIds = [491, 492, 489, 488];
 
-  test('should return refresh for pending status', () => {
+  test('should return fetch for pending status (off-page new job)', () => {
     expect(
       getWsAction(
         { group_name: 'jobs', type: 'job', status: 'pending', unified_job_id: 999 },
         pageItemIds
       )
-    ).toEqual({ type: 'refresh' });
+    ).toEqual({ type: 'fetch', jobId: 999 });
   });
 
-  test('should return refresh for new status', () => {
+  test('should return fetch for new status (off-page new job)', () => {
     expect(
       getWsAction(
         { group_name: 'jobs', type: 'job', status: 'new', unified_job_id: 999 },
         pageItemIds
       )
-    ).toEqual({ type: 'refresh' });
+    ).toEqual({ type: 'fetch', jobId: 999 });
   });
 
   test('should return fetch for each final status when job is on page', () => {
@@ -335,11 +335,11 @@ describe('getWsAction', () => {
       ).toEqual({ type: 'fetch', jobId: 492 });
     }
   });
-  test('should return refresh for each final status when job is not on page', () => {
+  test('should return skip for each final status when job is not on page', () => {
     for (const status of ['successful', 'failed', 'error', 'canceled']) {
       expect(
         getWsAction({ group_name: 'jobs', type: 'job', status, unified_job_id: 9999 }, pageItemIds)
-      ).toEqual({ type: 'refresh' });
+      ).toEqual({ type: 'skip' });
     }
   });
 
@@ -419,7 +419,7 @@ describe('getWsAction', () => {
         { group_name: 'jobs', type: 'project_update', status: 'pending', unified_job_id: 999 },
         pageItemIds
       )
-    ).toEqual({ type: 'refresh' });
+    ).toEqual({ type: 'fetch', jobId: 999 });
   });
 });
 
@@ -439,16 +439,18 @@ describe('JobsList WebSocket handler integration', () => {
     expect(capturedOnMessage).toBeDefined();
   }
 
-  test('should call full list refresh on pending status', async () => {
-    let listFetchCount = 0;
+  test('should fetch individual job via filtered list query on pending status for new job', async () => {
+    let fetchedWithId: string | null = null;
+    let fetchedCountDisabled: string | null = null;
     server.events.on('request:match', ({ request }) => {
-      if (request.url.includes('/unified_jobs/') && !request.url.match(/\/unified_jobs\/\d+\//)) {
-        listFetchCount++;
+      const url = new URL(request.url);
+      if (url.pathname.includes('/unified_jobs/') && url.searchParams.get('id')) {
+        fetchedWithId = url.searchParams.get('id');
+        fetchedCountDisabled = url.searchParams.get('count_disabled');
       }
     });
 
     await renderAndWaitForJobs();
-    const initialCount = listFetchCount;
 
     capturedOnMessage!({
       group_name: 'jobs',
@@ -458,20 +460,23 @@ describe('JobsList WebSocket handler integration', () => {
     });
 
     await waitFor(() => {
-      expect(listFetchCount).toBeGreaterThan(initialCount);
+      expect(fetchedWithId).toBe('999');
+      expect(fetchedCountDisabled).toBe('1');
     });
 
     server.events.removeAllListeners();
   }, 15000);
 
-  test('should fetch individual job on final status for on-page job instead of full refresh', async () => {
-    let detailFetchId: string | undefined;
-    server.use(
-      http.get('*/jobs/:id/', ({ params }) => {
-        detailFetchId = params['id'] as string;
-        return HttpResponse.json({ ...jobsFixture.results[1], status: 'successful' });
-      })
-    );
+  test('should fetch individual job via filtered list query on final status for on-page job', async () => {
+    let fetchedWithId: string | null = null;
+    let fetchedCountDisabled: string | null = null;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/unified_jobs/') && url.searchParams.get('id')) {
+        fetchedWithId = url.searchParams.get('id');
+        fetchedCountDisabled = url.searchParams.get('count_disabled');
+      }
+    });
 
     await renderAndWaitForJobs();
 
@@ -483,18 +488,21 @@ describe('JobsList WebSocket handler integration', () => {
     });
 
     await waitFor(() => {
-      expect(detailFetchId).toBe('492');
+      expect(fetchedWithId).toBe('492');
+      expect(fetchedCountDisabled).toBe('1');
     });
+
+    server.events.removeAllListeners();
   }, 15000);
 
-  test('should fetch individual job on intermediate status for on-page job', async () => {
-    let detailFetchId: string | undefined;
-    server.use(
-      http.get('*/jobs/:id/', ({ params }) => {
-        detailFetchId = params['id'] as string;
-        return HttpResponse.json({ ...jobsFixture.results[1], status: 'running' });
-      })
-    );
+  test('should fetch individual job via filtered list query on intermediate status', async () => {
+    let fetchedWithId: string | null = null;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/unified_jobs/') && url.searchParams.get('id')) {
+        fetchedWithId = url.searchParams.get('id');
+      }
+    });
 
     await renderAndWaitForJobs();
 
@@ -506,18 +514,20 @@ describe('JobsList WebSocket handler integration', () => {
     });
 
     await waitFor(() => {
-      expect(detailFetchId).toBe('492');
+      expect(fetchedWithId).toBe('492');
     });
+
+    server.events.removeAllListeners();
   }, 15000);
 
   test('should skip for intermediate status when job is not on page', async () => {
-    let detailFetched = false;
-    server.use(
-      http.get('*/jobs/:id/', () => {
-        detailFetched = true;
-        return HttpResponse.json({});
-      })
-    );
+    let fetchedWithId: string | null = null;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/unified_jobs/') && url.searchParams.get('id')) {
+        fetchedWithId = url.searchParams.get('id');
+      }
+    });
 
     await renderAndWaitForJobs();
 
@@ -530,6 +540,7 @@ describe('JobsList WebSocket handler integration', () => {
 
     await new Promise((r) => setTimeout(r, 500));
 
-    expect(detailFetched).toBe(false);
+    expect(fetchedWithId).toBeNull();
+    server.events.removeAllListeners();
   }, 15000);
 });

--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -328,13 +328,27 @@ describe('getWsAction', () => {
     ).toEqual({ type: 'fetch', jobId: 999 });
   });
 
-  test('should return fetch for each final status when job is on page', () => {
+  test('should return patch with status and finished for each final status when job is on page', () => {
+    const finished = '2026-06-26T20:51:27.549537Z';
     for (const status of ['successful', 'failed', 'error', 'canceled']) {
       expect(
-        getWsAction({ group_name: 'jobs', type: 'job', status, unified_job_id: 492 }, pageItemIds)
-      ).toEqual({ type: 'fetch', jobId: 492 });
+        getWsAction(
+          { group_name: 'jobs', type: 'job', status, unified_job_id: 492, finished },
+          pageItemIds
+        )
+      ).toEqual({ type: 'patch', jobId: 492, data: { status, finished } });
     }
   });
+
+  test('should return patch with status only for final status on page when finished is missing', () => {
+    expect(
+      getWsAction(
+        { group_name: 'jobs', type: 'job', status: 'successful', unified_job_id: 492 },
+        pageItemIds
+      )
+    ).toEqual({ type: 'patch', jobId: 492, data: { status: 'successful' } });
+  });
+
   test('should return skip for each final status when job is not on page', () => {
     for (const status of ['successful', 'failed', 'error', 'canceled']) {
       expect(
@@ -343,22 +357,28 @@ describe('getWsAction', () => {
     }
   });
 
-  test('should return fetch for intermediate status when job is on page', () => {
-    expect(
-      getWsAction(
-        { group_name: 'jobs', type: 'job', status: 'running', unified_job_id: 492 },
-        pageItemIds
-      )
-    ).toEqual({ type: 'fetch', jobId: 492 });
+  test('should return patch with status and started for running status when job is on page', () => {
+    const before = new Date().toISOString();
+    const result = getWsAction(
+      { group_name: 'jobs', type: 'job', status: 'running', unified_job_id: 492 },
+      pageItemIds
+    );
+    const after = new Date().toISOString();
+    expect(result).toMatchObject({ type: 'patch', jobId: 492, data: { status: 'running' } });
+    if (result.type === 'patch') {
+      expect(result.data.started).toBeDefined();
+      expect(result.data.started! >= before).toBe(true);
+      expect(result.data.started! <= after).toBe(true);
+    }
   });
 
-  test('should return fetch for waiting status when job is on page', () => {
+  test('should return patch with status only for waiting status when job is on page', () => {
     expect(
       getWsAction(
         { group_name: 'jobs', type: 'job', status: 'waiting', unified_job_id: 491 },
         pageItemIds
       )
-    ).toEqual({ type: 'fetch', jobId: 491 });
+    ).toEqual({ type: 'patch', jobId: 491, data: { status: 'waiting' } });
   });
 
   test('should return skip for intermediate status when job is not on page', () => {
@@ -404,13 +424,12 @@ describe('getWsAction', () => {
     expect(getWsAction(undefined, pageItemIds)).toEqual({ type: 'skip' });
   });
 
-  test('should handle workflow_job type', () => {
-    expect(
-      getWsAction(
-        { group_name: 'jobs', type: 'workflow_job', status: 'running', unified_job_id: 491 },
-        pageItemIds
-      )
-    ).toEqual({ type: 'fetch', jobId: 491 });
+  test('should handle workflow_job type on page', () => {
+    const result = getWsAction(
+      { group_name: 'jobs', type: 'workflow_job', status: 'running', unified_job_id: 491 },
+      pageItemIds
+    );
+    expect(result).toMatchObject({ type: 'patch', jobId: 491, data: { status: 'running' } });
   });
 
   test('should handle project_update type', () => {
@@ -467,14 +486,12 @@ describe('JobsList WebSocket handler integration', () => {
     server.events.removeAllListeners();
   }, 15000);
 
-  test('should fetch individual job via filtered list query on final status for on-page job', async () => {
+  test('should patch on-page job in place without API call on final status', async () => {
     let fetchedWithId: string | null = null;
-    let fetchedCountDisabled: string | null = null;
     server.events.on('request:match', ({ request }) => {
       const url = new URL(request.url);
       if (url.pathname.includes('/unified_jobs/') && url.searchParams.get('id')) {
         fetchedWithId = url.searchParams.get('id');
-        fetchedCountDisabled = url.searchParams.get('count_disabled');
       }
     });
 
@@ -485,17 +502,16 @@ describe('JobsList WebSocket handler integration', () => {
       type: 'job',
       status: 'successful',
       unified_job_id: 492,
+      finished: '2026-06-26T20:51:27.549537Z',
     });
 
-    await waitFor(() => {
-      expect(fetchedWithId).toBe('492');
-      expect(fetchedCountDisabled).toBe('1');
-    });
+    await new Promise((r) => setTimeout(r, 500));
 
+    expect(fetchedWithId).toBeNull();
     server.events.removeAllListeners();
   }, 15000);
 
-  test('should fetch individual job via filtered list query on intermediate status', async () => {
+  test('should patch on-page job in place without API call on intermediate status', async () => {
     let fetchedWithId: string | null = null;
     server.events.on('request:match', ({ request }) => {
       const url = new URL(request.url);
@@ -513,10 +529,9 @@ describe('JobsList WebSocket handler integration', () => {
       unified_job_id: 492,
     });
 
-    await waitFor(() => {
-      expect(fetchedWithId).toBe('492');
-    });
+    await new Promise((r) => setTimeout(r, 500));
 
+    expect(fetchedWithId).toBeNull();
     server.events.removeAllListeners();
   }, 15000);
 

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -4,9 +4,10 @@ import { requestGet } from '@ansible/common-ui/crud/Data';
 import { CubesIcon } from '@patternfly/react-icons';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { awxAPI } from '../../common/api/awx-utils';
 import { createThrottle } from '../../common/util/createThrottle';
 import { useDomainsStore } from '../../common/domains/useDomains';
+import { awxAPI } from '../../common/api/awx-utils';
+import { AwxItemsResponse } from '../../common/AwxItemsResponse';
 import { useAwxView } from '../../common/useAwxView';
 import { useAwxWebSocketSubscription } from '../../common/useAwxWebSocket';
 import { UnifiedJob } from '../../interfaces/UnifiedJob';
@@ -23,7 +24,7 @@ export type WebSocketMessage = {
   unified_job_id?: number;
 };
 
-const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
+// const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
 const NEW_JOB_STATUSES = new Set(['new', 'pending']);
 
 export type WsAction = { type: 'refresh' } | { type: 'fetch'; jobId: number } | { type: 'skip' };
@@ -47,18 +48,14 @@ export function getWsAction(
   const jobId = message?.unified_job_id;
 
   if (!status || !jobId) return { type: 'refresh' };
-  if (NEW_JOB_STATUSES.has(status)) {
-    return { type: 'refresh' };
-  }
 
-  if (pageItemIds.includes(jobId)) {
-    return { type: 'fetch', jobId };
-  }
+  // Job already visible on current page — fetch updated data via filtered query
+  if (pageItemIds.includes(jobId)) return { type: 'fetch', jobId };
 
-  if (FINAL_STATUSES.has(status)) {
-    return { type: 'refresh' };
-  }
+  // New job — fetch via filtered query so it can be upserted into the list
+  if (NEW_JOB_STATUSES.has(status)) return { type: 'fetch', jobId };
 
+  // All other off-page status changes — let periodic polling handle reordering
   return { type: 'skip' };
 }
 
@@ -82,7 +79,7 @@ export function JobsList(props: {
 
   usePersistentFilters('jobs');
 
-  const { refresh, updateItem, pageItems } = view;
+  const { refresh, upsertItem, listUrl, pageItems } = view;
   const throttledRefresh = useMemo(
     () =>
       createThrottle(() => {
@@ -95,8 +92,10 @@ export function JobsList(props: {
   // Stable refs to avoid re-render loop in WS subscription
   const pageItemsRef = useRef(pageItems);
   pageItemsRef.current = pageItems;
-  const updateItemRef = useRef(updateItem);
-  updateItemRef.current = updateItem;
+  const upsertItemRef = useRef(upsertItem);
+  upsertItemRef.current = upsertItem;
+  const listUrlRef = useRef(listUrl);
+  listUrlRef.current = listUrl;
 
   const handleWebSocketMessage = useCallback(
     (message?: WebSocketMessage) => {
@@ -108,10 +107,17 @@ export function JobsList(props: {
           throttledRefresh();
           break;
         case 'fetch': {
-          const item = pageItemsRef.current?.find((i) => i.id === action.jobId);
-          const url = item?.url ?? awxAPI`/unified_jobs/${action.jobId.toString()}/`;
-          requestGet<UnifiedJob>(url).then(
-            (updatedJob) => updateItemRef.current(updatedJob),
+          const parsed = new URL(listUrlRef.current, 'http://localhost');
+          parsed.searchParams.set('id', action.jobId.toString());
+          parsed.searchParams.set('page_size', '1');
+          parsed.searchParams.set('count_disabled', '1');
+          const fetchUrl = `${parsed.pathname}?${parsed.searchParams.toString()}`;
+          requestGet<AwxItemsResponse<UnifiedJob>>(fetchUrl).then(
+            (response) => {
+              if (response.results.length > 0) {
+                upsertItemRef.current(response.results[0]);
+              }
+            },
             () => throttledRefresh()
           );
           break;

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -22,12 +22,17 @@ export type WebSocketMessage = {
   type?: string;
   status?: string;
   unified_job_id?: number;
+  finished?: string;
 };
 
-// const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
+const FINAL_STATUSES = new Set(['successful', 'failed', 'error', 'canceled']);
 const NEW_JOB_STATUSES = new Set(['new', 'pending']);
 
-export type WsAction = { type: 'refresh' } | { type: 'fetch'; jobId: number } | { type: 'skip' };
+export type WsAction =
+  | { type: 'refresh' }
+  | { type: 'fetch'; jobId: number }
+  | { type: 'patch'; jobId: number; data: Partial<UnifiedJob> }
+  | { type: 'skip' };
 
 export function getWsAction(
   message: WebSocketMessage | undefined,
@@ -49,8 +54,16 @@ export function getWsAction(
 
   if (!status || !jobId) return { type: 'refresh' };
 
-  // Job already visible on current page — fetch updated data via filtered query
-  if (pageItemIds.includes(jobId)) return { type: 'fetch', jobId };
+  if (pageItemIds.includes(jobId)) {
+    const patch: Partial<UnifiedJob> = { status: status as UnifiedJob['status'] };
+    if (status === 'running') {
+      patch.started = new Date().toISOString();
+    }
+    if (FINAL_STATUSES.has(status) && message.finished) {
+      patch.finished = message.finished;
+    }
+    return { type: 'patch', jobId, data: patch };
+  }
 
   // New job — fetch via filtered query so it can be upserted into the list
   if (NEW_JOB_STATUSES.has(status)) return { type: 'fetch', jobId };
@@ -120,6 +133,13 @@ export function JobsList(props: {
             },
             () => throttledRefresh()
           );
+          break;
+        }
+        case 'patch': {
+          const existing = pageItemsRef.current?.find((i) => i.id === action.jobId);
+          if (existing) {
+            upsertItemRef.current({ ...existing, ...action.data });
+          }
           break;
         }
         case 'skip':

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -47,9 +47,18 @@ export function getWsAction(
   const jobId = message?.unified_job_id;
 
   if (!status || !jobId) return { type: 'refresh' };
-  if (NEW_JOB_STATUSES.has(status) || FINAL_STATUSES.has(status)) return { type: 'refresh' };
+  if (NEW_JOB_STATUSES.has(status)) {
+    return { type: 'refresh' };
+  }
 
-  if (pageItemIds.includes(jobId)) return { type: 'fetch', jobId };
+  if (pageItemIds.includes(jobId)) {
+    return { type: 'fetch', jobId };
+  }
+
+  if (FINAL_STATUSES.has(status)) {
+    return { type: 'refresh' };
+  }
+
   return { type: 'skip' };
 }
 


### PR DESCRIPTION
## Summary

Significantly reduces network traffic on the Jobs list, mostly to the unified_jobs endpoint. Reworks how websocket messages are handled:

- When a job starts, only that job is fetched from unified_jobs. Any list filters are included so filtered jobs don't appear on list.
- When job status changes, status is updated in memory without fetching from API
- When job enters `running` status, the Started time is approximated at the time the message is received
- When a job finishes, and the duration is calculated based on started/finished times.
- SWR refresh interval (default 60s) will periodically refresh the entire page so list data should not become too stale or out of sync

NOTE: when a new job is added to the page, this attempts to maintain sorting on the page to match the API sorting, but there is potential for the order of jobs listed to change. In my testing, this is pretty stable, but if any shifting order is jarring, we may need to revert to a full load of the page when a new job comes in.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

