### PR TITLE
AAP-80833 XLAB Enabling the CSV export button in Dashboard's UI

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -3,8 +3,13 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
-import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
+import {
+  IToolbarFilter,
+  PageAlertToasterProvider,
+  ToolbarFilterType,
+} from '@ansible/ansible-ui-framework';
 import { AutomationDashboard } from './AutomationDashboard';
+import { useAutomationDashboardToolbar } from './components';
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
 import { useAutomationDashboardCollectionStatus } from './common/useAutomationDashboardCollectionStatus';
 import type {
@@ -44,7 +49,12 @@ vi.mock('./components', () => ({
   ),
   DashboardChartCard: ({ title }: { title: string }) => <div>{title}</div>,
   DashboardTableCard: ({ title }: { title: string }) => <div>{title}</div>,
-  DashboardMainTableCard: () => <div data-testid="dashboard-main-table-card" />,
+  DashboardMainTableCard: ({ toolbarFilters }: { toolbarFilters?: IToolbarFilter[] }) => (
+    <div
+      data-testid="dashboard-main-table-card"
+      data-toolbar-filter-keys={toolbarFilters?.map((filter) => filter.key).join(',') ?? ''}
+    />
+  ),
 }));
 
 vi.mock('./views/useAutomationDashboardView', () => ({
@@ -208,6 +218,28 @@ describe('AutomationDashboard', () => {
 
     // Main table card placeholder (internals covered by DashboardMainTableCard.test.tsx)
     expect(screen.getByTestId('dashboard-main-table-card')).toBeInTheDocument();
+  });
+
+  test('should pass toolbarFilters through to DashboardMainTableCard', () => {
+    const mockToolbarFilters: IToolbarFilter[] = [
+      {
+        type: ToolbarFilterType.DateRange,
+        key: 'period',
+        label: 'Period',
+        query: 'period',
+        options: [{ label: 'Last 7 days', value: 'last_7_days' }],
+        placeholder: 'Filter by period',
+        isRequired: true,
+      },
+    ];
+    vi.mocked(useAutomationDashboardToolbar).mockReturnValueOnce(mockToolbarFilters);
+
+    render(testWrapper());
+
+    expect(screen.getByTestId('dashboard-main-table-card')).toHaveAttribute(
+      'data-toolbar-filter-keys',
+      'period'
+    );
   });
 
   // ─── Save as PDF button ────────────────────────────────────────────────────

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -238,7 +238,10 @@ export function AutomationDashboard() {
 
           <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
             <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
-              <DashboardMainTableCard {...view}></DashboardMainTableCard>
+              <DashboardMainTableCard
+                {...view}
+                toolbarFilters={toolbarFilters}
+              ></DashboardMainTableCard>
             </Grid>
           </GridItem>
         </PageDashboard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardExportButton.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardExportButton.test.tsx
@@ -1,0 +1,124 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
+import { ExportIcon, PrintIcon } from '@patternfly/react-icons';
+import { DashboardExportButton } from './DashboardExportButton';
+import type { IAutomationDashboardExportButton } from '../types';
+
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <MemoryRouter>
+      <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderButton(overrides: Partial<IAutomationDashboardExportButton> = {}) {
+  const props: IAutomationDashboardExportButton = {
+    exportType: 'csv',
+    title: 'Export as CSV',
+    icon: ExportIcon,
+    onExport: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return render(<DashboardExportButton {...props} />, { wrapper: Wrapper });
+}
+
+describe('DashboardExportButton', () => {
+  // --- Disabled state ---
+
+  test('should render disabled button when isDisabled is true', () => {
+    renderButton({ isDisabled: true });
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
+  });
+
+  test('should render disabled print button for html exportType', () => {
+    renderButton({ exportType: 'html', title: 'Print report', icon: PrintIcon, isDisabled: true });
+    expect(screen.getByTestId('dashboard-export-button-html')).toBeDisabled();
+  });
+
+  // --- Enabled state ---
+
+  test('should render enabled export button when not disabled', () => {
+    renderButton();
+    expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
+  });
+
+  // --- Dropdown options ---
+
+  test('should call onExport with "summary" when Summary is clicked', async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(undefined);
+    renderButton({ onExport });
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Summary' }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('summary'));
+  });
+
+  test('should call onExport with "roi" when Roi is clicked', async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(undefined);
+    renderButton({ onExport });
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'ROI' }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('roi'));
+  });
+
+  test('should call onExport with "trends" when Trends is clicked', async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(undefined);
+    renderButton({ onExport });
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Trends' }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalledWith('trends'));
+  });
+
+  // --- Loading state ---
+
+  test('should disable button while export is in progress', async () => {
+    const user = userEvent.setup();
+    let resolve!: () => void;
+    const onExport = vi.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolve = r;
+      })
+    );
+    renderButton({ onExport });
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Summary' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
+    });
+
+    resolve();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
+    });
+  });
+
+  test('should re-enable button after onExport throws', async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockRejectedValue(new Error('Export failed'));
+    renderButton({ onExport });
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Summary' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardExportButton.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardExportButton.tsx
@@ -1,0 +1,81 @@
+import { IAutomationDashboardExportButton, ReportType } from '../types';
+import {
+  IPageAction,
+  PageActions,
+  PageActionSelection,
+  PageActionType,
+} from '@ansible/ansible-ui-framework';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+
+export function DashboardExportButton(props: Readonly<IAutomationDashboardExportButton>) {
+  const { t } = useTranslation();
+  const { exportType, title, icon: Icon, onExport, isDisabled } = props;
+  const [inProgress, setInProgress] = useState<boolean>(false);
+
+  const handleExport = async (reportType: ReportType) => {
+    setInProgress(true);
+    try {
+      await onExport(reportType);
+    } catch {
+      // onExport handles its own error display
+    } finally {
+      setInProgress(false);
+    }
+  };
+
+  const actions: IPageAction<object>[] = [
+    {
+      type: PageActionType.Dropdown,
+      icon: Icon,
+      variant: ButtonVariant.primary,
+      isPinned: true,
+      selection: PageActionSelection.None,
+      label: title,
+      actions: [
+        {
+          type: PageActionType.Button,
+          selection: PageActionSelection.None,
+          label: t('Summary'),
+          onClick: () => {
+            void handleExport('summary');
+          },
+        },
+        {
+          type: PageActionType.Button,
+          selection: PageActionSelection.None,
+          label: t('ROI'),
+          onClick: () => {
+            void handleExport('roi');
+          },
+        },
+        {
+          type: PageActionType.Button,
+          selection: PageActionSelection.None,
+          label: t('Trends'),
+          onClick: () => {
+            void handleExport('trends');
+          },
+        },
+      ],
+    },
+  ];
+
+  if (isDisabled || inProgress) {
+    return (
+      <Button
+        id={`dashboard-export-button-${exportType}`}
+        data-testid={`dashboard-export-button-${exportType}`}
+        icon={<Icon />}
+        isDisabled={true}
+        variant="primary"
+        onClick={undefined}
+        isLoading={inProgress}
+      >
+        {title}
+      </Button>
+    );
+  }
+  return <PageActions actions={actions} />;
+}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -7,7 +7,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 import { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
+import {
+  IToolbarFilter,
+  PageAlertToasterProvider,
+  ToolbarFilterType,
+} from '@ansible/ansible-ui-framework';
 import { DashboardMainTableCard } from './DashboardMainTableCard';
 import type { IAutomationDashboardView, IDashboardDetails, IJobTemplate } from '../types';
 
@@ -71,6 +75,21 @@ const mockDetails: IDashboardDetails = {
 
 const mockRefresh = vi.fn();
 
+const mockToolbarFilters: IToolbarFilter[] = [
+  {
+    type: ToolbarFilterType.DateRange,
+    key: 'period',
+    label: 'Period',
+    query: 'period',
+    options: [
+      { label: 'Last 7 days', value: 'last_7_days' },
+      { label: 'Custom', value: 'custom', isCustom: true },
+    ],
+    placeholder: 'Filter by period',
+    isRequired: true,
+  },
+];
+
 type MainTableView = IAutomationDashboardView['mainTableView'];
 
 function buildMainTableView(overrides: Partial<MainTableView> = {}): MainTableView {
@@ -83,7 +102,7 @@ function buildMainTableView(overrides: Partial<MainTableView> = {}): MainTableVi
     setSort: vi.fn(),
     sortDirection: 'asc',
     setSortDirection: vi.fn(),
-    filterState: {},
+    filterState: { period: ['last_7_days'] },
     setFilterState: vi.fn(),
     clearAllFilters: vi.fn(),
     itemCount: 1,
@@ -99,6 +118,7 @@ function buildMainTableView(overrides: Partial<MainTableView> = {}): MainTableVi
 function buildProps(overrides: Partial<IAutomationDashboardView> = {}): IAutomationDashboardView {
   return {
     mainTableView: buildMainTableView(),
+    toolbarFilters: mockToolbarFilters,
     details: mockDetails,
     detailsError: undefined,
     detailsLoading: false,
@@ -360,23 +380,26 @@ describe('DashboardMainTableCard', () => {
     expect(screen.getByText('60')).toBeInTheDocument();
   });
 
-  // --- Input readOnly ---
+  // --- Toolbar row ---
+
   test('should disable export CSV button when loading is true', () => {
     renderCard(buildProps({ loading: true }));
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
   });
 
-  // TODO: Update to `not.toBeDisabled()` once `|| true` is removed from controlsDisabled in DashboardTableToolbarRow.
-  test('should disable export CSV button while BE is not yet implemented', () => {
+  test('should enable export CSV button for superuser with data', () => {
     renderCard();
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
   });
-
-  // --- Toolbar row ---
 
   test('should disable export CSV when itemCount is 0', () => {
     renderCard(buildProps({ mainTableView: buildMainTableView({ itemCount: 0, pageItems: [] }) }));
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
+  });
+
+  test('should disable export CSV when a required toolbar filter is missing a value', () => {
+    renderCard(buildProps({ mainTableView: buildMainTableView({ filterState: {} }) }));
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
   });
 
   test('should disable export CSV when mainTableView itemCount is undefined', () => {
@@ -385,16 +408,18 @@ describe('DashboardMainTableCard', () => {
         mainTableView: buildMainTableView({ itemCount: undefined as unknown as number }),
       })
     );
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
   });
 
-  // TODO: Re-enable once `|| true` is removed from controlsDisabled in DashboardTableToolbarRow.
-  test.skip('should call onExportCsv when export button is clicked', async () => {
+  test('should call exportCsv with reportType when dropdown option is selected', async () => {
     const user = userEvent.setup();
-    const exportCsv = vi.fn();
+    const exportCsv = vi.fn().mockResolvedValue(undefined);
     renderCard(buildProps({ exportCsv }));
-    await user.click(screen.getByTestId('btn-export-csv'));
-    expect(exportCsv).toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Summary' }));
+
+    await waitFor(() => expect(exportCsv).toHaveBeenCalledWith('summary'));
   });
 
   // --- Empty state ---

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -43,6 +43,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     loading,
     detailsError,
     isFilterStateDefault,
+    toolbarFilters,
   } = props;
   const { t } = useTranslation();
   const { activeAwxUser } = useAwxActiveUser();
@@ -224,7 +225,9 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           costState={costState}
           setCostState={setCostState}
           refresh={refresh}
-          onExportCsv={() => void exportCsv()}
+          onExportCsv={exportCsv}
+          filterState={mainTableView?.filterState}
+          toolbarFilters={toolbarFilters}
         ></DashboardTableToolbarRow>
         <div
           ref={ref}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
@@ -7,7 +7,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 import { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
+import {
+  IToolbarFilter,
+  PageAlertToasterProvider,
+  ToolbarFilterType,
+} from '@ansible/ansible-ui-framework';
 import { DashboardTableToolbarRow } from './DashboardTableToolbarRow';
 import type { DashboardTableToolbarProps, ISubscriptionCosts } from '../types';
 
@@ -43,6 +47,21 @@ const defaultCostState: ISubscriptionCosts = {
 const mockSetCostState = vi.fn();
 const mockRefresh = vi.fn();
 
+const mockToolbarFilters: IToolbarFilter[] = [
+  {
+    type: ToolbarFilterType.DateRange,
+    key: 'period',
+    label: 'Period',
+    query: 'period',
+    options: [
+      { label: 'Last 7 days', value: 'last_7_days' },
+      { label: 'Custom', value: 'custom', isCustom: true },
+    ],
+    placeholder: 'Filter by period',
+    isRequired: true,
+  },
+];
+
 function buildProps(
   overrides: Partial<DashboardTableToolbarProps> = {}
 ): DashboardTableToolbarProps {
@@ -53,6 +72,8 @@ function buildProps(
     setCostState: mockSetCostState,
     refresh: mockRefresh,
     onExportCsv: vi.fn(),
+    toolbarFilters: mockToolbarFilters,
+    filterState: { period: ['last_7_days'] },
     ...overrides,
   };
 }
@@ -98,7 +119,7 @@ describe('DashboardTableToolbarRow', () => {
     expect(screen.getByTestId('engineer_avg_hourly_rate')).toBeInTheDocument();
     expect(screen.getByTestId('monthly_subscription_cost')).toBeInTheDocument();
     expect(screen.getByTestId('switch-time-taken-automation-toggle')).toBeInTheDocument();
-    expect(screen.getByTestId('btn-export-csv')).toBeInTheDocument();
+    expect(screen.getByTestId('export-as-csv')).toBeInTheDocument();
   });
 
   test('should display initial values from costState', () => {
@@ -123,44 +144,55 @@ describe('DashboardTableToolbarRow', () => {
 
   test('should render without crashing when costState is undefined', () => {
     renderRow(buildProps({ costState: undefined }));
-    expect(screen.getByTestId('btn-export-csv')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeInTheDocument();
   });
 
   // --- Export CSV button ---
 
-  // TODO: Update to `not.toBeDisabled()` once `|| true` is removed from controlsDisabled.
-  test('should disable export button while BE is not yet implemented', () => {
+  test('should enable export button for superuser with data', () => {
     renderRow();
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
   });
 
   test('should disable export button when isLoading is true', () => {
     renderRow(buildProps({ isLoading: true }));
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
   });
 
   test('should disable export button when itemCount is 0', () => {
     renderRow(buildProps({ itemCount: 0 }));
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
   });
 
-  // TODO: Re-enable once `|| true` is removed from controlsDisabled.
-  test.skip('should call onExportCsv when export button is clicked', async () => {
+  test('should disable export button when a required toolbar filter is missing a value', () => {
+    renderRow(buildProps({ filterState: {} }));
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
+  });
+
+  test('should disable export button when custom period filter is missing a start date', () => {
+    renderRow(buildProps({ filterState: { period: ['custom'] } }));
+    expect(screen.getByTestId('dashboard-export-button-csv')).toBeDisabled();
+  });
+
+  test('should call onExportCsv with reportType when dropdown option is selected', async () => {
     const user = userEvent.setup();
-    const onExportCsv = vi.fn();
+    const onExportCsv = vi.fn().mockResolvedValue(undefined);
     renderRow(buildProps({ onExportCsv }));
-    await user.click(screen.getByTestId('btn-export-csv'));
-    expect(onExportCsv).toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('export-as-csv'));
+    await user.click(screen.getByRole('menuitem', { name: 'Summary' }));
+
+    await waitFor(() => expect(onExportCsv).toHaveBeenCalledWith('summary'));
   });
 
   // --- Inputs disabled ---
-  test('should disable all controls when not superuser', () => {
+  test('should disable cost inputs and switch when not superuser', () => {
     mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: { is_superuser: false } });
     renderRow();
     expect(screen.getByTestId('engineer_avg_hourly_rate')).toBeDisabled();
     expect(screen.getByTestId('monthly_subscription_cost')).toBeDisabled();
     expect(screen.getByTestId('switch-time-taken-automation-toggle')).toBeDisabled();
-    expect(screen.getByTestId('btn-export-csv')).toBeDisabled();
+    expect(screen.getByTestId('export-as-csv')).not.toBeDisabled();
   });
 
   test('should not call put when not superuser', async () => {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -1,4 +1,5 @@
-import { Button, Flex, FlexItem, Switch } from '@patternfly/react-core';
+import { Flex, FlexItem, Switch } from '@patternfly/react-core';
+import { ExportIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import { DashboardTableInputField } from './DashboardTableInputField';
 import { DashboardTableToolbarProps, ISubscriptionCosts } from '../types';
@@ -8,11 +9,22 @@ import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { usePutRequest } from '../../../../common/crud/usePutRequest';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { DashboardExportButton } from './DashboardExportButton';
+import { hasValidRequiredFilters } from '../utils/queryString';
 
 const SWITCH_ID = 'switch-time-taken-automation';
 
 export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
-  const { costState, itemCount, setCostState, refresh, onExportCsv } = props;
+  const {
+    costState,
+    itemCount,
+    setCostState,
+    refresh,
+    onExportCsv,
+    isLoading,
+    toolbarFilters,
+    filterState,
+  } = props;
   const { t } = useTranslation();
   const alertToaster = usePageAlertToaster();
   const putRequest = usePutRequest<ISubscriptionCosts, ISubscriptionCosts>();
@@ -22,6 +34,7 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
   );
 
   const controlsDisabled = !costState || !activeAwxUser?.is_superuser;
+  const filtersValid = hasValidRequiredFilters(toolbarFilters, filterState);
 
   const toolbarChangeHandler = async <K extends keyof ISubscriptionCosts>(
     value: ISubscriptionCosts[K],
@@ -154,16 +167,13 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
           />
         </FlexItem>
         <FlexItem alignSelf={{ md: 'alignSelfFlexEnd', default: 'alignSelfFlexStart' }}>
-          <Button
-            id="btn-export-csv"
-            data-testid="btn-export-csv"
-            variant="secondary"
-            onClick={onExportCsv}
-            // TODO: Remove `|| true` once CSV export is implemented on the BE.
-            isDisabled={controlsDisabled || (itemCount ?? 0) === 0 || !onExportCsv || true}
-          >
-            {t('Export as CSV')}
-          </Button>
+          <DashboardExportButton
+            exportType={'csv'}
+            title={t('Export as CSV')}
+            icon={ExportIcon}
+            isDisabled={isLoading || !itemCount || !costState || !filtersValid}
+            onExport={onExportCsv ?? (() => Promise.resolve())}
+          ></DashboardExportButton>
         </FlexItem>
       </Flex>
     </Flex>

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
+import { ComponentClass, Dispatch, SetStateAction } from 'react';
 import { IFilterState, IToolbarFilter } from '@ansible/ansible-ui-framework';
 import { IAutomationDashboardBaseView } from '../common/useAutomationDashboardBaseView';
 
@@ -146,7 +146,9 @@ export type DashboardTableToolbarProps = {
   costState: ISubscriptionCosts | undefined;
   setCostState: Dispatch<SetStateAction<ISubscriptionCosts | undefined>> | undefined;
   refresh: () => Promise<void>;
-  onExportCsv?: () => void;
+  onExportCsv?: (reportType: ReportType) => Promise<void>;
+  toolbarFilters?: IToolbarFilter[];
+  filterState?: IFilterState;
 };
 
 // ─── View Type ────────────────────────────────────────────────────────────────
@@ -160,8 +162,22 @@ export type IAutomationDashboardView = {
   setCostState: Dispatch<SetStateAction<ISubscriptionCosts | undefined>>;
   loading: boolean;
   refresh: () => Promise<void>;
-  exportCsv: () => Promise<void>;
+  exportCsv: (reportType: ReportType) => Promise<void>;
   exportPdf: () => Promise<void>;
   isFilterStateDefault: boolean;
   registerClearCallback: (callback: () => void) => void;
+  toolbarFilters?: IToolbarFilter[];
+};
+
+// ─── Export Types ─────────────────────────────────────────────────────────────
+
+export type ReportType = 'summary' | 'roi' | 'trends';
+
+// ─── Export Button Type ───────────────────────────────────────────────────────────
+export type IAutomationDashboardExportButton = {
+  exportType: 'csv' | 'html';
+  title: string;
+  icon: ComponentClass;
+  isDisabled?: boolean;
+  onExport: (reportType: ReportType) => Promise<void>;
 };

--- a/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.test.tsx
@@ -214,14 +214,14 @@ describe('useAutomationDashboardView', () => {
 
   // --- exportCsv ---
 
-  test('should call exportCsvBase and manage loading on exportCsv', async () => {
+  test('should call exportCsvBase with reportType and manage loading on exportCsv', async () => {
     const { result } = renderHook(() => useAutomationDashboardView({ toolbarFilters: [] }));
 
     await act(async () => {
-      await result.current.exportCsv();
+      await result.current.exportCsv('summary');
     });
 
-    expect(mockExportCsvBase).toHaveBeenCalled();
+    expect(mockExportCsvBase).toHaveBeenCalledWith('summary');
     expect(result.current.loading).toBe(false);
   });
 
@@ -231,7 +231,7 @@ describe('useAutomationDashboardView', () => {
 
     await act(async () => {
       try {
-        await result.current.exportCsv();
+        await result.current.exportCsv('summary');
       } catch {
         // expected
       }

--- a/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useAutomationDashboardView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { IFilterState, IToolbarFilter } from '../../../../../framework';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { AutomationDashboardDateRangeFilterPresets } from '../constants';
-import { IAutomationDashboardView, IJobTemplate } from '../types';
+import { IAutomationDashboardView, IJobTemplate, ReportType } from '../types';
 import { useGetReportDetails } from './useGetReportDetails';
 import { useSubscriptionCostState } from './useSubscriptionCostState';
 import { useExportCsv } from './useExportCsv';
@@ -89,14 +89,17 @@ export function useAutomationDashboardView(options: {
   const exportCsvBase = useExportCsv(toolbarFilters, filterState, QUERY_PARAMS);
   const exportPdfBase = useExportPdf(toolbarFilters, filterState, QUERY_PARAMS);
 
-  const exportCsv = useCallback(async () => {
-    setLoading(true);
-    try {
-      await exportCsvBase();
-    } finally {
-      setLoading(false);
-    }
-  }, [exportCsvBase]);
+  const exportCsv = useCallback(
+    async (reportType: ReportType) => {
+      setLoading(true);
+      try {
+        await exportCsvBase(reportType);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [exportCsvBase]
+  );
 
   const exportPdf = useCallback(async () => {
     setLoading(true);

--- a/frontend/awx/analytics/automation-dashboard/views/useExportCsv.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/views/useExportCsv.test.ts
@@ -6,14 +6,19 @@ import { useExportCsv } from './useExportCsv';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockAddAlert } = vi.hoisted(() => ({
+const { mockAddAlert, mockDownloadBlobFile } = vi.hoisted(() => ({
   mockAddAlert: vi.fn(),
+  mockDownloadBlobFile: vi.fn(),
 }));
 
 vi.mock('../../../../../framework', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../../framework')>();
   return { ...actual, usePageAlertToaster: vi.fn(() => ({ addAlert: mockAddAlert })) };
 });
+
+vi.mock('../../../../../framework/utils/download-file', () => ({
+  downloadBlobFile: mockDownloadBlobFile,
+}));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -25,12 +30,22 @@ const nameFilter: IToolbarFilter = {
   comparison: 'contains',
 };
 
+const periodFilter: IToolbarFilter = {
+  type: ToolbarFilterType.DateRange,
+  key: 'period',
+  label: 'Period',
+  query: 'period',
+  options: [
+    { label: 'Last 7 days', value: 'last_7_days' },
+    { label: 'Custom', value: 'custom', isCustom: true },
+  ],
+  placeholder: 'Filter by period',
+};
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useExportCsv', () => {
   let fetchSpy: MockInstance;
-  let createObjectUrlSpy: MockInstance;
-  let revokeObjectUrlSpy: MockInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,16 +54,11 @@ describe('useExportCsv', () => {
     fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response(mockBlob, { status: 200 }));
-
-    createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
-    revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     vi.useRealTimers();
     fetchSpy.mockRestore();
-    createObjectUrlSpy.mockRestore();
-    revokeObjectUrlSpy.mockRestore();
   });
 
   // --- Basic ---
@@ -60,21 +70,19 @@ describe('useExportCsv', () => {
 
   // --- Success path ---
 
-  test('should fetch CSV endpoint and trigger programmatic download', async () => {
+  test('should fetch export endpoint and trigger programmatic download', async () => {
     const { result } = renderHook(() => useExportCsv([], {}, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     expect(fetchSpy).toHaveBeenCalledOnce();
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('dashboard_reports/report/csv/'),
+      expect.stringContaining('dashboard_reports/report/export/'),
       expect.anything()
     );
-    expect(createObjectUrlSpy).toHaveBeenCalledWith(expect.any(Blob));
-
-    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:mock-url');
+    expect(mockDownloadBlobFile).toHaveBeenCalledOnce();
   });
 
   test('should not call window.open', async () => {
@@ -82,7 +90,7 @@ describe('useExportCsv', () => {
     const { result } = renderHook(() => useExportCsv([], {}, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     expect(openSpy).not.toHaveBeenCalled();
@@ -91,11 +99,33 @@ describe('useExportCsv', () => {
 
   // --- URL building ---
 
+  test('should include report_type param in the URL', async () => {
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('roi');
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toContain('report_type=roi');
+  });
+
+  test('should include export_format=csv param in the URL', async () => {
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toContain('export_format=csv');
+  });
+
   test('should include queryParams in the URL', async () => {
     const { result } = renderHook(() => useExportCsv([], {}, { period: 'last_7_days' }));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     const [url] = fetchSpy.mock.calls[0] as [string];
@@ -106,7 +136,7 @@ describe('useExportCsv', () => {
     const { result } = renderHook(() => useExportCsv([nameFilter], { name: ['my-template'] }, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     const [url] = fetchSpy.mock.calls[0] as [string];
@@ -119,12 +149,135 @@ describe('useExportCsv', () => {
     );
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     const [url] = fetchSpy.mock.calls[0] as [string];
     expect(url).toContain('tz=Europe%2FLjubljana');
     expect(url).toContain('name=ansible');
+  });
+
+  test('should include start_date and end_date in the URL for a custom period filter', async () => {
+    const { result } = renderHook(() =>
+      useExportCsv([periodFilter], { period: ['custom', '2024-01-01', '2024-01-31'] }, {})
+    );
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toContain('period=custom');
+    expect(url).toContain('start_date=2024-01-01');
+    expect(url).toContain('end_date=2024-01-31');
+  });
+
+  // --- Filename derivation ---
+
+  test('should use fallback filename with reportType and date when no Content-Disposition header', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15'));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('roi');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith(
+      'automation-dashboard-roi-2024-06-15',
+      'csv',
+      expect.any(Blob)
+    );
+  });
+
+  test('should use filename from plain Content-Disposition header, stripping .csv extension', async () => {
+    const headers = new Headers({ 'Content-Disposition': 'attachment; filename="my-export.csv"' });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('my-export', 'csv', expect.any(Blob));
+  });
+
+  test('should decode RFC 5987 percent-encoded filename from Content-Disposition', async () => {
+    const headers = new Headers({
+      'Content-Disposition': "attachment; filename*=UTF-8''my%20report.csv",
+    });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('trends');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('my report', 'csv', expect.any(Blob));
+  });
+
+  test('should prefer filename*= over filename= when both are present (RFC 6266)', async () => {
+    const headers = new Headers({
+      'Content-Disposition':
+        'attachment; filename="fallback.csv"; filename*=UTF-8\'\'correct%20name.csv',
+    });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('correct name', 'csv', expect.any(Blob));
+  });
+
+  test('should handle RFC 5987 filename with non-empty language tag', async () => {
+    const headers = new Headers({
+      'Content-Disposition': "attachment; filename*=UTF-8'en'my%20report.csv",
+    });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('my report', 'csv', expect.any(Blob));
+  });
+
+  test('should use plain filename as-is when it contains a literal % (no URIError)', async () => {
+    const headers = new Headers({
+      'Content-Disposition': 'attachment; filename="50%_hosts.csv"',
+    });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('50%_hosts', 'csv', expect.any(Blob));
+    expect(mockAddAlert).not.toHaveBeenCalled();
+  });
+
+  test('should trim whitespace from filename before use', async () => {
+    const headers = new Headers({
+      'Content-Disposition': 'attachment; filename="export.csv "',
+    });
+    const mockBlob = new Blob(['col1'], { type: 'text/csv' });
+    fetchSpy.mockResolvedValueOnce(new Response(mockBlob, { status: 200, headers }));
+    const { result } = renderHook(() => useExportCsv([], {}, {}));
+
+    await act(async () => {
+      await result.current('summary');
+    });
+
+    expect(mockDownloadBlobFile).toHaveBeenCalledWith('export', 'csv', expect.any(Blob));
   });
 
   // --- Error path ---
@@ -136,13 +289,13 @@ describe('useExportCsv', () => {
     const { result } = renderHook(() => useExportCsv([], {}, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     expect(mockAddAlert).toHaveBeenCalledWith(
       expect.objectContaining({ variant: 'danger', title: 'Failed to export CSV.' })
     );
-    expect(createObjectUrlSpy).not.toHaveBeenCalled();
+    expect(mockDownloadBlobFile).not.toHaveBeenCalled();
   });
 
   test('should show danger alert with error message when fetch throws a network error', async () => {
@@ -150,7 +303,7 @@ describe('useExportCsv', () => {
     const { result } = renderHook(() => useExportCsv([], {}, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     expect(mockAddAlert).toHaveBeenCalledWith(
@@ -167,7 +320,7 @@ describe('useExportCsv', () => {
     const { result } = renderHook(() => useExportCsv([], {}, {}));
 
     await act(async () => {
-      await result.current();
+      await result.current('summary');
     });
 
     expect(mockAddAlert).toHaveBeenCalledWith(

--- a/frontend/awx/analytics/automation-dashboard/views/useExportCsv.ts
+++ b/frontend/awx/analytics/automation-dashboard/views/useExportCsv.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  filtersToSearchObj,
   IFilterState,
   IToolbarFilter,
   paramsToSearchObj,
@@ -10,7 +9,9 @@ import {
 } from '../../../../../framework';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { requestCommon } from '../../../../common/crud/requestCommon';
-import { downloadCvsFile } from '../../../../../framework/utils/download-file';
+import { downloadBlobFile } from '../../../../../framework/utils/download-file';
+import { ReportType } from '../types';
+import { filtersToSearchObj } from '../utils/queryString';
 
 /**
  * Returns a stable async callback that fetches the CSV export for the current
@@ -23,11 +24,11 @@ export function useExportCsv(
   toolbarFilters: IToolbarFilter[],
   filterState: IFilterState,
   queryParams: QueryParams
-): () => Promise<void> {
+): (reportType: ReportType) => Promise<void> {
   const alertToaster = usePageAlertToaster();
   const { t } = useTranslation();
   const downloadCsv = useCallback(
-    async (url: string) => {
+    async (url: string, reportType: ReportType) => {
       let errorMsg: string | undefined = undefined;
       let error = false;
       try {
@@ -36,8 +37,22 @@ export function useExportCsv(
           method: 'GET',
         });
         if (response.ok) {
-          const content = await response.text();
-          downloadCvsFile('AAP_Automation_Dashboard_Report', [content]);
+          const blob = await response.blob();
+          const disposition = response.headers.get('Content-Disposition');
+          // RFC 5987 takes priority per RFC 6266: charset'language'encoded-value
+          const rfc5987 = disposition?.match(/filename\*=[a-z0-9-]+'[a-z-]*'([^;\n]+)/i)?.[1];
+          // Plain filename fallback
+          const plain = disposition?.match(/\bfilename="?([^";\n]+)"?/i)?.[1];
+          const endDate = new Date().toISOString().split('T')[0];
+          let filename: string;
+          if (rfc5987) {
+            filename = decodeURIComponent(rfc5987.trim()).replace(/\.csv$/i, '');
+          } else if (plain) {
+            filename = plain.trim().replace(/\.csv$/i, '');
+          } else {
+            filename = `automation-dashboard-${reportType}-${endDate}`;
+          }
+          downloadBlobFile(filename, 'csv', blob);
         } else {
           error = true;
           errorMsg = `${response.status} ${response.statusText}`;
@@ -58,12 +73,17 @@ export function useExportCsv(
     [alertToaster, t]
   );
 
-  return useCallback(async () => {
-    const params = new URLSearchParams([
-      ...paramsToSearchObj(queryParams),
-      ...filtersToSearchObj(toolbarFilters, filterState),
-    ]);
-    const url = metricsAPI`/dashboard_reports/report/csv/?${params.toString()}`;
-    await downloadCsv(url);
-  }, [toolbarFilters, filterState, queryParams, downloadCsv]);
+  return useCallback(
+    async (reportType: ReportType) => {
+      const params = new URLSearchParams([
+        ...paramsToSearchObj(queryParams),
+        ...filtersToSearchObj(toolbarFilters, filterState),
+        ['report_type', reportType],
+        ['export_format', 'csv'],
+      ]);
+      const url = metricsAPI`/dashboard_reports/report/export/?${params.toString()}`;
+      await downloadCsv(url, reportType);
+    },
+    [toolbarFilters, filterState, queryParams, downloadCsv]
+  );
 }


### PR DESCRIPTION
## Summary

[AAP-80833](https://redhat.atlassian.net/browse/AAP-80833) Enabling the CSV export button in Dashboard's UI 

This pull request refactors and enhances the export functionality in the Automation Dashboard, introducing a more flexible export button component and supporting multiple report types for export. It updates the export logic to handle different report types, improves test coverage, and cleans up code to use consistent test IDs and props.

**Export Functionality Improvements:**

* Introduced a new `DashboardExportButton` component that supports exporting different report types (summary, ROI, trends) and handles loading and disabled states. The button uses a dropdown for report type selection and can be configured for CSV or HTML export. (`DashboardExportButton.tsx`, `DashboardExportButton.test.tsx`, `types/index.ts`) [[1]](diffhunk://#diff-80c1a3c86923c88cd8aed66c22a0c686691eed6e1200d4962fadd81876fbd92dR1-R81) [[2]](diffhunk://#diff-cd15c9246c1804c4d3500f3ba256874cc9cebc7b311f47aad3bb2d036cef1233R1-R124) [[3]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbL163-R180) [[4]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbL149-R149)
* Updated the export logic in `useAutomationDashboardView` and related hooks to accept a `reportType` parameter, enabling the export of specific report types. (`useAutomationDashboardView.tsx`, `useExportCsv.test.ts`, `useAutomationDashboardView.test.tsx`) [[1]](diffhunk://#diff-496d1bb07692fb9f7336607cef13a60ec400a344b13c452009b4173828b7da6fL84-R94) [[2]](diffhunk://#diff-6b58c1c471e22bffcb21569cda450bf8b0bd9e988fd1d00a716b1e79ecb09809L187-R194) [[3]](diffhunk://#diff-6b58c1c471e22bffcb21569cda450bf8b0bd9e988fd1d00a716b1e79ecb09809L204-R204) [[4]](diffhunk://#diff-2de2d5bb2cd1ab2609cb60ad47e5412969648ffb7a9b24004a752ed63b97ab53L9-R22)

**Component and Prop Refactoring:**

* Updated `DashboardTableToolbarRow` and `DashboardMainTableCard` to use the new export button and pass the correct export handler signature, removing legacy code and props. (`DashboardTableToolbarRow.tsx`, `DashboardMainTableCard.tsx`, `types/index.ts`) [[1]](diffhunk://#diff-c5bf117bdc1765adbd49308947e402a2746a7c64c3da9037bcb9b4f4381e2f42L157-R165) [[2]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L227-R227) [[3]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbL149-R149)

**Testing and Test ID Consistency:**

* Refactored tests to use updated test IDs and verify the new export dropdown behavior, including enabling/disabling logic and correct callback invocation with report types. (`DashboardTableToolbarRow.test.tsx`, `DashboardMainTableCard.test.tsx`) [[1]](diffhunk://#diff-231d4fd541a9772ebae254da701085ad66dbecadc4949aefd43bb045799859f8L101-R101) [[2]](diffhunk://#diff-231d4fd541a9772ebae254da701085ad66dbecadc4949aefd43bb045799859f8L126-R164) [[3]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806L359-R373) [[4]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806L384-R393)

**Type and Interface Updates:**

* Added new types for export report types and export button props, ensuring type safety and clarity throughout the dashboard components. (`types/index.ts`)

These changes collectively make the export feature more robust, user-friendly, and easier to extend in the future.
## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots
<img width="1147" height="609" alt="image" src="https://github.com/user-attachments/assets/60115be9-7857-48b5-8f0c-672b930a4eac" />

<img width="1147" height="609" alt="image" src="https://github.com/user-attachments/assets/08d3d19b-a2b8-49ad-a5b0-5e2278c032eb" />

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
