### PR TITLE
ci: add waiting-on-author, conflict detection, and e2e status workflows

### DIFF
--- a/.github/workflows/pr-e2e-status.yml
+++ b/.github/workflows/pr-e2e-status.yml
@@ -1,0 +1,73 @@
+name: PR E2E Status
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  e2e-triggered:
+    name: E2E Triggered
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '/run-playwright')
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "e2e: pending" --repo "$REPO" --color "FBCA04" --description "E2E tests not yet triggered" --force 2>/dev/null || true
+          gh label create "e2e: running" --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Update e2e labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20pending" -X DELETE 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: running"
+
+          # Remove waiting-on-author if no other failure reasons exist
+          CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-checks -->"))] | length')
+          SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+          CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
+
+          if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+          fi
+
+  e2e-completed:
+    name: E2E Completed
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.pull_request
+      && github.event.comment.user.login == 'aap-pde-ci-bot'
+      && contains(github.event.comment.body, 'Currents dashboard')
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "e2e: running" --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "e2e: done"    --repo "$REPO" --color "0E8A16" --description "E2E tests completed" --force 2>/dev/null || true
+
+      - name: Update e2e labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20running" -X DELETE 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: done"

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -210,6 +210,14 @@ jobs:
                     APPLIED="$APPLIED sonar-failed"
                   fi
 
+                  # Check for outstanding changes_requested reviews
+                  CHANGES_REQUESTED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                    --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | map(.user.login) | unique | length')
+                  if [ "$CHANGES_REQUESTED" -gt 0 ]; then
+                    NEEDS_AUTHOR="true"
+                    APPLIED="$APPLIED changes-requested"
+                  fi
+
                   if [ "$NEEDS_AUTHOR" = "true" ]; then
                     gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
                   else

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -12,6 +12,7 @@ on:
           - size
           - risk
           - type
+          - status
           - community
           - workspace
 
@@ -152,6 +153,95 @@ jobs:
                 [ "$BUG" -ge 1 ] && APPLIED="$APPLIED bug-fix"
                 [ "$ENHANCEMENT" -ge 1 ] && APPLIED="$APPLIED enhancement"
                 echo "PR #$PR_NUMBER:${APPLIED:- (none)}"
+              done
+
+  backfill-status:
+    name: Backfill Status Labels
+    if: inputs.labels == 'all' || inputs.labels == 'status'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label all open PRs with status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+          gh label create "e2e: pending"      --repo "$REPO" --color "FBCA04" --description "E2E tests not yet triggered" --force 2>/dev/null || true
+          gh label create "e2e: running"      --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "e2e: done"         --repo "$REPO" --color "0E8A16" --description "E2E tests completed" --force 2>/dev/null || true
+
+          BOT_FILTER='select(.author.login != "dependabot[bot]" and .author.login != "red-hat-konflux[bot]" and .author.login != "app/red-hat-konflux")'
+
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r ".[] | \"\(.number) \(.author.login)\"" \
+            | while read -r PR_NUMBER AUTHOR; do
+                IS_BOT="false"
+                if [[ "$AUTHOR" == "dependabot[bot]" || "$AUTHOR" == "app/red-hat-konflux" || "$AUTHOR" == "red-hat-konflux[bot]" ]]; then
+                  IS_BOT="true"
+                fi
+
+                APPLIED=""
+
+                # --- Check suite status (waiting-on-author for non-bots) ---
+                if [ "$IS_BOT" = "false" ]; then
+                  CHECK_STATUS=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json state --jq '[.[] | select(.state == "FAILURE")] | length' 2>/dev/null || echo "0")
+                  MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
+
+                  # Latest sonarqubecloud bot comment
+                  SONAR_COMMENT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                    --jq '[.[] | select(.user.login == "sonarqubecloud[bot]" or .user.login == "sonarcloud[bot]")] | last | .body // ""')
+                  SONAR_PASSED=$(echo "$SONAR_COMMENT" | grep -ci 'Quality Gate passed' || true)
+                  SONAR_FAILED="0"
+                  if [ -n "$SONAR_COMMENT" ] && [ "$SONAR_PASSED" -eq 0 ]; then
+                    SONAR_FAILED="1"
+                  fi
+
+                  NEEDS_AUTHOR="false"
+                  if [ "$CHECK_STATUS" -gt 0 ]; then
+                    NEEDS_AUTHOR="true"
+                    APPLIED="$APPLIED checks-failed"
+                  fi
+                  if [ "$MERGEABLE" = "CONFLICTING" ]; then
+                    NEEDS_AUTHOR="true"
+                    APPLIED="$APPLIED conflicts"
+                  fi
+                  if [ "$SONAR_FAILED" -eq 1 ]; then
+                    NEEDS_AUTHOR="true"
+                    APPLIED="$APPLIED sonar-failed"
+                  fi
+
+                  if [ "$NEEDS_AUTHOR" = "true" ]; then
+                    gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+                  else
+                    gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+                  fi
+                fi
+
+                # --- E2E status (all PRs including bots) ---
+                for label in "e2e: pending" "e2e: running" "e2e: done"; do
+                  gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
+                done
+
+                HAS_RUN_PW=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                  --jq '[.[] | select(.body | test("/run-playwright"))] | length')
+                HAS_CURRENTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                  --jq '[.[] | select(.user.login == "aap-pde-ci-bot" and (.body | contains("Currents dashboard")))] | length')
+
+                if [ "$HAS_CURRENTS" -gt 0 ]; then
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: done"
+                  APPLIED="$APPLIED e2e:done"
+                elif [ "$HAS_RUN_PW" -gt 0 ]; then
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: running"
+                  APPLIED="$APPLIED e2e:running"
+                else
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: pending"
+                  APPLIED="$APPLIED e2e:pending"
+                  if [ "$IS_BOT" = "false" ]; then
+                    gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+                  fi
+                fi
+
+                echo "PR #$PR_NUMBER ($AUTHOR):${APPLIED:- (none)}"
               done
 
   backfill-workspace:

