### PR TITLE
SonarCloud Fix: Resolve reliability and accessibility issues (S6638, S1763, S905, S4158, PageWithoutTitleCheck)

### DIFF
--- a/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilderUtils.tsx
+++ b/frontend/awx/analytics/AnalyticsReportBuilder/AnalyticsReportBuilderUtils.tsx
@@ -64,7 +64,6 @@ export const getClickableText = (
   if (isNoName(item, key)) return '-';
   if (isOther(item, key)) return '-';
   if (timeFields.includes(key)) return formatTotalTime(+item[key]);
-  if (costFields.includes(key)) return currencyFormatter(+item[key]);
   if (Object.keys(countMapper).includes(key) && item.id !== -1 && item.name) {
     return (
       <Tooltip content={`View ${item.name} usage`}>
@@ -132,8 +131,6 @@ export const isAvgDuration = (item: Record<string, string | number>, key: string
 export const DEFAULT_NAMESPACE = 'default';
 
 const timeFields: string[] = ['elapsed'];
-const costFields: string[] = [];
-
 export const formatTotalTime = (elapsed: number): string =>
   new Date(elapsed * 1000).toISOString().substr(11, 8);
 

--- a/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
+++ b/frontend/awx/resources/inventories/components/RunCommandSteps.tsx
@@ -162,7 +162,7 @@ export function RunCommandExecutionEnvionment(props: { orgId: string }) {
       <PageFormSelectExecutionEnvironment
         name="execution_environment"
         label={t('Execution Environment')}
-        organizationId={Number(props.orgId) ?? ''}
+        organizationId={Number(props.orgId)}
       />
     </PageFormSection>
   );

--- a/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
+++ b/frontend/awx/resources/inventories/inventoryHostsPage/InventoryHostGroups.tsx
@@ -25,7 +25,7 @@ export function InventoryHostGroups(props: { page: string }) {
   const isHostPage: boolean = props.page === 'host';
   const params = useParams<{ id: string; inventory_type: string; host_id: string }>();
   const { host } = useGetHost(isHostPage ? (params.id ?? '') : (params.host_id ?? ''));
-  const inventoryId = String(host?.inventory) ?? '';
+  const inventoryId = String(host?.inventory ?? '');
   const hostId = isHostPage ? (params.id ?? '') : (params.host_id ?? '');
 
   const toolbarFilters = useHostsGroupsFilters(`hosts/${hostId ?? ''}/all_groups`);

--- a/platform/access/teams/components/PlatformTeamAssignRoles.tsx
+++ b/platform/access/teams/components/PlatformTeamAssignRoles.tsx
@@ -46,9 +46,6 @@ export function objectIdForResource(
     default:
       return resource.id;
   }
-  return resourceType.substring(0, resourceType.indexOf('.')) === 'galaxy'
-    ? parsePulpIDFromURL(resource?.pulp_href)
-    : resource.id;
 }
 export function PlatformTeamAssignRoles() {
   const { t } = useTranslation();

--- a/platform/index.html
+++ b/platform/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/platform-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ansible Automation Platform</title>
   </head>
   <body>
     <div id="root"></div>

--- a/platform/resource/PlatformAwxUser.tsx
+++ b/platform/resource/PlatformAwxUser.tsx
@@ -20,12 +20,14 @@ export function PlatformAwxUser(props: Readonly<{ route?: string }>) {
   }
 
   if (platformResponse.error) {
-    <Page>
-      <EmptyStateCustom
-        title={t('Error')}
-        description={t('An error occurred while loading the resource.')}
-      />
-    </Page>;
+    return (
+      <Page>
+        <EmptyStateCustom
+          title={t('Error')}
+          description={t('An error occurred while loading the resource.')}
+        />
+      </Page>
+    );
   }
 
   if (!platformResponse.data?.summary_fields.resource.resource_type) {


### PR DESCRIPTION
## Summary

Addresses 6 SonarCloud violations across `platform` and `frontend/awx`:

- **S905 — Bug fix**: `PlatformAwxUser.tsx` error handler created a JSX element without `return`, so the error state silently fell through to the next condition instead of rendering the error page. Added the missing `return`.
- **S1763**: Removed unreachable code after `switch` statement in `objectIdForResource` — every case (including `default`) already returns, making lines after the switch dead code.
- **S6638** (×2): Fixed constant nullishness checks where `Number()` and `String()` (which never return null/undefined) were paired with `??` fallbacks that could never trigger.
- **S4158**: Removed dead branch using `costFields.includes(key)` — `costFields` is defined as `[]` and never mutated, so the check is always false. Also removed the unused `costFields` constant.
- **PageWithoutTitleCheck**: Added `<title>Ansible Automation Platform</title>` to `platform/index.html`.

**Rules with 0 open issues (already clean):** S5852 (Regex DoS), S2245 (Pseudo-random values).

SonarCloud dashboard: https://sonarcloud.io/project/issues?id=ansible_ansible-ui&types=BUG

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

Validation passed: `npm run tsc && npm run eslint`.

All 6 modified files pass TypeScript type checking and ESLint with zero warnings. The S905 fix (`PlatformAwxUser.tsx`) is a genuine bug fix — error states now correctly render instead of silently falling through.