### PR TITLE
fix(awx): add WS throttle to Workflow Approvals list (AAP-78140)

### DIFF
--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovals.test.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovals.test.tsx
@@ -1,10 +1,22 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { WorkflowApprovals } from './WorkflowApprovals';
+
+let capturedOnMessage: ((message: unknown) => void) | undefined;
+
+vi.mock('../../common/useAwxWebSocket', () => ({
+  useAwxWebSocketSubscription: (
+    _events: Record<string, string[]>,
+    onMessage: (message: unknown) => void
+  ) => {
+    capturedOnMessage = onMessage;
+    return { sendMessage: vi.fn(), lastMessage: null, readyState: 1 };
+  },
+}));
 
 const mockWorkflowApprovals = {
   count: 2,
@@ -48,7 +60,10 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  capturedOnMessage = undefined;
+});
 afterAll(() => server.close());
 
 describe('WorkflowApprovals', () => {
@@ -75,5 +90,116 @@ describe('WorkflowApprovals', () => {
       expect(screen.getByText('Test Approval 1')).toBeInTheDocument();
       expect(screen.getByText('Test Approval 2')).toBeInTheDocument();
     });
+  });
+});
+
+describe('WorkflowApprovals WebSocket handler', () => {
+  async function renderAndWait() {
+    render(
+      <MemoryRouter>
+        <WorkflowApprovals />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Test Approval 1')).toBeInTheDocument();
+    });
+    expect(capturedOnMessage).toBeDefined();
+  }
+
+  it('should trigger refresh on workflow_approval WS message', async () => {
+    let fetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/workflow_approvals/') && request.method === 'GET') {
+        fetchCount++;
+      }
+    });
+
+    await renderAndWait();
+    const initialFetchCount = fetchCount;
+
+    act(() => {
+      capturedOnMessage!({ group_name: 'jobs', type: 'workflow_approval' });
+    });
+
+    await waitFor(() => {
+      expect(fetchCount).toBeGreaterThan(initialFetchCount);
+    });
+
+    server.events.removeAllListeners();
+  });
+
+  it('should ignore WS messages with non-matching type', async () => {
+    let fetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/workflow_approvals/') && request.method === 'GET') {
+        fetchCount++;
+      }
+    });
+
+    await renderAndWait();
+    const initialFetchCount = fetchCount;
+
+    act(() => {
+      capturedOnMessage!({ group_name: 'jobs', type: 'job' });
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(fetchCount).toBe(initialFetchCount);
+    server.events.removeAllListeners();
+  });
+
+  it('should ignore WS messages with non-matching group_name', async () => {
+    let fetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/workflow_approvals/') && request.method === 'GET') {
+        fetchCount++;
+      }
+    });
+
+    await renderAndWait();
+    const initialFetchCount = fetchCount;
+
+    act(() => {
+      capturedOnMessage!({ group_name: 'inventories', type: 'workflow_approval' });
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(fetchCount).toBe(initialFetchCount);
+    server.events.removeAllListeners();
+  });
+
+  it('should throttle multiple rapid WS messages to a single immediate refresh', async () => {
+    let fetchCount = 0;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/workflow_approvals/') && request.method === 'GET') {
+        fetchCount++;
+      }
+    });
+
+    await renderAndWait();
+    const initialFetchCount = fetchCount;
+
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        capturedOnMessage!({ group_name: 'jobs', type: 'workflow_approval' });
+      }
+    });
+
+    // Leading edge fires 1 call synchronously; the other 9 are coalesced
+    await waitFor(() => {
+      expect(fetchCount).toBe(initialFetchCount + 1);
+    });
+
+    // Wait a short time — still no additional calls within the throttle window
+    await new Promise((r) => setTimeout(r, 200));
+    expect(fetchCount).toBe(initialFetchCount + 1);
+
+    server.events.removeAllListeners();
   });
 });

--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovals.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovals.tsx
@@ -1,12 +1,13 @@
 import { PageHeader, PageLayout, PageTable } from '@ansible/ansible-ui-framework';
 import { usePersistentFilters } from '@ansible/common-ui/PersistentFilters';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityStreamIcon } from '../../common/ActivityStreamIcon';
 import { awxAPI } from '../../common/api/awx-utils';
 import { useAwxConfig } from '../../common/useAwxConfig';
 import { useAwxView } from '../../common/useAwxView';
 import { useAwxWebSocketSubscription } from '../../common/useAwxWebSocket';
+import { createThrottle } from '../../common/util/createThrottle';
 import { useGetDocsUrl } from '@ansible/common-ui/utils/useGetDocsUrl';
 import { WorkflowApproval } from '../../interfaces/WorkflowApproval';
 import { useWorkflowApprovalToolbarActions } from './hooks/useWorkflowApprovalToolbarActions';
@@ -30,19 +31,28 @@ export function WorkflowApprovals() {
   const config = useAwxConfig();
 
   const { refresh } = view;
+  const throttledRefresh = useMemo(
+    () =>
+      createThrottle(() => {
+        refresh().catch(() => {});
+      }, 5000),
+    [refresh]
+  );
+  useEffect(() => () => throttledRefresh.cancel(), [throttledRefresh]);
+
   const handleWebSocketMessage = useCallback(
     (message?: { group_name?: string; type?: string }) => {
       switch (message?.group_name) {
         case 'jobs':
           switch (message?.type) {
             case 'workflow_approval':
-              void refresh();
+              throttledRefresh();
               break;
           }
           break;
       }
     },
-    [refresh]
+    [throttledRefresh]
   );
 
   useAwxWebSocketSubscription(


### PR DESCRIPTION
## Summary

Adds `createThrottle` (5-second window) to the Workflow Approvals WebSocket handler, consistent with the existing Jobs list pattern. Previously, `WorkflowApprovals.tsx` called `refresh()` directly on every WS message with no throttle, which could cause request pileup under heavy approval traffic.

- Leading edge fires immediately so the UI reflects changes without delay
- Rapid subsequent messages within the 5s window are coalesced into a single trailing call
- Timer is cleaned up on component unmount

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Navigate to Workflow Approvals list
2. Trigger multiple workflow approvals rapidly
3. Verify the list refreshes without request pileup — the UI updates promptly on the first event, then coalesces subsequent rapid events

### Vitest

6 tests passing (2 existing + 4 new WebSocket handler tests):
- `should trigger refresh on workflow_approval WS message`
- `should ignore WS messages with non-matching type`
- `should ignore WS messages with non-matching group_name`
- `should throttle multiple rapid WS messages to a single immediate refresh`


Made with [Cursor](https://cursor.com)