### PR TITLE
test: add coverage tests for PageTable and PageToolbar (90%+)

### DIFF
--- a/framework/PageTable/PageLoadingTable.test.tsx
+++ b/framework/PageTable/PageLoadingTable.test.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PageLoadingTable } from './PageLoadingTable';
+
+describe('PageLoadingTable', () => {
+  it('should render default 10 skeleton rows', () => {
+    render(<PageLoadingTable />);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(10);
+  });
+
+  it('should render custom row count via rows prop', () => {
+    render(<PageLoadingTable rows={5} />);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(5);
+  });
+});

--- a/framework/PageTable/PageMultiSelectList.test.tsx
+++ b/framework/PageTable/PageMultiSelectList.test.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { IToolbarFilter } from '../PageToolbar/PageToolbarFilter';
+import { ITableColumn } from './PageTableColumn';
+import { PageMultiSelectList, PageMultiSelectListProps } from './PageMultiSelectList';
+
+vi.mock('./PageTable', () => ({
+  PageTable: (props: Record<string, unknown>) => (
+    <div data-testid="mock-page-table" data-show-select={props.showSelect} />
+  ),
+}));
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+const testColumns: ITableColumn<TestItem>[] = [
+  {
+    header: 'Name',
+    card: 'name',
+    cell: (item) => item.name,
+    value: (item) => item.name,
+  },
+];
+
+const testFilters: IToolbarFilter[] = [];
+
+function buildView(
+  overrides: Partial<PageMultiSelectListProps<TestItem>['view']> = {}
+): PageMultiSelectListProps<TestItem>['view'] {
+  return {
+    page: 1,
+    setPage: vi.fn(),
+    perPage: 10,
+    setPerPage: vi.fn(),
+    sort: 'name',
+    setSort: vi.fn(),
+    sortDirection: 'asc' as const,
+    setSortDirection: vi.fn(),
+    filterState: {},
+    setFilterState: vi.fn(),
+    clearAllFilters: vi.fn(),
+    selectedItems: [],
+    selectItem: vi.fn(),
+    selectItems: vi.fn(),
+    unselectItem: vi.fn(),
+    unselectItems: vi.fn(),
+    isSelected: vi.fn(() => false),
+    selectAll: vi.fn(),
+    unselectAll: vi.fn(),
+    allSelected: false,
+    keyFn: (item: TestItem) => item.id,
+    pageItems: [],
+    itemCount: 0,
+    ...overrides,
+  };
+}
+
+describe('PageMultiSelectList', () => {
+  it('should show Skeleton when loading', () => {
+    const view = buildView({ itemCount: undefined, error: undefined });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    const skeleton = document.querySelector('.pf-v6-c-skeleton');
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it('should show "none selected" text when no items selected', () => {
+    const view = buildView({ selectedItems: [], itemCount: 5 });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('None - Please make a selection below.')).toBeInTheDocument();
+  });
+
+  it('should show selected item labels', () => {
+    const items: TestItem[] = [
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Beta' },
+    ];
+    const view = buildView({ selectedItems: items, itemCount: 5 });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('should call unselectItem when label close button is clicked', async () => {
+    const user = userEvent.setup();
+    const unselectItem = vi.fn();
+    const items: TestItem[] = [{ id: 1, name: 'Alpha' }];
+    const view = buildView({ selectedItems: items, itemCount: 5, unselectItem });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    await user.click(closeButton);
+
+    expect(unselectItem).toHaveBeenCalledWith(items[0]);
+  });
+
+  it('should use labelForSelectedItems prop when provided', () => {
+    const view = buildView({ selectedItems: [], itemCount: 5 });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList
+          view={view}
+          tableColumns={testColumns}
+          toolbarFilters={testFilters}
+          labelForSelectedItems="Chosen items"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Chosen items')).toBeInTheDocument();
+    expect(screen.queryByText('Selected')).not.toBeInTheDocument();
+  });
+
+  it('should show default "Selected" label when labelForSelectedItems is not provided', () => {
+    const view = buildView({ selectedItems: [], itemCount: 5 });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Selected')).toBeInTheDocument();
+  });
+
+  it('should render PageTable', () => {
+    const view = buildView({
+      itemCount: 2,
+      pageItems: [
+        { id: 1, name: 'Alpha' },
+        { id: 2, name: 'Beta' },
+      ],
+    });
+    render(
+      <MemoryRouter>
+        <PageMultiSelectList view={view} tableColumns={testColumns} toolbarFilters={testFilters} />
+      </MemoryRouter>
+    );
+
+    const table = screen.getByTestId('mock-page-table');
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveAttribute('data-show-select', 'true');
+  });
+});

--- a/framework/PageTable/PagePagination.test.tsx
+++ b/framework/PageTable/PagePagination.test.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PagePagination } from './PagePagination';
+
+describe('PagePagination', () => {
+  it('should render pagination with item count', () => {
+    render(
+      <PagePagination
+        itemCount={100}
+        page={1}
+        perPage={10}
+        setPage={vi.fn()}
+        setPerPage={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('pagination')).toBeInTheDocument();
+  });
+
+  it('should call setPage when navigating to next page', async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+    render(
+      <PagePagination
+        itemCount={100}
+        page={1}
+        perPage={10}
+        setPage={setPage}
+        setPerPage={vi.fn()}
+      />
+    );
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    await user.click(nextButton);
+    expect(setPage).toHaveBeenCalledWith(2);
+  });
+
+  it('should call setPerPage when changing per page', async () => {
+    const user = userEvent.setup();
+    const setPerPage = vi.fn();
+    render(
+      <PagePagination
+        itemCount={100}
+        page={1}
+        perPage={10}
+        setPage={vi.fn()}
+        setPerPage={setPerPage}
+        perPageOptions={[
+          { title: '10', value: 10 },
+          { title: '20', value: 20 },
+          { title: '50', value: 50 },
+        ]}
+      />
+    );
+
+    const perPageMenu = screen.getByRole('button', { name: /1 - 10 of 100/i });
+    await user.click(perPageMenu);
+
+    const option20 = screen.getByRole('menuitem', { name: /20 per page/i });
+    await user.click(option20);
+    expect(setPerPage).toHaveBeenCalledWith(20);
+  });
+});

--- a/framework/PageTable/PageTable.test.tsx
+++ b/framework/PageTable/PageTable.test.tsx
@@ -71,6 +71,8 @@ describe('PageTable Component', () => {
     props?: Partial<BaseTestProps> & {
       emptyStateDescription?: string;
       emptyStateActions?: IPageAction<MockItem>[];
+      emptyStateButtonText?: string;
+      emptyStateButtonClick?: () => void;
     }
   ) => {
     return render(
@@ -153,8 +155,128 @@ describe('PageTable Component', () => {
       rowActions: actions,
     });
 
-    // Verify the items are rendered with their rows
     expect(screen.getByText('Item 1')).toBeInTheDocument();
     expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  it('should render loading state when pageItems is undefined', () => {
+    renderPageTable({
+      pageItems: undefined,
+      itemCount: undefined,
+    });
+
+    const skeletons = document.querySelectorAll('.pf-v6-c-skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('should render filtered empty state when itemCount is 0 with active filters', () => {
+    renderPageTable({
+      itemCount: 0,
+      pageItems: [],
+      filterState: { name: ['test'] },
+    });
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(
+      screen.getByText('No results match this filter criteria. Clear all filters and try again.')
+    ).toBeInTheDocument();
+  });
+
+  it('should render custom emptyState when provided', () => {
+    render(
+      <MemoryRouter>
+        <PageTable<MockItem>
+          keyFn={keyFn}
+          itemCount={0}
+          pageItems={[]}
+          tableColumns={tableColumns}
+          toolbarActions={toolbarActions}
+          rowActions={rowActions}
+          page={1}
+          perPage={10}
+          setPage={() => {}}
+          setPerPage={() => {}}
+          filterState={{}}
+          emptyState={<div>Custom empty state</div>}
+          errorStateTitle="Error"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Custom empty state')).toBeInTheDocument();
+  });
+
+  it('should render emptyStateButtonClick button', () => {
+    const onClick = vi.fn();
+
+    renderPageTable({
+      itemCount: 0,
+      pageItems: [],
+      emptyStateButtonText: 'Create New',
+      emptyStateButtonClick: onClick,
+    });
+
+    expect(screen.getByText('No items found')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create New' })).toBeInTheDocument();
+  });
+
+  it('should derive showSelect from Multiple toolbar action', () => {
+    const bulkActions: IPageAction<MockItem>[] = [
+      {
+        type: PageActionType.Button,
+        selection: PageActionSelection.Multiple,
+        label: 'Delete',
+        onClick: () => {},
+      },
+    ];
+
+    renderPageTable({
+      toolbarActions: bulkActions,
+      isSelected: () => false,
+      selectedItems: [],
+      selectItem: () => {},
+      unselectItem: () => {},
+    });
+
+    const checkboxHeaders = document.querySelectorAll('[data-testid="selections-column-header"]');
+    expect(checkboxHeaders.length).toBeGreaterThan(0);
+  });
+
+  it('should hide pagination when autoHidePagination and items fit in one page', () => {
+    const { container } = renderPageTable({
+      autoHidePagination: true,
+      itemCount: 2,
+      perPage: 10,
+    });
+
+    const pagination = container.querySelector('.pf-v6-c-pagination');
+    expect(pagination).not.toBeInTheDocument();
+  });
+
+  it('should show pagination when autoHidePagination but items exceed perPage', () => {
+    const manyItems = Array.from({ length: 15 }, (_, i) => ({
+      id: i + 1,
+      name: `Item ${i + 1}`,
+      description: `Description ${i + 1}`,
+    }));
+
+    renderPageTable({
+      autoHidePagination: true,
+      itemCount: 15,
+      pageItems: manyItems,
+      perPage: 10,
+    });
+
+    const pagination = document.querySelector('.pf-v6-c-pagination');
+    expect(pagination).toBeInTheDocument();
+  });
+
+  it('should hide pagination when disablePagination is true', () => {
+    const { container } = renderPageTable({
+      disablePagination: true,
+    });
+
+    const pagination = container.querySelector('.pf-v6-c-pagination');
+    expect(pagination).not.toBeInTheDocument();
   });
 });

--- a/framework/PageTable/PageTable.test.tsx
+++ b/framework/PageTable/PageTable.test.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { IPageAction, PageActionSelection, PageActionType } from '../PageActions/PageAction';
 import { IFilterState } from '../PageToolbar/PageToolbarFilter';
 import { PageTable, PageTableProps } from './PageTable';
-import { ITableColumn } from './PageTableColumn';
+import { ColumnTableOption, ITableColumn } from './PageTableColumn';
 
 describe('PageTable Component', () => {
   interface MockItem {
@@ -278,5 +279,338 @@ describe('PageTable Component', () => {
 
     const pagination = container.querySelector('.pf-v6-c-pagination');
     expect(pagination).not.toBeInTheDocument();
+  });
+
+  it('should render selection checkbox column when showSelect is true', () => {
+    renderPageTable({
+      showSelect: true,
+      isSelected: () => false,
+      selectedItems: [],
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+    });
+
+    expect(screen.getByTestId('selections-column-header')).toBeInTheDocument();
+    const checkboxCells = screen.getAllByTestId('checkbox-column-cell');
+    expect(checkboxCells).toHaveLength(mockItems.length);
+  });
+
+  it('should call selectItems when header select-all checkbox is clicked', async () => {
+    const user = userEvent.setup();
+    const selectItems = vi.fn();
+
+    renderPageTable({
+      showSelect: true,
+      isSelected: () => false,
+      selectedItems: [],
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+      selectItems,
+      unselectAll: vi.fn(),
+    });
+
+    const headerCheckbox = within(screen.getByTestId('selections-column-header')).getByRole(
+      'checkbox'
+    );
+    await user.click(headerCheckbox);
+
+    expect(selectItems).toHaveBeenCalledWith(mockItems);
+  });
+
+  it('should call unselectAll when header checkbox is clicked while all selected', async () => {
+    const user = userEvent.setup();
+    const unselectAll = vi.fn();
+
+    renderPageTable({
+      showSelect: true,
+      isSelected: () => true,
+      selectedItems: [...mockItems],
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+      selectItems: vi.fn(),
+      unselectAll,
+    });
+
+    const headerCheckbox = within(screen.getByTestId('selections-column-header')).getByRole(
+      'checkbox'
+    );
+    await user.click(headerCheckbox);
+
+    expect(unselectAll).toHaveBeenCalled();
+  });
+
+  it('should render expand toggle for description columns and reveal content on click', async () => {
+    const user = userEvent.setup();
+    const columnsWithDescription: ITableColumn<MockItem>[] = [
+      {
+        header: 'Name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Details',
+        cell: (item) => item.description,
+        table: ColumnTableOption.description,
+        value: (item) => item.description,
+      },
+    ];
+
+    renderPageTable({
+      tableColumns: columnsWithDescription,
+    });
+
+    const expandCells = screen.getAllByTestId('expand-column-cell');
+    expect(expandCells).toHaveLength(mockItems.length);
+
+    const firstExpandButton = within(expandCells[0]).getByRole('button');
+    await user.click(firstExpandButton);
+
+    expect(screen.getByText('First item description')).toBeInTheDocument();
+  });
+
+  it('should call onSelect when a row is clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    renderPageTable({
+      onSelect,
+      isSelected: () => false,
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+    });
+
+    await user.click(screen.getByTestId('row-id-1'));
+
+    expect(onSelect).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should call unselectAll before selecting when isSelectMultiple is false', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const unselectAll = vi.fn();
+    const selectItem = vi.fn();
+
+    renderPageTable({
+      onSelect,
+      isSelectMultiple: false,
+      isSelected: () => false,
+      selectItem,
+      unselectItem: vi.fn(),
+      unselectAll,
+    });
+
+    await user.click(screen.getByTestId('row-id-1'));
+
+    expect(unselectAll).toHaveBeenCalled();
+    expect(selectItem).toHaveBeenCalledWith(mockItems[0]);
+    expect(onSelect).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should unselectItem when clicking a selected row in multi-select mode', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const unselectItem = vi.fn();
+
+    renderPageTable({
+      onSelect,
+      isSelectMultiple: true,
+      isSelected: (item) => item.id === 1,
+      selectItem: vi.fn(),
+      unselectItem,
+    });
+
+    await user.click(screen.getByTestId('row-id-1'));
+
+    expect(unselectItem).toHaveBeenCalledWith(mockItems[0]);
+    expect(onSelect).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should disable unchecked row checkboxes when maxSelections is reached', () => {
+    renderPageTable({
+      showSelect: true,
+      maxSelections: 1,
+      isSelected: (item) => item.id === 1,
+      selectedItems: [mockItems[0]],
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+    });
+
+    const checkboxCells = screen.getAllByTestId('checkbox-column-cell');
+    const firstCheckbox = within(checkboxCells[0]).getByRole('checkbox');
+    const secondCheckbox = within(checkboxCells[1]).getByRole('checkbox');
+
+    expect(firstCheckbox).not.toBeDisabled();
+    expect(secondCheckbox).toBeDisabled();
+  });
+
+  it('should render sort headers for columns with sort property', () => {
+    const sortableColumns: ITableColumn<MockItem>[] = [
+      {
+        header: 'Name',
+        cell: (item) => item.name,
+        sort: 'name',
+      },
+      {
+        header: 'Description',
+        cell: (item) => item.description,
+      },
+    ];
+
+    const setSort = vi.fn();
+    const setSortDirection = vi.fn();
+
+    renderPageTable({
+      tableColumns: sortableColumns,
+      sort: 'name',
+      setSort,
+      sortDirection: 'asc',
+      setSortDirection,
+    });
+
+    const nameHeader = screen.getByTestId('name-column-header');
+    const sortButton = within(nameHeader).getByRole('button');
+    expect(sortButton).toBeInTheDocument();
+  });
+
+  it('should call setSort and setSortDirection when a sort header is clicked', async () => {
+    const user = userEvent.setup();
+    const sortableColumns: ITableColumn<MockItem>[] = [
+      {
+        header: 'Name',
+        cell: (item) => item.name,
+        sort: 'name',
+      },
+    ];
+
+    const setSort = vi.fn();
+    const setSortDirection = vi.fn();
+
+    renderPageTable({
+      tableColumns: sortableColumns,
+      sort: 'name',
+      setSort,
+      sortDirection: 'asc',
+      setSortDirection,
+    });
+
+    const nameHeader = screen.getByTestId('name-column-header');
+    const sortButton = within(nameHeader).getByRole('button');
+    await user.click(sortButton);
+
+    expect(setSort).toHaveBeenCalledWith('name');
+    expect(setSortDirection).toHaveBeenCalled();
+  });
+
+  it('should render table with compact variant when compact is true', () => {
+    renderPageTable({ compact: true });
+
+    const table = document.querySelector('table.pf-v6-c-table');
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveClass('pf-m-compact');
+  });
+
+  it('should render list view when disableTableView is true', () => {
+    renderPageTable({ disableTableView: true });
+
+    const dataList = document.querySelector('[class*="pf-v6-c-data-list"]');
+    expect(dataList).toBeInTheDocument();
+    expect(document.querySelector('table.pf-v6-c-table')).not.toBeInTheDocument();
+  });
+
+  it('should render card view when both table and list views are disabled', () => {
+    renderPageTable({ disableTableView: true, disableListView: true });
+
+    expect(document.querySelector('table.pf-v6-c-table')).not.toBeInTheDocument();
+    expect(document.querySelector('[class*="pf-v6-c-data-list"]')).not.toBeInTheDocument();
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  it('should render row action cells when rowActions are provided', () => {
+    renderPageTable();
+
+    const actionCells = screen.getAllByTestId('actions-column-cell');
+    expect(actionCells).toHaveLength(mockItems.length);
+    expect(screen.getByTestId('action-column-header')).toBeInTheDocument();
+  });
+
+  it('should render column header cells with correct data-testid', () => {
+    renderPageTable();
+
+    expect(screen.getByTestId('name-column-header')).toBeInTheDocument();
+    expect(screen.getByTestId('description-column-header')).toBeInTheDocument();
+  });
+
+  it('should render column data cells with correct data-testid', () => {
+    renderPageTable();
+
+    const nameCells = screen.getAllByTestId('name-column-cell');
+    expect(nameCells).toHaveLength(mockItems.length);
+    const descCells = screen.getAllByTestId('description-column-cell');
+    expect(descCells).toHaveLength(mockItems.length);
+  });
+
+  it('should call selectItem when a row checkbox is checked', async () => {
+    const user = userEvent.setup();
+    const selectItem = vi.fn();
+
+    renderPageTable({
+      showSelect: true,
+      isSelected: () => false,
+      selectedItems: [],
+      selectItem,
+      unselectItem: vi.fn(),
+    });
+
+    const checkboxCells = screen.getAllByTestId('checkbox-column-cell');
+    const firstCheckbox = within(checkboxCells[0]).getByRole('checkbox');
+    await user.click(firstCheckbox);
+
+    expect(selectItem).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should call unselectItem when a selected row checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    const unselectItem = vi.fn();
+
+    renderPageTable({
+      showSelect: true,
+      isSelected: (item) => item.id === 1,
+      selectedItems: [mockItems[0]],
+      selectItem: vi.fn(),
+      unselectItem,
+    });
+
+    const checkboxCells = screen.getAllByTestId('checkbox-column-cell');
+    const firstCheckbox = within(checkboxCells[0]).getByRole('checkbox');
+    await user.click(firstCheckbox);
+
+    expect(unselectItem).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('should render expanded row with custom expandedRow function', async () => {
+    const user = userEvent.setup();
+
+    renderPageTable({
+      expandedRow: (item) => <div>Expanded: {item.name}</div>,
+    });
+
+    const expandCells = screen.getAllByTestId('expand-column-cell');
+    const firstExpandButton = within(expandCells[0]).getByRole('button');
+    await user.click(firstExpandButton);
+
+    expect(screen.getByText('Expanded: Item 1')).toBeInTheDocument();
+  });
+
+  it('should render onSelect radio buttons when isSelectMultiple is false', () => {
+    renderPageTable({
+      onSelect: vi.fn(),
+      isSelectMultiple: false,
+      isSelected: () => false,
+      selectItem: vi.fn(),
+      unselectItem: vi.fn(),
+    });
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(mockItems.length);
   });
 });

--- a/framework/PageTable/PageTableCard.test.tsx
+++ b/framework/PageTable/PageTableCard.test.tsx
@@ -325,4 +325,127 @@ describe('useColumnsToTableCardFn', () => {
 
     expect(card.cardBody).toBeTruthy();
   });
+
+  it('should hide description when descriptionColumn.value returns falsy', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+      {
+        header: 'Description',
+        type: 'description',
+        value: () => undefined,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { queryByText } = render(<MemoryRouter>{card.cardBody}</MemoryRouter>);
+    expect(queryByText('Test description')).not.toBeInTheDocument();
+  });
+
+  it('should use cell function when name column has no value function', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { getByText } = render(<MemoryRouter>{card.title}</MemoryRouter>);
+    expect(getByText('Test Item')).toBeInTheDocument();
+  });
+
+  it('should split string title on "/" characters', () => {
+    const itemWithSlash: TestItem = {
+      ...testItem,
+      name: 'org/repo/branch',
+    };
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(itemWithSlash);
+
+    const { getByText } = render(<MemoryRouter>{card.title}</MemoryRouter>);
+    expect(getByText('org')).toBeInTheDocument();
+    expect(getByText('repo')).toBeInTheDocument();
+    expect(getByText('branch')).toBeInTheDocument();
+  });
+
+  it('should render non-string cardTitle without splitting', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: () => <em>custom element</em>,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { container } = render(<MemoryRouter>{card.title}</MemoryRouter>);
+    expect(container.querySelector('em')).toBeInTheDocument();
+  });
+
+  it('should render visible card columns in card body', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+      {
+        header: 'Details',
+        cell: (item) => item.description,
+        value: (item) => item.description,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { getByText } = render(<MemoryRouter>{card.cardBody}</MemoryRouter>);
+    expect(getByText('Details')).toBeInTheDocument();
+    expect(getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('should render non-description type description column with TableColumnCell', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+      {
+        header: 'Summary',
+        card: 'description',
+        cell: (item) => item.description,
+        value: (item) => item.description,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { getByText } = render(<MemoryRouter>{card.cardBody}</MemoryRouter>);
+    expect(getByText('Test description')).toBeInTheDocument();
+  });
 });

--- a/framework/PageTable/PageTableCard.test.tsx
+++ b/framework/PageTable/PageTableCard.test.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { ITableColumn } from './PageTableColumn';
 import { PageTableCard, useColumnsToTableCardFn } from './PageTableCard';
-import { renderHook } from '@testing-library/react';
 
 interface TestItem {
   id: number;

--- a/framework/PageTable/PageTableCard.test.tsx
+++ b/framework/PageTable/PageTableCard.test.tsx
@@ -1,0 +1,329 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { ITableColumn } from './PageTableColumn';
+import { PageTableCard, useColumnsToTableCardFn } from './PageTableCard';
+import { renderHook } from '@testing-library/react';
+
+interface TestItem {
+  id: number;
+  name: string;
+  description: string;
+  count: number;
+  labels: string[];
+}
+
+const keyFn = (item: TestItem) => item.id;
+
+const testItem: TestItem = {
+  id: 1,
+  name: 'Test Item',
+  description: 'Test description',
+  count: 5,
+  labels: ['label1', 'label2'],
+};
+
+describe('PageTableCard', () => {
+  it('should render card with title and body', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Test Title</span>,
+            cardBody: <div>Card body content</div>,
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Card body content')).toBeInTheDocument();
+  });
+
+  it('should render subtitle when provided', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            subtitle: <span>Subtitle text</span>,
+            cardBody: <div />,
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Subtitle text')).toBeInTheDocument();
+  });
+
+  it('should render defaultCardSubtitle when no subtitle in card', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            cardBody: <div />,
+          })}
+          defaultCardSubtitle={<span>Default subtitle</span>}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Default subtitle')).toBeInTheDocument();
+  });
+
+  it('should render badge without tooltip', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            cardBody: <div />,
+            badge: 'New',
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('should render badge with tooltip', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            cardBody: <div />,
+            badge: 'Info',
+            badgeTooltip: 'Tooltip content',
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Info')).toBeInTheDocument();
+  });
+
+  it('should render alert when alertTitle is provided', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            cardBody: <div />,
+            alertTitle: 'Warning alert',
+            alertVariant: 'warning',
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Warning alert')).toBeInTheDocument();
+  });
+
+  it('should render labels in footer', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCard
+          item={testItem}
+          itemToCardFn={() => ({
+            id: 1,
+            title: <span>Title</span>,
+            cardBody: <div />,
+            labels: [{ label: 'Production' }, { label: 'Active' }],
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Production')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});
+
+describe('useColumnsToTableCardFn', () => {
+  it('should map name column to card title', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.id).toBe(1);
+  });
+
+  it('should map subtitle column', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+        value: (item) => item.name,
+      },
+      {
+        header: 'Type',
+        card: 'subtitle',
+        cell: (item) => item.description,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.subtitle).toBeTruthy();
+  });
+
+  it('should map description column', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Description',
+        type: 'description',
+        value: (item) => item.description,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.cardBody).toBeTruthy();
+  });
+
+  it('should map count columns', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Count',
+        type: 'count',
+        value: (item) => item.count,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.cardBody).toBeTruthy();
+  });
+
+  it('should map labels column', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Labels',
+        type: 'labels',
+        value: (item) => item.labels,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.labels).toHaveLength(2);
+    expect(card.labels?.[0].label).toBe('label1');
+  });
+
+  it('should skip hidden card columns', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Hidden',
+        card: 'hidden',
+        cell: () => 'hidden content',
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.id).toBe(1);
+  });
+
+  it('should render Link when name column has to()', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        type: 'text',
+        card: 'name',
+        value: (item) => item.name,
+        to: (item) => `/items/${item.id}`,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    const { getByRole } = render(<MemoryRouter>{card.title}</MemoryRouter>);
+    expect(getByRole('link')).toBeInTheDocument();
+  });
+
+  it('should render empty flex body when no content columns', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.cardBody).toBeTruthy();
+  });
+
+  it('should filter out columns with falsy value', () => {
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        card: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Empty',
+        cell: () => null,
+        value: () => undefined,
+      },
+    ];
+
+    const { result } = renderHook(() => useColumnsToTableCardFn(columns, keyFn));
+    const card = result.current(testItem);
+
+    expect(card.cardBody).toBeTruthy();
+  });
+});

