### PR TITLE
ci: match workflow_run trigger for stable branch PR workflow name

### DIFF
--- a/.github/workflows/pr-waiting-on-author-checks.yml
+++ b/.github/workflows/pr-waiting-on-author-checks.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - PR Checks
+      - Platform PR
     types:
       - completed
 

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -5,7 +5,6 @@ on:
   workflow_run:
     workflows:
       - PR Checks
-      - Platform PR
     types:
       - completed
 

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -5,6 +5,7 @@ on:
   workflow_run:
     workflows:
       - PR Checks
+      - Platform PR
     types:
       - completed
 


### PR DESCRIPTION
> :warning: **This PR depends on #3369 and must be merged after it.** #3369 introduces the `pr-waiting-on-author-checks.yml` file that this PR patches.

## Summary

PRs targeting stable branches run the `platform-pull-request.yml` workflow (`name: Platform PR`), while PRs targeting `devel` run `pull-request.yml` (`name: PR Checks`). The `workflow_run` trigger in `pr-waiting-on-author-checks.yml` only matched `PR Checks`, so the `e2e: pending` label and check-failure notifications never ran on PRs targeting stable branches.

Adds `- Platform PR` to the `workflow_run.workflows` list in `pr-waiting-on-author-checks.yml` so the trigger fires for PRs against any branch.

Note: `sonar_pr.yml` has the same `workflow_run` trigger but is intentionally left unchanged — `platform-pull-request.yml` already includes an inline SonarQube job, so adding "Platform PR" there would cause duplicate analysis.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [x] Other (please specify)

CI workflow fix

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

- **#3369** must be merged first (introduces the file this PR modifies)

## Testing

### Ephemeral E2E Tests

N/A — CI-only change.

### Manual Testing

1. After merge, open a PR targeting a stable branch
2. Wait for "Platform PR" checks to pass
3. Confirm `e2e: pending` label is automatically applied

### Screenshots

N/A — no visual changes.