### PR TITLE
Add e2e coverage for Jobs list 'Launched by' filter

### DIFF
--- a/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
+++ b/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
@@ -10,7 +10,6 @@ import { clickPageAction } from '../../../../commands/clickPageAction';
 import { createE2EName } from '../../../../commands/createE2EName';
 import { waitForJobStatus } from '../../../../commands/waitForJobStatus';
 import { filterTable } from '../../../../commands/filterTable';
-import { clearTableFilters } from '../../../../commands/clearTableFilters';
 
 test.beforeEach(setupBefore({ path: '/execution/jobs' }));
 test.afterEach(setupAfter);
@@ -140,47 +139,18 @@ test.describe('Jobs: Delete', () => {
     // Verify job is removed from the list - it should no longer appear
     await expect(page.getByRole('row', { name: jobTemplateName })).not.toBeVisible();
   });
-});
-
-test.describe('Jobs: Filtering', () => {
-  let organizationName: string;
-  let inventoryName: string;
-  let jobTemplateName: string;
-
-  test.beforeEach(async ({ page }) => {
-    organizationName = await Organization.ui.create(page);
-    inventoryName = await Inventory.ui.create(page);
-    jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
-  });
-
-  test.afterEach(async ({ page }) => {
-    // Use API-based deletion to properly cancel running jobs before cleanup
-    try {
-      await JobTemplate.api.deleteByName(page, jobTemplateName);
-    } catch {
-      // Ignore cleanup errors
-    }
-    try {
-      await Inventory.ui.delete(page, inventoryName);
-    } catch {
-      // Ignore cleanup errors
-    }
-    try {
-      await Organization.ui.delete(page, organizationName);
-    } catch {
-      // Ignore cleanup errors
-    }
-  });
 
   test('can filter jobs by Launched by', { tag: ['@not_mock'] }, async ({ page }) => {
-    await JobTemplate.ui.run(page, jobTemplateName, { inventoryName, doNotWait: false });
+    await JobTemplate.ui.run(page, jobTemplateName, { inventoryName, doNotWait: true });
 
     await navigateTo(page, 'Automation Execution', 'Jobs');
     await filterTable({ filterLabel: 'Launched by', filterValue: 'admin' }, page);
+    // Combine with a Name filter so the assertion below is pagination-safe
+    // regardless of how many other admin-launched jobs exist in the environment.
+    await filterTable({ filterLabel: 'Name', filterValue: jobTemplateName }, page);
 
+    await expect(page.locator('tbody')).toBeVisible({ timeout: 10000 });
     await expect(page.getByRole('row', { name: jobTemplateName })).toBeVisible();
-
-    await clearTableFilters(page);
   });
 });
 

--- a/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
+++ b/playwright/tests/integration/automation-execution/jobs/jobs.spec.ts
@@ -10,6 +10,7 @@ import { clickPageAction } from '../../../../commands/clickPageAction';
 import { createE2EName } from '../../../../commands/createE2EName';
 import { waitForJobStatus } from '../../../../commands/waitForJobStatus';
 import { filterTable } from '../../../../commands/filterTable';
+import { clearTableFilters } from '../../../../commands/clearTableFilters';
 
 test.beforeEach(setupBefore({ path: '/execution/jobs' }));
 test.afterEach(setupAfter);
@@ -138,6 +139,48 @@ test.describe('Jobs: Delete', () => {
 
     // Verify job is removed from the list - it should no longer appear
     await expect(page.getByRole('row', { name: jobTemplateName })).not.toBeVisible();
+  });
+});
+
+test.describe('Jobs: Filtering', () => {
+  let organizationName: string;
+  let inventoryName: string;
+  let jobTemplateName: string;
+
+  test.beforeEach(async ({ page }) => {
+    organizationName = await Organization.ui.create(page);
+    inventoryName = await Inventory.ui.create(page);
+    jobTemplateName = await JobTemplate.ui.create(page, { inventoryName });
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Use API-based deletion to properly cancel running jobs before cleanup
+    try {
+      await JobTemplate.api.deleteByName(page, jobTemplateName);
+    } catch {
+      // Ignore cleanup errors
+    }
+    try {
+      await Inventory.ui.delete(page, inventoryName);
+    } catch {
+      // Ignore cleanup errors
+    }
+    try {
+      await Organization.ui.delete(page, organizationName);
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  test('can filter jobs by Launched by', { tag: ['@not_mock'] }, async ({ page }) => {
+    await JobTemplate.ui.run(page, jobTemplateName, { inventoryName, doNotWait: false });
+
+    await navigateTo(page, 'Automation Execution', 'Jobs');
+    await filterTable({ filterLabel: 'Launched by', filterValue: 'admin' }, page);
+
+    await expect(page.getByRole('row', { name: jobTemplateName })).toBeVisible();
+
+    await clearTableFilters(page);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3414.

#3332 added a "Launched by" toolbar filter to the Jobs list but it shipped with only a hook-level Vitest test, no Playwright e2e coverage. This adds an e2e test to `jobs.spec.ts` following the same `filterTable` pattern already used for the "Created by"/"Modified by" filters elsewhere in the suite (e.g. `credential-types.spec.ts`):

- Launches a job via a freshly created job template.
- Navigates to the Jobs list and filters by "Launched by" = `admin`.
- Asserts the launched job's row is visible, then clears filters.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Test-only change, adds one test to one existing spec file.

## Testing

### Ephemeral E2E Tests

Will trigger via `/run-playwright` once preliminary checks pass.

### Manual Testing

- `npx tsc --noEmit`, `npx eslint --max-warnings=0`, and `npx prettier --check` all pass on the changed file in `/playwright`.
- Not run against a live AAP instance locally (no live backend available in this environment); the test is tagged `@not_mock` so it'll run automatically once `/run-playwright` triggers the ephemeral e2e job.