### PR TITLE
ci: clear e2e: done label when /run-playwright re-triggers e2e

### DIFF
--- a/.github/workflows/pr-e2e-status.yml
+++ b/.github/workflows/pr-e2e-status.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20pending" -X DELETE 2>/dev/null || true
           gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20failed" -X DELETE 2>/dev/null || true
+          gh api "repos/$REPO/issues/$PR_NUMBER/labels/e2e:%20done" -X DELETE 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "e2e: running"
 
           # Delete e2e failure comment if it exists


### PR DESCRIPTION
## Summary

Without this fix, re-triggering e2e via `/run-playwright` on a PR that already completed leaves both `e2e: done` and `e2e: running` labels simultaneously. This adds `e2e: done` to the list of labels cleared by the `e2e-triggered` job.

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

- #3369 (adds the `e2e: failed` handling that this branch builds on)

## Testing

### Manual Testing

1. On a PR with `e2e: done` label, post `/run-playwright`
2. Verify `e2e: done` is removed and `e2e: running` is added (not both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)