### PR TITLE
Revert "feat: update empty state messaging across AAP for consistency (AAP-70100)"

### DIFF
--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.test.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.test.tsx
@@ -59,6 +59,5 @@ describe('ManagementJobSchedules', () => {
     await waitFor(() => {
       expect(screen.getByText('No schedules yet')).toBeInTheDocument();
     });
-    expect(screen.getByText('Create a schedule to populate this list.')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobSchedules.tsx
@@ -35,7 +35,7 @@ export function ManagementJobSchedules() {
       emptyState={
         <PageTableEmptyState
           title={t('No schedules yet')}
-          description={t('Create a schedule to populate this list.')}
+          description={t('To get started, create a schedule.')}
         >
           <ButtonLink
             icon={<PlusCircleIcon />}

--- a/frontend/awx/administration/notifiers/Notifiers.test.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.test.tsx
@@ -183,7 +183,9 @@ describe('Notifiers', () => {
 
       await waitFor(() => {
         expect(screen.getByText('No notifiers found.')).toBeInTheDocument();
-        expect(screen.getByText('Create a notifier to populate this list.')).toBeInTheDocument();
+        expect(
+          screen.getByText('Please create notifiers to populate this list.')
+        ).toBeInTheDocument();
       });
 
       const createNotifier =

--- a/frontend/awx/administration/notifiers/Notifiers.tsx
+++ b/frontend/awx/administration/notifiers/Notifiers.tsx
@@ -81,7 +81,7 @@ export function Notifiers() {
           canAddNotificationTemplate ? (
             <PageTableEmptyState
               title={t('No notifiers found.')}
-              description={t('Create a notifier to populate this list.')}
+              description={t('Please create notifiers to populate this list.')}
             >
               <ButtonLink
                 icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/TeamAccess.test.tsx
+++ b/frontend/awx/resources/TeamAccess.test.tsx
@@ -45,9 +45,9 @@ describe('Resource Team Access', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/No teams are assigned to this credentials/)).toBeInTheDocument();
+      expect(screen.getByText(/No teams assigned to credential/)).toBeInTheDocument();
       expect(
-        screen.getByText(/To get started, assign a team to this credentials./)
+        screen.getByText(/To get started, assign teams to this credential./)
       ).toBeInTheDocument();
       expect(screen.getByText(/Assign teams/)).toBeInTheDocument();
     });

--- a/frontend/awx/resources/hosts/Hosts.test.tsx
+++ b/frontend/awx/resources/hosts/Hosts.test.tsx
@@ -56,7 +56,7 @@ describe('Hosts - Standalone Route', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/There are currently no hosts/i)).toBeInTheDocument();
+    expect(await screen.findByText(/there are currently no hosts added/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /create host/i })).toBeInTheDocument();
   });
 
@@ -126,7 +126,9 @@ describe('InventoryHosts - Regular Inventory Route', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/No hosts are assigned to this inventory/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/there are currently no hosts added to this inventory/i)
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /create host/i })).toBeInTheDocument();
   });
 

