### PR TITLE
Add e2e coverage for OAuth application PKCE Required field

### DIFF
--- a/playwright/tests/integration/platform/oauth-applications/oauth-applications.spec.ts
+++ b/playwright/tests/integration/platform/oauth-applications/oauth-applications.spec.ts
@@ -155,8 +155,6 @@ test.describe('OAuth Applications', () => {
         await navigateTo(page, 'Access Management', 'OAuth Applications');
         await clickTableRow({ filterLabel: 'Name', text: application.name }, page);
 
-        await expect(page.getByTestId('pkce-required')).toContainText('No');
-
         // Click edit
         await page.getByRole('button', { name: 'Edit OAuth application', exact: true }).click();
         await expect(page.getByRole('heading', { name: `Edit ${application.name}` })).toBeVisible();

--- a/playwright/tests/integration/platform/oauth-applications/oauth-applications.spec.ts
+++ b/playwright/tests/integration/platform/oauth-applications/oauth-applications.spec.ts
@@ -59,6 +59,11 @@ test.describe('OAuth Applications', () => {
         // Verify skip authorization switch is present
         await expect(page.getByText('Skip Authorization')).toBeVisible();
 
+        // PKCE Required should default to checked; uncheck it for this application
+        const pkceCheckbox = page.getByRole('checkbox', { name: 'PKCE Required' });
+        await expect(pkceCheckbox).toBeChecked();
+        await pkceCheckbox.uncheck();
+
         // Submit
         await page.getByRole('button', { name: /create oauth application/i }).click();
 
@@ -78,6 +83,9 @@ test.describe('OAuth Applications', () => {
 
         // Verify post logout redirect URIs is displayed on the details page
         await expect(page.getByText('https://example.com/logout')).toBeVisible();
+
+        // Verify PKCE required was disabled
+        await expect(page.getByTestId('pkce-required')).toContainText('No');
 
         // Cleanup: delete the application via API
         const appsData = await gatewayAPI.get<{ results: Application[] }>(page, `applications/`, {
@@ -132,6 +140,7 @@ test.describe('OAuth Applications', () => {
         skip_authorization: false,
         redirect_uris: 'https://example.com/callback',
         authorization_grant_type: 'password',
+        pkce_required: false,
       });
     });
 
@@ -140,11 +149,13 @@ test.describe('OAuth Applications', () => {
     });
 
     test(
-      'should edit algorithm and skip authorization fields',
+      'should edit algorithm, skip authorization, and PKCE required fields',
       { tag: ['@not_mock'] },
       async ({ page }) => {
         await navigateTo(page, 'Access Management', 'OAuth Applications');
         await clickTableRow({ filterLabel: 'Name', text: application.name }, page);
+
+        await expect(page.getByTestId('pkce-required')).toContainText('No');
 
         // Click edit
         await page.getByRole('button', { name: 'Edit OAuth application', exact: true }).click();
@@ -155,11 +166,17 @@ test.describe('OAuth Applications', () => {
         await algorithmSelect.click();
         await page.getByText('HMAC with SHA-2 256').click();
 
+        // Enable PKCE required
+        const pkceCheckbox = page.getByRole('checkbox', { name: 'PKCE Required' });
+        await expect(pkceCheckbox).not.toBeChecked();
+        await pkceCheckbox.check();
+
         // Save
         await page.getByRole('button', { name: /save oauth application/i }).click();
 
         // Verify the details page shows updated values
         await expect(page.getByText('HMAC with SHA-2 256')).toBeVisible();
+        await expect(page.getByTestId('pkce-required')).toContainText('Yes');
       }
     );
   });

--- a/playwright/utils/oauthApplication.ts
+++ b/playwright/utils/oauthApplication.ts
@@ -12,6 +12,7 @@ export interface CreateOAuthApplicationOptions {
   redirect_uris?: string;
   algorithm?: '' | 'RS256' | 'HS256';
   skip_authorization?: boolean;
+  pkce_required?: boolean;
   post_logout_redirect_uris?: string;
 }
 
@@ -28,6 +29,7 @@ export const OAuthApplication = {
         algorithm: options.algorithm ?? '',
         skip_authorization: options.skip_authorization ?? false,
         post_logout_redirect_uris: options.post_logout_redirect_uris ?? '',
+        ...(options.pkce_required !== undefined && { pkce_required: options.pkce_required }),
       });
 
       if (!application) {

--- a/playwright/utils/oauthApplication.ts
+++ b/playwright/utils/oauthApplication.ts
@@ -29,6 +29,9 @@ export const OAuthApplication = {
         algorithm: options.algorithm ?? '',
         skip_authorization: options.skip_authorization ?? false,
         post_logout_redirect_uris: options.post_logout_redirect_uris ?? '',
+        // Unlike the fields above, pkce_required is only sent when the caller explicitly
+        // asks for it, so callers that don't care about it get the server's real default
+        // instead of one hardcoded here.
         ...(options.pkce_required !== undefined && { pkce_required: options.pkce_required }),
       });
 


### PR DESCRIPTION
## Summary

The PKCE Required toggle added in #3371 shipped with unit/component test coverage but no Playwright e2e coverage. This adds that coverage, folded into the two existing tests that already exercise the OAuth application create/edit forms (rather than new standalone tests) to avoid redundant full browser round trips:

- "should create an OAuth application with all fields" now also asserts PKCE Required defaults to checked and persists as unchecked after being disabled.
- "should edit algorithm, skip authorization, and PKCE required fields" (renamed from the algorithm/skip-authorization-only test) now also toggles PKCE Required on and verifies it on the details page.
- Extends the `OAuthApplication` playwright utility to support setting `pkce_required` via the API for test setup, without changing the default payload sent by existing callers.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Test-only change, narrowly scoped to one existing spec file and one playwright test utility.

## Testing

### Ephemeral E2E Tests

Will trigger via `/run-playwright` once preliminary checks pass.

### Manual Testing

- `npx tsc --noEmit`, `npx eslint --max-warnings=0`, and `npx prettier --check` all pass on the changed files in `/playwright`.
- Not run against a live AAP instance locally (no live backend available in this environment); tests are tagged `@not_mock` so they'll run automatically once `/run-playwright` triggers the ephemeral e2e job.