### PR TITLE
Add PKCE Required toggle to OAuth application UI

### DIFF
--- a/frontend/awx/interfaces/Application.ts
+++ b/frontend/awx/interfaces/Application.ts
@@ -16,6 +16,7 @@ export interface Application {
   client_secret?: string;
   authorization_grant_type?: string;
   skip_authorization?: boolean;
+  pkce_required?: boolean;
   summary_fields: {
     user_capabilities: {
       edit: boolean;

--- a/platform/access/oauth-applications/OAuthApplicationDetails.test.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationDetails.test.tsx
@@ -66,6 +66,7 @@ const mockApplication: Application = {
   client_secret: 'test-client-secret',
   authorization_grant_type: 'authorization-code',
   skip_authorization: false,
+  pkce_required: true,
   algorithm: '',
   summary_fields: {
     user_capabilities: {
@@ -166,6 +167,20 @@ describe('ApplicationDetailInner', () => {
       { wrapper: SwrTestWrapper }
     );
     expect(screen.getByTestId('skip-authorization')).toHaveTextContent('Yes');
+  });
+
+  test('should display "No" when pkce_required is false', () => {
+    render(<ApplicationDetailInner application={{ ...mockApplication, pkce_required: false }} />, {
+      wrapper: SwrTestWrapper,
+    });
+    expect(screen.getByTestId('pkce-required')).toHaveTextContent('No');
+  });
+
+  test('should display "Yes" when pkce_required is true', () => {
+    render(<ApplicationDetailInner application={{ ...mockApplication, pkce_required: true }} />, {
+      wrapper: SwrTestWrapper,
+    });
+    expect(screen.getByTestId('pkce-required')).toHaveTextContent('Yes');
   });
 
   test('should fall back to raw values when OPTIONS is unavailable', async () => {

--- a/platform/access/oauth-applications/OAuthApplicationDetails.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationDetails.tsx
@@ -67,6 +67,9 @@ export function ApplicationDetailInner(props: Readonly<{ application: Applicatio
       <PageDetail label={t('Skip Authorization')}>
         {props.application.skip_authorization ? t('Yes') : t('No')}
       </PageDetail>
+      <PageDetail label={t('PKCE Required')}>
+        {props.application.pkce_required ? t('Yes') : t('No')}
+      </PageDetail>
       <PageDetail label={t('Client ID')} fullWidth>
         <CopyCell text={props.application.client_id} />
       </PageDetail>

--- a/platform/access/oauth-applications/OAuthApplicationForm.test.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationForm.test.tsx
@@ -94,6 +94,7 @@ describe('OAuthApplicationForm', () => {
     client_secret: 'test-client-secret',
     authorization_grant_type: 'authorization-code',
     skip_authorization: false,
+    pkce_required: true,
     summary_fields: {
       user_capabilities: {
         edit: true,
@@ -141,6 +142,11 @@ describe('OAuthApplicationForm', () => {
         skip_authorization: {
           type: 'boolean',
           help_text: 'Set True to skip authorization step for completely trusted applications.',
+        },
+        pkce_required: {
+          type: 'boolean',
+          help_text:
+            'When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.',
         },
         redirect_uris: {
           type: 'string',
@@ -255,6 +261,7 @@ describe('OAuthApplicationForm', () => {
       expect(screen.getByText('Client type')).toBeInTheDocument();
       expect(screen.getByText('Algorithm')).toBeInTheDocument();
       expect(screen.getByText('Skip Authorization')).toBeInTheDocument();
+      expect(screen.getByText('PKCE Required')).toBeInTheDocument();
       expect(screen.getByText('Organization')).toBeInTheDocument();
     });
 
@@ -417,6 +424,12 @@ describe('OAuthApplicationForm', () => {
     test('should display skip authorization switch with default off', async () => {
       await waitFor(() => {
         expect(screen.getByText('Skip Authorization')).toBeInTheDocument();
+      });
+    });
+
+    test('should display PKCE required switch', async () => {
+      await waitFor(() => {
+        expect(screen.getByText('PKCE Required')).toBeInTheDocument();
       });
     });
 
@@ -652,6 +665,61 @@ describe('OAuthApplicationForm', () => {
     });
   });
 
+  describe('EditOAuthApplication - PKCE Required field', () => {
+    afterEach(() => {
+      cleanup();
+      server.resetHandlers();
+    });
+
+    test('should display PKCE required switch when application has it enabled', async () => {
+      server.use(
+        http.get(gatewayAPI`/applications/5/`, () => {
+          return HttpResponse.json({
+            ...mockApplication,
+            id: 5,
+            pkce_required: true,
+          });
+        })
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/access/oauth-applications/5/edit']}>
+          <Routes>
+            <Route path="/access/oauth-applications/:id/edit" element={<EditOAuthApplication />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('PKCE Required')).toBeInTheDocument();
+      });
+    });
+
+    test('should display PKCE required switch when application has it disabled', async () => {
+      server.use(
+        http.get(gatewayAPI`/applications/6/`, () => {
+          return HttpResponse.json({
+            ...mockApplication,
+            id: 6,
+            pkce_required: false,
+          });
+        })
+      );
+
+      render(
+        <MemoryRouter initialEntries={['/access/oauth-applications/6/edit']}>
+          <Routes>
+            <Route path="/access/oauth-applications/:id/edit" element={<EditOAuthApplication />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('PKCE Required')).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('EditOAuthApplication - Algorithm field', () => {
     afterEach(() => {
       cleanup();
@@ -747,6 +815,7 @@ describe('OAuthApplicationForm', () => {
       expect(screen.getByText('Client type')).toBeInTheDocument();
       expect(screen.getByText('Algorithm')).toBeInTheDocument();
       expect(screen.getByText('Skip Authorization')).toBeInTheDocument();
+      expect(screen.getByText('PKCE Required')).toBeInTheDocument();
       expect(screen.getByText('Organization')).toBeInTheDocument();
     });
 

--- a/platform/access/oauth-applications/OAuthApplicationForm.test.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationForm.test.tsx
@@ -421,13 +421,13 @@ describe('OAuthApplicationForm', () => {
       });
     });
 
-    test('should display skip authorization switch with default off', async () => {
+    test('should display skip authorization checkbox with default off', async () => {
       await waitFor(() => {
         expect(screen.getByText('Skip Authorization')).toBeInTheDocument();
       });
     });
 
-    test('should display PKCE required switch', async () => {
+    test('should display PKCE required checkbox', async () => {
       await waitFor(() => {
         expect(screen.getByText('PKCE Required')).toBeInTheDocument();
       });
@@ -624,7 +624,7 @@ describe('OAuthApplicationForm', () => {
       server.resetHandlers();
     });
 
-    test('should display skip authorization switch when application has it enabled', async () => {
+    test('should display skip authorization checkbox when application has it enabled', async () => {
       server.use(
         http.get(gatewayAPI`/applications/4/`, () => {
           return HttpResponse.json({
@@ -648,7 +648,7 @@ describe('OAuthApplicationForm', () => {
       });
     });
 
-    test('should display skip authorization switch when application has it disabled', async () => {
+    test('should display skip authorization checkbox when application has it disabled', async () => {
       render(
         <MemoryRouter initialEntries={['/access/oauth-applications/1/edit']}>
           <Routes>
@@ -671,7 +671,7 @@ describe('OAuthApplicationForm', () => {
       server.resetHandlers();
     });
 
-    test('should display PKCE required switch when application has it enabled', async () => {
+    test('should display PKCE required checkbox when application has it enabled', async () => {
       server.use(
         http.get(gatewayAPI`/applications/5/`, () => {
           return HttpResponse.json({
@@ -695,7 +695,7 @@ describe('OAuthApplicationForm', () => {
       });
     });
 
-    test('should display PKCE required switch when application has it disabled', async () => {
+    test('should display PKCE required checkbox when application has it disabled', async () => {
       server.use(
         http.get(gatewayAPI`/applications/6/`, () => {
           return HttpResponse.json({

--- a/platform/access/oauth-applications/OAuthApplicationForm.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationForm.tsx
@@ -3,7 +3,7 @@ import {
   CopyCell,
   PageFormSelect,
   PageFormSubmitHandler,
-  PageFormSwitch,
+  PageFormCheckbox,
   PageFormTextArea,
   PageHeader,
   PageLayout,
@@ -96,6 +96,7 @@ export function CreateOAuthApplication() {
           client_type: 'confidential',
           algorithm: '',
           skip_authorization: false,
+          pkce_required: true,
         }}
       >
         <OAuthApplicationInputs mode="create" />
@@ -322,12 +323,12 @@ function OAuthApplicationInputs(props: Readonly<{ mode: 'create' | 'edit' }>) {
           )
         }
       />
-      <PageFormSwitch<Application>
+      <PageFormCheckbox<Application>
         name="skip_authorization"
         label={t('Skip Authorization')}
         labelHelp={fields?.skip_authorization?.help_text}
       />
-      <PageFormSwitch<Application>
+      <PageFormCheckbox<Application>
         name="pkce_required"
         label={t('PKCE Required')}
         labelHelp={fields?.pkce_required?.help_text}

--- a/platform/access/oauth-applications/OAuthApplicationForm.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationForm.tsx
@@ -327,6 +327,11 @@ function OAuthApplicationInputs(props: Readonly<{ mode: 'create' | 'edit' }>) {
         label={t('Skip Authorization')}
         labelHelp={fields?.skip_authorization?.help_text}
       />
+      <PageFormSwitch<Application>
+        name="pkce_required"
+        label={t('PKCE Required')}
+        labelHelp={fields?.pkce_required?.help_text}
+      />
       <PageFormTextInput<Application>
         name="redirect_uris"
         label={t('Redirect URIs')}

--- a/platform/access/oauth-applications/OAuthApplicationsTable.test.tsx
+++ b/platform/access/oauth-applications/OAuthApplicationsTable.test.tsx
@@ -74,6 +74,7 @@ describe('OAuthApplicationsTable', () => {
         client_secret: 'test-client-secret',
         authorization_grant_type: 'authorization-code',
         skip_authorization: false,
+        pkce_required: true,
         summary_fields: {
           user_capabilities: {
             edit: true,
@@ -101,6 +102,7 @@ describe('OAuthApplicationsTable', () => {
         client_id: 'test-client-id-2',
         authorization_grant_type: 'password',
         skip_authorization: false,
+        pkce_required: true,
         summary_fields: {
           user_capabilities: {
             edit: true,


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/AAP-83347

Adds a "PKCE Required" toggle to the OAuth application create/edit form and details page. This surfaces the new `pkce_required` field from the DAB backend ([AAP-83346](https://redhat.atlassian.net/browse/AAP-83346)), allowing administrators to configure per-application PKCE enforcement from the UI. The toggle follows the same pattern as the existing "Skip Authorization" switch.

  ## Type of Change

  - [ ] Bug fix
  - [x] Enhancement
  - [x] Tests
  - [ ] Documentation
  - [ ] Other (please specify)

  ## Risk Analysis - REQUIRED

  - [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers,
  build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
  - [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace,
  component library updates, test infrastructure). Limited blast radius but touches common code paths.
  - [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates).
  Minimal risk of unintended side effects.

  ## Dependencies

  - Requires the `pkce_required` field on the `OAuth2Application` model in django-ansible-base
  ([AAP-83346](https://redhat.atlassian.net/browse/AAP-83346), PR:
  [mabashian/django-ansible-base#1](https://github.com/mabashian/django-ansible-base/pull/1))

  ## Testing

  ### Ephemeral E2E Tests

  Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

  > Tests run against a fresh AAP instance (version based on branch).

  ### Manual Testing

  1. Navigate to Access > OAuth Applications > Create
  2. Verify "PKCE Required" toggle appears below "Skip Authorization"
  3. Create an application — confirm the toggle value is submitted
  4. View the application details page — confirm "PKCE Required: Yes" or "No" displays
  5. Edit the application — confirm the toggle reflects the saved value and can be changed

  ### Screenshots
  
  
<img width="1206" height="631" alt="Screenshot 2026-07-17 at 12 55 56 PM" src="https://github.com/user-attachments/assets/311ff17f-5413-45f5-ac4e-4a189c46ad92" />
<img width="1188" height="618" alt="Screenshot 2026-07-17 at 12 56 38 PM" src="https://github.com/user-attachments/assets/f3615991-0410-44e7-b815-565410d3fff9" />
<img width="1199" height="629" alt="Screenshot 2026-07-17 at 12 56 49 PM" src="https://github.com/user-attachments/assets/57797250-92cd-43b9-bf89-6f3bf2e24626" />
<img width="497" height="275" alt="Screenshot 2026-07-17 at 12 57 31 PM" src="https://github.com/user-attachments/assets/9c457dfc-c0ea-4372-b217-f177c18fa12c" />
