### PR TITLE
fix(test): wrap useAutomationDashboardBaseView tests with SWR config

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardBaseView.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardBaseView.test.ts
@@ -1,7 +1,15 @@
 /* eslint-disable i18next/no-literal-string */
-import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  act,
+  renderHook as rtlRenderHook,
+  waitFor,
+  type RenderHookOptions,
+  type RenderHookResult,
+} from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { createElement, type ReactNode } from 'react';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import {
   IToolbarDateRangeFilter,
@@ -10,6 +18,21 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAutomationDashboardBaseView } from './useAutomationDashboardBaseView';
+
+function SwrWrapper({ children }: Readonly<{ children: ReactNode }>) {
+  return createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), shouldRetryOnError: false } },
+    children
+  );
+}
+
+function renderHook<Result, Props>(
+  render: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props>
+): RenderHookResult<Result, Props> {
+  return rtlRenderHook(render, { ...options, wrapper: SwrWrapper });
+}
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/frontend/awx/resources/inventories/InventoryForm.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { CreateInventory, EditInventory } from './InventoryForm';
@@ -428,11 +429,13 @@ describe('InventoryForm', () => {
       );
 
       render(
-        <MemoryRouter initialEntries={['/inventories/inventory/1/edit']}>
-          <Routes>
-            <Route path="/inventories/:inventory_type/:id/edit" element={<EditInventory />} />
-          </Routes>
-        </MemoryRouter>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <MemoryRouter initialEntries={['/inventories/inventory/1/edit']}>
+            <Routes>
+              <Route path="/inventories/:inventory_type/:id/edit" element={<EditInventory />} />
+            </Routes>
+          </MemoryRouter>
+        </SWRConfig>
       );
 
       expect(screen.queryByDisplayValue('test')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fix consistently failing tests that were blocking CI across all PRs. Both failures share the same root cause: tests using bare `render`/`renderHook` from `@testing-library/react` without SWR cache isolation.

**Fix 1: `useAutomationDashboardBaseView.test.ts`** (introduced by PR #3311)
- Test `should keep the error and stay on the same page when a 500 occurs on a page greater than 1` was failing with `AssertionError: expected undefined to be defined`
- Without `shouldRetryOnError: false`, SWR silently retries 500 errors and never surfaces the error object
- Fix: Wrap all `renderHook` calls with `SWRConfig` that disables retry and uses a fresh cache

**Fix 2: `InventoryForm.test.tsx`** (introduced by PR #3316)
- Test `should show loading page while fetching inventory data` was flaky
- SWR cache from previous tests served stale data, skipping the loading state entirely
- Fix: Wrap the specific test's `render` with `SWRConfig` using a fresh cache provider

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped (two test file fixes, no production code changes)

## Testing

All tests pass locally in both files:
```
npx vitest run frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardBaseView.test.ts
# Test Files  1 passed (1)
#      Tests  19 passed (19)

npx vitest run frontend/awx/resources/inventories/InventoryForm.test.tsx
# Test Files  1 passed (1)
#      Tests  20 passed (20)
```