--- a/framework/PageTable/PageTableCards.test.tsx
+++ b/framework/PageTable/PageTableCards.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { ITableColumn } from './PageTableColumn';
+import { PageTableCards } from './PageTableCards';
+
+interface MockItem {
+  id: number;
+  name: string;
+}
+
+const tableColumns: ITableColumn<MockItem>[] = [
+  {
+    header: 'Name',
+    cell: (item) => item.name,
+    card: 'name',
+  },
+];
+
+const keyFn = (item: MockItem) => item.id;
+
+describe('PageTableCards', () => {
+  it('should render cards for items', () => {
+    const items: MockItem[] = [
+      { id: 1, name: 'Card One' },
+      { id: 2, name: 'Card Two' },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableCards
+          keyFn={keyFn}
+          pageItems={items}
+          tableColumns={tableColumns}
+          itemCount={2}
+          page={1}
+          perPage={10}
+          setPage={vi.fn()}
+          setPerPage={vi.fn()}
+          clearAllFilters={vi.fn()}
+          errorStateTitle="Error"
+          emptyStateTitle="No items"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Card One')).toBeInTheDocument();
+    expect(screen.getByText('Card Two')).toBeInTheDocument();
+  });
+
+  it('should show empty state when itemCount is 0', () => {
+    render(
+      <MemoryRouter>
+        <PageTableCards
+          keyFn={keyFn}
+          pageItems={[]}
+          tableColumns={tableColumns}
+          itemCount={0}
+          page={1}
+          perPage={10}
+          setPage={vi.fn()}
+          setPerPage={vi.fn()}
+          clearAllFilters={vi.fn()}
+          errorStateTitle="Error"
+          emptyStateTitle="No items"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /no results found/i })).toBeInTheDocument();
+  });
+});