--- a/.github/workflows/pr-waiting-on-author-checks.yml
+++ b/.github/workflows/pr-waiting-on-author-checks.yml
@@ -40,6 +40,11 @@ jobs:
         run: |
           AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
           echo "login=$AUTHOR" >> "$GITHUB_OUTPUT"
+          if [[ "$AUTHOR" == "dependabot[bot]" || "$AUTHOR" == "app/red-hat-konflux" || "$AUTHOR" == "red-hat-konflux[bot]" ]]; then
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Ensure labels exist
         env:
@@ -50,7 +55,7 @@ jobs:
           gh label create "e2e: pending"      --repo "$REPO" --color "FBCA04" --description "E2E tests not yet triggered" --force 2>/dev/null || true
 
       - name: Handle check failure
-        if: github.event.workflow_run.conclusion == 'failure'
+        if: github.event.workflow_run.conclusion == 'failure' && steps.author.outputs.is_bot == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -79,13 +84,12 @@ jobs:
 
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
 
-      - name: Handle check success
-        if: github.event.workflow_run.conclusion == 'success'
+      - name: Handle check success (cleanup waiting-on-author)
+        if: github.event.workflow_run.conclusion == 'success' && steps.author.outputs.is_bot == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          AUTHOR: ${{ steps.author.outputs.login }}
         run: |
           # Delete the checks failure comment if it exists
           EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
@@ -99,8 +103,6 @@ jobs:
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
           CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
-
-          # Check if e2e: pending should keep waiting-on-author
           E2E_PENDING_LABEL=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
             --jq '[.[] | select(.name == "e2e: pending")] | length')
 
@@ -108,10 +110,21 @@ jobs:
             gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
           fi
 
