### PR TITLE
[5/5] test: add coverage for remaining organization components

### DIFF
--- a/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
+++ b/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { render, screen } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { PageFormPlatformOrganizationSelect } from './PageFormPlatformOrganizationSelect';
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const FormWrapper = () => {
+    const form = useForm({
+      defaultValues: {
+        organization: null,
+      },
+    });
+
+    return (
+      <MemoryRouter>
+        <FormProvider {...form}>{children}</FormProvider>
+      </MemoryRouter>
+    );
+  };
+
+  return <FormWrapper />;
+}
+
+describe('PageFormPlatformOrganizationSelect', () => {
+  it('should render the select component', () => {
+    render(
+      <TestWrapper>
+        <PageFormPlatformOrganizationSelect name="organization" />
+      </TestWrapper>
+    );
+
+    expect(screen.getByLabelText('Organization')).toBeInTheDocument();
+  });
+
+  it('should render with default label when not specified', () => {
+    render(
+      <TestWrapper>
+        <PageFormPlatformOrganizationSelect name="organization" />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('Organization')).toBeInTheDocument();
+  });
+
+  it('should render the select button', () => {
+    render(
+      <TestWrapper>
+        <PageFormPlatformOrganizationSelect name="organization" />
+      </TestWrapper>
+    );
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
+++ b/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
@@ -2,27 +2,32 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { render, screen } from '@testing-library/react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, UseFormReturn, useForm } from 'react-hook-form';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { PageFormPlatformOrganizationSelect } from './PageFormPlatformOrganizationSelect';
 
+interface FormWrapperProps {
+  children: React.ReactNode;
+  form: UseFormReturn;
+}
+
+function FormWrapper({ children, form }: FormWrapperProps) {
+  return (
+    <MemoryRouter>
+      <FormProvider {...form}>{children}</FormProvider>
+    </MemoryRouter>
+  );
+}
+
 function TestWrapper({ children }: { children: React.ReactNode }) {
-  const FormWrapper = () => {
-    const form = useForm({
-      defaultValues: {
-        organization: null,
-      },
-    });
+  const form = useForm({
+    defaultValues: {
+      organization: null,
+    },
+  });
 
-    return (
-      <MemoryRouter>
-        <FormProvider {...form}>{children}</FormProvider>
-      </MemoryRouter>
-    );
-  };
-
-  return <FormWrapper />;
+  return <FormWrapper form={form}>{children}</FormWrapper>;
 }
 
 describe('PageFormPlatformOrganizationSelect', () => {

--- a/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
+++ b/platform/access/organizations/components/PageFormPlatformOrganizationSelect.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react';
 import { FormProvider, UseFormReturn, useForm } from 'react-hook-form';
 import { MemoryRouter } from 'react-router-dom';
@@ -9,7 +10,7 @@ import { PageFormPlatformOrganizationSelect } from './PageFormPlatformOrganizati
 
 interface FormWrapperProps {
   children: React.ReactNode;
-  form: UseFormReturn;
+  form: UseFormReturn<any>;
 }
 
 function FormWrapper({ children, form }: FormWrapperProps) {

--- a/platform/access/organizations/hooks/useSelectOrganization.test.tsx
+++ b/platform/access/organizations/hooks/useSelectOrganization.test.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { renderHook } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
+import { PlatformOrganization } from '../../../interfaces/PlatformOrganization';
 import { useSelectOrganization } from './useSelectOrganization';
 
 describe('useSelectOrganization', () => {
@@ -20,7 +23,7 @@ describe('useSelectOrganization', () => {
     });
 
     expect(() => {
-      result.current(() => {}, { id: 1, name: 'Test Org' });
+      result.current(() => {}, { id: 1, name: 'Test Org' } as PlatformOrganization);
     }).not.toThrow();
   });
 });

--- a/platform/access/organizations/hooks/useSelectOrganization.test.tsx
+++ b/platform/access/organizations/hooks/useSelectOrganization.test.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { useSelectOrganization } from './useSelectOrganization';
+
+describe('useSelectOrganization', () => {
+  it('should return a function', () => {
+    const { result } = renderHook(() => useSelectOrganization(), {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    expect(result.current).toBeInstanceOf(Function);
+  });
+
+  it('should be callable with organization selection parameters', () => {
+    const { result } = renderHook(() => useSelectOrganization(), {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    expect(() => {
+      result.current(() => {}, { id: 1, name: 'Test Org' });
+    }).not.toThrow();
+  });
+});

--- a/platform/access/organizations/utils/getAddedAndRemovedPlatformRoles.test.tsx
+++ b/platform/access/organizations/utils/getAddedAndRemovedPlatformRoles.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { PlatformRbacRole } from '../../../interfaces/PlatformRbacRole';
+import { getAddedAndRemovedPlatformRoles } from './getAddedAndRemovedPlatformRoles';
+
+describe('getAddedAndRemovedPlatformRoles', () => {
+  it('should return empty array when no roles change', () => {
+    const roles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(roles, roles);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should identify added roles', () => {
+    const originalRoles = [{ id: 1, name: 'Admin' }] as PlatformRbacRole[];
+    const updatedRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(2);
+    expect(result[0].name).toBe('User');
+    expect(result[0].remove).toBeUndefined();
+  });
+
+  it('should identify removed roles', () => {
+    const originalRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+    const updatedRoles = [{ id: 1, name: 'Admin' }] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(2);
+    expect(result[0].name).toBe('User');
+    expect(result[0].remove).toBe(true);
+  });
+
+  it('should handle both added and removed roles', () => {
+    const originalRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+    const updatedRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 3, name: 'Editor' },
+    ] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(2);
+
+    const addedRole = result.find((r) => r.id === 3);
+    expect(addedRole).toBeDefined();
+    expect(addedRole?.remove).toBeUndefined();
+
+    const removedRole = result.find((r) => r.id === 2);
+    expect(removedRole).toBeDefined();
+    expect(removedRole?.remove).toBe(true);
+  });
+
+  it('should handle empty original roles', () => {
+    const originalRoles = [] as PlatformRbacRole[];
+    const updatedRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => !r.remove)).toBe(true);
+  });
+
+  it('should handle empty updated roles', () => {
+    const originalRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+    const updatedRoles = [] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.remove === true)).toBe(true);
+  });
+
+  it('should not duplicate roles in result', () => {
+    const originalRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'User' },
+    ] as PlatformRbacRole[];
+    const updatedRoles = [
+      { id: 3, name: 'Editor' },
+      { id: 4, name: 'Viewer' },
+    ] as PlatformRbacRole[];
+
+    const result = getAddedAndRemovedPlatformRoles(originalRoles, updatedRoles);
+
+    expect(result).toHaveLength(4);
+
+    const ids = result.map((r) => r.id);
+    const uniqueIds = new Set(ids);
+    expect(ids.length).toBe(uniqueIds.size);
+  });
+});


### PR DESCRIPTION
## Summary
Part 5 of 5: Test coverage for remaining organization components - utility functions, hooks, and select components.

## Test plan
- Added utility tests for `getAddedAndRemovedPlatformRoles` (7 tests)
- Added hook tests for `useSelectOrganization` (2 tests)
- Added component tests for `PageFormPlatformOrganizationSelect` (3 tests)
- All tests passing
- No ESLint errors
- Total: 12 new tests

## Related PRs
- Part 1/5: #3336 (Create component)
- Part 2/5: #3337 (Edit component)
- Part 3/5: #3338 (Wizard steps)
- Part 4/5: #3339 (Hooks)
- Part 5/5: This PR (Remaining components)

**Merge order**: Should be merged after PRs 1-4 above.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Tests (non-breaking change which adds or modifies tests)
- [ ] Documentation (non-breaking change which adds or modifies documentation)
- [ ] Other (non-breaking change that doesn't fit any of the above)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.


🤖 Generated with [Claude Code](https://claude.com/claude-code)