--- a/framework/PageTable/PageTableColumn.test.tsx
+++ b/framework/PageTable/PageTableColumn.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { PageTableViewTypeE } from '../PageToolbar/PageTableViewType';

--- a/framework/PageTable/PageTableColumn.test.tsx
+++ b/framework/PageTable/PageTableColumn.test.tsx
@@ -1,0 +1,477 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { PageTableViewTypeE } from '../PageToolbar/PageTableViewType';
+import {
+  ColumnCardOption,
+  ColumnDashboardOption,
+  ColumnListOption,
+  ColumnModalOption,
+  ColumnTableOption,
+  ITableColumn,
+  TableColumnCell,
+  useColumnsWithoutExpandedRow,
+  useColumnsWithoutSort,
+  useDashboardColumns,
+  useDescriptionColumns,
+  useExpandedColumns,
+  useVisibleCardColumns,
+  useVisibleColumns,
+  useVisibleListColumns,
+  useVisibleModalColumns,
+  useVisibleTableColumns,
+} from './PageTableColumn';
+
+vi.mock('../PageSettings/PageSettingsProvider', () => ({
+  usePageSettings: vi.fn(() => ({ dateFormat: 'date-time' })),
+}));
+
+vi.mock('../useFrameworkTranslations', () => ({
+  useFrameworkTranslations: () => [{ by: 'by' }],
+}));
+
+interface TestItem {
+  id: number;
+  name: string;
+  description: string;
+  count: number;
+  labels: string[];
+  created: string;
+}
+
+const testItem: TestItem = {
+  id: 1,
+  name: 'Test Resource',
+  description: 'A test description',
+  count: 42,
+  labels: ['prod', 'stable'],
+  created: '2024-06-15T14:30:00Z',
+};
+
+function buildColumns(): ITableColumn<TestItem>[] {
+  return [
+    {
+      header: 'Name',
+      type: 'text',
+      value: (item) => item.name,
+      sort: 'name',
+      card: 'name',
+      list: 'name',
+    },
+    {
+      header: 'Description',
+      type: 'description',
+      value: (item) => item.description,
+      table: ColumnTableOption.description,
+    },
+    {
+      header: 'Count',
+      type: 'count',
+      value: (item) => item.count,
+    },
+    {
+      header: 'Labels',
+      type: 'labels',
+      value: (item) => item.labels,
+    },
+    {
+      header: 'Created',
+      type: 'datetime',
+      value: (item) => item.created,
+      sort: 'created',
+    },
+    {
+      header: 'Custom',
+      cell: (item) => <span>{item.name} (custom)</span>,
+    },
+  ];
+}
+
+describe('TableColumnCell', () => {
+  const renderCell = (column: ITableColumn<TestItem> | undefined) =>
+    render(
+      <MemoryRouter>
+        <TableColumnCell item={testItem} column={column} />
+      </MemoryRouter>
+    );
+
+  it('should render column.cell(item) for default type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Custom',
+      cell: (item) => <span>{item.name} (custom)</span>,
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('Test Resource (custom)')).toBeInTheDocument();
+  });
+
+  it('should render TextCell for text type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Name',
+      type: 'text',
+      value: (item) => item.name,
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('Test Resource')).toBeInTheDocument();
+  });
+
+  it('should render TextCell with link for text type with to', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Name',
+      type: 'text',
+      value: (item) => item.name,
+      to: () => '/resources/1',
+    };
+
+    renderCell(column);
+
+    const link = screen.getByRole('link', { name: 'Test Resource' });
+    expect(link).toHaveAttribute('href', '/resources/1');
+  });
+
+  it('should render description div for description type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Description',
+      type: 'description',
+      value: (item) => item.description,
+    };
+
+    renderCell(column);
+
+    const element = screen.getByText('A test description');
+    expect(element.tagName).toBe('DIV');
+    expect(element).toHaveStyle({ minWidth: '200px', whiteSpace: 'normal' });
+  });
+
+  it('should render DateTimeCell for datetime type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Created',
+      type: 'datetime',
+      value: (item) => item.created,
+    };
+
+    const { container } = renderCell(column);
+
+    expect(container.querySelector('.date-time')).toBeInTheDocument();
+  });
+
+  it('should render count value for count type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Count',
+      type: 'count',
+      value: (item) => item.count,
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('should render dash when count value is undefined', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Count',
+      type: 'count',
+      value: () => undefined,
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should render LabelsCell for labels type', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Labels',
+      type: 'labels',
+      value: (item) => item.labels,
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('stable')).toBeInTheDocument();
+  });
+
+  it('should render LabelsCell with empty array when labels value is undefined', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Labels',
+      type: 'labels',
+      value: () => undefined,
+    };
+
+    const { container } = renderCell(column);
+
+    expect(container.querySelector('.pf-v6-c-label')).not.toBeInTheDocument();
+  });
+
+  it('should render empty fragment when column is undefined', () => {
+    const { container } = renderCell(undefined);
+
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('useVisibleTableColumns', () => {
+  it('should filter out hidden columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], table: ColumnTableOption.hidden };
+
+    const { result } = renderHook(() => useVisibleTableColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should filter out description columns', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleTableColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Description')).toBeUndefined();
+  });
+
+  it('should filter out expanded columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], table: ColumnTableOption.expanded };
+
+    const { result } = renderHook(() => useVisibleTableColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should keep columns without table option', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleTableColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Name')).toBeDefined();
+    expect(result.current.find((c) => c.header === 'Custom')).toBeDefined();
+  });
+});
+
+describe('useVisibleListColumns', () => {
+  it('should filter out list-hidden columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], list: ColumnListOption.hidden };
+
+    const { result } = renderHook(() => useVisibleListColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should keep columns without list option', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleListColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Created')).toBeDefined();
+  });
+
+  it('should keep columns with non-hidden list options', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], list: ColumnListOption.primary };
+
+    const { result } = renderHook(() => useVisibleListColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeDefined();
+  });
+});
+
+describe('useVisibleCardColumns', () => {
+  it('should filter out card-hidden columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], card: ColumnCardOption.hidden };
+
+    const { result } = renderHook(() => useVisibleCardColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should keep columns without card option', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleCardColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Labels')).toBeDefined();
+  });
+});
+
+describe('useVisibleModalColumns', () => {
+  it('should filter out modal-hidden columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], modal: ColumnModalOption.hidden };
+
+    const { result } = renderHook(() => useVisibleModalColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should keep columns without modal option', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleModalColumns(columns));
+
+    expect(result.current.length).toBe(columns.length);
+  });
+});
+
+describe('useDescriptionColumns', () => {
+  it('should return only description columns', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useDescriptionColumns(columns));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].header).toBe('Description');
+  });
+
+  it('should not include hidden columns', () => {
+    const columns = buildColumns();
+    columns[1] = { ...columns[1], table: ColumnTableOption.hidden };
+
+    const { result } = renderHook(() => useDescriptionColumns(columns));
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('should return empty array when no description columns exist', () => {
+    const columns = buildColumns().filter((c) => c.header !== 'Description');
+
+    const { result } = renderHook(() => useDescriptionColumns(columns));
+
+    expect(result.current).toHaveLength(0);
+  });
+});
+
+describe('useExpandedColumns', () => {
+  it('should return only expanded columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], table: ColumnTableOption.expanded };
+
+    const { result } = renderHook(() => useExpandedColumns(columns));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].header).toBe('Count');
+  });
+
+  it('should not include hidden columns', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useExpandedColumns(columns));
+
+    expect(result.current.find((c) => c.table === ColumnTableOption.hidden)).toBeUndefined();
+  });
+
+  it('should return empty array when no expanded columns exist', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useExpandedColumns(columns));
+
+    expect(result.current).toHaveLength(0);
+  });
+});
+
+describe('useColumnsWithoutSort', () => {
+  it('should remove sort from all columns', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useColumnsWithoutSort(columns));
+
+    result.current.forEach((col) => {
+      expect(col.sort).toBeUndefined();
+    });
+  });
+
+  it('should preserve other column properties', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useColumnsWithoutSort(columns));
+
+    expect(result.current[0].header).toBe('Name');
+    expect(result.current.length).toBe(columns.length);
+  });
+});
+
+describe('useColumnsWithoutExpandedRow', () => {
+  it('should clear expanded table option', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], table: ColumnTableOption.expanded };
+
+    const { result } = renderHook(() => useColumnsWithoutExpandedRow(columns));
+
+    expect(result.current[2].table).toBeUndefined();
+  });
+
+  it('should preserve non-expanded table options', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useColumnsWithoutExpandedRow(columns));
+
+    const descCol = result.current.find((c) => c.header === 'Description');
+    expect(descCol?.table).toBe(ColumnTableOption.description);
+  });
+});
+
+describe('useDashboardColumns', () => {
+  it('should filter out dashboard-hidden columns', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], dashboard: ColumnDashboardOption.hidden };
+
+    const { result } = renderHook(() => useDashboardColumns(columns));
+
+    expect(result.current.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should remove sort from all columns', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useDashboardColumns(columns));
+
+    result.current.forEach((col) => {
+      expect(col.sort).toBeUndefined();
+    });
+  });
+
+  it('should clear expanded table option', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], table: ColumnTableOption.expanded };
+
+    const { result } = renderHook(() => useDashboardColumns(columns));
+
+    const countCol = result.current.find((c) => c.header === 'Count');
+    expect(countCol?.table).toBeUndefined();
+  });
+});
+
+describe('useVisibleColumns', () => {
+  it('should return table-visible columns for Table view', () => {
+    const columns = buildColumns();
+
+    const { result } = renderHook(() => useVisibleColumns(columns, PageTableViewTypeE.Table));
+
+    expect(result.current?.find((c) => c.header === 'Description')).toBeUndefined();
+    expect(result.current?.find((c) => c.header === 'Name')).toBeDefined();
+  });
+
+  it('should return list-visible columns for List view', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], list: ColumnListOption.hidden };
+
+    const { result } = renderHook(() => useVisibleColumns(columns, PageTableViewTypeE.List));
+
+    expect(result.current?.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+
+  it('should return card-visible columns for Cards view', () => {
+    const columns = buildColumns();
+    columns[2] = { ...columns[2], card: ColumnCardOption.hidden };
+
+    const { result } = renderHook(() => useVisibleColumns(columns, PageTableViewTypeE.Cards));
+
+    expect(result.current?.find((c) => c.header === 'Count')).toBeUndefined();
+  });
+});

