### PR TITLE
XLAB Automation Dashboard: Hourly rate capped at 1000

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.tsx
@@ -120,7 +120,7 @@ export function DashboardTableToolbarRow(props: DashboardTableToolbarProps) {
             id="engineer_avg_hourly_rate"
             value={costState?.engineer_avg_hourly_rate}
             min={1}
-            max={1000000}
+            max={1000}
             onChange={(value) => {
               void toolbarChangeHandler(value, 'engineer_avg_hourly_rate');
             }}


### PR DESCRIPTION
## Summary
AAP-82306 Automation Dashboard: Hourly rate field accepts unreasonably large values — should be capped at $1,000
<!-- What changed and why? -->
This pull request makes a small adjustment to the `DashboardTableToolbarRow` component by lowering the maximum allowed value for the `engineer_avg_hourly_rate` input from 1,000,000 to 1,000. This change helps ensure more reasonable input values for this field.
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="970" height="648" alt="image" src="https://github.com/user-attachments/assets/9fc3d735-65fc-46c5-baae-11f962b311cd" />