--- a/frontend/awx/resources/hosts/Hosts.tsx
+++ b/frontend/awx/resources/hosts/Hosts.tsx
@@ -71,8 +71,8 @@ export function Hosts() {
           emptyState={
             canCreateHost ? (
               <PageTableEmptyState
-                title={t('There are currently no hosts.')}
-                description={t('Create a host to populate this list.')}
+                title={t('There are currently no hosts added')}
+                description={t('Please create a host by using the button below.')}
               >
                 <ButtonLink
                   icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.test.tsx
@@ -9,13 +9,11 @@ import { InventoryGroups } from './InventoryGroups';
 const server = setupServer(
   http.options(awxAPI`/groups/`, () => HttpResponse.json({ actions: { POST: {}, GET: {} } })),
   http.options(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/inventories/') && request.url.includes('/groups/'),
+    ({ request }) => request.url.includes('/inventories/') && request.url.includes('/groups/'),
     () => HttpResponse.json({ actions: { GET: {} } })
   ),
   http.get(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/inventories/') && request.url.includes('/groups/'),
+    ({ request }) => request.url.includes('/inventories/') && request.url.includes('/groups/'),
     () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })
   )
 );
@@ -36,7 +34,7 @@ describe('InventoryGroups', () => {
 
     await waitFor(() => {
       const emptyText =
-        screen.queryByText('No groups are assigned to this inventory.') ??
+        screen.queryByText('There are currently no groups added to this inventory.') ??
         screen.queryByText('Create group');
       expect(emptyText).toBeInTheDocument();
     });

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryGroups.tsx
@@ -45,11 +45,11 @@ export function InventoryGroups() {
     emptyStateDescription = t('Please add Items to populate this list');
   } else {
     emptyStateTitle = canCreateGroup
-      ? t('No groups are assigned to this inventory.')
+      ? t('There are currently no groups added to this inventory.')
       : t('You do not have permission to create a group');
 
     emptyStateDescription = canCreateGroup
-      ? t('Create a group to assign to this inventory.')
+      ? t('Please create a group by using the button below.')
       : t('Please contact your organization administrator if there is an issue with your access.');
   }
 

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.test.tsx
@@ -55,7 +55,9 @@ describe('InventoryHosts Component Button Visibility', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('No hosts are assigned to this inventory.')).toBeInTheDocument();
+      expect(
+        screen.getByText('There are currently no hosts added to this inventory.')
+      ).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /Create host/i })).toBeInTheDocument();
     });
   });

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryHosts.tsx
@@ -44,11 +44,11 @@ export function InventoryHosts() {
 
   if (params.inventory_type === 'inventory') {
     emptyStateTitle = canCreateHost
-      ? t('No hosts are assigned to this inventory.')
+      ? t('There are currently no hosts added to this inventory.')
       : t('You do not have permission to create a host.');
 
     emptyStateDescription = canCreateHost
-      ? t('Create a host to populate this list.')
+      ? t('Please create a host by using the button below.')
       : t('Please contact your organization administrator if there is an issue with your access.');
   } else {
     emptyStateTitle = t('No hosts found');

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.test.tsx
@@ -11,12 +11,12 @@ const emptySources = { count: 0, next: null, previous: null, results: [] };
 const server = setupServer(
   http.options(awxAPI`/inventory_sources/`, () => HttpResponse.json({ actions: { POST: {} } })),
   http.options(
-    ({ request }: { request: Request }) =>
+    ({ request }) =>
       request.url.includes('/inventories/') && request.url.includes('inventory_sources'),
     () => HttpResponse.json({ actions: { GET: {} } })
   ),
   http.get(
-    ({ request }: { request: Request }) =>
+    ({ request }) =>
       request.url.includes('/inventories/') && request.url.includes('inventory_sources'),
     () => HttpResponse.json(emptySources)
   )
@@ -37,7 +37,7 @@ describe('InventorySources', () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByText('There are currently no sources assigned to this inventory.')
+        screen.getByText('There are currently no sources added to this inventory.')
       ).toBeInTheDocument();
     });
   });

