### PR TITLE
fix(ci): scope codecov/project check to unit-tests flag only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,9 @@
 coverage:
   status:
     project:
-      unit:
+      default:
         flags:
           - unit-tests
-      e2e:
-        flags:
-          - e2e-tests
-        informational: true
   ignore:
     - "**/*.test.ts"
     - "**/*.test.tsx"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 coverage:
+  status:
+    project:
+      default:
+        flags:
+          - unit-tests
   ignore:
     - "**/*.test.ts"
     - "**/*.test.tsx"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,13 @@
 coverage:
   status:
     project:
-      default:
+      unit:
         flags:
           - unit-tests
+      e2e:
+        flags:
+          - e2e-tests
+        informational: true
   ignore:
     - "**/*.test.ts"
     - "**/*.test.tsx"


### PR DESCRIPTION
## Summary

The nightly e2e coverage uploads (AAP-72998) inflated the `devel` baseline to ~63%. Since PRs only run unit tests (~55%), every PR now fails the `codecov/project` check with a ~6% apparent regression.

Changes:
- Split the `codecov/project` status check into two separate checks:
  - **codecov/project/unit** - evaluates only the `unit-tests` flag (blocks PRs if unit coverage drops)
  - **codecov/project/e2e** - evaluates only the `e2e-tests` flag with `informational: true` (reports e2e coverage trends without blocking PRs)

This way PRs are only gated on unit-test coverage, while e2e coverage trends are still visible on devel commits.

Jira: [AAP-72998](https://redhat.atlassian.net/browse/AAP-72998)

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

CI configuration fix for Codecov status checks.

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped (codecov.yml config only, no application code changes)