### PR TITLE
ci: add PR type labeling workflow for bug-fix and enhancement

### DIFF
--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -11,6 +11,7 @@ on:
           - all
           - size
           - risk
+          - type
           - community
           - workspace
 
@@ -113,6 +114,44 @@ jobs:
                 else
                   echo "PR #$PR_NUMBER -> skipped (no valid risk selection)"
                 fi
+              done
+
+  backfill-type:
+    name: Backfill Type Labels
+    if: inputs.labels == 'all' || inputs.labels == 'type'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs by issue type
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "bug-fix"     --repo "$REPO" --color "D93F0B" --description "Bug fix" --force 2>/dev/null || true
+          gh label create "enhancement" --repo "$REPO" --color "A2EEEF" --description "Enhancement" --force 2>/dev/null || true
+
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | .number' \
+            | while read -r PR_NUMBER; do
+                PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
+                BUG=$(echo "$PR_BODY" | grep -ci '\- \[x\] Bug fix' || true)
+                ENHANCEMENT=$(echo "$PR_BODY" | grep -ci '\- \[x\] Enhancement' || true)
+
+                if [ "$BUG" -ge 1 ]; then
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "bug-fix"
+                else
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/bug-fix" -X DELETE 2>/dev/null || true
+                fi
+
+                if [ "$ENHANCEMENT" -ge 1 ]; then
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "enhancement"
+                else
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/enhancement" -X DELETE 2>/dev/null || true
+                fi
+
+                APPLIED=""
+                [ "$BUG" -ge 1 ] && APPLIED="$APPLIED bug-fix"
+                [ "$ENHANCEMENT" -ge 1 ] && APPLIED="$APPLIED enhancement"
+                echo "PR #$PR_NUMBER:${APPLIED:- (none)}"
               done
 
   backfill-workspace:

--- a/.github/workflows/pr-type-label.yml
+++ b/.github/workflows/pr-type-label.yml
@@ -1,0 +1,50 @@
+name: PR Type Label
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-type:
+    name: Label PR Type
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect issue type from PR description
+        id: detect
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BUG=$(echo "$PR_BODY" | grep -ci '\- \[x\] Bug fix' || true)
+          ENHANCEMENT=$(echo "$PR_BODY" | grep -ci '\- \[x\] Enhancement' || true)
+
+          echo "bug=$BUG" >> "$GITHUB_OUTPUT"
+          echo "enhancement=$ENHANCEMENT" >> "$GITHUB_OUTPUT"
+
+      - name: Apply type labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BUG: ${{ steps.detect.outputs.bug }}
+          ENHANCEMENT: ${{ steps.detect.outputs.enhancement }}
+        run: |
+          gh label create "bug-fix"     --repo "$REPO" --color "D93F0B" --description "Bug fix" --force 2>/dev/null || true
+          gh label create "enhancement" --repo "$REPO" --color "A2EEEF" --description "Enhancement" --force 2>/dev/null || true
+
+          if [ "$BUG" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "bug-fix"
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/bug-fix" -X DELETE 2>/dev/null || true
+          fi
+
+          if [ "$ENHANCEMENT" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "enhancement"
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/enhancement" -X DELETE 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Summary

- Add a new `pr-type-label.yml` workflow that parses the "Type of Change" checkboxes in PR descriptions and applies `bug-fix` or `enhancement` labels accordingly
- Add a `type` option to the `pr-label-backfill.yml` workflow for retroactive labeling of open PRs
- Labels stay in sync with the PR description — added when checked, removed when unchecked

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Open a PR with "Bug fix" checked → verify `bug-fix` label is added
2. Edit PR to uncheck "Bug fix" → verify label is removed
3. Check "Enhancement" → verify `enhancement` label is added
4. Both checked → verify both labels coexist
5. Run backfill workflow with `type` option → verify labels applied to open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)