--- a/framework/PageTable/PageTableEmptyState.test.tsx
+++ b/framework/PageTable/PageTableEmptyState.test.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PageTableEmptyState } from './PageTableEmptyState';
+
+describe('PageTableEmptyState', () => {
+  it('should render title and default icon', () => {
+    render(<PageTableEmptyState title="No items found" />);
+    expect(screen.getByRole('heading', { name: 'No items found' })).toBeInTheDocument();
+  });
+
+  it('should render description when provided', () => {
+    render(<PageTableEmptyState title="No items" description="Try adjusting your filters" />);
+    expect(screen.getByText('Try adjusting your filters')).toBeInTheDocument();
+  });
+
+  it('should render footer children', () => {
+    render(
+      <PageTableEmptyState title="No items">
+        <button>Create item</button>
+      </PageTableEmptyState>
+    );
+    expect(screen.getByRole('button', { name: 'Create item' })).toBeInTheDocument();
+  });
+});

--- a/framework/PageTable/PageTableList.test.tsx
+++ b/framework/PageTable/PageTableList.test.tsx
@@ -248,4 +248,63 @@ describe('PageTableList', () => {
 
     expect(screen.queryByText('should not appear')).not.toBeInTheDocument();
   });
+
+  it('should render labels column', () => {
+    const columnsWithLabels: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Tags',
+        type: 'labels',
+        value: () => ['production', 'active'],
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithLabels}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText('production').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('active').length).toBeGreaterThan(0);
+  });
+
+  it('should skip primary column when value() returns falsy', () => {
+    const columnsWithFalsyPrimary: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Optional Field',
+        cell: () => 'should not render',
+        value: () => undefined,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithFalsyPrimary}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Item One')).toBeInTheDocument();
+    expect(screen.queryByText('Optional Field')).not.toBeInTheDocument();
+    expect(screen.queryByText('should not render')).not.toBeInTheDocument();
+  });
 });

--- a/framework/PageTable/PageTableList.test.tsx
+++ b/framework/PageTable/PageTableList.test.tsx
@@ -1,0 +1,251 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { PageActionSelection, PageActionType } from '../PageActions/PageAction';
+import { ITableColumn } from './PageTableColumn';
+import { PageTableList } from './PageTableList';
+
+interface TestItem {
+  id: number;
+  name: string;
+  description: string;
+}
+
+const keyFn = (item: TestItem) => item.id;
+
+const testItems: TestItem[] = [
+  { id: 1, name: 'Item One', description: 'First item' },
+  { id: 2, name: 'Item Two', description: 'Second item' },
+];
+
+const baseColumns: ITableColumn<TestItem>[] = [
+  {
+    header: 'Name',
+    list: 'name',
+    cell: (item) => item.name,
+  },
+  {
+    header: 'Description',
+    type: 'description',
+    value: (item) => item.description,
+  },
+];
+
+const baseProps = {
+  keyFn,
+  tableColumns: baseColumns,
+  page: 1,
+  perPage: 10,
+  setPage: vi.fn(),
+  setPerPage: vi.fn(),
+  emptyStateTitle: 'No items',
+  errorStateTitle: 'Error',
+  filterState: {},
+};
+
+describe('PageTableList', () => {
+  it('should render DataList items for pageItems', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList {...baseProps} pageItems={testItems} itemCount={2} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Item One')).toBeInTheDocument();
+    expect(screen.getByText('Item Two')).toBeInTheDocument();
+  });
+
+  it('should show empty state when itemCount is 0', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList {...baseProps} pageItems={[]} itemCount={0} clearAllFilters={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('should render checkbox when showSelect is true', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          pageItems={testItems}
+          itemCount={2}
+          showSelect
+          isSelected={() => false}
+          selectItem={vi.fn()}
+          unselectItem={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const checkboxes = document.querySelectorAll('[data-testid="data-list-check"]');
+    expect(checkboxes.length).toBe(2);
+  });
+
+  it('should render row actions', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          pageItems={testItems}
+          itemCount={2}
+          rowActions={[
+            {
+              type: PageActionType.Button,
+              selection: PageActionSelection.Single,
+              label: 'Edit',
+              onClick: vi.fn(),
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    const actionCells = document.querySelectorAll('[data-testid="data-list-action"]');
+    expect(actionCells.length).toBe(2);
+  });
+
+  it('should render description column content', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList {...baseProps} pageItems={testItems} itemCount={2} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('First item')).toBeInTheDocument();
+    expect(screen.getByText('Second item')).toBeInTheDocument();
+  });
+
+  it('should use defaultSubtitle when no subtitle column', () => {
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          pageItems={testItems}
+          itemCount={2}
+          defaultSubtitle="Resource"
+        />
+      </MemoryRouter>
+    );
+
+    const subtitles = screen.getAllByText('Resource');
+    expect(subtitles).toHaveLength(2);
+  });
+
+  it('should render secondary columns', () => {
+    const columnsWithSecondary: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'ID',
+        list: 'secondary',
+        cell: (item) => `#${item.id}`,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithSecondary}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    const idHeaders = screen.getAllByText('ID');
+    expect(idHeaders).toHaveLength(2);
+  });
+
+  it('should render count columns', () => {
+    const columnsWithCount: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Members',
+        type: 'count',
+        value: () => 42,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithCount}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    const memberHeaders = screen.getAllByText('Members');
+    expect(memberHeaders.length).toBeGreaterThan(0);
+  });
+
+  it('should skip columns with falsy value', () => {
+    const columnsWithFalsy: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Optional',
+        cell: () => null,
+        value: () => undefined,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithFalsy}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Item One')).toBeInTheDocument();
+  });
+
+  it('should hide list-hidden columns', () => {
+    const columnsWithHidden: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        list: 'name',
+        cell: (item) => item.name,
+      },
+      {
+        header: 'Hidden Column',
+        list: 'hidden',
+        cell: () => 'should not appear',
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <PageTableList
+          {...baseProps}
+          tableColumns={columnsWithHidden}
+          pageItems={testItems}
+          itemCount={2}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('should not appear')).not.toBeInTheDocument();
+  });
+});

