### PR TITLE
fix: add Launched By filter to Jobs list

### DIFF
--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -75,6 +75,20 @@ export function useCreatedByToolbarFilter() {
   );
 }
 
+export function useLaunchedByToolbarFilter() {
+  const { t } = useTranslation();
+  return useMemo<IToolbarFilter>(
+    () => ({
+      key: 'launched-by',
+      label: t('Launched by (username)'),
+      type: ToolbarFilterType.MultiText,
+      query: 'created_by__username__icontains',
+      comparison: 'contains',
+    }),
+    [t]
+  );
+}
+
 export function useModifiedByToolbarFilter() {
   const { t } = useTranslation();
   return useMemo<IToolbarFilter>(

--- a/frontend/awx/common/awx-toolbar-filters.tsx
+++ b/frontend/awx/common/awx-toolbar-filters.tsx
@@ -80,7 +80,7 @@ export function useLaunchedByToolbarFilter() {
   return useMemo<IToolbarFilter>(
     () => ({
       key: 'launched-by',
-      label: t('Launched by (username)'),
+      label: t('Launched by'),
       type: ToolbarFilterType.MultiText,
       query: 'created_by__username__icontains',
       comparison: 'contains',

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.test.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.test.tsx
@@ -58,12 +58,28 @@ describe('useJobsFilters', () => {
     await waitFor(
       () => {
         expect(result.current).toBeDefined();
-        expect(result.current.length).toEqual(27);
+        expect(result.current.length).toEqual(28);
       },
       { timeout: 10000 }
     );
 
-    // 24 filterable fields from API + 3 additional filters (search, labels, limit) = 27 total
-    expect(result.current).toHaveLength(27);
+    // 24 filterable fields from API + 4 additional filters (search, labels, launched-by, limit) = 28 total
+    expect(result.current).toHaveLength(28);
+  });
+
+  test('Includes launched-by filter', { timeout: 15000 }, async () => {
+    const { result } = renderHook(() => useJobsFilters());
+
+    await waitFor(
+      () => {
+        expect(result.current.length).toBeGreaterThan(0);
+      },
+      { timeout: 10000 }
+    );
+
+    const launchedByFilter = result.current.find((f) => f.key === 'launched-by');
+    expect(launchedByFilter).toBeDefined();
+    expect(launchedByFilter?.query).toBe('created_by__username__icontains');
+    expect(launchedByFilter?.label).toBe('Launched by (username)');
   });
 });

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.test.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.test.tsx
@@ -80,6 +80,6 @@ describe('useJobsFilters', () => {
     const launchedByFilter = result.current.find((f) => f.key === 'launched-by');
     expect(launchedByFilter).toBeDefined();
     expect(launchedByFilter?.query).toBe('created_by__username__icontains');
-    expect(launchedByFilter?.label).toBe('Launched by (username)');
+    expect(launchedByFilter?.label).toBe('Launched by');
   });
 });

--- a/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsFilters.tsx
@@ -1,6 +1,7 @@
 import { QueryParams } from '@ansible/ansible-ui-framework';
 import {
   useLabelsToolbarFilter,
+  useLaunchedByToolbarFilter,
   useSearchToolbarFilter,
   useLimitToolbarFilter,
 } from '../../../common/awx-toolbar-filters';
@@ -9,10 +10,11 @@ import { useDynamicToolbarFilters } from '../../../common/useDynamicFilters';
 export function useJobsFilters(queryParams: QueryParams = {}) {
   const searchFilter = useSearchToolbarFilter();
   const labelsToolbarFilter = useLabelsToolbarFilter();
+  const launchedByFilter = useLaunchedByToolbarFilter();
   const limitFilter = useLimitToolbarFilter();
   const toolBarFilters = useDynamicToolbarFilters({
     optionsPath: 'unified_jobs',
-    preSortedKeys: ['search', 'name', 'labels', 'description', 'status'],
+    preSortedKeys: ['search', 'name', 'labels', 'description', 'status', 'launched-by'],
     preFilledValueKeys: {
       name: {
         apiPath: 'unified_jobs',
@@ -23,7 +25,7 @@ export function useJobsFilters(queryParams: QueryParams = {}) {
         queryParams: queryParams,
       },
     },
-    additionalFilters: [searchFilter, labelsToolbarFilter, limitFilter],
+    additionalFilters: [searchFilter, labelsToolbarFilter, launchedByFilter, limitFilter],
   });
 
   return toolBarFilters;


### PR DESCRIPTION
## Summary

The Jobs list page was missing a "Launched by (username)" toolbar filter, preventing users from filtering jobs by the user who launched them. This was a regression from AAP 2.4 where the filter existed.

**Root cause:** The `useJobsFilters` hook relied solely on dynamic filters from the `/unified_jobs/` OPTIONS endpoint, which does not expose `created_by` as a filterable field. Other list pages (templates, credentials) solved this by explicitly adding filter hooks as additional filters, but the Jobs list omitted it.

**Fix:** Created a `useLaunchedByToolbarFilter` hook (queries `created_by__username__icontains`) and wired it into `useJobsFilters` via `additionalFilters` and `preSortedKeys`.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment \`/run-playwright\` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

1. Navigate to **Jobs** list page
2. Open the filter dropdown in the toolbar
3. Verify "Launched by (username)" appears as a filter option
4. Enter a username and confirm the list filters correctly by \`created_by__username__icontains\`

### Unit Tests

- Added regression test verifying the \`launched-by\` filter exists with correct query parameter and label
- Updated existing filter count test (27 → 28: 24 from API + 4 additional)
- All vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)