### PR TITLE
Fix/label workflows fork permissions

### DIFF
--- a/.github/workflows/pr-community-label.yml
+++ b/.github/workflows/pr-community-label.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   label-community:

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -85,9 +85,10 @@ jobs:
           gh label create "risk:medium" --repo "$REPO" --color "FBCA04" --description "Medium risk PR" --force 2>/dev/null || true
           gh label create "risk:low"    --repo "$REPO" --color "0E8A16" --description "Low risk PR" --force 2>/dev/null || true
 
-          gh pr list --repo "$REPO" --state open --json number,body,author --limit 500 \
-            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number)\t\(.body)"' \
-            | while IFS=$'\t' read -r PR_NUMBER PR_BODY; do
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
                 HIGH=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*High\*\*' || true)
                 MEDIUM=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Medium\*\*' || true)
                 LOW=$(echo "$PR_BODY" | grep -ci '\- \[x\] \*\*Low\*\*' || true)

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:

--- a/.github/workflows/pr-risk-analysis.yml
+++ b/.github/workflows/pr-risk-analysis.yml
@@ -1,7 +1,7 @@
 name: PR Risk Analysis
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 permissions:

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 jobs:

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -1,7 +1,7 @@
 name: PR Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/pr-workspace-label.yml
+++ b/.github/workflows/pr-workspace-label.yml
@@ -1,7 +1,7 @@
 name: PR Workspace Label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary

Fix 403 errors on label workflows for fork (community) PRs.

`pull_request` events from forks always get a read-only `GITHUB_TOKEN` regardless of declared permissions — this is a GitHub security restriction. Switch size, workspace, and risk label workflows from `pull_request` to `pull_request_target`, which runs in the base repo context with full write access.

This is safe because none of these workflows check out or execute fork code — they only use `gh pr diff`, `gh pr edit`, and `gh pr view`.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Manual Testing
