### PR TITLE
ci: add e2e: failed label and fix /run-playwright false positive triggers

### DIFF
--- a/.github/workflows/pr-e2e-failed.yml
+++ b/.github/workflows/pr-e2e-failed.yml
@@ -1,0 +1,83 @@
+name: PR E2E Failed
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  e2e-pipeline-failed:
+    name: E2E Pipeline Failed
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.check_run.name, 'aap-ui-e2e-pull-request')
+      && (github.event.check_run.conclusion == 'failure'
+          || github.event.check_run.conclusion == 'cancelled'
+          || github.event.check_run.conclusion == 'timed_out')
+    steps:
+      - name: Find associated PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.check_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for commit $HEAD_SHA"
+            exit 0
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author --jq '.author.login')
+          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
+
+          IS_BOT="false"
+          if [[ "$AUTHOR" == "dependabot[bot]" || "$AUTHOR" == "app/red-hat-konflux" || "$AUTHOR" == "red-hat-konflux[bot]" ]]; then
+            IS_BOT="true"
+          fi
+          echo "is_bot=$IS_BOT" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure labels exist
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "e2e: failed"       --repo "$REPO" --color "D93F0B" --description "E2E pipeline failed" --force 2>/dev/null || true
+          gh label create "e2e: running"      --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
+
+      - name: Update labels and comment
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+          IS_BOT: ${{ steps.pr.outputs.is_bot }}
+          CONCLUSION: ${{ github.event.check_run.conclusion }}
+          CHECK_URL: ${{ github.event.check_run.html_url }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20running" -X DELETE 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: failed"
+
+          BODY="<!-- waiting-on-author-e2e -->"$'\n'
+          BODY+="@${AUTHOR} — The E2E pipeline ${CONCLUSION}. Please check the [pipeline run](${CHECK_URL}) and re-trigger with \`/run-playwright\` if needed."
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-e2e -->")) | .id' | tail -1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+          fi
+
+          if [ "$IS_BOT" = "false" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "waiting-on-author"
+          fi

--- a/.github/workflows/pr-e2e-failed.yml
+++ b/.github/workflows/pr-e2e-failed.yml
@@ -13,6 +13,7 @@ jobs:
   e2e-pipeline-failed:
     name: E2E Pipeline Failed
     runs-on: ubuntu-latest
+    # contains() is intentional — Konflux check run names include dynamic suffixes (e.g. pipeline run ID)
     if: >-
       contains(github.event.check_run.name, 'aap-ui-e2e-pull-request')
       && (github.event.check_run.conclusion == 'failure'
@@ -66,8 +67,15 @@ jobs:
           gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20running" -X DELETE 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: failed"
 
+          case "$CONCLUSION" in
+            failure)   STATUS_TEXT="failed" ;;
+            cancelled) STATUS_TEXT="was cancelled" ;;
+            timed_out) STATUS_TEXT="timed out" ;;
+            *)         STATUS_TEXT="$CONCLUSION" ;;
+          esac
+
           BODY="<!-- waiting-on-author-e2e -->"$'\n'
-          BODY+="@${AUTHOR} — The E2E pipeline ${CONCLUSION}. Please check the [pipeline run](${CHECK_URL}) and re-trigger with \`/run-playwright\` if needed."
+          BODY+="@${AUTHOR} — The E2E pipeline ${STATUS_TEXT}. Please check the [pipeline run](${CHECK_URL}) and re-trigger with \`/run-playwright\` if needed."
 
           EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq '.[] | select(.body | contains("<!-- waiting-on-author-e2e -->")) | .id' | tail -1)

--- a/.github/workflows/pr-e2e-status.yml
+++ b/.github/workflows/pr-e2e-status.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.issue.pull_request
-      && contains(github.event.comment.body, '/run-playwright')
+      && github.event.comment.body == '/run-playwright'
     steps:
       - name: Ensure labels exist
         env:

--- a/.github/workflows/pr-e2e-status.yml
+++ b/.github/workflows/pr-e2e-status.yml
@@ -91,3 +91,19 @@ jobs:
           if [ -n "$E2E_COMMENT_ID" ]; then
             gh api "repos/$REPO/issues/comments/$E2E_COMMENT_ID" -X DELETE
           fi
+
+          # Remove waiting-on-author if no other failure reasons exist
+          CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-checks -->"))] | length')
+          SONAR=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
+          CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
+          CHANGES_REQUESTED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | map(.user.login) | unique | length')
+          E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '[.[] | select(.name == "e2e: pending")] | length')
+
+          if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$CHANGES_REQUESTED" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
+          fi

--- a/.github/workflows/pr-e2e-status.yml
+++ b/.github/workflows/pr-e2e-status.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           gh label create "e2e: pending" --repo "$REPO" --color "FBCA04" --description "E2E tests not yet triggered" --force 2>/dev/null || true
           gh label create "e2e: running" --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "e2e: failed"  --repo "$REPO" --color "D93F0B" --description "E2E pipeline failed" --force 2>/dev/null || true
           gh label create "waiting-on-author" --repo "$REPO" --color "E4E669" --description "PR requires author attention" --force 2>/dev/null || true
 
       - name: Update e2e labels
@@ -33,7 +34,15 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20pending" -X DELETE 2>/dev/null || true
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20failed" -X DELETE 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: running"
+
+          # Delete e2e failure comment if it exists
+          E2E_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-e2e -->")) | .id' | tail -1)
+          if [ -n "$E2E_COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$E2E_COMMENT_ID" -X DELETE
+          fi
 
           # Remove waiting-on-author if no other failure reasons exist
           CHECKS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
@@ -42,8 +51,10 @@ jobs:
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
           CONFLICTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
+          CHANGES_REQUESTED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | map(.user.login) | unique | length')
 
-          if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ]; then
+          if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$CHANGES_REQUESTED" -eq 0 ]; then
             gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
           fi
 
@@ -61,6 +72,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh label create "e2e: running" --repo "$REPO" --color "1D76DB" --description "E2E tests in progress" --force 2>/dev/null || true
+          gh label create "e2e: failed"  --repo "$REPO" --color "D93F0B" --description "E2E pipeline failed" --force 2>/dev/null || true
           gh label create "e2e: done"    --repo "$REPO" --color "0E8A16" --description "E2E tests completed" --force 2>/dev/null || true
 
       - name: Update e2e labels
@@ -70,4 +82,12 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20running" -X DELETE 2>/dev/null || true
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20failed" -X DELETE 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: done"
+
+          # Delete e2e failure comment if it exists
+          E2E_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- waiting-on-author-e2e -->")) | .id' | tail -1)
+          if [ -n "$E2E_COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$E2E_COMMENT_ID" -X DELETE
+          fi

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -231,7 +231,7 @@ jobs:
                 done
 
                 HAS_RUN_PW=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-                  --jq '[.[] | select(.body | test("/run-playwright"))] | length')
+                  --jq '[.[] | select(.body == "/run-playwright")] | length')
                 HAS_CURRENTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
                   --jq '[.[] | select(.user.login == "aap-pde-ci-bot" and (.body | contains("Currents dashboard")))] | length')
 

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -226,7 +226,7 @@ jobs:
                 fi
 
                 # --- E2E status (all PRs including bots) ---
-                for label in "e2e: pending" "e2e: running" "e2e: done"; do
+                for label in "e2e: pending" "e2e: running" "e2e: done" "e2e: failed"; do
                   gh api "repos/$REPO/issues/$PR_NUMBER/labels/$label" -X DELETE 2>/dev/null || true
                 done
 

--- a/.github/workflows/pr-waiting-on-author-checks.yml
+++ b/.github/workflows/pr-waiting-on-author-checks.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           # Add e2e: pending if /run-playwright hasn't been commented yet
           RUN_PW=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '[.[] | select(.body | test("/run-playwright"))] | length')
+            --jq '[.[] | select(.body == "/run-playwright")] | length')
           if [ "$RUN_PW" -eq 0 ]; then
             gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: pending"
             # Only add waiting-on-author for non-bot PRs

--- a/.github/workflows/pr-waiting-on-author-checks.yml
+++ b/.github/workflows/pr-waiting-on-author-checks.yml
@@ -105,8 +105,10 @@ jobs:
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
           E2E_PENDING_LABEL=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
             --jq '[.[] | select(.name == "e2e: pending")] | length')
+          E2E_FAILED_LABEL=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '[.[] | select(.name == "e2e: failed")] | length')
 
