### PR TITLE
[AAP-80862] Fix EDA external credential not pre-selected in Secret Management modal

### DIFF
--- a/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
+++ b/frontend/eda/common/PageFormSingleSelectEdaResource.tsx
@@ -199,7 +199,8 @@ function SelectResource<
 
 function EdaAsyncName(props: { url: string; id: number; nameProp?: string }) {
   const { t } = useTranslation();
-  const { data, isLoading, error } = useGetItem<Record<string, string>>(props.url, props.id);
+  const baseUrl = props.url.split('?')[0];
+  const { data, isLoading, error } = useGetItem<Record<string, string>>(baseUrl, props.id);
   if (isLoading) return <Spinner size="md" />;
   if (error) return t('Not found');
   if (!data) return t('Not found');

--- a/playwright/tests/integration/automation-decisions/credentials/credentials-external-linking.spec.ts
+++ b/playwright/tests/integration/automation-decisions/credentials/credentials-external-linking.spec.ts
@@ -197,6 +197,17 @@ test.describe('EDA External Credentials - Linking', () => {
           await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
           await expect(page.getByRole('textbox', { name: 'Password' })).toBeDisabled();
         });
+
+        await test.step('Open secret management modal and verify external credential is pre-selected', async () => {
+          const passwordGroup = page.getByTestId('inputs-password-form-group');
+          await passwordGroup.getByTestId('secret-management-input').click();
+
+          const dialog = page.getByRole('dialog');
+          await expect(dialog.getByText('Secret Management System')).toBeVisible();
+          await expect(dialog.getByTestId('id')).toContainText(externalCredentialName);
+
+          await dialog.getByRole('button', { name: 'Cancel' }).click();
+        });
       } finally {
         if (createdCredentialId) {
           await EdaCredential.api.delete(page, createdCredentialId);


### PR DESCRIPTION
## Summary

When editing an EDA credential that has fields linked to an external secret management system, the Secret Management System modal does not pre-select the external credential in the dropdown. The metadata fields (secret path, secret key, etc.) are populated correctly, but the "External credential" dropdown appears empty.

The root cause is in the `EdaAsyncName` component: it receives the full API URL including query parameters (e.g. `/eda-credentials/?credential_type__kind=external`) and passes it directly to `useGetItem`, which appends `/{id}/` to the URL. This produces an invalid URL like `/eda-credentials/?credential_type__kind=external/2/`, causing the label lookup to fail silently.

The AWX equivalent (`PageFormSingleSelectAwxResource`) already handles this correctly by stripping query parameters before passing the URL to `AsyncQueryLabel`. This change applies the same fix to the EDA component.

Fixes: [AAP-80862](https://redhat.atlassian.net/browse/AAP-80862)

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Changes

- **`frontend/eda/common/PageFormSingleSelectEdaResource.tsx`**: Strip query parameters from the URL before passing to `useGetItem` in `EdaAsyncName`, consistent with how AWX handles it in `PageFormSingleSelectAwxResource`.
- **`playwright/.../credentials-external-linking.spec.ts`**: Added a test step to verify the external credential is pre-selected in the modal when editing a credential with linked fields.

## Test plan

- [x] Linter passes (no new errors introduced)
- [x] All CI checks pass (eslint, tsc, prettier, vitest, build)
- [ ] Existing Playwright external credential linking tests pass
- [ ] New test step verifies external credential name is shown in the dropdown on edit
- [ ] Manual verification: create an EDA credential linked to an external source, edit it, open the Secret Management modal, and confirm the external credential is pre-selected

Signed-off-by: Alexey Masolov <amasolov@redhat.com>