### PR TITLE
Fix version dropdown ordering on collection detail page (AAP-78435)

### DIFF
--- a/framework/PageInputs/PageAsyncSingleSelect.test.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.test.tsx
@@ -120,4 +120,184 @@ describe('PageAsyncSingleSelect', () => {
       expect(screen.getByRole('button', { name: 'Option 11' })).toBeInTheDocument();
     });
   });
+
+  it('should sort options alphabetically by default', async () => {
+    const user = userEvent.setup();
+    const unsortedQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [
+          { value: 3, label: 'Zebra' },
+          { value: 1, label: 'Apple' },
+          { value: 2, label: 'Mango' },
+        ],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} />);
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Apple');
+    expect(options[1]).toHaveTextContent('Mango');
+    expect(options[2]).toHaveTextContent('Zebra');
+  });
+
+  it('should preserve original order when disableSortOptions is true', async () => {
+    const user = userEvent.setup();
+    const unsortedQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [
+          { value: 3, label: 'Zebra' },
+          { value: 1, label: 'Apple' },
+          { value: 2, label: 'Mango' },
+        ],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} disableSortOptions />);
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Zebra')).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Zebra');
+    expect(options[1]).toHaveTextContent('Apple');
+    expect(options[2]).toHaveTextContent('Mango');
+  });
+
+  it('should sort options when disableSortOptions is false', async () => {
+    const user = userEvent.setup();
+    const unsortedQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [
+          { value: 3, label: 'Zebra' },
+          { value: 1, label: 'Apple' },
+          { value: 2, label: 'Mango' },
+        ],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} disableSortOptions={false} />);
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Apple');
+    expect(options[1]).toHaveTextContent('Mango');
+    expect(options[2]).toHaveTextContent('Zebra');
+  });
+
+  it('should deduplicate options while preserving order when disableSortOptions is true', async () => {
+    const user = userEvent.setup();
+    const duplicateQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [
+          { value: 1, label: 'First' },
+          { value: 2, label: 'Second' },
+          { value: 1, label: 'First Duplicate' },
+          { value: 3, label: 'Third' },
+        ],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={duplicateQuery} disableSortOptions />);
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('First')).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent('First');
+    expect(options[1]).toHaveTextContent('Second');
+    expect(options[2]).toHaveTextContent('Third');
+  });
+
+  it('should auto-select the only option when remaining is 0 and disableSortOptions is true', async () => {
+    const user = userEvent.setup();
+    const singleOptionQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [{ value: 42, label: 'Only Option' }],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={singleOptionQuery} disableSortOptions />);
+
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Only Option' })).toBeInTheDocument();
+    });
+  });
+
+  it('should pass disableSortOptions prop to the underlying PageSingleSelect', async () => {
+    const user = userEvent.setup();
+    const unsortedQuery = (): Promise<{
+      options: { value: number; label: string }[];
+      remaining: number;
+      next: number;
+    }> =>
+      Promise.resolve({
+        options: [
+          { value: 1, label: 'Charlie' },
+          { value: 2, label: 'Alpha' },
+          { value: 3, label: 'Bravo' },
+        ],
+        remaining: 0,
+        next: 2,
+      });
+
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} disableSortOptions />);
+    await user.click(screen.getByRole('button', { name: 'Select value' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Charlie');
+    expect(options[1]).toHaveTextContent('Alpha');
+    expect(options[2]).toHaveTextContent('Bravo');
+
+    await user.click(screen.getByText('Alpha'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Alpha' })).toBeInTheDocument();
+    });
+  });
 });

--- a/framework/PageInputs/PageAsyncSingleSelect.test.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.test.tsx
@@ -60,6 +60,21 @@ function PageAsyncSingleSelectTest(
   );
 }
 