+      - name: Handle check success (e2e pending)
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          IS_BOT: ${{ steps.author.outputs.is_bot }}
+        run: |
           # Add e2e: pending if /run-playwright hasn't been commented yet
           RUN_PW=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq '[.[] | select(.body | test("/run-playwright"))] | length')
           if [ "$RUN_PW" -eq 0 ]; then
             gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: pending"
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+            # Only add waiting-on-author for non-bot PRs
+            if [ "$IS_BOT" = "false" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+            fi
           fi

--- a/.github/workflows/pr-waiting-on-author-checks.yml
+++ b/.github/workflows/pr-waiting-on-author-checks.yml
@@ -1,0 +1,117 @@
+name: PR Waiting on Author (Checks)
+
+on:
+  workflow_run:
+    workflows:
+      - PR Checks
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-on-check-result:
+    name: Label on Check Result
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_number
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract PR number
+        id: pr
+        run: echo "number=$(head -n1 pr_number.txt | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Get PR author
+        id: author
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          echo "login=$AUTHOR" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+          gh label create "e2e: pending"      --repo "$REPO" --color "FBCA04" --description "E2E tests not yet triggered" --force 2>/dev/null || true
+
+      - name: Handle check failure
+        if: github.event.workflow_run.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          AUTHOR: ${{ steps.author.outputs.login }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          FAILED_JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join("\n")')
+
+          BODY="<!-- waiting-on-author-checks -->"$'\n'
+          BODY+="@${AUTHOR} — The following PR checks have failed:"$'\n'
+          while IFS= read -r job; do
+            [ -n "$job" ] && BODY+="- ❌ ${job}"$'\n'
+          done <<< "$FAILED_JOBS"
+          BODY+=$'\n'"Please address these failures."
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-checks -->")) | .id' | tail -1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+
+      - name: Handle check success
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          AUTHOR: ${{ steps.author.outputs.login }}
+        run: |
+          # Delete the checks failure comment if it exists
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-checks -->")) | .id' | tail -1)
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X DELETE
+          fi
+
+          # Only remove waiting-on-author if no other failure comments exist
+          SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+          CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
+
+          # Check if e2e: pending should keep waiting-on-author
+          E2E_PENDING_LABEL=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '[.[] | select(.name == "e2e: pending")] | length')
+
+          if [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING_LABEL" -eq 0 ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+          fi
+
+          # Add e2e: pending if /run-playwright hasn't been commented yet
+          RUN_PW=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | test("/run-playwright"))] | length')
+          if [ "$RUN_PW" -eq 0 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: pending"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+          fi

--- a/.github/workflows/pr-waiting-on-author-conflicts.yml
+++ b/.github/workflows/pr-waiting-on-author-conflicts.yml
@@ -14,7 +14,10 @@ permissions:
 jobs:
   check-single-pr:
     name: Check PR for Conflicts
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'red-hat-konflux[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Ensure labels exist
@@ -103,7 +106,7 @@ jobs:
           sleep 30
 
           gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
-            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number) \(.author.login)"' \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]" and .author.login != "red-hat-konflux[bot]" and .author.login != "app/red-hat-konflux") | "\(.number) \(.author.login)"' \
             | while read -r PR_NUMBER AUTHOR; do
                 STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
 

--- a/.github/workflows/pr-waiting-on-author-conflicts.yml
+++ b/.github/workflows/pr-waiting-on-author-conflicts.yml
@@ -1,0 +1,142 @@
+name: PR Waiting on Author (Conflicts)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  push:
+    branches: [main, devel]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  check-single-pr:
+    name: Check PR for Conflicts
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Wait for mergeable state
+        id: mergeable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          for i in 1 2 3 4 5; do
+            STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
+            if [ "$STATE" != "UNKNOWN" ]; then
+              echo "state=$STATE" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "state=UNKNOWN" >> "$GITHUB_OUTPUT"
+
+      - name: Handle conflicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          STATE: ${{ steps.mergeable.outputs.state }}
+        run: |
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->")) | .id' | tail -1)
+
+          if [ "$STATE" = "CONFLICTING" ]; then
+            BODY="<!-- waiting-on-author-conflicts -->"$'\n'
+            BODY+="@${AUTHOR} — This PR has merge conflicts with the base branch. Please rebase or merge to resolve them."
+
+            if [ -n "$EXISTING_ID" ]; then
+              gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body="$BODY"
+            else
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+            fi
+
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+          else
+            # No conflicts — clean up
+            if [ -n "$EXISTING_ID" ]; then
+              gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X DELETE
+            fi
+
+            # Only remove waiting-on-author if no other failure comments exist
+            CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '[.[] | select(.body | contains("<!-- waiting-on-author-checks -->"))] | length')
+            SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+            E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+              --jq '[.[] | select(.name == "e2e: pending")] | length')
+
+            if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+              gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+            fi
+          fi
+
+  check-all-prs:
+    name: Check All PRs for Conflicts
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Scan open PRs for conflicts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Give GitHub time to recompute mergeable states after the push
+          sleep 30
+
+          gh pr list --repo "$REPO" --state open --json number,author --limit 500 \
+            | jq -r '.[] | select(.author.login != "dependabot[bot]") | "\(.number) \(.author.login)"' \
+            | while read -r PR_NUMBER AUTHOR; do
+                STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq '.mergeable')
+
+                EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                  --jq '.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->")) | .id' | tail -1)
+
+                if [ "$STATE" = "CONFLICTING" ]; then
+                  BODY="<!-- waiting-on-author-conflicts -->"$'\n'
+                  BODY+="@${AUTHOR} — This PR has merge conflicts with the base branch. Please rebase or merge to resolve them."
+
+                  if [ -n "$EXISTING_ID" ]; then
+                    gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body="$BODY"
+                  else
+                    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+                  fi
+
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+                  echo "PR #$PR_NUMBER -> CONFLICTING"
+                else
+                  if [ -n "$EXISTING_ID" ]; then
+                    gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X DELETE
+
+                    CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                      --jq '[.[] | select(.body | contains("<!-- waiting-on-author-checks -->"))] | length')
+                    SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                      --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+                    E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+                      --jq '[.[] | select(.name == "e2e: pending")] | length')
+
+                    if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+                      gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+                    fi
+                  fi
+                  echo "PR #$PR_NUMBER -> OK"
+                fi
+              done