--- a/framework/PageTable/useTableItems.test.tsx
+++ b/framework/PageTable/useTableItems.test.tsx
@@ -1,0 +1,502 @@
+/* eslint-disable i18next/no-literal-string */
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  useFiltered,
+  usePaged,
+  useSelected,
+  useSelectedInMemory,
+  useSorted,
+  useTableItems,
+} from './useTableItems';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+const keyFn = (item: TestItem) => item.id;
+
+const items: TestItem[] = [
+  { id: 1, name: 'Charlie' },
+  { id: 2, name: 'Alice' },
+  { id: 3, name: 'Bob' },
+];
+
+describe('useSelected', () => {
+  it('should initialize with empty selection', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.allSelected).toBe(false);
+  });
+
+  it('should initialize with defaultSelection', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn, [items[0], items[1]]));
+
+    expect(result.current.selectedItems).toHaveLength(2);
+    expect(result.current.isSelected(items[0])).toBe(true);
+    expect(result.current.isSelected(items[1])).toBe(true);
+  });
+
+  it('should select and unselect a single item', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(1);
+    expect(result.current.isSelected(items[0])).toBe(true);
+
+    act(() => result.current.unselectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(0);
+    expect(result.current.isSelected(items[0])).toBe(false);
+  });
+
+  it('should not duplicate when selecting same item twice', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectItem(items[0]));
+    act(() => result.current.selectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(1);
+  });
+
+  it('should not change state when unselecting an item that is not selected', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.unselectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('should bulk select via selectItems', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectItems([items[0], items[1]]));
+    expect(result.current.selectedItems).toHaveLength(2);
+  });
+
+  it('should select all items via selectAll', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selectedItems).toHaveLength(3);
+    expect(result.current.allSelected).toBe(true);
+  });
+
+  it('should unselect all items', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selectedItems).toHaveLength(3);
+
+    act(() => result.current.unselectAll());
+    expect(result.current.selectedItems).toHaveLength(0);
+    expect(result.current.allSelected).toBe(false);
+  });
+
+  it('should not change state when unselectAll on empty selection', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    const before = result.current.selectedItems;
+    act(() => result.current.unselectAll());
+    expect(result.current.selectedItems).toBe(before);
+  });
+
+  it('should bulk unselect via unselectItems', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectAll());
+    act(() => result.current.unselectItems([items[0], items[2]]));
+    expect(result.current.selectedItems).toHaveLength(1);
+    expect(result.current.isSelected(items[1])).toBe(true);
+  });
+
+  it('should update selected item reference when items list changes', () => {
+    const initialItems = [{ id: 1, name: 'Old' }];
+    const { result, rerender } = renderHook(({ items }) => useSelected(items, keyFn), {
+      initialProps: { items: initialItems },
+    });
+
+    act(() => result.current.selectItem(initialItems[0]));
+    expect(result.current.selectedItems[0].name).toBe('Old');
+
+    const updatedItems = [{ id: 1, name: 'New' }];
+    rerender({ items: updatedItems });
+    expect(result.current.selectedItems[0].name).toBe('New');
+  });
+
+  it('should compute allSelected correctly', () => {
+    const { result } = renderHook(() => useSelected(items, keyFn));
+
+    act(() => result.current.selectItems([items[0], items[1]]));
+    expect(result.current.allSelected).toBe(false);
+
+    act(() => result.current.selectItem(items[2]));
+    expect(result.current.allSelected).toBe(true);
+  });
+});
+
+describe('useSelectedInMemory', () => {
+  it('should initialize with empty selection', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.allSelected).toBe(false);
+  });
+
+  it('should handle undefined items', () => {
+    const { result } = renderHook(() => useSelectedInMemory(undefined, keyFn));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.allSelected).toBe(false);
+  });
+
+  it('should select and unselect items', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectItem(items[0]));
+    expect(result.current.isSelected(items[0])).toBe(true);
+
+    act(() => result.current.unselectItem(items[0]));
+    expect(result.current.isSelected(items[0])).toBe(false);
+  });
+
+  it('should not change state when selecting the same item reference', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectItem(items[0]));
+    act(() => result.current.selectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(1);
+  });
+
+  it('should not change state when unselecting an item not in selection', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.unselectItem(items[0]));
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('should select all items', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selectedItems).toHaveLength(3);
+    expect(result.current.allSelected).toBe(true);
+  });
+
+  it('should select all with undefined items using empty array', () => {
+    const { result } = renderHook(() => useSelectedInMemory(undefined, keyFn));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('should unselect all', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectAll());
+    act(() => result.current.unselectAll());
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('should not change state when unselectAll on empty selection', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    const before = result.current.selectedItems;
+    act(() => result.current.unselectAll());
+    expect(result.current.selectedItems).toBe(before);
+  });
+
+  it('should bulk unselect via unselectItems', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectAll());
+    act(() => result.current.unselectItems([items[0], items[2]]));
+    expect(result.current.selectedItems).toHaveLength(1);
+    expect(result.current.isSelected(items[1])).toBe(true);
+  });
+
+  it('should remove stale selections when items change', () => {
+    const { result, rerender } = renderHook(({ items }) => useSelectedInMemory(items, keyFn), {
+      initialProps: { items },
+    });
+
+    act(() => result.current.selectItem(items[2]));
+    expect(result.current.isSelected(items[2])).toBe(true);
+
+    rerender({ items: [items[0], items[1]] });
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('should update item reference when same key appears with new object', () => {
+    const initialItems = [{ id: 1, name: 'Old' }];
+    const { result, rerender } = renderHook(({ items }) => useSelectedInMemory(items, keyFn), {
+      initialProps: { items: initialItems },
+    });
+
+    act(() => result.current.selectItem(initialItems[0]));
+    expect(result.current.selectedItems[0].name).toBe('Old');
+
+    const updatedItems = [{ id: 1, name: 'New' }];
+    rerender({ items: updatedItems });
+    expect(result.current.selectedItems[0].name).toBe('New');
+  });
+
+  it('should bulk select via selectItems', () => {
+    const { result } = renderHook(() => useSelectedInMemory(items, keyFn));
+
+    act(() => result.current.selectItems([items[0], items[1]]));
+    expect(result.current.selectedItems).toHaveLength(2);
+  });
+});
+
+describe('useSorted', () => {
+  it('should return empty array for undefined items', () => {
+    const { result } = renderHook(() => useSorted<TestItem>(undefined));
+
+    expect(result.current.sorted).toEqual([]);
+    expect(result.current.sort).toBeUndefined();
+  });
+
+  it('should pass through items when no sort is set', () => {
+    const { result } = renderHook(() => useSorted(items));
+
+    expect(result.current.sorted).toBe(items);
+  });
+
+  it('should sort ascending', () => {
+    const { result } = renderHook(() => useSorted(items));
+
+    act(() =>
+      result.current.setSort({
+        id: 'name',
+        sortFn: (a, b) => a.name.localeCompare(b.name),
+        direction: 'asc',
+      })
+    );
+
+    expect(result.current.sorted.map((i) => i.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+  });
+
+  it('should sort descending', () => {
+    const { result } = renderHook(() => useSorted(items));
+
+    act(() =>
+      result.current.setSort({
+        id: 'name',
+        sortFn: (a, b) => a.name.localeCompare(b.name),
+        direction: 'desc',
+      })
+    );
+
+    expect(result.current.sorted.map((i) => i.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+  });
+});
+
+describe('useFiltered', () => {
+  it('should return all items when no filterFn is set', () => {
+    const { result } = renderHook(() => useFiltered(items, keyFn));
+
+    expect(result.current.filtered).toEqual(items);
+  });
+
+  it('should filter items with a custom filterFn', () => {
+    const { result } = renderHook(() => useFiltered(items, keyFn));
+
+    act(() => result.current.setFilterFn((item: TestItem) => item.name.startsWith('A')));
+    expect(result.current.filtered).toHaveLength(1);
+    expect(result.current.filtered[0].name).toBe('Alice');
+  });
+
+  it('should clear filter when filterFn set to undefined', () => {
+    const { result } = renderHook(() => useFiltered(items, keyFn));
+
+    act(() => result.current.setFilterFn((item: TestItem) => item.name === 'Alice'));
+    expect(result.current.filtered).toHaveLength(1);
+
+    act(() => result.current.setFilterFn(undefined));
+    expect(result.current.filtered).toEqual(items);
+  });
+
+  it('should update cache when item reference changes', () => {
+    const mutableItems = [
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Beta' },
+    ];
+    const { result, rerender } = renderHook(({ items }) => useFiltered(items, keyFn), {
+      initialProps: { items: mutableItems },
+    });
+
+    act(() => result.current.setFilterFn((item: TestItem) => item.name.startsWith('A')));
+    expect(result.current.filtered).toHaveLength(1);
+
+    const updatedItems = [
+      { id: 1, name: 'Bravo' },
+      { id: 2, name: 'Beta' },
+    ];
+    rerender({ items: updatedItems });
+    expect(result.current.filtered).toHaveLength(0);
+  });
+});
+
+describe('usePaged', () => {
+  const manyItems: TestItem[] = Array.from({ length: 25 }, (_, i) => ({
+    id: i + 1,
+    name: `Item ${i + 1}`,
+  }));
+
+  it('should return first page of items', () => {
+    const { result } = renderHook(() => usePaged(manyItems));
+
+    expect(result.current.paged).toHaveLength(10);
+    expect(result.current.page).toBe(1);
+    expect(result.current.perPage).toBe(10);
+  });
+
+  it('should navigate to second page', () => {
+    const { result } = renderHook(() => usePaged(manyItems));
+
+    act(() => result.current.setPage(2));
+    expect(result.current.paged).toHaveLength(10);
+    expect(result.current.paged[0].name).toBe('Item 11');
+  });
+
+  it('should handle last page with fewer items', () => {
+    const { result } = renderHook(() => usePaged(manyItems));
+
+    act(() => result.current.setPage(3));
+    expect(result.current.paged).toHaveLength(5);
+    expect(result.current.paged[0].name).toBe('Item 21');
+  });
+
+  it('should change perPage', () => {
+    const { result } = renderHook(() => usePaged(manyItems));
+
+    act(() => result.current.setPerPage(5));
+    expect(result.current.paged).toHaveLength(5);
+    expect(result.current.perPage).toBe(5);
+  });
+
+  it('should reset to page 1 when current page exceeds total pages', () => {
+    const { result } = renderHook(() => usePaged(manyItems));
+
+    act(() => result.current.setPage(3));
+    expect(result.current.page).toBe(3);
+
+    act(() => result.current.setPerPage(25));
+    expect(result.current.page).toBe(1);
+  });
+
+  it('should preserve array reference when slice is unchanged', () => {
+    const { result, rerender } = renderHook(({ source }) => usePaged(source), {
+      initialProps: { source: manyItems },
+    });
+    const firstPaged = result.current.paged;
+
+    rerender({ source: manyItems });
+    expect(result.current.paged).toBe(firstPaged);
+  });
+});
+
+describe('useTableItems (integration)', () => {
+  it('should expose all composed hooks', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.sorted).toEqual(items);
+    expect(result.current.filtered).toBeDefined();
+    expect(result.current.searched).toBeDefined();
+    expect(result.current.paged).toBeDefined();
+    expect(result.current.page).toBe(1);
+    expect(result.current.perPage).toBe(10);
+  });
+
+  it('should pipe items through sort → filter → search → page', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    act(() =>
+      result.current.setSort({
+        id: 'name',
+        sortFn: (a, b) => a.name.localeCompare(b.name),
+        direction: 'asc',
+      })
+    );
+    expect(result.current.sorted.map((i) => i.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+
+    act(() => result.current.setFilterFn((item: TestItem) => item.name !== 'Bob'));
+    expect(result.current.filtered).toHaveLength(2);
+  });
+
+  it('should select page of items', () => {
+    const manyItems: TestItem[] = Array.from({ length: 25 }, (_, i) => ({
+      id: i + 1,
+      name: `Item ${i + 1}`,
+    }));
+    const { result } = renderHook(() => useTableItems(manyItems, keyFn));
+
+    act(() => result.current.selectPage());
+    expect(result.current.selectedItems).toHaveLength(10);
+  });
+
+  it('should select all searched items', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selectedItems).toHaveLength(3);
+    expect(result.current.allSelected).toBe(true);
+  });
+
+  it('should initialize search from defaults', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn, { search: 'test' }));
+
+    expect(result.current.search).toBe('test');
+  });
+
+  it('should debounce search updates', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    act(() => result.current.setSearch('hello'));
+    expect(result.current.search).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.search).toBe('hello');
+
+    vi.useRealTimers();
+  });
+
+  it('should filter and rank items by search score', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    act(() =>
+      result.current.setSearchFn((item: TestItem, search: string) => {
+        if (item.name.toLowerCase().includes(search.toLowerCase())) return 0;
+        return 1;
+      })
+    );
+
+    vi.useFakeTimers();
+    act(() => result.current.setSearch('alice'));
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.searched).toHaveLength(1);
+    expect(result.current.searched[0].name).toBe('Alice');
+
+    vi.useRealTimers();
+  });
+
+  it('should show all items when search is empty', () => {
+    const { result } = renderHook(() => useTableItems(items, keyFn));
+
+    act(() =>
+      result.current.setSearchFn((item: TestItem, search: string) => {
+        if (item.name.toLowerCase().includes(search.toLowerCase())) return 0;
+        return 1;
+      })
+    );
+
+    expect(result.current.searched).toHaveLength(3);
+  });
+});

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarBrowseAdapter.test.ts
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarBrowseAdapter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { multiSelectBrowseAdapter } from './ToolbarAsyncMultiSelectFilter';
+import { singleSelectBrowseAdapter } from './ToolbarAsyncSingleSelectFilter';
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+describe('multiSelectBrowseAdapter', () => {
+  it('should call selectFn, map items via keyFn', () => {
+    const selectFn = vi.fn((onSelect: (items: TestItem[]) => void) => {
+      onSelect([
+        { id: '1', name: 'Item 1' },
+        { id: '2', name: 'Item 2' },
+      ]);
+    });
+    const keyFn = (item: TestItem) => item.id;
+    const objectFn = (name: string) => ({ id: name, name });
+
+    const adapter = multiSelectBrowseAdapter(selectFn, keyFn, objectFn);
+    const onSelect = vi.fn();
+    adapter(onSelect);
+
+    expect(selectFn).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith(['1', '2']);
+  });
+
+  it('should use customOnSelect when provided', () => {
+    const selectFn = vi.fn((onSelect: (items: TestItem[]) => void) => {
+      onSelect([{ id: '1', name: 'Item 1' }]);
+    });
+    const keyFn = (item: TestItem) => item.id;
+    const objectFn = (name: string) => ({ id: name, name });
+    const customOnSelect = vi.fn();
+
+    const adapter = multiSelectBrowseAdapter(selectFn, keyFn, objectFn, customOnSelect);
+    const onSelect = vi.fn();
+    adapter(onSelect);
+
+    expect(customOnSelect).toHaveBeenCalledWith([{ id: '1', name: 'Item 1' }]);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should map defaultSelections through objectFn', () => {
+    const selectFn = vi.fn();
+    const keyFn = (item: TestItem) => item.id;
+    const objectFn = vi.fn((name: string) => ({ id: name, name }));
+
+    const adapter = multiSelectBrowseAdapter(selectFn, keyFn, objectFn);
+    const onSelect = vi.fn();
+    adapter(onSelect, ['sel1', 'sel2']);
+
+    expect(objectFn).toHaveBeenCalledWith('sel1');
+    expect(objectFn).toHaveBeenCalledWith('sel2');
+    expect(selectFn).toHaveBeenCalledWith(expect.any(Function), [
+      { id: 'sel1', name: 'sel1' },
+      { id: 'sel2', name: 'sel2' },
+    ]);
+  });
+});
+
+describe('singleSelectBrowseAdapter', () => {
+  it('should call selectFn, map item via keyFn', () => {
+    const selectFn = vi.fn((onSelect: (item: TestItem) => void) => {
+      onSelect({ id: '42', name: 'Test' });
+    });
+    const keyFn = (item: TestItem) => item.id;
+    const objectFn = (name: string) => ({ id: name, name });
+
+    const adapter = singleSelectBrowseAdapter(selectFn, keyFn, objectFn);
+    const onSelect = vi.fn();
+    adapter(onSelect);
+
+    expect(selectFn).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith('42');
+  });
+
+  it('should use customOnSelect when provided', () => {
+    const selectFn = vi.fn((onSelect: (item: TestItem) => void) => {
+      onSelect({ id: '5', name: 'Five' });
+    });
+    const keyFn = (item: TestItem) => item.id;
+    const objectFn = (name: string) => ({ id: name, name });
+    const customOnSelect = vi.fn();
+
+    const adapter = singleSelectBrowseAdapter(selectFn, keyFn, objectFn, customOnSelect);
+    const onSelect = vi.fn();
+    adapter(onSelect);
+
+    expect(customOnSelect).toHaveBeenCalledWith({ id: '5', name: 'Five' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ToolbarDateRangeFilter } from './ToolbarDateRangeFilter';
+
+const defaultOptions = [
+  { label: 'Last 7 days', value: 'last7days' },
+  { label: 'Last 30 days', value: 'last30days' },
+  { label: 'Custom', value: 'custom', isCustom: true },
+];
+
+describe('ToolbarDateRangeFilter', () => {
+  it('should render preset options in select', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('Select range'));
+
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    expect(screen.getByText('Last 30 days')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+  });
+
+  it('should call setFilterValues when preset selected', async () => {
+    const user = userEvent.setup();
+    const setFilterValues = vi.fn();
+
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    await user.click(screen.getByText('Select range'));
+    await user.click(screen.getByText('Last 7 days'));
+
+    expect(setFilterValues).toHaveBeenCalled();
+    const setterFn = setFilterValues.mock.calls[0][0] as () => string[];
+    expect(setterFn()).toEqual(['last7days']);
+  });
+
+  it('should auto-select defaultValue when isRequired and no selection', () => {
+    const setFilterValues = vi.fn();
+
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        setFilterValues={setFilterValues}
+        isRequired={true}
+        defaultValue="last30days"
+      />
+    );
+
+    expect(setFilterValues).toHaveBeenCalled();
+    const setterFn = setFilterValues.mock.calls[0][0] as () => string[];
+    expect(setterFn()).toEqual(['last30days']);
+  });
+
+  it('should render DateRange pickers when custom option selected', () => {
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Start date')).toBeInTheDocument();
+    expect(screen.getByLabelText('End date')).toBeInTheDocument();
+  });
+});

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
@@ -12,15 +12,23 @@ import {
   PageToolbarFiltersProps,
   ToolbarFilterType,
 } from '../PageToolbarFilter';
+import { IToolbarAsyncMultiSelectFilter } from './ToolbarAsyncMultiSelectFilter';
+import { IToolbarAsyncSingleSelectFilter } from './ToolbarAsyncSingleSelectFilter';
 import { IToolbarDateRangeFilter } from './ToolbarDateRangeFilter';
 import { IToolbarMultiSelectFilter } from './ToolbarMultiSelectFilter';
 import { IToolbarSingleSelectFilter } from './ToolbarSingleSelectFilter';
-import { IToolbarMultiTextFilter, IToolbarSingleTextFilter } from './ToolbarTextFilter';
+import {
+  IToolbarMultiTextFilter,
+  IToolbarSearchFilter,
+  IToolbarSingleTextFilter,
+} from './ToolbarTextFilter';
 
 function ToolbarFiltersTest(
-  props: Omit<PageToolbarFiltersProps, 'filterState' | 'setFilterState'>
+  props: Omit<PageToolbarFiltersProps, 'filterState' | 'setFilterState'> & {
+    initialFilterState?: IFilterState;
+  }
 ) {
-  const [filterState, setFilterState] = useState<IFilterState>({});
+  const [filterState, setFilterState] = useState<IFilterState>(props.initialFilterState ?? {});
   const clearAllFilters = () => setFilterState((_filters) => ({}));
   return (
     <>
@@ -107,6 +115,49 @@ function createMultiSelectFilter(
       { value: '3', label: 'Option 3' },
     ],
     placeholder: `Filter by ms${index}`,
+    ...options,
+  };
+}
+
+function createSearchFilter(index: number, options?: { isPinned?: boolean }): IToolbarSearchFilter {
+  return {
+    type: ToolbarFilterType.Search,
+    key: `search${index}`,
+    query: `search${index}`,
+    label: `Search ${index}`,
+    placeholder: `Search by s${index}`,
+    ...options,
+  };
+}
+
+function createAsyncSingleSelectFilter(
+  index: number,
+  options?: { isPinned?: boolean }
+): IToolbarAsyncSingleSelectFilter {
+  return {
+    type: ToolbarFilterType.AsyncSingleSelect,
+    key: `ass${index}`,
+    query: `ass${index}`,
+    label: `Async Single ${index}`,
+    placeholder: `Filter by ass${index}`,
+    queryOptions: () => Promise.resolve([{ value: '1', label: 'Option 1' }]),
+    queryLabel: (value: string) => value,
+    ...options,
+  };
+}
+
+function createAsyncMultiSelectFilter(
+  index: number,
+  options?: { isPinned?: boolean }
+): IToolbarAsyncMultiSelectFilter {
+  return {
+    type: ToolbarFilterType.AsyncMultiSelect,
+    key: `ams${index}`,
+    query: `ams${index}`,
+    label: `Async Multi ${index}`,
+    placeholder: `Filter by ams${index}`,
+    queryOptions: () => Promise.resolve([{ value: '1', label: 'Option 1' }]),
+    queryLabel: (value: string) => value,
     ...options,
   };
 }
@@ -290,6 +341,203 @@ describe('PageToolbarFilters', () => {
   it('should render date range filter with required default', () => {
     render(<ToolbarFiltersTest toolbarFilters={[dateRangeFilter]} />);
 
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+  });
+
+  it('should render search filter type', () => {
+    const filter = createSearchFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByPlaceholderText('Search by s1')).toBeInTheDocument();
+  });
+
+  it('should allow typing in search filter', async () => {
+    const user = userEvent.setup();
+    const filter = createSearchFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    const input = screen.getByPlaceholderText('Search by s1');
+    await user.type(input, 'hello');
+
+    expect(input).toHaveValue('hello');
+  });
+
+  it('should render async single select filter', () => {
+    const filter = createAsyncSingleSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByText('Filter by ass1')).toBeInTheDocument();
+  });
+
+  it('should render async multi select filter', () => {
+    const filter = createAsyncMultiSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByText('Filter by ams1')).toBeInTheDocument();
+  });
+
+  it('should render non-pinned date range filter with chips', () => {
+    const nonPinnedDateRange: IToolbarDateRangeFilter = {
+      type: ToolbarFilterType.DateRange,
+      key: 'date_np',
+      query: 'date_np',
+      label: 'Date NP',
+      options: [
+        { value: 'last7days', label: 'Last 7 days' },
+        { value: 'last30days', label: 'Last 30 days' },
+      ],
+      placeholder: 'Filter by date np',
+    };
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[nonPinnedDateRange]}
+        initialFilterState={{ date_np: ['last7days'] }}
+      />
+    );
+
+    const matches = screen.getAllByText('Last 7 days');
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should render chip labels for non-pinned single select filter', () => {
+    const filter = createSingleSelectFilter(1);
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} initialFilterState={{ ss1: ['2'] }} />);
+
+    const matches = screen.getAllByText('Option 2');
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should render chip labels for multi-text filter', () => {
+    const filter = createMultiTextFilter(1, { isPinned: true });
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[filter]}
+        initialFilterState={{ mt1: ['alpha', 'beta'] }}
+      />
+    );
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+  });
+
+  it('should render multi-text as single-text when limitFiltersToOneOrOperation and another filter has 2+ values', () => {
+    const multiText = createMultiTextFilter(1, { isPinned: true });
+    const multiText2 = createMultiTextFilter(2, { isPinned: true });
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[multiText, multiText2]}
+        limitFiltersToOneOrOperation
+        initialFilterState={{ mt1: ['a', 'b'] }}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('Filter by mt2')).toBeInTheDocument();
+  });
+
+  it('should render multi-select as single-select when limitFiltersToOneOrOperation and another filter has 2+ values', () => {
+    const multiSelect = createMultiSelectFilter(1, { isPinned: true });
+    const multiSelect2 = createMultiSelectFilter(2, { isPinned: true });
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[multiSelect, multiSelect2]}
+        limitFiltersToOneOrOperation
+        initialFilterState={{ ms1: ['1', '2'] }}
+      />
+    );
+
+    expect(screen.getByText('Filter by ms2')).toBeInTheDocument();
+  });
+
+  it('should render async multi-select as single-select when limitFiltersToOneOrOperation and another filter has 2+ values', () => {
+    const asyncMulti = createAsyncMultiSelectFilter(1, { isPinned: true });
+    const asyncMulti2 = createAsyncMultiSelectFilter(2, { isPinned: true });
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[asyncMulti, asyncMulti2]}
+        limitFiltersToOneOrOperation
+        initialFilterState={{ ams1: ['1', '2'] }}
+      />
+    );
+
+    expect(screen.getByText('Filter by ams2')).toBeInTheDocument();
+  });
+
+  it('should render chip labels for non-pinned multi-select filter', () => {
+    const filter = createMultiSelectFilter(1);
+
+    render(
+      <ToolbarFiltersTest toolbarFilters={[filter]} initialFilterState={{ ms1: ['1', '3'] }} />
+    );
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
+
+  it('should render async single select chip with queryLabel', () => {
+    const filter = createAsyncSingleSelectFilter(1);
+
+    render(
+      <ToolbarFiltersTest toolbarFilters={[filter]} initialFilterState={{ ass1: ['myvalue'] }} />
+    );
+
+    const matches = screen.getAllByText('myvalue');
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render async multi select chips with queryLabel', () => {
+    const filter = createAsyncMultiSelectFilter(1);
+
+    render(
+      <ToolbarFiltersTest
+        toolbarFilters={[filter]}
+        initialFilterState={{ ams1: ['val1', 'val2'] }}
+      />
+    );
+
+    expect(screen.getByText('val1')).toBeInTheDocument();
+    expect(screen.getByText('val2')).toBeInTheDocument();
+  });
+
+  it('should render search filter as non-pinned grouped filter', () => {
+    const filter = createSearchFilter(1);
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByPlaceholderText('Search by s1')).toBeInTheDocument();
+    expect(screen.getByText('Search 1')).toBeInTheDocument();
+  });
+
+  it('should render all filter types together', () => {
+    const filters: IToolbarFilter[] = [
+      createSearchFilter(1, { isPinned: true }),
+      createSingleTextFilter(1, { isPinned: true }),
+      createMultiTextFilter(1, { isPinned: true }),
+      createSingleSelectFilter(1, { isPinned: true }),
+      createMultiSelectFilter(1, { isPinned: true }),
+      createAsyncSingleSelectFilter(1, { isPinned: true }),
+      createAsyncMultiSelectFilter(1, { isPinned: true }),
+      dateRangeFilter,
+    ];
+
+    render(<ToolbarFiltersTest toolbarFilters={filters} />);
+
+    expect(screen.getByPlaceholderText('Search by s1')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter by st1')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter by mt1')).toBeInTheDocument();
+    expect(screen.getByText('Filter by ss1')).toBeInTheDocument();
+    expect(screen.getByText('Filter by ms1')).toBeInTheDocument();
+    expect(screen.getByText('Filter by ass1')).toBeInTheDocument();
+    expect(screen.getByText('Filter by ams1')).toBeInTheDocument();
     expect(screen.getByText('Last 7 days')).toBeInTheDocument();
   });
 });

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
@@ -186,7 +186,110 @@ describe('PageToolbarFilters', () => {
     const input = screen.getByPlaceholderText('Filter by mt1');
     await user.type(input, 'test');
 
-    // Multi-text filter should have an apply button
     expect(screen.getByRole('button', { name: 'apply filter' })).toBeInTheDocument();
+  });
+
+  it('should render single grouped filter directly without selector', () => {
+    const filter = createSingleTextFilter(1);
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByPlaceholderText('Filter by st1')).toBeInTheDocument();
+  });
+
+  it('should render filter key selector for multiple grouped filters', () => {
+    const filter1 = createSingleTextFilter(1);
+    const filter2 = createSingleTextFilter(2);
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter1, filter2]} />);
+
+    expect(screen.getByPlaceholderText('Filter by st1')).toBeInTheDocument();
+  });
+
+  it('should render single select filter', () => {
+    const filter = createSingleSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByText('Filter by ss1')).toBeInTheDocument();
+  });
+
+  it('should add filter chip on multi-text Enter', async () => {
+    const user = userEvent.setup();
+    const filter = createMultiTextFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    const input = screen.getByPlaceholderText('Filter by mt1');
+    await user.type(input, 'value1{Enter}');
+
+    const filterState = screen.getByTestId('filter-state');
+    expect(filterState.textContent).toContain('value1');
+  });
+
+  it('should not render chips for pinned SingleSelect filter', () => {
+    const filter = createSingleSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.queryByRole('group', { name: 'Single-Select 1' })).not.toBeInTheDocument();
+  });
+
+  it('should not render chips for pinned DateRange filter', () => {
+    render(<ToolbarFiltersTest toolbarFilters={[dateRangeFilter]} />);
+
+    expect(screen.queryByRole('group', { name: 'Date Range' })).not.toBeInTheDocument();
+  });
+
+  it('should render empty when no toolbar filters', () => {
+    const { container } = render(<ToolbarFiltersTest toolbarFilters={[]} />);
+
+    expect(container.querySelector('[data-testid="text-input"]')).not.toBeInTheDocument();
+  });
+
+  it('should render empty when toolbar filters is undefined', () => {
+    const { container } = render(<ToolbarFiltersTest toolbarFilters={undefined} />);
+
+    expect(container.querySelector('[data-testid="text-input"]')).not.toBeInTheDocument();
+  });
+
+  it('should hide label for pinned single-select with no value', () => {
+    const filter = createSingleSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.queryByText('Single-Select 1')).not.toBeInTheDocument();
+  });
+
+  it('should render label for single non-pinned filter', () => {
+    const filter = createSingleTextFilter(1);
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByText('Single-Text 1')).toBeInTheDocument();
+  });
+
+  it('should render both grouped and pinned filters', () => {
+    const grouped = createSingleTextFilter(1);
+    const pinned = createSingleTextFilter(2, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[grouped, pinned]} />);
+
+    expect(screen.getByPlaceholderText('Filter by st1')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter by st2')).toBeInTheDocument();
+  });
+
+  it('should render multi-select filter', () => {
+    const filter = createMultiSelectFilter(1, { isPinned: true });
+
+    render(<ToolbarFiltersTest toolbarFilters={[filter]} />);
+
+    expect(screen.getByText('Filter by ms1')).toBeInTheDocument();
+  });
+
+  it('should render date range filter with required default', () => {
+    render(<ToolbarFiltersTest toolbarFilters={[dateRangeFilter]} />);
+
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument();
   });
 });

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarFilters.test.tsx
@@ -140,7 +140,12 @@ function createAsyncSingleSelectFilter(
     query: `ass${index}`,
     label: `Async Single ${index}`,
     placeholder: `Filter by ass${index}`,
-    queryOptions: () => Promise.resolve([{ value: '1', label: 'Option 1' }]),
+    queryOptions: () =>
+      Promise.resolve({
+        remaining: 0,
+        options: [{ value: '1', label: 'Option 1' }],
+        next: 0,
+      }),
     queryLabel: (value: string) => value,
     ...options,
   };
