### PR TITLE
fix(ci): reliable Codecov coverage with carryforward

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -131,8 +131,8 @@ jobs:
           path: coverage/combined
           retention-days: 7
           if-no-files-found: error
-      - name: Upload unit test coverage to Codecov (OIDC)
-        if: ${{ !vars.CODECOV_URL }}
+      - name: Upload coverage to Codecov (OIDC)
+        if: ${{ !vars.CODECOV_URL && needs.vitest-awx.result == 'success' && needs.vitest.result == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -140,8 +140,8 @@ jobs:
           flags: unit-tests
           disable_search: true
           fail_ci_if_error: false
-      - name: Upload unit test coverage to Codecov (Token)
-        if: ${{ vars.CODECOV_URL }}
+      - name: Upload coverage to Codecov (Token)
+        if: ${{ vars.CODECOV_URL && needs.vitest-awx.result == 'success' && needs.vitest.result == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -151,6 +151,9 @@ jobs:
           flags: unit-tests
           disable_search: true
           fail_ci_if_error: false
+      - name: Skip Codecov upload (incomplete coverage)
+        if: ${{ needs.vitest-awx.result != 'success' || needs.vitest.result != 'success' }}
+        run: echo "::warning::Skipping Codecov upload — one or more test shards failed. Codecov will carry forward the last complete upload."
 
   sonarqube-code-quality:
     name: Sonar (branch analysis)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -159,8 +159,8 @@ jobs:
           path: coverage/combined
           retention-days: 7
           if-no-files-found: error
-      - name: Upload unit test coverage to Codecov (OIDC)
-        if: ${{ !vars.CODECOV_URL }}
+      - name: Upload coverage to Codecov (OIDC)
+        if: ${{ !vars.CODECOV_URL && needs.vitest-awx.result == 'success' && needs.vitest.result == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -168,8 +168,8 @@ jobs:
           flags: unit-tests
           disable_search: true
           fail_ci_if_error: false
-      - name: Upload unit test coverage to Codecov (Token)
-        if: ${{ vars.CODECOV_URL }}
+      - name: Upload coverage to Codecov (Token)
+        if: ${{ vars.CODECOV_URL && needs.vitest-awx.result == 'success' && needs.vitest.result == 'success' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -179,6 +179,9 @@ jobs:
           flags: unit-tests
           disable_search: true
           fail_ci_if_error: false
+      - name: Skip Codecov upload (incomplete coverage)
+        if: ${{ needs.vitest-awx.result != 'success' || needs.vitest.result != 'success' }}
+        run: echo "::warning::Skipping Codecov upload — one or more test shards failed. Codecov will carry forward the last complete upload."
       - name: Save off PR Number
         run: echo "PR ${{ github.event.number }}" > pr_number.txt
       - name: Upload PR Number

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,7 @@
 coverage:
   status:
     project:
-      default:
-        flags:
-          - unit-tests
+      default: true
   ignore:
     - "**/*.test.ts"
     - "**/*.test.tsx"
@@ -17,3 +15,9 @@ coverage:
     - "**/swagger.json"
     - "**/openapi.json"
     - "**/package-lock.json"
+
+flags:
+  unit-tests:
+    carryforward: true
+  e2e-tests:
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,7 @@ coverage:
     - "**/swagger.json"
     - "**/openapi.json"
     - "**/package-lock.json"
+
+flags:
+  unit-tests:
+    carryforward: true


### PR DESCRIPTION
## Summary

- Remove `unit-tests` flag filter from Codecov project status so the chart, overview, and commit status all show combined unit + e2e coverage (~74%)
- Add `carryforward: true` on both `unit-tests` and `e2e-tests` flags so PRs (which only upload unit tests) carry forward the nightly e2e data instead of showing a false regression
- Gate Codecov upload on all vitest shards passing to prevent incomplete data from replacing the baseline

## Problem

Three inconsistent numbers from the same tool on the same branch:
- **GitHub commit status**: 51% (filtered to unit-tests flag only)
- **Codecov chart/overview**: 74% (combined unit + e2e, the real number)
- **On shard failure**: could drop to 42% (incomplete upload accepted as truth)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped