### PR TITLE
ci: add PR labeling workflows for size, risk, and community

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,9 +27,3 @@ vitest:
       - any-glob-to-any-file:
           - '**/*.test.ts'
           - '**/*.test.tsx'
-          - '**/*.spec.ts'
-          - '**/*.spec.tsx'
-ci:
-  - changed-files:
-      - any-glob-to-any-file:
-          - '.github/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,21 +1,35 @@
-AWX:
-  - frontend/awx/**/*
-  - cypress/e2e/awx/**/*
-
-EDA:
-  - frontend/eda/**/*
-  - cypress/e2e/eda/**/*
-
-HUB:
-  - frontend/hub/**/*
-  - cypress/e2e/hub/**/*
-
-E2E:
-  - cypress/e2e/**
-
-CCT:
-  - framework/**/*.cy.*
-  - frontend/**/*.cy.*
-
-AFW:
-  - framework/**/*
+controller:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/awx/**'
+hub:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/hub/**'
+eda:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/eda/**'
+framework:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'framework/**'
+platform:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'platform/**'
+playwright:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'playwright/**'
+vitest:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.test.ts'
+          - '**/*.test.tsx'
+          - '**/*.spec.ts'
+          - '**/*.spec.tsx'
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/pr-community-label.yml
+++ b/.github/workflows/pr-community-label.yml
@@ -1,0 +1,44 @@
+name: Community PR Label
+
+on:
+  pull_request_target:
+    types: [opened]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-community:
+    name: Label Community PRs
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.repository == 'ansible/ansible-ui'
+      && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add community label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
+          echo "Labeled PR #$PR_NUMBER as community (from fork: ${{ github.event.pull_request.head.repo.full_name }})"
+
+  backfill:
+    name: Backfill Community Labels
+    if: github.event_name == 'workflow_dispatch' && github.repository == 'ansible/ansible-ui'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open fork PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "$REPO" --state open --json number,headRepositoryOwner,isCrossRepository --limit 500 \
+            | jq -r '.[] | select(.isCrossRepository == true) | .number' \
+            | while read -r PR_NUMBER; do
+                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
+                echo "PR #$PR_NUMBER labeled as community"
+              done

--- a/.github/workflows/pr-community-label.yml
+++ b/.github/workflows/pr-community-label.yml
@@ -23,6 +23,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          gh label create "community" --repo "$REPO" --color "7057FF" --description "Community contribution from fork" --force 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
           echo "Labeled PR #$PR_NUMBER as community (from fork: ${{ github.event.pull_request.head.repo.full_name }})"
 
@@ -36,6 +37,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
+          gh label create "community" --repo "$REPO" --color "7057FF" --description "Community contribution from fork" --force 2>/dev/null || true
           gh pr list --repo "$REPO" --state open --json number,headRepositoryOwner,isCrossRepository --limit 500 \
             | jq -r '.[] | select(.isCrossRepository == true) | .number' \
             | while read -r PR_NUMBER; do

--- a/.github/workflows/pr-community-label.yml
+++ b/.github/workflows/pr-community-label.yml
@@ -3,7 +3,6 @@ name: Community PR Label
 on:
   pull_request_target:
     types: [opened]
-  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -12,8 +11,7 @@ jobs:
   label-community:
     name: Label Community PRs
     if: >-
-      github.event_name == 'pull_request_target'
-      && github.repository == 'ansible/ansible-ui'
+      github.repository == 'ansible/ansible-ui'
       && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
@@ -26,21 +24,3 @@ jobs:
           gh label create "community" --repo "$REPO" --color "7057FF" --description "Community contribution from fork" --force 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
           echo "Labeled PR #$PR_NUMBER as community (from fork: ${{ github.event.pull_request.head.repo.full_name }})"
-
-  backfill:
-    name: Backfill Community Labels
-    if: github.event_name == 'workflow_dispatch' && github.repository == 'ansible/ansible-ui'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Label all open fork PRs
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh label create "community" --repo "$REPO" --color "7057FF" --description "Community contribution from fork" --force 2>/dev/null || true
-          gh pr list --repo "$REPO" --state open --json number,headRepositoryOwner,isCrossRepository --limit 500 \
-            | jq -r '.[] | select(.isCrossRepository == true) | .number' \
-            | while read -r PR_NUMBER; do
-                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
-                echo "PR #$PR_NUMBER labeled as community"
-              done

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -130,8 +130,9 @@ jobs:
           gh label create "platform"   --repo "$REPO" --color "0052CC" --description "Changes in platform" --force 2>/dev/null || true
           gh label create "playwright" --repo "$REPO" --color "E4E669" --description "Changes in playwright" --force 2>/dev/null || true
           gh label create "vitest"     --repo "$REPO" --color "BFD4F2" --description "Changes to vitest test files" --force 2>/dev/null || true