+const unsortedOptionsQuery = (): Promise<{
+  options: { value: number; label: string }[];
+  remaining: number;
+  next: number;
+}> =>
+  Promise.resolve({
+    options: [
+      { value: 3, label: 'Zebra' },
+      { value: 1, label: 'Apple' },
+      { value: 2, label: 'Mango' },
+    ],
+    remaining: 0,
+    next: 2,
+  });
+
 describe('PageAsyncSingleSelect', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -123,22 +138,8 @@ describe('PageAsyncSingleSelect', () => {
 
   it('should sort options alphabetically by default', async () => {
     const user = userEvent.setup();
-    const unsortedQuery = (): Promise<{
-      options: { value: number; label: string }[];
-      remaining: number;
-      next: number;
-    }> =>
-      Promise.resolve({
-        options: [
-          { value: 3, label: 'Zebra' },
-          { value: 1, label: 'Apple' },
-          { value: 2, label: 'Mango' },
-        ],
-        remaining: 0,
-        next: 2,
-      });
 
-    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} />);
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedOptionsQuery} />);
     await user.click(screen.getByRole('button', { name: 'Select value' }));
 
     await waitFor(() => {
@@ -153,22 +154,8 @@ describe('PageAsyncSingleSelect', () => {
 
   it('should preserve original order when disableSortOptions is true', async () => {
     const user = userEvent.setup();
-    const unsortedQuery = (): Promise<{
-      options: { value: number; label: string }[];
-      remaining: number;
-      next: number;
-    }> =>
-      Promise.resolve({
-        options: [
-          { value: 3, label: 'Zebra' },
-          { value: 1, label: 'Apple' },
-          { value: 2, label: 'Mango' },
-        ],
-        remaining: 0,
-        next: 2,
-      });
 
-    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} disableSortOptions />);
+    render(<PageAsyncSingleSelectTest queryOptions={unsortedOptionsQuery} disableSortOptions />);
     await user.click(screen.getByRole('button', { name: 'Select value' }));
 
     await waitFor(() => {
@@ -183,22 +170,10 @@ describe('PageAsyncSingleSelect', () => {
 
   it('should sort options when disableSortOptions is false', async () => {
     const user = userEvent.setup();
-    const unsortedQuery = (): Promise<{
-      options: { value: number; label: string }[];
-      remaining: number;
-      next: number;
-    }> =>
-      Promise.resolve({
-        options: [
-          { value: 3, label: 'Zebra' },
-          { value: 1, label: 'Apple' },
-          { value: 2, label: 'Mango' },
-        ],
-        remaining: 0,
-        next: 2,
-      });
 
-    render(<PageAsyncSingleSelectTest queryOptions={unsortedQuery} disableSortOptions={false} />);
+    render(
+      <PageAsyncSingleSelectTest queryOptions={unsortedOptionsQuery} disableSortOptions={false} />
+    );
     await user.click(screen.getByRole('button', { name: 'Select value' }));
 
     await waitFor(() => {

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -110,13 +110,15 @@ export function PageAsyncSingleSelect<
               uniqueValues.add(option.value);
               return true;
             });
-            newOptions.sort((a, b) => {
-              const lhs = a.label.toLowerCase();
-              const rhs = b.label.toLowerCase();
-              if (lhs < rhs) return -1;
-              if (lhs > rhs) return 1;
-              return 0;
-            });
+            if (!props.disableSortOptions) {
+              newOptions.sort((a, b) => {
+                const lhs = a.label.toLowerCase();
+                const rhs = b.label.toLowerCase();
+                if (lhs < rhs) return -1;
+                if (lhs > rhs) return 1;
+                return 0;
+              });
+            }
             if (!searchValue && result.remaining === 0 && newOptions.length === 1) {
               // Defer onSelect to avoid setState during render
               setTimeout(() => onSelect(newOptions[0].value), 0);
@@ -243,6 +245,7 @@ export function PageAsyncSingleSelect<
       isLoading={loading}
       queryLabel={props.queryLabel}
       disableAutoSelect
+      disableSortOptions={props.disableSortOptions}
       isRequired={props.isRequired}
       toggle={
         loadingError

--- a/framework/PageInputs/PageAsyncSingleSelect.tsx
+++ b/framework/PageInputs/PageAsyncSingleSelect.tsx
@@ -141,7 +141,7 @@ export function PageAsyncSingleSelect<
       return true;
     });
     return () => abortController.abort();
-  }, [onSelect, queryOptions, searchValue, t, writeInOption]);
+  }, [onSelect, props.disableSortOptions, queryOptions, searchValue, t, writeInOption]);
 
   const onLoadMore = useCallback(
     (e: React.MouseEvent) => {

--- a/frontend/hub/collections/CollectionPage/CollectionPage.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.test.tsx
@@ -212,6 +212,55 @@ describe('CollectionPage', () => {
     });
   });
 
+  test('should request versions sorted by descending version order', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.get(
+        ({ request }) => {
+          return request.url.includes('/v3/plugin/ansible/search/collection-versions/');
+        },
+        ({ request }) => {
+          capturedUrls.push(request.url);
+          return HttpResponse.json(mockCollectionResponse);
+        }
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/collections/published/testnamespace/testcollection']}>
+        <CollectionPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'testnamespace.testcollection' })
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const versionListUrl = capturedUrls.find((url) => url.includes('order_by=-version'));
+      expect(versionListUrl).toBeDefined();
+    });
+  });
+
+  test('should render version selector with disableSortOptions', async () => {
+    render(
+      <MemoryRouter initialEntries={['/collections/published/testnamespace/testcollection']}>
+        <CollectionPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'testnamespace.testcollection' })
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('version-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('browse-collection-version')).toBeInTheDocument();
+  });
+
   test('should handle API error in getCollectionData and set collection to null', async () => {
     server.use(
       http.get(

--- a/frontend/hub/collections/CollectionPage/CollectionPage.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionPage.tsx
@@ -176,7 +176,7 @@ export function CollectionPage() {
   }
 
   const { data: versions } = useGet<HubItemsResponse<CollectionVersionSearch>>(
-    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}`,
+    hubAPI`/v3/plugin/ansible/search/collection-versions/?name=${name}&namespace=${namespace}&repository_name=${repository}&order_by=-version`,
     undefined,
     { refreshInterval: 1000 }
   );
@@ -350,6 +350,7 @@ export function CollectionPage() {
             <PageAsyncSingleSelect<Partial<CollectionVersionSearch>>
               id="version-selector"
               isRequired
+              disableSortOptions
               queryOptions={queryOptions}
               onSelect={(value) => {
                 setCollection(value);


### PR DESCRIPTION
Fixes AAP-78435. The version dropdown on the collection detail page sorts versions as strings (4.7.10 before 4.7.5) due to two issues:

1. The initial version list fetch doesn't pass order_by=-version (the pagination "Load more" call does, but the first load doesn't)
2. PageAsyncSingleSelect alphabetically sorts all loaded options, and the disableSortOptions prop was never passed through to PageSingleSelect

Changes:
- Add order_by=-version to the initial fetch
- Add disableSortOptions to the version dropdown
- Fix disableSortOptions prop passthrough in PageAsyncSingleSelect

Companion backend fix: https://github.com/ansible-automation-platform/galaxy_ng/pull/644

Tested on AAP 2.6-next using aap-dev.

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.