--- a/.github/workflows/pr-waiting-on-author-review.yml
+++ b/.github/workflows/pr-waiting-on-author-review.yml
@@ -1,0 +1,59 @@
+name: PR Waiting on Author (Review)
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-on-review:
+    name: Label on Review
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'red-hat-konflux[bot]'
+    steps:
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Handle changes requested
+        if: github.event.review.state == 'changes_requested'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+
+      - name: Handle approval
+        if: github.event.review.state == 'approved'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Check if any other reviewer still has changes_requested
+          PENDING_CHANGES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | map(.user.login) | unique | length')
+
+          # Also check for other waiting-on-author reasons
+          CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-checks -->"))] | length')
+          SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+          CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
+          E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '[.[] | select(.name == "e2e: pending")] | length')
+
+          if [ "$PENDING_CHANGES" -eq 0 ] && [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+          fi

--- a/.github/workflows/pr-waiting-on-author-sonar.yml
+++ b/.github/workflows/pr-waiting-on-author-sonar.yml
@@ -34,6 +34,12 @@ jobs:
         run: |
           AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
 
+          # Skip waiting-on-author for bot PRs
+          if [[ "$AUTHOR" == "dependabot[bot]" || "$AUTHOR" == "app/red-hat-konflux" || "$AUTHOR" == "red-hat-konflux[bot]" ]]; then
+            echo "Skipping — bot PR (author: $AUTHOR)"
+            exit 0
+          fi
+
           GATE_PASSED=$(echo "$COMMENT_BODY" | grep -ci 'Quality Gate passed' || true)
 
           if [ "$GATE_PASSED" -ge 1 ]; then

--- a/.github/workflows/pr-waiting-on-author-sonar.yml
+++ b/.github/workflows/pr-waiting-on-author-sonar.yml
@@ -1,0 +1,72 @@
+name: PR Waiting on Author (SonarQube)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-on-sonar-failure:
+    name: Label on SonarQube Failure
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.pull_request
+      && (github.event.comment.user.login == 'sonarqubecloud[bot]'
+          || github.event.comment.user.login == 'sonarcloud[bot]')
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Check quality gate and label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+
+          GATE_PASSED=$(echo "$COMMENT_BODY" | grep -ci 'Quality Gate passed' || true)
+
+          if [ "$GATE_PASSED" -ge 1 ]; then
+            # Quality gate passed — delete any existing sonar comment
+            EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '.[] | select(.body | contains("<!-- waiting-on-author-sonar -->")) | .id' | tail -1)
+            if [ -n "$EXISTING_ID" ]; then
+              gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X DELETE
+            fi
+            exit 0
+          fi
+
+          # Quality gate failed — extract details from the comment
+          NEW_ISSUES=$(echo "$COMMENT_BODY" | grep -oP '\d+(?=\s+New issue)' || echo "unknown")
+          HOTSPOTS=$(echo "$COMMENT_BODY" | grep -oP '\d+(?=\s+Security Hotspot)' || echo "unknown")
+          COVERAGE=$(echo "$COMMENT_BODY" | grep -oP '[\d.]+%(?=\s+Coverage)' || echo "unknown")
+          DUPLICATION=$(echo "$COMMENT_BODY" | grep -oP '[\d.]+%(?=\s+Duplication)' || echo "unknown")
+
+          BODY="<!-- waiting-on-author-sonar -->"$'\n'
+          BODY+="@${AUTHOR} — SonarQube Quality Gate failed:"$'\n'
+          [ "$NEW_ISSUES" != "unknown" ]  && BODY+="- New issues: ${NEW_ISSUES}"$'\n'
+          [ "$HOTSPOTS" != "unknown" ]    && BODY+="- Security Hotspots: ${HOTSPOTS}"$'\n'
+          [ "$COVERAGE" != "unknown" ]    && BODY+="- Coverage on New Code: ${COVERAGE}"$'\n'
+          [ "$DUPLICATION" != "unknown" ] && BODY+="- Duplication on New Code: ${DUPLICATION}"$'\n'
+          BODY+=$'\n'"Please address the SonarQube findings."
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-sonar -->")) | .id' | tail -1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"


