### PR TITLE
[AAP-74856] XLAB Add missing chart hover and tooltip interactions

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -199,6 +199,7 @@ export function AutomationDashboard() {
                 variant={'lineChart'}
                 error={view.detailsError}
                 errorStateTitle={t('Error loading host chart')}
+                legendLabel={t('Hosts')}
               ></DashboardChartCard>
               <DashboardChartCard
                 id="job-chart-card"
@@ -211,6 +212,7 @@ export function AutomationDashboard() {
                 data={details?.job_chart ?? { kind: 'day', items: [] }}
                 errorStateTitle={t('Error loading job chart')}
                 error={view.detailsError}
+                legendLabel={t('Job runs')}
               ></DashboardChartCard>
             </Grid>
           </GridItem>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.test.tsx
@@ -13,7 +13,7 @@ const defaultProps: DashboardChartCardProps = {
   errorStateTitle: 'Chart Error',
 };
 
-const expectedFormatted = (12345).toLocaleString();
+const expectedFormatted = (12345).toLocaleString('en-US');
 
 describe('DashboardChartCard', () => {
   test('should render summary value in locale format', () => {
@@ -92,5 +92,21 @@ describe('DashboardChartCard', () => {
   test('should render lineChart variant', () => {
     render(<DashboardChartCard {...defaultProps} variant="lineChart" />);
     expect(screen.getByText(expectedFormatted)).toBeInTheDocument();
+  });
+
+  test('should render "Count" legend label for chart data', () => {
+    render(<DashboardChartCard {...defaultProps} />);
+    expect(screen.getByText('Count')).toBeInTheDocument();
+  });
+
+  test('should not render "Count" legend label when error is provided', () => {
+    render(<DashboardChartCard {...defaultProps} error={new Error('Chart failed')} />);
+    expect(screen.queryByText('Count')).not.toBeInTheDocument();
+  });
+
+  test('should render custom legendLabel instead of default "Count" when provided', () => {
+    render(<DashboardChartCard {...defaultProps} legendLabel="Hosts" />);
+    expect(screen.getByText('Hosts')).toBeInTheDocument();
+    expect(screen.queryByText('Count')).not.toBeInTheDocument();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
@@ -2,9 +2,12 @@ import { PageDashboardCard, PageDashboardChart } from '@ansible/ansible-ui-frame
 import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import { DashboardChartCardProps, IDashboardChartItem } from '../types';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
+import { useTranslation } from 'react-i18next';
 
 export function DashboardChartCard(props: DashboardChartCardProps) {
-  const { id, title, help, summaryValue, data, variant, error, errorStateTitle } = props;
+  const { id, title, help, summaryValue, data, variant, error, errorStateTitle, legendLabel } =
+    props;
+  const { t } = useTranslation();
   const blueColor = 'var(--pf-t--chart--color--blue--300)';
   const mapChartItem = (
     chartItem: IDashboardChartItem,
@@ -36,19 +39,19 @@ export function DashboardChartCard(props: DashboardChartCardProps) {
     const value = chartItem.value;
     return { label, value };
   };
-
+  const usFormat = 'en-US';
   const values = data?.items?.map((item, index, array) => mapChartItem(item, index, array)) ?? [];
   const content = (
     <Flex direction={{ default: 'row' }} style={{ height: '100%' }}>
       <FlexItem>
         <Title headingLevel="h2" style={{ fontSize: 'xxx-large', lineHeight: 1, fontWeight: 400 }}>
-          {summaryValue || summaryValue === 0 ? summaryValue.toLocaleString() : '--'}
+          {summaryValue || summaryValue === 0 ? summaryValue.toLocaleString(usFormat) : '--'}
         </Title>
       </FlexItem>
 
       <FlexItem style={{ height: '90%', width: '100%' }}>
         <PageDashboardChart
-          groups={[{ color: blueColor, values: values ?? [] }]}
+          groups={[{ label: legendLabel ?? t('Count'), color: blueColor, values: values ?? [] }]}
           variant={variant}
           allowZero
           onlyIntegerTicks

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -124,6 +124,8 @@ export type DashboardChartCardProps = DashboardCommonCardProps & {
   variant: 'barChart' | 'lineChart';
   summaryValue?: number;
   data: IDashboardChart;
+  /** Label shown in the chart legend for the data series. Defaults to a generic "Count" label. */
+  legendLabel?: string;
 };
 
 export type DashboardTableInputFieldProps = {


### PR DESCRIPTION
## Summary
AAP-74856 Add missing chart hover and tooltip interactions
<!-- What changed and why? -->
This pull request enhances the `DashboardChartCard` component to support customizable legend labels and ensures consistent number formatting. It also adds comprehensive tests for the new legend label behavior.

**DashboardChartCard legend label improvements:**

* Added a new `legendLabel` prop to `DashboardChartCard` (and its type definition), allowing consumers to specify a custom label for the chart legend; defaults to "Count" if not provided. [[1]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbR127-R128) [[2]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454R5-R10) [[3]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454L39-R54)
* Updated the Automation Dashboard to pass context-specific legend labels ("Hosts" and "Job runs") to the relevant charts. [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R202) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R215)

**Number formatting consistency:**

* Standardized number formatting in both the component and its tests to use the 'en-US' locale for consistency. [[1]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454L39-R54) [[2]](diffhunk://#diff-b808d284187b39b5c33276db0a8b4731c17d37b641363bed566a23fd6d35b075L16-R16)

**Testing improvements:**

* Added tests to verify that the default legend label ("Count") is shown, that it is not shown when there is an error, and that a custom legend label is rendered when provided.
## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="1244" height="932" alt="image" src="https://github.com/user-attachments/assets/e9037b6b-2e5d-463e-962e-22fe3ec78570" />

<img width="868" height="946" alt="image" src="https://github.com/user-attachments/assets/9080eca0-d114-4ce4-bbec-2e7b1cae4263" />

