### PR TITLE
fix: add missing permissions and fix risk backfill body parsing

### DIFF
--- a/.github/workflows/pr-community-label.yml
+++ b/.github/workflows/pr-community-label.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   label-community:

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -85,9 +85,10 @@ jobs:
           gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
           gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
 
-          gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
-            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
-            | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
                 HIGH=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*High\*\*' || true)
                 MEDIUM=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Medium\*\*' || true)
                 LOW=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Low\*\*' || true)

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

Two fixes for the PR labeling workflows:

1. **Risk backfill not applying labels** — The `jq -r` output included raw newlines from PR bodies, causing `read` to split each line as a separate loop iteration. `PR_NUMBER` received lines of markdown instead of actual PR numbers. Fixed by looping over PR numbers only and fetching each body individually with `gh pr view`.

2. **403 errors on label creation/removal** — All label workflows had `pull-requests: write` but were missing `issues: write`, which is required by `gh label create` and the labels REST API. Added `issues: write` to all four workflows (size, risk, community, backfill).

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Manual Testing

1. After merge, verify size labels are applied on new PRs (no more 403 errors)
2. Run "PR Label Backfill" from Actions tab → select `risk` → verify PRs with valid risk selections get labeled
3. Run "PR Label Backfill" → select `all` → verify no permission errors

### Screenshots

N/A — CI-only changes.
