### PR TITLE
[AAP-80860] Fix EDA role wizard resource type dropdown and search

### DIFF
--- a/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
+++ b/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourceTypeStep.tsx
@@ -4,10 +4,7 @@ import { useOptions } from '@ansible/common-ui/crud/useOptions';
 import { useTranslation } from 'react-i18next';
 import { edaAPI } from '../../../common/eda-utils';
 
-interface ContentTypeOption {
-  value: string;
-  display_name: string;
-}
+type ContentTypeOption = [string, string];
 
 export function EdaSelectResourceTypeStep() {
   const { t } = useTranslation();
@@ -28,13 +25,13 @@ export function EdaSelectResourceTypeStep() {
       name="resourceType"
       options={options
         .filter(
-          (option) =>
-            option.value.startsWith('eda.') &&
+          ([value, _]) =>
+            value?.startsWith('eda.') &&
             !['extravar', 'auditrule', 'rulebookprocess', 'rulebook'].some(function (v) {
-              return option.value.endsWith(v);
+              return value.endsWith(v);
             })
         )
-        .map(({ value, display_name }) => ({
+        .map(([value, display_name]) => ({
           value,
           label: display_name,
         }))}

--- a/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourcesStep.tsx
+++ b/frontend/eda/access/common/EdaRolesWizardSteps/EdaSelectResourcesStep.tsx
@@ -80,7 +80,7 @@ export function EdaSelectResourcesStep(props: { userOrTeamName: string }) {
         key: 'name',
         label: t('Name'),
         type: ToolbarFilterType.MultiText,
-        query: 'name',
+        query: 'name__icontains',
         comparison: 'contains',
       },
     ],


### PR DESCRIPTION
## Summary

- Fix empty "Resource type" dropdown in EDA role wizard by parsing OPTIONS choices as tuples (matching AWX implementation)
- Switch EDA resource selection toolbar filter to `name__icontains` for case-insensitive search (missed in #3122)

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Navigate to EDA > Users, select a user, click "Add roles"
- Verify the "Resource type" dropdown now lists EDA resource types (Credentials, Projects, Rulebook Activations, Decision Environments, etc.)
- Select a resource type and verify the resource list loads
- Search for a resource by name using different case and verify it is found

Relates to #3122