+          gh label create "ci"         --repo "$REPO" --color "D4C5F9" --description "Changes in .github" --force 2>/dev/null || true
 
-          ALL_LABELS="controller hub eda framework platform playwright vitest"
+          ALL_LABELS="controller hub eda framework platform playwright vitest ci"
 
           gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
             | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
@@ -145,6 +146,7 @@ jobs:
                 PLATFORM=$(echo "$FILES" | grep -c '^platform/' || true)
                 PLAYWRIGHT=$(echo "$FILES" | grep -c '^playwright/' || true)
                 VITEST=$(echo "$FILES" | grep -cE '\.(test|spec)\.(ts|tsx|js|jsx)$' || true)
+                CI=$(echo "$FILES" | grep -c '^\.github/' || true)
 
                 for label in $ALL_LABELS; do
                   gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
@@ -158,6 +160,7 @@ jobs:
                 [ "$PLATFORM" -gt 0 ]   && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "platform" && APPLIED="$APPLIED platform"
                 [ "$PLAYWRIGHT" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "playwright" && APPLIED="$APPLIED playwright"
                 [ "$VITEST" -gt 0 ]     && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "vitest" && APPLIED="$APPLIED vitest"
+                [ "$CI" -gt 0 ]         && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ci" && APPLIED="$APPLIED ci"
 
                 echo "PR #$PR_NUMBER:${APPLIED:- (none)}"
               done

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -130,9 +130,7 @@ jobs:
           gh label create "platform"   --repo "$REPO" --color "0052CC" --description "Changes in platform" --force 2>/dev/null || true
           gh label create "playwright" --repo "$REPO" --color "E4E669" --description "Changes in playwright" --force 2>/dev/null || true
           gh label create "vitest"     --repo "$REPO" --color "BFD4F2" --description "Changes to vitest test files" --force 2>/dev/null || true
-          gh label create "ci"         --repo "$REPO" --color "D4C5F9" --description "Changes in .github" --force 2>/dev/null || true
-
-          ALL_LABELS="controller hub eda framework platform playwright vitest ci"
+          ALL_LABELS="controller hub eda framework platform playwright vitest"
 
           gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
             | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
@@ -145,9 +143,7 @@ jobs:
                 FRAMEWORK=$(echo "$FILES" | grep -c '^framework/' || true)
                 PLATFORM=$(echo "$FILES" | grep -c '^platform/' || true)
                 PLAYWRIGHT=$(echo "$FILES" | grep -c '^playwright/' || true)
-                VITEST=$(echo "$FILES" | grep -cE '\.(test|spec)\.(ts|tsx|js|jsx)$' || true)
-                CI=$(echo "$FILES" | grep -c '^\.github/' || true)
-
+                VITEST=$(echo "$FILES" | grep -cE '\.test\.(ts|tsx)$' || true)
                 for label in $ALL_LABELS; do
                   gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
                 done
@@ -160,8 +156,6 @@ jobs:
                 [ "$PLATFORM" -gt 0 ]   && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "platform" && APPLIED="$APPLIED platform"
                 [ "$PLAYWRIGHT" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "playwright" && APPLIED="$APPLIED playwright"
                 [ "$VITEST" -gt 0 ]     && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "vitest" && APPLIED="$APPLIED vitest"
-                [ "$CI" -gt 0 ]         && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ci" && APPLIED="$APPLIED ci"
-
                 echo "PR #$PR_NUMBER:${APPLIED:- (none)}"
               done
 

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -12,6 +12,7 @@ on:
           - size
           - risk
           - community
+          - workspace
 
 permissions:
   pull-requests: write
@@ -110,6 +111,55 @@ jobs:
                 else
                   echo "PR #$PR_NUMBER -> skipped (no valid risk selection)"
                 fi
+              done
+
+  backfill-workspace:
+    name: Backfill Workspace Labels
+    if: inputs.labels == 'all' || inputs.labels == 'workspace'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs by workspace
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "controller" --repo "$REPO" --color "1D76DB" --description "Changes in frontend/awx" --force 2>/dev/null || true
+          gh label create "hub"        --repo "$REPO" --color "0075CA" --description "Changes in frontend/hub" --force 2>/dev/null || true
+          gh label create "eda"        --repo "$REPO" --color "008672" --description "Changes in frontend/eda" --force 2>/dev/null || true
+          gh label create "framework"  --repo "$REPO" --color "6F42C1" --description "Changes in framework" --force 2>/dev/null || true
+          gh label create "platform"   --repo "$REPO" --color "0052CC" --description "Changes in platform" --force 2>/dev/null || true
+          gh label create "playwright" --repo "$REPO" --color "E4E669" --description "Changes in playwright" --force 2>/dev/null || true
+          gh label create "vitest"     --repo "$REPO" --color "BFD4F2" --description "Changes to vitest test files" --force 2>/dev/null || true
+
+          ALL_LABELS="controller hub eda framework platform playwright vitest"
+
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+
+                CONTROLLER=$(echo "$FILES" | grep -c '^frontend/awx/' || true)
+                HUB=$(echo "$FILES" | grep -c '^frontend/hub/' || true)
+                EDA=$(echo "$FILES" | grep -c '^frontend/eda/' || true)
+                FRAMEWORK=$(echo "$FILES" | grep -c '^framework/' || true)
+                PLATFORM=$(echo "$FILES" | grep -c '^platform/' || true)
+                PLAYWRIGHT=$(echo "$FILES" | grep -c '^playwright/' || true)
+                VITEST=$(echo "$FILES" | grep -cE '\.(test|spec)\.(ts|tsx|js|jsx)$' || true)
+
+                for label in $ALL_LABELS; do
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
+                done
+
+                APPLIED=""
+                [ "$CONTROLLER" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "controller" && APPLIED="$APPLIED controller"
+                [ "$HUB" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "hub" && APPLIED="$APPLIED hub"
+                [ "$EDA" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "eda" && APPLIED="$APPLIED eda"
+                [ "$FRAMEWORK" -gt 0 ]  && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "framework" && APPLIED="$APPLIED framework"
+                [ "$PLATFORM" -gt 0 ]   && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "platform" && APPLIED="$APPLIED platform"
+                [ "$PLAYWRIGHT" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "playwright" && APPLIED="$APPLIED playwright"
+                [ "$VITEST" -gt 0 ]     && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "vitest" && APPLIED="$APPLIED vitest"
+
+                echo "PR #$PR_NUMBER:${APPLIED:- (none)}"
               done
 
   backfill-community:

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -1,0 +1,131 @@
+name: PR Label Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      labels:
+        description: 'Which labels to backfill'
+        required: true
+        type: choice
+        options:
+          - all
+          - size
+          - risk
+          - community
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  backfill-size:
+    name: Backfill Size Labels
+    if: inputs.labels == 'all' || inputs.labels == 'size'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs by size
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "size/XS" --repo "$REPO" --color "3CBF00" --description "Extra small PR" --force 2>/dev/null || true
+          gh label create "size/S"  --repo "$REPO" --color "5D9801" --description "Small PR" --force 2>/dev/null || true
+          gh label create "size/M"  --repo "$REPO" --color "7F7203" --description "Medium PR" --force 2>/dev/null || true
+          gh label create "size/L"  --repo "$REPO" --color "A14C05" --description "Large PR" --force 2>/dev/null || true
+
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                LINES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" \
+                  | awk '
+                    /^diff --git/ {
+                      file = $0
+                      skip = (file ~ /\.(test|spec)\.(ts|tsx|js|jsx)/) || \
+                             (file ~ /\/playwright\//) || \
+                             (file ~ /\/__tests__\//) || \
+                             (file ~ /\/test\//) || \
+                             (file ~ /\.test\./) || \
+                             (file ~ /\.spec\./)
+                      next
+                    }
+                    skip { next }
+                    /^[+-]/ && !/^(\+\+\+|---)/ { count++ }
+                    END { print count+0 }
+                  ')
+
+                if [ "$LINES" -lt 10 ]; then
+                  SIZE_LABEL="size/XS"
+                elif [ "$LINES" -lt 50 ]; then
+                  SIZE_LABEL="size/S"
+                elif [ "$LINES" -lt 200 ]; then
+                  SIZE_LABEL="size/M"
+                else
+                  SIZE_LABEL="size/L"
+                fi
+
+                for label in "size/XS" "size/S" "size/M" "size/L"; do
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
+                done
+                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
+                echo "PR #$PR_NUMBER: $LINES lines -> $SIZE_LABEL"
+              done
+
+  backfill-risk:
+    name: Backfill Risk Labels
+    if: inputs.labels == 'all' || inputs.labels == 'risk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs with risk levels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "risk:high"   --repo "$REPO" --color "D93F0B" --description "High risk PR" --force 2>/dev/null || true
+          gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
+          gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
+
+          gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
+            | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
+                HIGH=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*High\*\*' || true)
+                MEDIUM=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Medium\*\*' || true)
+                LOW=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Low\*\*' || true)
+
+                TOTAL=$((HIGH + MEDIUM + LOW))
+
+                if [ "$TOTAL" -eq 1 ]; then
+                  if [ "$HIGH" -eq 1 ]; then
+                    LEVEL="high"
+                  elif [ "$MEDIUM" -eq 1 ]; then
+                    LEVEL="medium"
+                  else
+                    LEVEL="low"
+                  fi
+
+                  for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
+                    gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
+                  done
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "risk:${LEVEL}"
+                  echo "PR #$PR_NUMBER -> risk:${LEVEL}"
+                else
+                  echo "PR #$PR_NUMBER -> skipped (no valid risk selection)"
+                fi
+              done
+
+  backfill-community:
+    name: Backfill Community Labels
+    if: (inputs.labels == 'all' || inputs.labels == 'community') && github.repository == 'ansible/ansible-ui'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open fork PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "community" --repo "$REPO" --color "7057FF" --description "Community contribution from fork" --force 2>/dev/null || true
+          gh pr list --repo "$REPO" --state open --json number,headRepositoryOwner,isCrossRepository --limit 500 \
+            | jq -r '.[] | select(.isCrossRepository == true) | .number' \
+            | while read -r PR_NUMBER; do
+                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "community"
+                echo "PR #$PR_NUMBER labeled as community"
+              done

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -3,7 +3,6 @@ name: PR Risk Analysis
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -12,9 +11,7 @@ permissions:
 jobs:
   check-risk-analysis:
     name: Risk Analysis Required
-    if: >-
-      github.event_name == 'pull_request'
-      && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check risk level is selected
@@ -108,46 +105,3 @@ jobs:
         run: |
           echo "::error::${{ steps.check.outputs.message }}"
           exit 1
-
-  backfill:
-    name: Backfill Risk Labels
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Label all open PRs with risk levels
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Ensure all risk labels exist in the repo
-          gh label create "risk:high"   --repo "$REPO" --color "D93F0B" --description "High risk PR" --force 2>/dev/null || true
-          gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
-          gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
-
-          gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
-            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
-            | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
-                HIGH=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*High\*\*' || true)
-                MEDIUM=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Medium\*\*' || true)
-                LOW=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Low\*\*' || true)
-
-                TOTAL=$((HIGH + MEDIUM + LOW))
-
-                if [ "$TOTAL" -eq 1 ]; then
-                  if [ "$HIGH" -eq 1 ]; then
-                    LEVEL="high"
-                  elif [ "$MEDIUM" -eq 1 ]; then
-                    LEVEL="medium"
-                  else
-                    LEVEL="low"
-                  fi
-
-                  for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
-                    gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
-                  done
-                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "risk:${LEVEL}"
-                  echo "PR #$PR_NUMBER -> risk:${LEVEL}"
-                else
-                  echo "PR #$PR_NUMBER -> skipped (no valid risk selection)"
-                fi
-              done

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -61,9 +61,15 @@ jobs:
           if [ "$EXISTING" -eq 0 ]; then
             gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "$MESSAGE"
           fi
+          # Ensure all risk labels exist in the repo
+          gh label create "risk:high"   --repo "$REPO" --color "D93F0B" --description "High risk PR" --force 2>/dev/null || true
+          gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
+          gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
+          gh label create "missing-risk-analysis" --repo "$REPO" --color "B60205" --description "PR missing risk analysis" --force 2>/dev/null || true
+
           # Remove any stale risk level labels
           for label in "risk:high" "risk:medium" "risk:low"; do
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
           done
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "missing-risk-analysis"
 
@@ -83,9 +89,15 @@ jobs:
               -f event="DISMISS"
           fi
 
+          # Ensure all risk labels exist in the repo
+          gh label create "risk:high"   --repo "$REPO" --color "D93F0B" --description "High risk PR" --force 2>/dev/null || true
+          gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
+          gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
+          gh label create "missing-risk-analysis" --repo "$REPO" --color "B60205" --description "PR missing risk analysis" --force 2>/dev/null || true
+
           # Remove stale risk labels and the missing-risk-analysis label
           for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
           done
 
           # Apply the detected risk label
@@ -107,6 +119,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
+          # Ensure all risk labels exist in the repo
+          gh label create "risk:high"   --repo "$REPO" --color "D93F0B" --description "High risk PR" --force 2>/dev/null || true
+          gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
+          gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
+
           gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
             | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
             | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
@@ -126,7 +143,7 @@ jobs:
                   fi
 
                   for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
-                    gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+                    gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
                   done
                   gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "risk:${LEVEL}"
                   echo "PR #$PR_NUMBER -> risk:${LEVEL}"

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -3,6 +3,7 @@ name: PR Risk Analysis
 on:
   pull_request:
     types: [opened, edited, synchronize]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -11,7 +12,9 @@ permissions:
 jobs:
   check-risk-analysis:
     name: Risk Analysis Required
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check risk level is selected
@@ -35,10 +38,13 @@ jobs:
             echo "result=pass" >> "$GITHUB_OUTPUT"
             if [ "$HIGH" -eq 1 ]; then
               echo "Risk level: HIGH"
+              echo "level=high" >> "$GITHUB_OUTPUT"
             elif [ "$MEDIUM" -eq 1 ]; then
               echo "Risk level: MEDIUM"
+              echo "level=medium" >> "$GITHUB_OUTPUT"
             else
               echo "Risk level: LOW"
+              echo "level=low" >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -55,14 +61,19 @@ jobs:
           if [ "$EXISTING" -eq 0 ]; then
             gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "$MESSAGE"
           fi
+          # Remove any stale risk level labels
+          for label in "risk:high" "risk:medium" "risk:low"; do
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+          done
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "missing-risk-analysis"
 
-      - name: Dismiss review and remove label on success
+      - name: Dismiss review and apply risk label on success
         if: steps.check.outputs.result == 'pass'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          RISK_LEVEL: ${{ steps.check.outputs.level }}
         run: |
           # Find and dismiss any previous "request changes" review from the bot
           REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --jq '[.[] | select(.state == "CHANGES_REQUESTED" and .user.login == "github-actions[bot]")] | last | .id // empty')
@@ -72,11 +83,54 @@ jobs:
               -f event="DISMISS"
           fi
 
-          # Remove label if present
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "missing-risk-analysis" 2>/dev/null || true
+          # Remove stale risk labels and the missing-risk-analysis label
+          for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+          done
+
+          # Apply the detected risk label
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "risk:${RISK_LEVEL}"
 
       - name: Fail check if risk level is missing
         if: steps.check.outputs.result != 'pass'
         run: |
           echo "::error::${{ steps.check.outputs.message }}"
           exit 1
+
+  backfill:
+    name: Backfill Risk Labels
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs with risk levels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
+            | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
+                HIGH=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*High\*\*' || true)
+                MEDIUM=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Medium\*\*' || true)
+                LOW=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Low\*\*' || true)
+
+                TOTAL=$((HIGH + MEDIUM + LOW))
+
+                if [ "$TOTAL" -eq 1 ]; then
+                  if [ "$HIGH" -eq 1 ]; then
+                    LEVEL="high"
+                  elif [ "$MEDIUM" -eq 1 ]; then
+                    LEVEL="medium"
+                  else
+                    LEVEL="low"
+                  fi
+
+                  for label in "risk:high" "risk:medium" "risk:low" "missing-risk-analysis"; do
+                    gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+                  done
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "risk:${LEVEL}"
+                  echo "PR #$PR_NUMBER -> risk:${LEVEL}"
+                else
+                  echo "PR #$PR_NUMBER -> skipped (no valid risk selection)"
+                fi
+              done

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -1,0 +1,122 @@
+name: PR Size Label
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-size:
+    name: Label PR Size
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Count changed lines (excluding tests)
+        id: count
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          LINES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" \
+            | awk '
+              /^diff --git/ {
+                file = $0
+                # Skip test and spec files (Vitest / Playwright)
+                skip = (file ~ /\.(test|spec)\.(ts|tsx|js|jsx)/) || \
+                       (file ~ /\/playwright\//) || \
+                       (file ~ /\/__tests__\//) || \
+                       (file ~ /\/test\//) || \
+                       (file ~ /\.test\./) || \
+                       (file ~ /\.spec\./)
+                next
+              }
+              skip { next }
+              /^[+-]/ && !/^(\+\+\+|---)/ { count++ }
+              END { print count+0 }
+            ')
+
+          echo "lines=$LINES" >> "$GITHUB_OUTPUT"
+          echo "Changed lines (excluding tests): $LINES"
+
+      - name: Determine size label
+        id: size
+        env:
+          LINES: ${{ steps.count.outputs.lines }}
+        run: |
+          if [ "$LINES" -lt 10 ]; then
+            echo "label=size/XS" >> "$GITHUB_OUTPUT"
+          elif [ "$LINES" -lt 50 ]; then
+            echo "label=size/S" >> "$GITHUB_OUTPUT"
+          elif [ "$LINES" -lt 200 ]; then
+            echo "label=size/M" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=size/L" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply size label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SIZE_LABEL: ${{ steps.size.outputs.label }}
+        run: |
+          # Remove any existing size labels
+          for label in "size/XS" "size/S" "size/M" "size/L"; do
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+          done
+
+          # Apply the new size label
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
+          echo "Applied label: $SIZE_LABEL (${{ steps.count.outputs.lines }} changed lines)"
+
+  backfill:
+    name: Backfill Size Labels
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                LINES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" \
+                  | awk '
+                    /^diff --git/ {
+                      file = $0
+                      skip = (file ~ /\.(test|spec)\.(ts|tsx|js|jsx)/) || \
+                             (file ~ /\/playwright\//) || \
+                             (file ~ /\/__tests__\//) || \
+                             (file ~ /\/test\//) || \
+                             (file ~ /\.test\./) || \
+                             (file ~ /\.spec\./)
+                      next
+                    }
+                    skip { next }
+                    /^[+-]/ && !/^(\+\+\+|---)/ { count++ }
+                    END { print count+0 }
+                  ')
+
+                if [ "$LINES" -lt 10 ]; then
+                  SIZE_LABEL="size/XS"
+                elif [ "$LINES" -lt 50 ]; then
+                  SIZE_LABEL="size/S"
+                elif [ "$LINES" -lt 200 ]; then
+                  SIZE_LABEL="size/M"
+                else
+                  SIZE_LABEL="size/L"
+                fi
+
+                for label in "size/XS" "size/S" "size/M" "size/L"; do
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+                done
+                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
+                echo "PR #$PR_NUMBER: $LINES lines -> $SIZE_LABEL"
+              done

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -65,9 +65,15 @@ jobs:
           REPO: ${{ github.repository }}
           SIZE_LABEL: ${{ steps.size.outputs.label }}
         run: |
+          # Ensure all size labels exist in the repo
+          gh label create "size/XS" --repo "$REPO" --color "3CBF00" --description "Extra small PR" --force 2>/dev/null || true
+          gh label create "size/S"  --repo "$REPO" --color "5D9801" --description "Small PR" --force 2>/dev/null || true
+          gh label create "size/M"  --repo "$REPO" --color "7F7203" --description "Medium PR" --force 2>/dev/null || true
+          gh label create "size/L"  --repo "$REPO" --color "A14C05" --description "Large PR" --force 2>/dev/null || true
+
           # Remove any existing size labels
           for label in "size/XS" "size/S" "size/M" "size/L"; do
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
           done
 
           # Apply the new size label
@@ -84,6 +90,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
+          # Ensure all size labels exist in the repo
+          gh label create "size/XS" --repo "$REPO" --color "3CBF00" --description "Extra small PR" --force 2>/dev/null || true
+          gh label create "size/S"  --repo "$REPO" --color "5D9801" --description "Small PR" --force 2>/dev/null || true
+          gh label create "size/M"  --repo "$REPO" --color "7F7203" --description "Medium PR" --force 2>/dev/null || true
+          gh label create "size/L"  --repo "$REPO" --color "A14C05" --description "Large PR" --force 2>/dev/null || true
+
           gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
             | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
             | while read -r PR_NUMBER; do
@@ -115,7 +127,7 @@ jobs:
                 fi
 
                 for label in "size/XS" "size/S" "size/M" "size/L"; do
-                  gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" 2>/dev/null || true
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
                 done
                 gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
                 echo "PR #$PR_NUMBER: $LINES lines -> $SIZE_LABEL"

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -3,7 +3,6 @@ name: PR Size Label
 on:
   pull_request:
     types: [opened, synchronize]
-  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -12,7 +11,7 @@ permissions:
 jobs:
   label-size:
     name: Label PR Size
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Count changed lines (excluding tests)
@@ -79,56 +78,3 @@ jobs:
           # Apply the new size label
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
           echo "Applied label: $SIZE_LABEL (${{ steps.count.outputs.lines }} changed lines)"
-
-  backfill:
-    name: Backfill Size Labels
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Label all open PRs
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Ensure all size labels exist in the repo
-          gh label create "size/XS" --repo "$REPO" --color "3CBF00" --description "Extra small PR" --force 2>/dev/null || true
-          gh label create "size/S"  --repo "$REPO" --color "5D9801" --description "Small PR" --force 2>/dev/null || true
-          gh label create "size/M"  --repo "$REPO" --color "7F7203" --description "Medium PR" --force 2>/dev/null || true
-          gh label create "size/L"  --repo "$REPO" --color "A14C05" --description "Large PR" --force 2>/dev/null || true
-
-          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
-            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
-            | while read -r PR_NUMBER; do
-                LINES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" \
-                  | awk '
-                    /^diff --git/ {
-                      file = $0
-                      skip = (file ~ /\.(test|spec)\.(ts|tsx|js|jsx)/) || \
-                             (file ~ /\/playwright\//) || \
-                             (file ~ /\/__tests__\//) || \
-                             (file ~ /\/test\//) || \
-                             (file ~ /\.test\./) || \
-                             (file ~ /\.spec\./)
-                      next
-                    }
-                    skip { next }
-                    /^[+-]/ && !/^(\+\+\+|---)/ { count++ }
-                    END { print count+0 }
-                  ')
-
-                if [ "$LINES" -lt 10 ]; then
-                  SIZE_LABEL="size/XS"
-                elif [ "$LINES" -lt 50 ]; then
-                  SIZE_LABEL="size/S"
-                elif [ "$LINES" -lt 200 ]; then
-                  SIZE_LABEL="size/M"
-                else
-                  SIZE_LABEL="size/L"
-                fi
-
-                for label in "size/XS" "size/S" "size/M" "size/L"; do
-                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
-                done
-                gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$SIZE_LABEL"
-                echo "PR #$PR_NUMBER: $LINES lines -> $SIZE_LABEL"
-              done

--- a/.github/workflows/pr-workspace-label.yml
+++ b/.github/workflows/pr-workspace-label.yml
@@ -14,52 +14,6 @@ jobs:
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Detect workspaces and apply labels
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Define workspace label mappings (color codes: blue/teal palette)
-          gh label create "controller" --repo "$REPO" --color "1D76DB" --description "Changes in frontend/awx" --force 2>/dev/null || true
-          gh label create "hub"        --repo "$REPO" --color "0075CA" --description "Changes in frontend/hub" --force 2>/dev/null || true
-          gh label create "eda"        --repo "$REPO" --color "008672" --description "Changes in frontend/eda" --force 2>/dev/null || true
-          gh label create "framework"  --repo "$REPO" --color "6F42C1" --description "Changes in framework" --force 2>/dev/null || true
-          gh label create "platform"   --repo "$REPO" --color "0052CC" --description "Changes in platform" --force 2>/dev/null || true
-          gh label create "playwright" --repo "$REPO" --color "E4E669" --description "Changes in playwright" --force 2>/dev/null || true
-          gh label create "vitest"     --repo "$REPO" --color "BFD4F2" --description "Changes to vitest test files" --force 2>/dev/null || true
-
-          # Get list of changed files
-          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
-
-          # Detect which workspaces are touched
-          CONTROLLER=$(echo "$FILES" | grep -c '^frontend/awx/' || true)
-          HUB=$(echo "$FILES" | grep -c '^frontend/hub/' || true)
-          EDA=$(echo "$FILES" | grep -c '^frontend/eda/' || true)
-          FRAMEWORK=$(echo "$FILES" | grep -c '^framework/' || true)
-          PLATFORM=$(echo "$FILES" | grep -c '^platform/' || true)
-          PLAYWRIGHT=$(echo "$FILES" | grep -c '^playwright/' || true)
-          VITEST=$(echo "$FILES" | grep -cE '\.(test|spec)\.(ts|tsx|js|jsx)$' || true)
-
-          ALL_LABELS="controller hub eda framework platform playwright vitest"
-
-          # Remove all workspace labels first
-          for label in $ALL_LABELS; do
-            gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
-          done
-
-          # Apply labels for detected workspaces
-          APPLIED=""
-          [ "$CONTROLLER" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "controller" && APPLIED="$APPLIED controller"
-          [ "$HUB" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "hub" && APPLIED="$APPLIED hub"
-          [ "$EDA" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "eda" && APPLIED="$APPLIED eda"
-          [ "$FRAMEWORK" -gt 0 ]  && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "framework" && APPLIED="$APPLIED framework"
-          [ "$PLATFORM" -gt 0 ]   && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "platform" && APPLIED="$APPLIED platform"
-          [ "$PLAYWRIGHT" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "playwright" && APPLIED="$APPLIED playwright"
-          [ "$VITEST" -gt 0 ]     && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "vitest" && APPLIED="$APPLIED vitest"
-
-          if [ -n "$APPLIED" ]; then
-            echo "Applied labels:$APPLIED"
-          else
-            echo "No workspace labels to apply"
-          fi
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/pr-workspace-label.yml
+++ b/.github/workflows/pr-workspace-label.yml
@@ -1,0 +1,65 @@
+name: PR Workspace Label
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-workspace:
+    name: Label PR Workspaces
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect workspaces and apply labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Define workspace label mappings (color codes: blue/teal palette)
+          gh label create "controller" --repo "$REPO" --color "1D76DB" --description "Changes in frontend/awx" --force 2>/dev/null || true
+          gh label create "hub"        --repo "$REPO" --color "0075CA" --description "Changes in frontend/hub" --force 2>/dev/null || true
+          gh label create "eda"        --repo "$REPO" --color "008672" --description "Changes in frontend/eda" --force 2>/dev/null || true
+          gh label create "framework"  --repo "$REPO" --color "6F42C1" --description "Changes in framework" --force 2>/dev/null || true
+          gh label create "platform"   --repo "$REPO" --color "0052CC" --description "Changes in platform" --force 2>/dev/null || true
+          gh label create "playwright" --repo "$REPO" --color "E4E669" --description "Changes in playwright" --force 2>/dev/null || true
+          gh label create "vitest"     --repo "$REPO" --color "BFD4F2" --description "Changes to vitest test files" --force 2>/dev/null || true
+
+          # Get list of changed files
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+
+          # Detect which workspaces are touched
+          CONTROLLER=$(echo "$FILES" | grep -c '^frontend/awx/' || true)
+          HUB=$(echo "$FILES" | grep -c '^frontend/hub/' || true)
+          EDA=$(echo "$FILES" | grep -c '^frontend/eda/' || true)
+          FRAMEWORK=$(echo "$FILES" | grep -c '^framework/' || true)
+          PLATFORM=$(echo "$FILES" | grep -c '^platform/' || true)
+          PLAYWRIGHT=$(echo "$FILES" | grep -c '^playwright/' || true)
+          VITEST=$(echo "$FILES" | grep -cE '\.(test|spec)\.(ts|tsx|js|jsx)$' || true)
+
+          ALL_LABELS="controller hub eda framework platform playwright vitest"
+
+          # Remove all workspace labels first
+          for label in $ALL_LABELS; do
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
+          done
+
+          # Apply labels for detected workspaces
+          APPLIED=""
+          [ "$CONTROLLER" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "controller" && APPLIED="$APPLIED controller"
+          [ "$HUB" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "hub" && APPLIED="$APPLIED hub"
+          [ "$EDA" -gt 0 ]        && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "eda" && APPLIED="$APPLIED eda"
+          [ "$FRAMEWORK" -gt 0 ]  && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "framework" && APPLIED="$APPLIED framework"
+          [ "$PLATFORM" -gt 0 ]   && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "platform" && APPLIED="$APPLIED platform"
+          [ "$PLAYWRIGHT" -gt 0 ] && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "playwright" && APPLIED="$APPLIED playwright"
+          [ "$VITEST" -gt 0 ]     && gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "vitest" && APPLIED="$APPLIED vitest"
+
+          if [ -n "$APPLIED" ]; then
+            echo "Applied labels:$APPLIED"
+          else
+            echo "No workspace labels to apply"
+          fi


### PR DESCRIPTION
## Summary


Add automated PR labeling workflows to help categorize and filter the review queue for more efficient PR management:

- **pr-size-label.yml** — Labels PRs as `size/XS` (<10 lines), `size/S` (<50), `size/M` (<200), or `size/L` (200+) based on changed lines of dev code. Test files are excluded from the count.
- **pr-risk-analysis.yml** — Enhanced to apply `risk:high`, `risk:medium`, or `risk:low` labels based on the risk level selected in the PR description (in addition to existing review enforcement).
- **pr-workspace-label.yml** — Uses `actions/labeler@v5` with a declarative config (`.github/labeler.yml`) to label PRs by workspace: `controller`, `hub`, `eda`, `framework`, `platform`, `playwright`, `vitest`. A PR can receive multiple labels if it spans workspaces.
- **pr-community-label.yml** — Labels fork-based PRs as `community` so we can easily identify external contributions. Scoped to `ansible/ansible-ui` only — no effect when synced downstream.
- **pr-label-backfill.yml** — Standalone dispatch-only workflow to retroactively label all existing open PRs. Supports labeling all categories or selectively (size, risk, community, or workspace) via a dropdown in the Actions tab.

Also updates the existing `.github/labeler.yml` from legacy v4 syntax (with stale Cypress references) to v5 format.

Labels are auto-created with appropriate colors on first use — no manual setup needed.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

CI workflow additions for PR labeling automation.

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

> **Note:** These workflows must be merged to `devel` before they can be fully tested. GitHub Actions only picks up workflow files from the default branch for `workflow_dispatch` and `pull_request_target` triggers. The `pull_request`-triggered jobs (size, risk) will run on this PR itself, but the backfill and community label jobs require merging first.


### Manual Testing

1. Open a PR from a fork → verify `community` label is applied
2. Open a PR with dev code changes → verify appropriate `size/*` label is applied
3. Select a risk level in PR description → verify `risk:*` label is applied
4. Run each workflow manually via Actions tab → verify backfill labels all open PRs

### Screenshots

N/A — CI-only changes, no UI impact.
