### PR TITLE
fix: preserve flat mode in job output after job completion 

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.test.tsx
@@ -1,5 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { SWRConfig } from 'swr';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { testFixture as jobFixture } from '../jobDetails.fixture';
 import { JobOutputEvents } from './JobOutputEvents';
 
@@ -16,27 +19,90 @@ vi.mock('./useJobOutput', () => ({
   })),
 }));
 
-vi.mock('./useJobOutputChildrenSummary', () => ({
-  useJobOutputChildrenSummary: vi.fn(() => ({
-    childrenSummary: undefined,
-    isFlatMode: true,
-  })),
-}));
+const childrenSummaryUrl = ({ request }: { request: Request }) =>
+  request.url.includes('children_summary');
 
-describe('JobOutputEvents', () => {
-  it('should render with scroll controls wired to virtualized list', () => {
-    render(
+const server = setupServer(
+  http.get(childrenSummaryUrl, () =>
+    HttpResponse.json({
+      children_summary: { '1': { rowNumber: 1, numChildren: 3 } },
+      meta_event_nested_uuid: {},
+      event_processing_finished: true,
+      is_tree: true,
+    })
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function renderJobOutput(job: typeof jobFixture) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map() }}>
       <JobOutputEvents
-        job={jobFixture}
+        job={job}
         reloadJob={vi.fn()}
         toolbarFilters={[]}
         filterState={{}}
         isFollowModeEnabled={false}
         setIsFollowModeEnabled={vi.fn()}
       />
-    );
+    </SWRConfig>
+  );
+}
+
+describe('JobOutputEvents', () => {
+  it('should render scroll controls', () => {
+    renderJobOutput(jobFixture);
 
     expect(screen.getByRole('button', { name: 'Scroll first' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Scroll last' })).toBeInTheDocument();
+  });
+
+  it('should hide expand/collapse button when job is running (flat mode)', () => {
+    const runningJob = { ...jobFixture, status: 'running' as const };
+    renderJobOutput(runningJob);
+
+    expect(
+      screen.queryByRole('button', { name: /expand job events|collapse all job events/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should keep expand/collapse button hidden after a running job completes', () => {
+    const runningJob = { ...jobFixture, status: 'running' as const };
+    const { rerender } = renderJobOutput(runningJob);
+
+    expect(
+      screen.queryByRole('button', { name: /expand job events|collapse all job events/i })
+    ).not.toBeInTheDocument();
+
+    const completedJob = { ...jobFixture, status: 'successful' as const };
+    rerender(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <JobOutputEvents
+          job={completedJob}
+          reloadJob={vi.fn()}
+          toolbarFilters={[]}
+          filterState={{}}
+          isFollowModeEnabled={false}
+          setIsFollowModeEnabled={vi.fn()}
+        />
+      </SWRConfig>
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /expand job events|collapse all job events/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show expand/collapse button when job was already completed on mount', async () => {
+    renderJobOutput(jobFixture);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /expand job events|collapse all job events/i })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.tsx
@@ -1,5 +1,5 @@
 import { type IFilterState, type IToolbarFilter } from '@ansible/ansible-ui-framework';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { PageControls } from '../../../../common/PageControls';
 import { useVirtualizedList } from '../../../../common/utils/useVirtualized';
@@ -49,9 +49,16 @@ export function JobOutputEvents(props: IJobOutputEventsProps) {
   const [hostModalData, setHostModalData] = useState<IJobOutputRow | null>(null);
   const isFiltered = Object.keys(filterState).length > 0;
 
+  const wasRunningOnMount = useRef(isJobRunning(job.status));
+  useEffect(() => {
+    if (isJobRunning(job.status)) {
+      wasRunningOnMount.current = true;
+    }
+  }, [job.status]);
+
   const { childrenSummary, isFlatMode } = useJobOutputChildrenSummary(
     job,
-    isJobRunning(job.status) || isFiltered
+    wasRunningOnMount.current || isFiltered
   );
   const { jobEventCount, getJobOutputEvent, queryJobOutputEvent, jobEvents } = useJobOutput(
     job,


### PR DESCRIPTION
## Summary
When a user views job output while a job is running, the UI displays in flat mode. Previously, when the job completed, `isJobRunning()` flipped to `false`, switching the output to tree mode, causing a jarring reload and scroll position loss. 

This adds a `useRef` that latches the running state at mount time, so flat mode persists for the duration of the page session. Navigating away and back resets the ref, so completed jobs still load in tree mode normally.

Assisted-by: Claude Code

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

  1. Launch a job that runs for at least 10-15 seconds
  2. Open the job output page **while the job is running** — output shows in flat mode
  3. Wait for the job to **complete**
  4. **Expected:** output stays in flat mode, no jank, scroll position preserved
  5. Navigate to a **completed job** from the jobs list — should load in tree mode as usual

### Screenshots
https://github.com/user-attachments/assets/3f893c69-2f98-44d6-a1aa-b08dc0bbf9ab

Left screen: Bug. See output jank at the end of the run. 
Right screen: Bug fix. No jank and scroll positioned preserved. 