--- a/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventorySources.tsx
@@ -96,8 +96,8 @@ export function InventorySources() {
         emptyState={
           canCreateSource ? (
             <PageTableEmptyState
-              title={t('There are currently no sources assigned to this inventory.')}
-              description={t('Create a source to assign to this inventory.')}
+              title={t('There are currently no sources added to this inventory.')}
+              description={t('Please create a source by using the button below.')}
             >
               <ButtonLink
                 icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.test.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.test.tsx
@@ -114,30 +114,26 @@ const adHocCommandsOptions = { actions: { GET: {}, POST: {} } };
 
 const server = setupServer(
   http.get(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/hosts/') && !request.url.includes('all_groups'),
+    ({ request }) => request.url.includes('/hosts/') && !request.url.includes('all_groups'),
     () => HttpResponse.json(mockHost)
   ),
   http.options(awxAPI`/groups/`, () => HttpResponse.json(groupsOptionsWithPost)),
   http.options(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/hosts/') && request.url.includes('all_groups'),
+    ({ request }) => request.url.includes('/hosts/') && request.url.includes('all_groups'),
     () => HttpResponse.json(allGroupsOptions)
   ),
   http.options(
-    ({ request }: { request: Request }) =>
+    ({ request }) =>
       request.url.includes('/inventories/') && request.url.includes('ad_hoc_commands'),
     () => HttpResponse.json(adHocCommandsOptions)
   ),
   http.get(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/hosts/') && request.url.includes('all_groups'),
+    ({ request }) => request.url.includes('/hosts/') && request.url.includes('all_groups'),
     () => HttpResponse.json(mockGroups)
   ),
   http.get(
-    ({ request }: { request: Request }) =>
-      request.url.includes('/inventories/') && request.url.endsWith('/'),
-    ({ request }: { request: Request }) => {
+    ({ request }) => request.url.includes('/inventories/') && request.url.endsWith('/'),
+    ({ request }) => {
       const match = /\/inventories\/(\d+)\//.exec(request.url);
       const id = match ? Number.parseInt(match[1] ?? '1', 10) : 1;
       return HttpResponse.json({
@@ -200,7 +196,7 @@ describe('InventoryHostGroups', () => {
   it('should show empty state with Associate groups when user has permission', async () => {
     server.use(
       http.get(
-        ({ request }: { request: Request }) => request.url.includes('all_groups'),
+        ({ request }) => request.url.includes('all_groups'),
         () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })
       )
     );
@@ -208,8 +204,10 @@ describe('InventoryHostGroups', () => {
     renderInventoryHostGroups('inventory', '/inventories/inventory/1/hosts/1/groups');
 
     await waitFor(() => {
-      expect(screen.getByText('There are currently no groups.')).toBeInTheDocument();
-      expect(screen.getByText('Associate a group to populate this list.')).toBeInTheDocument();
+      expect(
+        screen.getByText('There are currently no groups associated with this host')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Please add a group by using the button below.')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Associate groups/ })).toBeInTheDocument();
     });
   });
@@ -218,7 +216,7 @@ describe('InventoryHostGroups', () => {
     server.use(
       http.options(awxAPI`/groups/`, () => HttpResponse.json(groupsOptionsWithoutPost)),
       http.get(
-        ({ request }: { request: Request }) => request.url.includes('all_groups'),
+        ({ request }) => request.url.includes('all_groups'),
         () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })
       )
     );
@@ -253,7 +251,7 @@ describe('InventoryHostGroups', () => {
   it('should display error when groups fail to load', async () => {
     server.use(
       http.get(
-        ({ request }: { request: Request }) => request.url.includes('all_groups'),
+        ({ request }) => request.url.includes('all_groups'),
         () => new HttpResponse(null, { status: 500 })
       )
     );
@@ -268,7 +266,7 @@ describe('InventoryHostGroups', () => {
   it('should disable Edit group when user lacks edit capability', async () => {
     server.use(
       http.get(
-        ({ request }: { request: Request }) => request.url.includes('all_groups'),
+        ({ request }) => request.url.includes('all_groups'),
         () => HttpResponse.json(groupsWithEditDisabled)
       )
     );

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -67,8 +67,8 @@ export function InventoryHostGroups(props: { page: string }) {
         emptyState={
           canCreateGroup ? (
             <PageTableEmptyState
-              title={t('There are currently no groups.')}
-              description={t('Associate a group to populate this list.')}
+              title={t('There are currently no groups associated with this host')}
+              description={t('Please add a group by using the button below.')}
             >
               <Button
                 icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/notifications/ResourceNotifications.test.tsx
+++ b/frontend/awx/resources/notifications/ResourceNotifications.test.tsx
@@ -9,27 +9,27 @@ const emptyNotifications = { count: 0, next: null, previous: null, results: [] }
 
 const server = setupServer(
   http.get(
-    ({ request }: { request: Request }) => request.url.includes('notification_templates_started'),
+    ({ request }) => request.url.includes('notification_templates_started'),
     () => HttpResponse.json(emptyNotifications)
   ),
   http.get(
-    ({ request }: { request: Request }) => request.url.includes('notification_templates_success'),
+    ({ request }) => request.url.includes('notification_templates_success'),
     () => HttpResponse.json(emptyNotifications)
   ),
   http.get(
-    ({ request }: { request: Request }) => request.url.includes('notification_templates_error'),
+    ({ request }) => request.url.includes('notification_templates_error'),
     () => HttpResponse.json(emptyNotifications)
   ),
   http.get(
-    ({ request }: { request: Request }) => request.url.includes('notification_templates_approvals'),
+    ({ request }) => request.url.includes('notification_templates_approvals'),
     () => HttpResponse.json(emptyNotifications)
   ),
   http.options(
-    ({ request }: { request: Request }) => request.url.includes('notification_templates'),
+    ({ request }) => request.url.includes('notification_templates'),
     () => HttpResponse.json({ actions: {} })
   ),
   http.get(
-    ({ request }: { request: Request }) =>
+    ({ request }) =>
       request.url.includes('/notification_templates') &&
       !request.url.includes('_started') &&
       !request.url.includes('_success') &&
@@ -52,7 +52,7 @@ describe('ResourceNotifications', () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByText('There are currently no notifications associated with this project.')
+        screen.getByText('There are currently no notifications added to this project.')
       ).toBeInTheDocument();
     });
   });

--- a/frontend/awx/resources/notifications/ResourceNotifications.tsx
+++ b/frontend/awx/resources/notifications/ResourceNotifications.tsx
@@ -108,12 +108,12 @@ export function ResourceNotifications({ resourceType, id }: { resourceType: stri
           } notifications`
         )}
         emptyStateTitle={t(
-          `There are currently no notifications associated with this ${
+          `There are currently no notifications added to this ${
             resourceToErrorMsg[resourceType as keyof ResourceTypeMapper]
           }.`
         )}
         emptyStateDescription={t(
-          'Contact your organization administrator if there is an issue with your access.'
+          'Please contact your organization administrator if there is an issue with your access.'
         )}
         emptyStateIcon={CubesIcon}
         {...view}

--- a/frontend/awx/resources/projects/Projects.test.tsx
+++ b/frontend/awx/resources/projects/Projects.test.tsx
@@ -55,26 +55,4 @@ describe('Projects', () => {
       expect(screen.getByText('Test Project')).toBeInTheDocument();
     });
   });
-
-  it('should display empty state when no projects exist', async () => {
-    server.use(
-      http.options(awxAPI`/projects/`, () => HttpResponse.json({ actions: { POST: {} } })),
-      http.get(awxAPI`/projects/`, () =>
-        HttpResponse.json({ count: 0, next: null, previous: null, results: [] })
-      )
-    );
-
-    render(
-      <MemoryRouter>
-        <Projects />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('There are currently no projects created for your organization.')
-      ).toBeInTheDocument();
-    });
-    expect(screen.getByText('Create a project to populate this list.')).toBeInTheDocument();
-  });
 });

--- a/frontend/awx/resources/projects/Projects.tsx
+++ b/frontend/awx/resources/projects/Projects.tsx
@@ -95,8 +95,8 @@ export function Projects() {
           emptyState={
             canCreateProject ? (
               <PageTableEmptyState
-                title={t('There are currently no projects created for your organization.')}
-                description={t('Create a project to populate this list.')}
+                title={t('There are currently no projects added to your organization.')}
+                description={t('Please create a project by using the button below.')}
               >
                 <ButtonLink
                   icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurvey.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurvey.tsx
@@ -145,7 +145,7 @@ export function TemplateSurveyInternal({
         canCreateSurvey ? (
           <PageTableEmptyState
             title={t('There are currently no survey questions.')}
-            description={t('Create a survey question to populate this list.')}
+            description={t('Create a survey question by clicking the button below.')}
           >
             <ButtonLink
               icon={<PlusCircleIcon />}

--- a/frontend/awx/resources/templates/TemplatesList.test.tsx
+++ b/frontend/awx/resources/templates/TemplatesList.test.tsx
@@ -73,7 +73,9 @@ describe('TemplatesList Empty State', () => {
         { timeout: 10000 }
       );
 
-      expect(screen.getByText('Create a template to populate this list.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Please create a template using the button below.')
+      ).toBeInTheDocument();
 
       const createButton = screen.getByTestId('create-template');
       expect(createButton).toBeInTheDocument();
@@ -150,7 +152,9 @@ describe('TemplatesList Empty State', () => {
         { timeout: 10000 }
       );
 
-      expect(screen.getByText('Create a template to populate this list.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Please create a template using the button below.')
+      ).toBeInTheDocument();
 
       const createButton = screen.getByTestId('create-template');
       expect(createButton).toBeInTheDocument();
@@ -222,7 +226,9 @@ describe('TemplatesList Empty State', () => {
         { timeout: 10000 }
       );
 
-      expect(screen.getByText('Create a template to populate this list.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Please create a template using the button below.')
+      ).toBeInTheDocument();
 
       const createButton = screen.getByTestId('create-template');
       expect(createButton).toBeInTheDocument();

--- a/frontend/awx/resources/templates/TemplatesList.tsx
+++ b/frontend/awx/resources/templates/TemplatesList.tsx
@@ -196,7 +196,7 @@ export function TemplatesList(props: Readonly<TemplatesListProps>) {
         ) : canCreateJobTemplate || canCreateWFJobTemplate ? (
           <PageTableEmptyState
             title={t('No templates yet')}
-            description={t('Create a template to populate this list.')}
+            description={t('Please create a template using the button below.')}
           >
             <PageActionsPinned actions={toolbarActions.slice(0, 1)} />
           </PageTableEmptyState>

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -167,7 +167,7 @@ export function JobsList(props: {
       emptyStateDescription={
         activeDomains.length > 0
           ? t('Please select a different domain or clear the current selection.')
-          : t('Run a job to populate this list.')
+          : t('Please run a job to populate this list.')
       }
       emptyStateIcon={CubesIcon}
       {...view}

--- a/frontend/awx/views/schedules/SchedulesList.test.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.test.tsx
@@ -38,38 +38,5 @@ describe('SchedulesList', () => {
     await waitFor(() => {
       expect(screen.getByText('No schedules yet')).toBeInTheDocument();
     });
-    expect(screen.getByText('Create a schedule to populate this list.')).toBeInTheDocument();
-  });
-
-  it('should show resources missing message when template missing resources', async () => {
-    const { Outlet } = await import('react-router-dom');
-
-    const TemplateWrapper = () => {
-      return <Outlet context={{ template: { type: 'job_template', summary_fields: {} } }} />;
-    };
-
-    render(
-      <MemoryRouter initialEntries={['/templates/1/schedules']}>
-        <Routes>
-          <Route element={<TemplateWrapper />}>
-            <Route
-              path="/templates/:id/schedules"
-              element={
-                <SchedulesList
-                  createSchedulePageId="awx-schedules-create"
-                  url="/api/v2/job_templates/1/schedules/"
-                />
-              }
-            />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Resources are missing from this template.')).toBeInTheDocument();
-    });
-    // Verify empty description (the uncovered branch)
-    expect(screen.queryByText('Create a schedule to populate this list.')).not.toBeInTheDocument();
   });
 });

--- a/frontend/awx/views/schedules/SchedulesList.tsx
+++ b/frontend/awx/views/schedules/SchedulesList.tsx
@@ -101,7 +101,9 @@ export function SchedulesList(props: {
     emptyStateTitle = isMissingResource
       ? t('Resources are missing from this template.')
       : t('No schedules yet');
-    emptyStateDescription = isMissingResource ? '' : t('Create a schedule to populate this list.');
+    emptyStateDescription = isMissingResource
+      ? ''
+      : t('Please create a schedule by using the button below.');
   } else {
     emptyStateTitle = t('You do not have permission to create a schedule');
     emptyStateDescription = t(

--- a/frontend/common/access/components/Access.tsx
+++ b/frontend/common/access/components/Access.tsx
@@ -233,10 +233,10 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
         break;
       case 'team':
         title = props.content_type_model
-          ? t('No teams are assigned to this {{resourceType}}.', {
+          ? t('No teams assigned to {{resourceType}}', {
               resourceType: getDisplayName(props.content_type_model),
             })
-          : t('No teams are assigned to this resource.');
+          : t('No teams assigned to this resource');
         break;
       case 'user-roles':
         title =
@@ -261,10 +261,10 @@ export function Access<T extends Assignment>(props: AccessProps<T>) {
     let title: string;
     if (props.accessListType === 'team') {
       title = props.content_type_model
-        ? t('To get started, assign a team to this {{resourceType}}.', {
+        ? t('To get started, assign teams to this {{resourceType}}.', {
             resourceType: getDisplayName(props.content_type_model),
           })
-        : t('To get started, assign a team to this resource.');
+        : t('To get started, assign teams to this resource.');
     } else {
       title = props.content_type_model
         ? t('To get started, assign users to this {{resourceType}}.', {

--- a/frontend/common/access/components/AccessList.tsx
+++ b/frontend/common/access/components/AccessList.tsx
@@ -153,10 +153,10 @@ export function AccessList<T extends UserRoleAccess>(props: AccessProps<T>) {
         break;
       case 'team':
         title = props.content_type_model
-          ? t('No teams are assigned to this {{resourceType}}.', {
+          ? t('No teams assigned to {{resourceType}}', {
               resourceType: getDisplayName(props.content_type_model),
             })
-          : t('No teams are assigned to this resource.');
+          : t('No teams assigned to this resource');
         break;
       case 'user-roles':
         title = t('There are currently no roles assigned to this user.');
@@ -174,10 +174,10 @@ export function AccessList<T extends UserRoleAccess>(props: AccessProps<T>) {
     let title: string;
     if (props.accessListType === 'team') {
       title = props.content_type_model
-        ? t('To get started, assign a team to this {{resourceType}}.', {
+        ? t('To get started, assign teams to this {{resourceType}}.', {
             resourceType: getDisplayName(props.content_type_model),
           })
-        : t('To get started, assign a team to this resource.');
+        : t('To get started, assign teams to this resource.');
     } else {
       title = props.content_type_model
         ? t('To get started, assign users to this {{resourceType}}.', {

--- a/frontend/common/access/components/PlatformAccess.tsx
+++ b/frontend/common/access/components/PlatformAccess.tsx
@@ -230,10 +230,10 @@ export function PlatformAccess<T extends Assignment>(props: PlatformAccessProps<
         break;
       case 'team':
         title = props.content_type_model
-          ? t('No teams are assigned to this {{resourceType}}.', {
+          ? t('No teams assigned to {{resourceType}}', {
               resourceType: getDisplayName(props.content_type_model),
             })
-          : t('No teams are assigned to this resource.');
+          : t('No teams assigned to this resource');
         break;
       case 'user-roles':
         title = t('There are currently no roles assigned to this user.');
@@ -251,10 +251,10 @@ export function PlatformAccess<T extends Assignment>(props: PlatformAccessProps<
     let title: string;
     if (props.accessListType === 'team') {
       title = props.content_type_model
-        ? t('To get started, assign a team to this {{resourceType}}.', {
+        ? t('To get started, assign teams to this {{resourceType}}.', {
             resourceType: getDisplayName(props.content_type_model),
           })
-        : t('To get started, assign a team to this resource.');
+        : t('To get started, assign teams to this resource.');
     } else {
       title = props.content_type_model
         ? t('To get started, assign users to this {{resourceType}}.', {

--- a/frontend/common/access/components/TeamAccess.test.tsx
+++ b/frontend/common/access/components/TeamAccess.test.tsx
@@ -89,13 +89,11 @@ describe('TeamAccess', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/No teams are assigned to this rulebook activation/)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/No teams assigned to rulebook activation/)).toBeInTheDocument();
     });
 
     expect(
-      screen.getByText(/To get started, assign a team to this rulebook activation./)
+      screen.getByText(/To get started, assign teams to this rulebook activation./)
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Assign teams/ })).toBeInTheDocument();
   });
@@ -121,7 +119,7 @@ describe('TeamAccess', () => {
 
     // Verify empty state is shown after request
     await waitFor(() => {
-      expect(screen.getByText(/No teams are assigned to this credentials/)).toBeInTheDocument();
+      expect(screen.getByText(/No teams assigned to credential/)).toBeInTheDocument();
     });
   });
 
@@ -146,9 +144,7 @@ describe('TeamAccess', () => {
 
     // Verify empty state is shown after request
     await waitFor(() => {
-      expect(
-        screen.getByText(/No teams are assigned to this rulebook activation/)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/No teams assigned to rulebook activation/)).toBeInTheDocument();
     });
   });
 
@@ -173,7 +169,7 @@ describe('TeamAccess', () => {
 
     // Verify empty state is shown after request
     await waitFor(() => {
-      expect(screen.getByText(/No teams are assigned to this namespace/)).toBeInTheDocument();
+      expect(screen.getByText(/No teams assigned to namespace/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Reverts ansible/ansible-ui#3266

ansible/ansible-ui#3266 introduced ~16 test failures in playwright. We need to revert it for now to restore test stability.

## Risk Analysis - REQUIRED

- [ ] **High** — Broad scope (e.g., core infrastructure, auth, shared components, data migrations). High risk of cascading failures.
- [ ] **Medium** — Moderate scope (e.g., new feature, multi-page change, API integration). Some risk of side effects.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

