### PR TITLE
fix(awx): stop unnecessary API polling in JobStatusBar (AAP-78171)

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { SWRConfiguration } from 'swr';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -55,7 +55,7 @@ describe('JobStatusBar polling', () => {
     mockUseGet.mockClear();
   });
 
-  it('should stop polling when job is finished', () => {
+  it('should pass undefined URL when job is finished', () => {
     const finishedJob = {
       ...baseJob,
       status: 'successful',
@@ -65,16 +65,10 @@ describe('JobStatusBar polling', () => {
 
     renderJobStatusBar(finishedJob);
 
-    const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
-      refreshInterval: (data: AwxItemsResponse<JobEvent>) => number;
-    };
-
-    expect(swrConfig.refreshInterval({ count: 0, results: [] } as AwxItemsResponse<JobEvent>)).toBe(
-      0
-    );
+    expect(mockUseGet.mock.calls[0][0]).toBeUndefined();
   });
 
-  it('should poll at 5000ms when job is running and playbook has not started', () => {
+  it('should poll at 5000ms when playbook job is running and playbook has not started', () => {
     const runningJob = {
       ...baseJob,
       status: 'running',
@@ -82,6 +76,8 @@ describe('JobStatusBar polling', () => {
     } as unknown as Job;
 
     renderJobStatusBar(runningJob);
+
+    expect(mockUseGet.mock.calls[0][0]).toContain('/jobs/1/job_events/');
 
     const swrConfig = mockUseGet.mock.calls[0][2] as unknown as {
       refreshInterval: (data: AwxItemsResponse<JobEvent>) => number;
@@ -111,5 +107,43 @@ describe('JobStatusBar polling', () => {
     } as AwxItemsResponse<JobEvent>;
 
     expect(swrConfig.refreshInterval(eventData)).toBe(0);
+  });
+
+  it('should pass undefined URL for non-playbook job types', () => {
+    const projectUpdateJob = {
+      ...baseJob,
+      type: 'project_update',
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(projectUpdateJob);
+
+    expect(mockUseGet.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it('should not show waiting label for non-playbook job types', () => {
+    const inventoryUpdateJob = {
+      ...baseJob,
+      type: 'inventory_update',
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(inventoryUpdateJob);
+
+    expect(screen.queryByTestId('waiting-label')).not.toBeInTheDocument();
+  });
+
+  it('should show waiting label for running playbook jobs before playbook starts', () => {
+    const runningJob = {
+      ...baseJob,
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(runningJob);
+
+    expect(screen.getByTestId('waiting-label')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
@@ -45,25 +45,21 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
   const [activeJobElapsedTime, setActiveJobElapsedTime] = useState('00:00:00');
   const [playbookStarted, setPlaybookStarted] = useState(false);
 
-  const eventsSlug = job.type === 'job' ? 'job_events' : 'events';
+  const isPlaybookJob = job.type === 'job';
+  const shouldPoll = isPlaybookJob && !playbookStarted && !job.finished;
 
-  const jobFinished = job.finished;
-  const refreshInterval = useCallback(
-    (latestData: AwxItemsResponse<JobEvent>) => {
-      if (jobFinished) return 0;
-      if (latestData?.results.length) {
-        const latestEvent = latestData.results[0];
-        if (latestEvent.event === 'playbook_on_start') {
-          return 0;
-        }
+  const refreshInterval = useCallback((latestData: AwxItemsResponse<JobEvent>) => {
+    if (latestData?.results.length) {
+      const latestEvent = latestData.results[0];
+      if (latestEvent.event === 'playbook_on_start') {
+        return 0;
       }
-      return 5000;
-    },
-    [jobFinished]
-  );
+    }
+    return 5000;
+  }, []);
 
   const { data: jobEvents } = useGet<AwxItemsResponse<JobEvent>>(
-    awxAPI`/${job.type}s/${job.id.toString()}/${eventsSlug}/`,
+    shouldPoll ? awxAPI`/jobs/${job.id.toString()}/job_events/` : undefined,
     {
       page_size: 1,
       counter: 1,
@@ -132,7 +128,7 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
             <h1>{job.name}</h1>
             <StatusCell status={job.status} />
           </HeaderTitle>
-          {!playbookStarted && job?.status === 'running' && (
+          {isPlaybookJob && !playbookStarted && job?.status === 'running' && (
             <Tooltip
               content={t(
                 'Setting up the job now. This involves retrieving the execution environment image' +


### PR DESCRIPTION
## Summary

`JobStatusBar` polled for `playbook_on_start` every 5 seconds even after the event was detected, and for non-playbook job types (project updates, inventory updates, etc.) that never emit it. Fixed by:

- Passing `undefined` URL to `useGet` once `playbookStarted` is true or the job is finished, fully disabling the SWR hook
- Skipping polling entirely for non-playbook job types (`project_update`, `inventory_update`, `workflow_job`, etc.)
- Gating the "Waiting to execute playbook" label to playbook job types only

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Launch a playbook job — the "Running initial setup" label should appear briefly, then disappear once the playbook starts. API polling for `playbook_on_start` should stop after detection.
2. View a project update, inventory update, or workflow job — the "Waiting to execute playbook" label should NOT appear, and no polling for `playbook_on_start` should occur.
3. View a finished job — no polling should occur at all.

### Vitest

10 tests passing (3 updated + 3 new polling/label tests in `JobStatusBar.test.tsx`, 4 existing in `JobOutput.test.tsx`).


Made with [Cursor](https://cursor.com)