-          if [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING_LABEL" -eq 0 ]; then
+          if [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING_LABEL" -eq 0 ] && [ "$E2E_FAILED_LABEL" -eq 0 ]; then
             gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
           fi
 

--- a/.github/workflows/pr-waiting-on-author-conflicts.yml
+++ b/.github/workflows/pr-waiting-on-author-conflicts.yml
@@ -79,8 +79,10 @@ jobs:
               --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
             E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
               --jq '[.[] | select(.name == "e2e: pending")] | length')
+            E2E_FAILED=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+              --jq '[.[] | select(.name == "e2e: failed")] | length')
 
-            if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+            if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ] && [ "$E2E_FAILED" -eq 0 ]; then
               gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
             fi
           fi
@@ -135,8 +137,10 @@ jobs:
                       --jq '[.[] | select(.body | contains("<!-- waiting-on-author-sonar -->"))] | length')
                     E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
                       --jq '[.[] | select(.name == "e2e: pending")] | length')
+                    E2E_FAILED=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+                      --jq '[.[] | select(.name == "e2e: failed")] | length')
 
-                    if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+                    if [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ] && [ "$E2E_FAILED" -eq 0 ]; then
                       gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
                     fi
                   fi

--- a/.github/workflows/pr-waiting-on-author-review.yml
+++ b/.github/workflows/pr-waiting-on-author-review.yml
@@ -53,7 +53,9 @@ jobs:
             --jq '[.[] | select(.body | contains("<!-- waiting-on-author-conflicts -->"))] | length')
           E2E_PENDING=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
             --jq '[.[] | select(.name == "e2e: pending")] | length')
+          E2E_FAILED=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '[.[] | select(.name == "e2e: failed")] | length')
 
-          if [ "$PENDING_CHANGES" -eq 0 ] && [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ]; then
+          if [ "$PENDING_CHANGES" -eq 0 ] && [ "$CHECKS" -eq 0 ] && [ "$SONAR" -eq 0 ] && [ "$CONFLICTS" -eq 0 ] && [ "$E2E_PENDING" -eq 0 ] && [ "$E2E_FAILED" -eq 0 ]; then
             gh api "repos/$REPO/issues/$PR_NUMBER/labels/waiting-on-author" -X DELETE 2>/dev/null || true
           fi


### PR DESCRIPTION
## Summary

- Add `e2e: failed` label when the Konflux `aap-ui-e2e-pull-request` check run fails, is cancelled, or times out
- Posts a comment tagging the author with a link to the failed pipeline run and a prompt to re-trigger with `/run-playwright`
- Adds `waiting-on-author` for non-bot PRs
- On re-trigger (`/run-playwright`) or Currents dashboard comment, `e2e: failed` and the failure comment are cleared
- Fix `/run-playwright` detection to require an exact match on the entire comment body, preventing false positives from comments that mention `/run-playwright` in prose

This addresses the scenario where the E2E pipeline fails due to infrastructure issues (e.g. kind cluster provisioning errors) and the PR gets stuck with `e2e: running` indefinitely.

### Changes

| File | Change |
|------|--------|
| `pr-e2e-failed.yml` (new) | Detects Konflux e2e check run failure via `check_run` event |
| `pr-e2e-status.yml` | Clears `e2e: failed` label and comment on `/run-playwright` re-trigger and Currents dashboard comment. Uses exact match (`== '/run-playwright'`) instead of substring `contains()` |
| `pr-waiting-on-author-checks.yml` | Uses exact match (`== "/run-playwright"`) in jq instead of regex `test()` |
| `pr-label-backfill.yml` | Uses exact match (`== "/run-playwright"`) in jq instead of regex `test()` |

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Trigger `/run-playwright` on a PR → verify `e2e: running` label
2. Konflux pipeline fails → verify `e2e: running` removed, `e2e: failed` + `waiting-on-author` added, comment posted with pipeline link
3. Re-trigger with `/run-playwright` → verify `e2e: failed` removed, `e2e: running` added, failure comment deleted, `waiting-on-author` removed (if no other reasons)
4. Currents dashboard posted after successful re-run → verify `e2e: done` label, any leftover `e2e: failed` cleared
5. Post a comment that mentions `/run-playwright` in prose → verify it does **not** trigger `e2e: running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)