### PR TITLE
fix flaky useDeleteEdaRoles test

### DIFF
--- a/frontend/eda/access/roles/hooks/useDeleteEdaRoles.test.tsx
+++ b/frontend/eda/access/roles/hooks/useDeleteEdaRoles.test.tsx
@@ -114,9 +114,12 @@ describe('useDeleteEdaRoles', () => {
     const submitButton = screen.getByRole('button', { name: 'Delete roles' });
     await user.click(submitButton);
 
-    await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
-    });
+    await waitFor(
+      () => {
+        expect(onComplete).toHaveBeenCalled();
+      },
+      { timeout: 3000 }
+    );
   });
 
   it('should show alert when built-in roles are selected', () => {


### PR DESCRIPTION
## Summary

Fixes flaky vitest.

The Bulk Action Dialog closes after 1s, so the assertion after saving needs to wait longer than that to ensure it is closed before the assertion times out.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
