### PR TITLE
fix: restore toolbar filter visibility in CRC builds

### DIFF
--- a/framework/PageFramework.css
+++ b/framework/PageFramework.css
@@ -34,6 +34,21 @@ table tbody tr td.expanded {
   margin-inline-start: 0 !important;
 }
 
+/* CRC strips PatternFly CSS (bundlePfModules: false) so the responsive overrides
+   that show ToolbarToggleGroup children at md+ breakpoints are missing. These rules
+   replicate that behavior scoped to our toolbar class. */
+@media (min-width: 48rem) {
+  .page-table-toolbar .pf-v6-c-toolbar__group.pf-m-toggle-group .pf-v6-c-toolbar__group,
+  .page-table-toolbar .pf-v6-c-toolbar__group.pf-m-toggle-group .pf-v6-c-toolbar__item {
+    display: flex;
+    flex: 0 1 auto;
+  }
+
+  .page-table-toolbar .pf-v6-c-toolbar__group.pf-m-toggle-group .pf-v6-c-toolbar__toggle {
+    display: none;
+  }
+}
+
 :root:where(.pf-v6-theme-dark) .pf-topology-content {
   background: var(--pf-topology-visualization-surface--BackgroundColor);
 }

--- a/framework/PageToolbar/PageToolbarToggleGroup.test.tsx
+++ b/framework/PageToolbar/PageToolbarToggleGroup.test.tsx
@@ -23,6 +23,32 @@ describe('PageToolbarToggleGroup', () => {
     expect(screen.getByText('Child Content')).toBeInTheDocument();
   });
 
+  it('should render with PF6 class names used by CRC CSS override', () => {
+    const { container } = render(
+      <Toolbar className="page-table-toolbar">
+        <ToolbarContent>
+          <PageToolbarToggleGroup id="test-group" toggleIcon={<FilterIcon />} breakpoint="md">
+            <ToolbarItem>
+              <span>Filter Widget</span>
+            </ToolbarItem>
+          </PageToolbarToggleGroup>
+        </ToolbarContent>
+      </Toolbar>
+    );
+
+    const toolbar = container.querySelector('.page-table-toolbar');
+    expect(toolbar).toBeInTheDocument();
+
+    const toggleGroup = toolbar?.querySelector('.pf-v6-c-toolbar__group.pf-m-toggle-group');
+    expect(toggleGroup).toBeInTheDocument();
+
+    const toolbarItem = toggleGroup?.querySelector('.pf-v6-c-toolbar__item');
+    expect(toolbarItem).toBeInTheDocument();
+
+    const toggle = toggleGroup?.querySelector('.pf-v6-c-toolbar__toggle');
+    expect(toggle).toBeInTheDocument();
+  });
+
   it('should toggle expanded state when clicked', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary

PF6's `ToolbarToggleGroup` hides child items by default (`display: none`) and shows them via responsive CSS at the `md` breakpoint (`min-width: 48rem`). In CRC, Chrome provides PF CSS but the responsive overrides for `.pf-m-show-on-md` are missing, causing toolbar filters and column headers to remain invisible while still being interactive.

This PR adds scoped CSS overrides in `PageFramework.css` that replicate the PF6 responsive show rules with higher specificity (since PF6 uses `:where()` with zero specificity). The rules are scoped to `.page-table-toolbar` to avoid affecting other toolbars, and are bundled in framework CSS which IS included in CRC builds.

A regression test verifies the PF6 class names our CSS rules target, so we'll catch any future PF class name changes.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Deploy to CRC stage
2. Navigate to Automation Hub
3. Verify column filters and column names are visible in table views
4. Verify filters still work when used

### Screenshots

N/A — requires CRC environment to reproduce.

Assisted-by: Claude Code / Opus 4.6 (Anthropic)