### PR TITLE
Add sync_highest_versions field to Hub remote form

### DIFF
--- a/frontend/hub/administration/remotes/RemoteForm.tsx
+++ b/frontend/hub/administration/remotes/RemoteForm.tsx
@@ -92,6 +92,7 @@ export function CreateRemote() {
           url: '',
           signed_only: false,
           sync_dependencies: false,
+          sync_highest_versions: null,
         }}
       >
         <HelperWrapper isNew />

--- a/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
+++ b/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
@@ -91,6 +91,9 @@ export function RemoteDetails() {
         <PageDetail label={t('Download only signed collections')}>
           {remote?.signed_only ? t('True') : t('False')}
         </PageDetail>
+        <PageDetail label={t('Sync latest versions')}>
+          {remote?.sync_highest_versions?.toString() ?? t('All versions')}
+        </PageDetail>
         <PageDetail label={t('Repositories')}>
           {repositories?.results?.length ? (
             <LabelGroup

--- a/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
+++ b/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
@@ -92,7 +92,7 @@ export function RemoteDetails() {
           {remote?.signed_only ? t('True') : t('False')}
         </PageDetail>
         <PageDetail label={t('Sync latest versions')}>
-          {remote?.sync_highest_versions?.toString() ?? t('All versions')}
+          {remote?.sync_highest_versions ? remote.sync_highest_versions.toString() : t('All versions')}
         </PageDetail>
         <PageDetail label={t('Repositories')}>
           {repositories?.results?.length ? (

--- a/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
+++ b/frontend/hub/administration/remotes/RemotePage/RemoteDetails.tsx
@@ -92,7 +92,9 @@ export function RemoteDetails() {
           {remote?.signed_only ? t('True') : t('False')}
         </PageDetail>
         <PageDetail label={t('Sync latest versions')}>
-          {remote?.sync_highest_versions ? remote.sync_highest_versions.toString() : t('All versions')}
+          {remote?.sync_highest_versions
+            ? remote.sync_highest_versions.toString()
+            : t('All versions')}
         </PageDetail>
         <PageDetail label={t('Repositories')}>
           {repositories?.results?.length ? (

--- a/frontend/hub/administration/remotes/Remotes.test.tsx
+++ b/frontend/hub/administration/remotes/Remotes.test.tsx
@@ -21,6 +21,7 @@ const mockRemotes: HubRemote[] = [
     tls_validation: true,
     signed_only: false,
     sync_dependencies: false,
+    sync_highest_versions: null,
     auth_url: null,
     proxy_url: null,
   },

--- a/frontend/hub/administration/remotes/Remotes.tsx
+++ b/frontend/hub/administration/remotes/Remotes.tsx
@@ -37,6 +37,7 @@ export interface HubRemote {
   url: string;
   signed_only: boolean;
   sync_dependencies: boolean;
+  sync_highest_versions: number | null;
   hidden_fields?: {
     is_set: boolean;
     name: 'client_key' | 'password' | 'proxy_username' | 'proxy_password' | 'token' | 'username';

--- a/frontend/hub/administration/remotes/components/RemoteInputs.tsx
+++ b/frontend/hub/administration/remotes/components/RemoteInputs.tsx
@@ -106,6 +106,16 @@ export function RemoteInputs({
           variant="info"
           title={t`Syncing dependencies outside of repository may cause an issue in repository sync.`}
         />
+        <PageFormTextInput<RemoteFormProps>
+          name="sync_highest_versions"
+          label={t('Sync latest versions')}
+          type="number"
+          labelHelpTitle={t('Sync latest versions')}
+          labelHelp={t(
+            'Number of latest versions to sync per collection. 0 or empty syncs all versions.'
+          )}
+          placeholder={t('All versions')}
+        />
       </PageFormGroup>
 
       <PageFormSecret

--- a/frontend/hub/administration/remotes/components/RemoteInputs.tsx
+++ b/frontend/hub/administration/remotes/components/RemoteInputs.tsx
@@ -110,9 +110,10 @@ export function RemoteInputs({
           name="sync_highest_versions"
           label={t('Sync latest versions')}
           type="number"
+          min={1}
           labelHelpTitle={t('Sync latest versions')}
           labelHelp={t(
-            'Number of latest versions to sync per collection. 0 or empty syncs all versions.'
+            'Number of latest versions to sync per collection. Empty syncs all versions.'
           )}
           placeholder={t('All versions')}
         />


### PR DESCRIPTION
## Summary

Adds the `sync_highest_versions` number input to the Hub remote configuration form so users can limit how many versions to sync per collection.

**Changes:**
- Type definition: added `sync_highest_versions: number | null` to `HubRemote`
- Form: added number input in the Options group after "Sync all dependencies"
- Detail view: displays the field value
- Test mock: added field to test data
- Default: `null` (sync all versions)

**5 files changed, 16 lines added.** Hub workspace only.

Depends on [galaxy_ng#660](https://github.com/ansible-automation-platform/galaxy_ng/pull/660) and [pulp_ansible#2563](https://github.com/pulp/pulp_ansible/pull/2563) (merged).

Ref: [AAP-79529](https://redhat.atlassian.net/browse/AAP-79529)

Assisted-by: Claude Code, model: claude-opus-4-6 <noreply@anthropic.com>

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
- [ ] **Medium** — Moderate complexity (e.g., new pages, significant refactors, shared component changes). Some risk of unintended side effects.
- [ ] **High** — Complex or wide-reaching changes (e.g., framework updates, cross-workspace impacts, authentication/authorization changes). High risk of unintended side effects.