### PR DESCRIPTION
## Summary

Add automated PR lifecycle labels and comments to help reviewers quickly identify PR readiness from the list view:

- **`waiting-on-author`** label + comment when PR checks fail (lists the specific failed jobs), SonarQube Quality Gate fails (lists findings), merge conflicts are detected, or a reviewer requests changes
- **`e2e: pending`** → **`e2e: running`** → **`e2e: done`** labels tracking the Playwright E2E test lifecycle based on `/run-playwright` comments and Currents dashboard bot comments
- Bot PRs (dependabot, red-hat-konflux) skip `waiting-on-author` but still receive e2e lifecycle labels
- **Backfill support** via the `status` option in the existing `pr-label-backfill.yml` workflow to retroactively label all open PRs

### Workflow details

| Workflow | Trigger | Label(s) | Comment |
|----------|---------|----------|---------|
| `pr-waiting-on-author-checks.yml` | `workflow_run` on "PR Checks" completed | `waiting-on-author` on failure, `e2e: pending` on success | Tags author with list of failed checks; deleted on success |
| `pr-waiting-on-author-sonar.yml` | `issue_comment` from `sonarqubecloud[bot]` | `waiting-on-author` on Quality Gate failure | Tags author with SonarQube findings summary; deleted on pass |
| `pr-waiting-on-author-conflicts.yml` | `pull_request_target` + `push` to main/devel | `waiting-on-author` on merge conflicts | Tags author to rebase; deleted when resolved |
| `pr-waiting-on-author-review.yml` | `pull_request_review` submitted | `waiting-on-author` on changes requested; removed on approval | No comment — label-only |
| `pr-e2e-status.yml` | `issue_comment` (`/run-playwright` or Currents bot) | `e2e: running` / `e2e: done` | No comment — label-only |
| `pr-label-backfill.yml` | `workflow_dispatch` (manual, option: `status`) | All of the above | Retroactively labels all open PRs based on current state |

### Comment behavior

- Comments use hidden HTML markers (`<!-- waiting-on-author-checks -->`, etc.) for reliable upsert/delete
- First failure posts a comment; subsequent failures update it in place (no spam)
- When the issue is resolved, the comment is deleted entirely
- `waiting-on-author` is only removed when ALL reasons are cleared (checks, sonar, conflicts, changes requested, e2e: pending)

### Backfill

Run the backfill workflow with the `status` option to retroactively label all open PRs. For each PR it checks:
- Current check suite results and merge conflicts → `waiting-on-author`
- Latest SonarQube bot comment → `waiting-on-author` if Quality Gate failed
- Outstanding `changes_requested` reviews → `waiting-on-author`
- `/run-playwright` and Currents dashboard comments → `e2e: pending` / `e2e: running` / `e2e: done`

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

- Depends on #3351 (`ci/pr-type-label`) for the base type labeling commit

## Testing

### Manual Testing

**Check failure flow:**
1. Open a PR with a failing check (e.g., lint error) → verify `waiting-on-author` label and comment listing the failed job(s)
2. Push a fix → verify comment is updated in place (not duplicated)
3. All checks pass → verify comment is deleted and label is removed

**SonarQube flow:**
4. PR with Quality Gate failure → verify `waiting-on-author` label and comment with findings
5. PR with Quality Gate passed → verify no label added, any prior sonar comment is deleted

**Conflict detection:**
6. Create a PR that conflicts with the base branch → verify `waiting-on-author` label and conflict comment
7. Rebase to resolve → verify comment deleted and label removed (if no other issues)
8. Merge to main/devel → verify all open PRs are scanned for new conflicts

**Review changes requested:**
9. Submit a review requesting changes → verify `waiting-on-author` label added
10. Submit an approving review → verify label removed (if no other issues remain)
11. One reviewer approves while another still has changes requested → verify label stays

**E2E lifecycle:**
12. PR checks pass without `/run-playwright` → verify `e2e: pending` + `waiting-on-author` labels
13. Comment `/run-playwright` → verify `e2e: pending` removed, `e2e: running` added
14. `aap-pde-ci-bot` posts Currents dashboard → verify `e2e: running` removed, `e2e: done` added

**Bot PRs:**
15. Dependabot/konflux PR with failing checks → verify NO `waiting-on-author` label or comment
16. Bot PR with passing checks → verify `e2e: pending` label IS added (without `waiting-on-author`)

**Backfill:**
17. Run backfill workflow with `status` option → verify all open PRs get correct labels based on current state (including outstanding changes_requested reviews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)