@@ -156,7 +161,12 @@ function createAsyncMultiSelectFilter(
     query: `ams${index}`,
     label: `Async Multi ${index}`,
     placeholder: `Filter by ams${index}`,
-    queryOptions: () => Promise.resolve([{ value: '1', label: 'Option 1' }]),
+    queryOptions: () =>
+      Promise.resolve({
+        remaining: 0,
+        options: [{ value: '1', label: 'Option 1' }],
+        next: 0,
+      }),
     queryLabel: (value: string) => value,
     ...options,
   };

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarTextFilter.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarTextFilter.test.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ToolbarTextMultiFilter, ToolbarSingleTextFilter } from './ToolbarTextFilter';
+
+describe('ToolbarTextMultiFilter', () => {
+  it('should call addFilter and clear input on Enter key', async () => {
+    const user = userEvent.setup();
+    const addFilter = vi.fn();
+
+    render(<ToolbarTextMultiFilter addFilter={addFilter} comparison="contains" />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'hello{Enter}');
+
+    expect(addFilter).toHaveBeenCalledWith('hello');
+    expect(input).toHaveValue('');
+  });
+
+  it('should call addFilter on apply button click', async () => {
+    const user = userEvent.setup();
+    const addFilter = vi.fn();
+
+    render(<ToolbarTextMultiFilter addFilter={addFilter} comparison="contains" />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'test');
+    await user.click(screen.getByRole('button', { name: 'apply filter' }));
+
+    expect(addFilter).toHaveBeenCalledWith('test');
+    expect(input).toHaveValue('');
+  });
+
+  it('should disable apply when empty', () => {
+    render(<ToolbarTextMultiFilter addFilter={vi.fn()} comparison="contains" />);
+
+    expect(screen.getByRole('button', { name: 'apply filter' })).toBeDisabled();
+  });
+
+  it('should show clear button and clear input on click', async () => {
+    const user = userEvent.setup();
+
+    render(<ToolbarTextMultiFilter addFilter={vi.fn()} comparison="contains" />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'value');
+
+    const clearButton = screen.getByRole('button', { name: 'clear filter' });
+    expect(clearButton).toBeInTheDocument();
+
+    await user.click(clearButton);
+    expect(input).toHaveValue('');
+  });
+
+  it('should use comparison-based placeholder when no custom placeholder', () => {
+    render(<ToolbarTextMultiFilter addFilter={vi.fn()} comparison="startsWith" />);
+
+    expect(screen.getByPlaceholderText('starts with')).toBeInTheDocument();
+  });
+});
+
+describe('ToolbarSingleTextFilter', () => {
+  it('should debounce value updates', async () => {
+    const user = userEvent.setup();
+    const setValue = vi.fn();
+
+    render(
+      <ToolbarSingleTextFilter setValue={setValue} value="" hasKey={true} comparison="contains" />
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'ab');
+
+    await waitFor(() => {
+      expect(setValue).toHaveBeenCalled();
+    });
+
+    const lastCall = setValue.mock.calls[setValue.mock.calls.length - 1][0] as string;
+    expect(lastCall).toContain('b');
+  });
+
+  it('should clear both local and parent value on clear button', async () => {
+    const user = userEvent.setup();
+    const setValue = vi.fn();
+
+    render(
+      <ToolbarSingleTextFilter
+        setValue={setValue}
+        value="initial"
+        hasKey={true}
+        comparison="contains"
+      />
+    );
+
+    const clearButton = screen.getByRole('button', { name: 'clear filter' });
+    await user.click(clearButton);
+
+    expect(setValue).toHaveBeenCalledWith('');
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should clear input when hasKey becomes false', () => {
+    const { rerender } = render(
+      <ToolbarSingleTextFilter
+        setValue={vi.fn()}
+        value="test"
+        hasKey={true}
+        comparison="contains"
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('test');
+
+    rerender(
+      <ToolbarSingleTextFilter
+        setValue={vi.fn()}
+        value="test"
+        hasKey={false}
+        comparison="contains"
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+});

--- a/framework/PageToolbar/PageToolbarSort.test.tsx
+++ b/framework/PageToolbar/PageToolbarSort.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { ITableColumn } from '../PageTable/PageTableColumn';

--- a/framework/PageToolbar/PageToolbarSort.test.tsx
+++ b/framework/PageToolbar/PageToolbarSort.test.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable i18next/no-literal-string */
+import { render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ITableColumn } from '../PageTable/PageTableColumn';
+import {
+  PageToolbarSort,
+  PageTableSortOption,
+  usePageToolbarSortOptionsFromColumns,
+} from './PageToolbarSort';
+
+describe('PageToolbarSort', () => {
+  it('should render nothing when no sortOptions', () => {
+    const { container } = render(<PageToolbarSort />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should render sort label and select with options', () => {
+    const sortOptions: PageTableSortOption[] = [
+      { label: 'Name', value: 'name', type: 'text' },
+      { label: 'Created', value: 'created', type: 'number' },
+    ];
+
+    render(
+      <PageToolbarSort
+        sort="name"
+        setSort={vi.fn()}
+        sortDirection="asc"
+        setSortDirection={vi.fn()}
+        sortOptions={sortOptions}
+      />
+    );
+
+    expect(screen.getByText('Sort')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  it('should toggle direction when direction button clicked', async () => {
+    const user = userEvent.setup();
+    const setSortDirection = vi.fn();
+    const sortOptions: PageTableSortOption[] = [{ label: 'Name', value: 'name', type: 'text' }];
+
+    render(
+      <PageToolbarSort
+        sort="name"
+        setSort={vi.fn()}
+        sortDirection="asc"
+        setSortDirection={setSortDirection}
+        sortOptions={sortOptions}
+      />
+    );
+
+    const buttons = screen.getAllByRole('button');
+    const directionButton = buttons[buttons.length - 1];
+    await user.click(directionButton);
+
+    expect(setSortDirection).toHaveBeenCalledWith('desc');
+  });
+});
+
+describe('usePageToolbarSortOptionsFromColumns', () => {
+  it('should map columns with sort to sort options', () => {
+    type TestItem = { id: number; name: string; count: number; desc: string };
+
+    const columns: ITableColumn<TestItem>[] = [
+      {
+        header: 'Name',
+        sort: 'name',
+        defaultSort: true,
+        type: 'text',
+        value: (item) => item.name,
+      },
+      {
+        header: 'Count',
+        sort: 'count',
+        type: 'count',
+        value: (item) => item.count,
+      },
+      {
+        header: 'Description',
+        sort: 'description',
+        type: 'text',
+        value: (item) => item.desc,
+      },
+      {
+        header: 'Other',
+        sort: 'other',
+        type: 'datetime',
+        value: () => undefined,
+      },
+    ];
+
+    const { result } = renderHook(() => usePageToolbarSortOptionsFromColumns(columns));
+
+    expect(result.current).toHaveLength(4);
+    expect(result.current[0]).toEqual(
+      expect.objectContaining({ label: 'Name', value: 'name', type: 'text' })
+    );
+    expect(result.current[1]).toEqual(
+      expect.objectContaining({ label: 'Count', value: 'count', type: 'number' })
+    );
+    expect(result.current[2]).toEqual(
+      expect.objectContaining({ label: 'Description', value: 'description', type: 'text' })
+    );
+    expect(result.current[3]).toEqual(expect.objectContaining({ label: 'Other', value: 'other' }));
+    expect(result.current[3].type).toBeUndefined();
+  });
+});

--- a/framework/PageToolbar/PageToolbarToggleGroup.test.tsx
+++ b/framework/PageToolbar/PageToolbarToggleGroup.test.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable i18next/no-literal-string */
+import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { FilterIcon } from '@patternfly/react-icons';
+import { PageToolbarToggleGroup } from './PageToolbarToggleGroup';
+
+describe('PageToolbarToggleGroup', () => {
+  it('should render children within toggle group', () => {
+    render(
+      <Toolbar>
+        <ToolbarContent>
+          <PageToolbarToggleGroup id="test-group" toggleIcon={<FilterIcon />} breakpoint="md">
+            <ToolbarItem>
+              <span>Child Content</span>
+            </ToolbarItem>
+          </PageToolbarToggleGroup>
+        </ToolbarContent>
+      </Toolbar>
+    );
+
+    expect(screen.getByText('Child Content')).toBeInTheDocument();
+  });
+
+  it('should toggle expanded state when clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Toolbar>
+        <ToolbarContent>
+          <PageToolbarToggleGroup id="test-group" toggleIcon={<FilterIcon />} breakpoint="md">
+            <ToolbarItem>
+              <span>Toggle Content</span>
+            </ToolbarItem>
+          </PageToolbarToggleGroup>
+        </ToolbarContent>
+      </Toolbar>
+    );
+
+    const toggleGroup = screen.getByText('Toggle Content').closest('[class*="pf-m-toggle-group"]');
+    expect(toggleGroup).toBeInTheDocument();
+
+    const toggleButton = toggleGroup?.querySelector('button.pf-v6-c-toolbar__toggle');
+    if (toggleButton) {
+      await user.click(toggleButton);
+      expect(toggleGroup).toHaveClass('pf-m-show');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add 171 tests across 15 test files to increase coverage for `framework/PageTable/` and `framework/PageToolbar/` directories toward the 90% target on Codecov and SonarQube.

**PageTable/ (132 tests, 10 files):**
- `useTableItems.test.tsx` — 47 tests covering 7 hooks (selection, sort, filter, search, pagination)
- `PageTable.test.tsx` — extended with 8 new tests (loading, filtered-empty, custom empty state, selection, pagination)
- `PageTableColumn.test.tsx` — 37 tests for `TableColumnCell` (all 6 column types) + 10 column filter hooks
- `PageTableCard.test.tsx` — 16 tests for card rendering + `useColumnsToTableCardFn` hook
- `PageTableList.test.tsx` — 10 tests for DataList rendering, selection, column types, row actions
- Small files: `PageLoadingTable`, `PageTableEmptyState`, `PagePagination`, `PageTableCards` — 10 tests

**PageToolbar/ (39 tests, 5 files):**
- `ToolbarFilters.test.tsx` — extended with 13 new tests (filter dispatch, chips, grouped/pinned, empty states)
- `PageToolbarSort.test.tsx` — 4 tests (sort icons, direction toggle, `usePageToolbarSortOptionsFromColumns` hook)
- `ToolbarTextFilter.test.tsx` — 8 tests (debounce, Enter/apply, clear, comparison placeholders)
- `ToolbarDateRangeFilter.test.tsx` — 4 tests (presets, required default, custom range pickers)
- `ToolbarBrowseAdapter.test.ts` — 5 tests (multi/single select adapter functions)
- `PageToolbarToggleGroup.test.tsx` — 2 tests (expand/collapse)

Jira: https://redhat.atlassian.net/browse/AAP-70842

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped (test-only changes, no production code modified)

## Testing

### Manual Testing

All 171 tests verified locally:
```
npx vitest run framework/PageTable/ framework/PageToolbar/ --reporter=verbose
# Test Files  15 passed (15)
#      Tests  171 passed (171)
```

Quality gates verified:
- `npm run tsc` — clean (only pre-existing chatbot error)
- `npm run eslint` — clean on all new/modified files
- `npm run prettier` — clean

Made with [Cursor](https://cursor.com)