### PR TITLE
fix: bump aap-ui-e2e pipeline bundle to fix clone-repo task

### DIFF
--- a/.tekton/aap-ui-e2e.yaml
+++ b/.tekton/aap-ui-e2e.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:434a81bd0d55a63923b7d916b2640aa6fd3766916d835ef4d2bd0f31ac66bc8d
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:89a4d806d3c5e2aee3eb6207b5abf6e3dd602f0e2685386ea4af9dd61e1e06bf
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->
This PR bumps the tekton pipeline bundle to address the failures with the `clone-repository` task.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

Fixes CI pipelines failing to clone the repository.

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.