### PR TITLE
AAP-82308 XLAB Add Time Saved column to jobs table

### DIFF
--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -120,6 +120,8 @@ const mockJobTemplate: IJobTemplate = {
   automated_costs: 100,
   manual_costs: 200,
   savings: 100,
+  time_savings: 1800,
+  time_savings_str: '00:30:00',
 };
 
 const mockDetails: IDashboardDetails = {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -55,6 +55,8 @@ const mockItem: IJobTemplate = {
   automated_costs: 100,
   manual_costs: 200,
   savings: 100,
+  time_savings: 3600,
+  time_savings_str: '01:00:00',
 };
 
 const mockDetails: IDashboardDetails = {
@@ -266,9 +268,10 @@ describe('DashboardMainTableCard', () => {
       screen.getByRole('columnheader', { name: /Time taken to manually execute/i })
     ).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Running time/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Time savings/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Automated cost/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Manual cost/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /Savings/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^Savings$/i })).toBeInTheDocument();
   });
 
   test('should show "time taken to create automation" column when include_template_creation_time_in_costs is true', () => {
@@ -340,6 +343,12 @@ describe('DashboardMainTableCard', () => {
     renderCard();
     expect(screen.getByText('00:30:00')).toBeInTheDocument();
     expect(screen.queryByText('1800')).not.toBeInTheDocument();
+  });
+
+  test('should render time_savings_str (not raw time_savings) in the Time savings column', () => {
+    renderCard();
+    expect(screen.getByText('01:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('3600')).not.toBeInTheDocument();
   });
 
   test('should format automated_costs, manual_costs and savings as currency', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -200,6 +200,12 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       sort: 'elapsed',
     },
     {
+      id: 'time_savings',
+      header: t('Time savings'),
+      cell: (item) => tableCell('time_savings_str', item),
+      sort: 'time_savings',
+    },
+    {
       id: 'automated_costs',
       header: t('Automated cost'),
       cell: (item) => tableCell('automated_costs', item),

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -32,6 +32,8 @@ export interface IJobTemplate {
   automated_costs: number;
   manual_costs: number;
   savings: number;
+  time_savings: number;
+  time_savings_str: string;
 }
 
 export interface ISubscriptionCosts {


### PR DESCRIPTION
[AAP-82308] Add Time Saved column to jobs table
## Summary
This pull request adds a new "Time savings" column to the automation dashboard main table, ensuring that the formatted time savings string is displayed and tested throughout the codebase. The changes include updating the data model, the table rendering logic, and associated tests.

**Dashboard Table Enhancements:**

* Added a new "Time savings" column to the `DashboardMainTableCard` component, displaying the formatted `time_savings_str` value and enabling sorting by raw `time_savings`. (`frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx`, [frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsxR202-R207](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R202-R207))

**Data Model Updates:**

* Extended the `IJobTemplate` interface to include `time_savings` (number) and `time_savings_str` (string) fields. (`frontend/awx/analytics/automation-dashboard/types/index.ts`, [frontend/awx/analytics/automation-dashboard/types/index.tsR35-R36](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbR35-R36))

**Testing Improvements:**

* Updated the test mock data to include `time_savings` and `time_savings_str` fields. (`frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx`, [frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsxR58-R59](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806R58-R59))
* Added a test to verify that the "Time savings" column header is rendered and that the formatted string (`time_savings_str`) is shown instead of the raw value. (`frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx`, [[1]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806R271-R274) [[2]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806R348-R353)

**Minor Test Fixes:**

* Adjusted a test to use a stricter regex for the "Savings" column header. (`frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx`, [frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsxR271-R274](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806R271-R274))
<!-- What changed and why? -->

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="1630" height="572" alt="image" src="https://github.com/user-attachments/assets/4ec29393-1e33-4ac2-8015-829228728b31" />
