### PR TITLE
AAP-82394  XLAB Fix Automation Dashboard layout

### DIFF
--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
@@ -67,6 +67,45 @@ describe('ToolbarDateRangeFilter', () => {
     expect(setterFn()).toEqual(['last30days']);
   });
 
+  it('should reset to defaultValue when X clicked and defaultValue is set', async () => {
+    const user = userEvent.setup();
+    const setFilterValues = vi.fn();
+
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['last7days']}
+        setFilterValues={setFilterValues}
+        defaultValue="last7days"
+      />
+    );
+
+    await user.click(screen.getByTestId('reset'));
+
+    expect(setFilterValues).toHaveBeenCalled();
+    const setterFn = setFilterValues.mock.calls[0][0] as () => string[];
+    expect(setterFn()).toEqual(['last7days']);
+  });
+
+  it('should do nothing when X clicked and no defaultValue is set', async () => {
+    const user = userEvent.setup();
+    const setFilterValues = vi.fn();
+
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['last7days']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    await user.click(screen.getByTestId('reset'));
+
+    expect(setFilterValues).not.toHaveBeenCalled();
+  });
+
   it('should render DateRange pickers when custom option selected', () => {
     render(
       <ToolbarDateRangeFilter

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
@@ -50,7 +50,12 @@ export function ToolbarDateRangeFilter(props: IToolbarDateRangeFilterProps) {
   }
 
   function onSelectChange(value: string | null) {
-    if (value === null) return;
+    if (value === null) {
+      if (defaultValue) {
+        setFilterValues(() => [defaultValue]);
+      }
+      return;
+    }
     const option = props.options.find((option) => option.value === value);
     if (option) {
       setFilterValues(() => [value]);

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -65,14 +65,19 @@ vi.mock('./components', () => ({
     items,
     emptyStateTitle,
     emptyStateDescription,
+    filterState,
   }: {
     title: string;
     items?: unknown[];
     emptyStateTitle?: string;
     emptyStateDescription?: string;
+    filterState?: Record<string, unknown>;
   }) => (
     <div>
       <div>{title}</div>
+      <div data-testid={`${title}-filter-state`}>
+        {filterState ? JSON.stringify(filterState) : 'none'}
+      </div>
       {(!items || items.length === 0) && (
         <div data-testid={`${title}-empty-state`}>
           {emptyStateTitle && <div data-testid="empty-state-title">{emptyStateTitle}</div>}
@@ -440,5 +445,51 @@ describe('AutomationDashboard', () => {
     expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'xs');
 
     clientWidthSpy.mockRestore();
+  });
+
+  test('should fall back to the minimum grid columns when a resize reports no width', () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(1450);
+
+    render(testWrapper());
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'xs');
+
+    const resizeCallback = vi.mocked(useResizeObserver).mock.calls[0][1];
+    act(() => {
+      resizeCallback({ contentRect: {} } as ResizeObserverEntry, {} as ResizeObserver);
+    });
+
+    // no reported width -> gridColumns falls back to 1, below the wide-layout range
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'md');
+
+    clientWidthSpy.mockRestore();
+  });
+
+  // ─── Filter state passthrough ──────────────────────────────────────────────
+
+  test('should pass the active filter state to the table cards when filters are not default', () => {
+    const activeFilterState = { template_name: ['demo'] };
+    vi.mocked(useAutomationDashboardView).mockReturnValueOnce({
+      ...mockView,
+      isFilterStateDefault: false,
+      mainTableView: { ...mockMainTableView, filterState: activeFilterState },
+    });
+
+    render(testWrapper());
+
+    expect(screen.getByTestId('Top 5 projects-filter-state')).toHaveTextContent(
+      JSON.stringify(activeFilterState)
+    );
+    expect(screen.getByTestId('Top 5 users-filter-state')).toHaveTextContent(
+      JSON.stringify(activeFilterState)
+    );
+  });
+
+  test('should not pass filter state to the table cards when filters are default', () => {
+    render(testWrapper());
+
+    expect(screen.getByTestId('Top 5 projects-filter-state')).toHaveTextContent('none');
+    expect(screen.getByTestId('Top 5 users-filter-state')).toHaveTextContent('none');
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -1,6 +1,6 @@
 import { vi, test, afterEach, describe, expect } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 import {
@@ -8,6 +8,7 @@ import {
   PageAlertToasterProvider,
   ToolbarFilterType,
 } from '@ansible/ansible-ui-framework';
+import useResizeObserver from '@react-hook/resize-observer';
 import { AutomationDashboard } from './AutomationDashboard';
 import { useAutomationDashboardToolbar } from './components';
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
@@ -19,6 +20,10 @@ import type {
   DashboardValueCardProps,
   IAutomationDashboardCollectionStatus,
 } from './types';
+
+vi.mock('@react-hook/resize-observer', () => ({
+  default: vi.fn(),
+}));
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -37,15 +42,22 @@ vi.mock('./common/useAutomationDashboardCollectionStatus', () => ({
 
 vi.mock('./components', () => ({
   useAutomationDashboardToolbar: vi.fn(() => []),
-  DashboardValueCard: ({ title, value, valueSuffix, linkText }: DashboardValueCardProps) => (
-    <>
+  DashboardValueCard: ({
+    id,
+    title,
+    value,
+    valueSuffix,
+    linkText,
+    width,
+  }: DashboardValueCardProps) => (
+    <div data-testid={id} data-width={width}>
       <span>{title}</span>
       <span>
         {typeof value === 'number' ? value.toLocaleString() : value}
         {valueSuffix ? ` ${valueSuffix}` : ''}
       </span>
       {linkText && <span>{linkText}</span>}
-    </>
+    </div>
   ),
   DashboardChartCard: ({ title }: { title: string }) => <div>{title}</div>,
   DashboardTableCard: ({
@@ -382,5 +394,51 @@ describe('AutomationDashboard', () => {
         'Automation data exists, but no runs are currently attributed to individual users.'
       )
     ).toBeInTheDocument();
+  });
+
+  // ─── Grid column layout ────────────────────────────────────────────────────
+
+  test('should use the container width to compute grid columns on mount', () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(500);
+
+    render(testWrapper());
+
+    // width 500 -> below the wide-layout column range, so value cards stay 'md'
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'md');
+
+    clientWidthSpy.mockRestore();
+  });
+
+  test('should switch value cards to the wide layout width when the container is wide enough', () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(1450);
+
+    render(testWrapper());
+
+    // width 1450 -> falls within the wide-layout column range
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'xs');
+
+    clientWidthSpy.mockRestore();
+  });
+
+  test('should recompute grid columns when the container is resized', () => {
+    const clientWidthSpy = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(500);
+
+    render(testWrapper());
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'md');
+
+    const resizeCallback = vi.mocked(useResizeObserver).mock.calls[0][1];
+    act(() => {
+      resizeCallback({ contentRect: { width: 1450 } } as ResizeObserverEntry, {} as ResizeObserver);
+    });
+
+    expect(screen.getByTestId('successful-jobs-card')).toHaveAttribute('data-width', 'xs');
+
+    clientWidthSpy.mockRestore();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import {
-  PageDashboard,
+  PageDashboardContext,
   PageHeader,
   PageLayout,
   useGetPageUrl,
 } from '@ansible/ansible-ui-framework';
 import { Grid, GridItem } from '@patternfly/react-core';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { AwxRoute } from '../../main/AwxRoutes';
 import {
   DashboardChartCard,
@@ -18,19 +18,12 @@ import {
 
 import { useAutomationDashboardView } from './views/useAutomationDashboardView';
 import { DashboardToolbar } from './components/DashboardToolbar';
-import styled from 'styled-components';
 import useResizeObserver from '@react-hook/resize-observer';
 import { useAutomationDashboardCollectionStatus } from './common/useAutomationDashboardCollectionStatus';
 import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingState';
+import { Scrollable } from '@ansible/ansible-ui-framework/components/Scrollable';
 
-const AutomationDashboardWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-`;
 const Divisor = 1662 / 24;
-/** Horizontal padding subtracted from container width before computing grid columns. */
-const DASHBOARD_PADDING_PX = 40;
 /** Breakpoint range (in grid columns) where value cards switch from 'md' to 'xs' size. */
 const WIDE_LAYOUT_MIN_COLUMNS = 16;
 const WIDE_LAYOUT_MAX_COLUMNS = 31;
@@ -39,7 +32,6 @@ export function AutomationDashboard() {
   const { t } = useTranslation();
   const toolbarFilters = useAutomationDashboardToolbar();
   const getPageUrl = useGetPageUrl();
-
   const description = t(
     'Discover the significant cost and time savings achieved by automating Ansible jobs with the Ansible Automation Platform. Explore how automation reduces manual effort, enhances efficiency, and optimizes IT operations across your organization.'
   );
@@ -54,190 +46,197 @@ export function AutomationDashboard() {
   const [gridColumns, setGridColumns] = useState(1);
 
   useLayoutEffect(() => {
-    const width = Math.max(
-      1,
-      Math.floor(((ref.current?.clientWidth ?? 0) - DASHBOARD_PADDING_PX) / Divisor)
-    );
+    const width = Math.max(1, Math.floor((ref.current?.clientWidth ?? 0) / Divisor));
     setGridColumns(width);
   }, []);
 
   useResizeObserver(ref, (entry) => {
-    const width = Math.max(
-      1,
-      Math.floor(((entry.contentRect.width ?? 0) - DASHBOARD_PADDING_PX) / Divisor)
-    );
+    const width = Math.max(1, Math.floor((entry.contentRect.width ?? 0) / Divisor));
     setGridColumns(width);
   });
-
-  // Show loading state while checking collection status
-  if (isLoading) {
-    return (
-      <AutomationDashboardWrapper ref={ref}>
-        <LoadingState />
-      </AutomationDashboardWrapper>
-    );
-  }
 
   const isWideLayout =
     WIDE_LAYOUT_MIN_COLUMNS <= gridColumns && gridColumns <= WIDE_LAYOUT_MAX_COLUMNS;
   const valueCardWidth = isWideLayout ? 'xs' : ('md' as const);
 
+  const pageDashboardContextValue = useMemo(() => ({ columns: gridColumns }), [gridColumns]);
+
+  const dashboardContent = (
+    <>
+      <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+        <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+          <DashboardValueCard
+            id="successful-jobs-card"
+            title={t('Successful jobs')}
+            help={t(
+              'Number of job runs that completed without error in the selected period. Use the ratio between successful and failed jobs to track automation health and reliability over time.'
+            )}
+            linkText={t('See all successful jobs')}
+            to={getPageUrl(AwxRoute.Jobs) + '?status=successful'}
+            value={details?.total_number_of_successful_jobs ?? noDataString}
+            error={view.detailsError}
+            errorStateTitle={t('Error loading successful jobs')}
+            width={valueCardWidth}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="failed-jobs-card"
+            title={t('Failed jobs')}
+            help={t(
+              'Number of job runs that ended in failure in the selected period. Review failed jobs to fix playbooks, credentials, or inventory issues and improve success rates.'
+            )}
+            linkText={t('See all failed jobs')}
+            to={getPageUrl(AwxRoute.Jobs) + '?status=failed'}
+            value={details?.total_number_of_failed_jobs ?? noDataString}
+            error={view.detailsError}
+            errorStateTitle={t('Error loading failed jobs')}
+            width={valueCardWidth}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="unique-hosts-card"
+            title={t('Hosts automated')}
+            help={t(
+              'Number of hosts that executed at least one automation job in the selected period. Indicates how much of your inventory is actively automated and can help with license or capacity planning.'
+            )}
+            value={details?.total_number_of_unique_hosts ?? noDataString}
+            error={view.detailsError}
+            errorStateTitle={t('Error loading unique hosts')}
+            width={valueCardWidth}
+          ></DashboardValueCard>
+          <DashboardValueCard
+            id="automation-hours-card"
+            title={t('Hours of automation')}
+            help={t(
+              'Sum of all job runtimes in the selected period. Reflects total automation workload and can inform capacity planning and resource allocation.'
+            )}
+            value={details?.total_hours_of_automation ?? noDataString}
+            valueSuffix={details?.total_hours_of_automation ? 'h' : undefined}
+            error={view.detailsError}
+            errorStateTitle={t('Error loading hours of automation')}
+            width={valueCardWidth}
+          ></DashboardValueCard>
+        </Grid>
+      </GridItem>
+      <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+        <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+          <DashboardTableCard
+            id="top-projects-card"
+            title={t('Top 5 projects')}
+            help={t(
+              'Projects ranked by total job count in the selected period. Helps identify which projects are driving the most automation activity.'
+            )}
+            firstColumnHeader={t('Project name')}
+            errorStateTitle={t('Error loading projects')}
+            items={details?.top_projects ?? []}
+            error={view.detailsError}
+            loading={view.detailsLoading}
+            clearAllFilters={view.mainTableView.clearAllFilters}
+            filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
+            emptyStateTitle={
+              view?.mainTableView?.itemCount ? t('No projects to rank') : t('No project data yet')
+            }
+            emptyStateDescription={
+              view?.mainTableView?.itemCount
+                ? t('Automation data exists, but no runs are currently associated with projects.')
+                : t('Project data will appear after your first automation runs.')
+            }
+          ></DashboardTableCard>
+          <DashboardTableCard
+            id="top-users-card"
+            title={t('Top 5 users')}
+            help={t(
+              'Users ranked by automation runs they triggered or that ran in their context in the selected period. Shows individual adoption and activity.'
+            )}
+            firstColumnHeader={t('User name')}
+            errorStateTitle={t('Error loading users')}
+            items={details?.top_users ?? []}
+            error={view.detailsError}
+            loading={view.detailsLoading}
+            clearAllFilters={view.mainTableView.clearAllFilters}
+            filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
+            emptyStateTitle={
+              view?.mainTableView?.itemCount ? t('No users to rank') : t('No user data yet')
+            }
+            emptyStateDescription={
+              view?.mainTableView?.itemCount
+                ? t(
+                    'Automation data exists, but no runs are currently attributed to individual users.'
+                  )
+                : t('User data will appear after your first automation runs.')
+            }
+          ></DashboardTableCard>
+          <DashboardChartCard
+            id="host-chart-card"
+            title={t('Number of hosts jobs are running on')}
+            help={t(
+              'Number of hosts that ran at least one job in the selected period. Complements run count by showing how broadly automation is applied across your inventory.'
+            )}
+            summaryValue={details?.total_number_of_host_job_runs ?? 0}
+            data={details?.host_chart ?? { kind: 'day', items: [] }}
+            variant={'lineChart'}
+            error={view.detailsError}
+            errorStateTitle={t('Error loading host chart')}
+            legendLabel={t('Hosts')}
+          ></DashboardChartCard>
+          <DashboardChartCard
+            id="job-chart-card"
+            title={t('Number of times jobs were run')}
+            help={t(
+              'Total number of job executions in the selected period, regardless of success or failure. Use this to understand automation volume, trends, and adoption over time.'
+            )}
+            variant={'barChart'}
+            summaryValue={details?.total_number_of_job_runs ?? 0}
+            data={details?.job_chart ?? { kind: 'day', items: [] }}
+            errorStateTitle={t('Error loading job chart')}
+            error={view.detailsError}
+            legendLabel={t('Job runs')}
+          ></DashboardChartCard>
+        </Grid>
+      </GridItem>
+
+      <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
+        <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
+          <DashboardMainTableCard
+            {...view}
+            toolbarFilters={toolbarFilters}
+            topCardsWidth={valueCardWidth}
+          />
+        </Grid>
+      </GridItem>
+    </>
+  );
+
   return (
-    <AutomationDashboardWrapper ref={ref}>
-      <PageLayout>
-        <PageHeader
-          title={t('Automation Dashboard')}
-          titleHelpTitle={t('Automation Dashboard')}
-          titleHelp={description}
-          description={description}
-        />
-        <DashboardToolbar
-          toolbarFilters={toolbarFilters}
-          {...view.mainTableView}
-          keyFn={(item) => item.id}
-          registerClearCallback={view.registerClearCallback}
-        />
-        <PageDashboard>
-          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
-            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
-              <DashboardValueCard
-                id="successful-jobs-card"
-                title={t('Successful jobs')}
-                help={t(
-                  'Number of job runs that completed without error in the selected period. Use the ratio between successful and failed jobs to track automation health and reliability over time.'
-                )}
-                linkText={t('See all successful jobs')}
-                to={getPageUrl(AwxRoute.Jobs) + '?status=successful'}
-                value={details?.total_number_of_successful_jobs ?? noDataString}
-                error={view.detailsError}
-                errorStateTitle={t('Error loading successful jobs')}
-                width={valueCardWidth}
-              ></DashboardValueCard>
-              <DashboardValueCard
-                id="failed-jobs-card"
-                title={t('Failed jobs')}
-                help={t(
-                  'Number of job runs that ended in failure in the selected period. Review failed jobs to fix playbooks, credentials, or inventory issues and improve success rates.'
-                )}
-                linkText={t('See all failed jobs')}
-                to={getPageUrl(AwxRoute.Jobs) + '?status=failed'}
-                value={details?.total_number_of_failed_jobs ?? noDataString}
-                error={view.detailsError}
-                errorStateTitle={t('Error loading failed jobs')}
-                width={valueCardWidth}
-              ></DashboardValueCard>
-              <DashboardValueCard
-                id="unique-hosts-card"
-                title={t('Hosts automated')}
-                help={t(
-                  'Number of hosts that executed at least one automation job in the selected period. Indicates how much of your inventory is actively automated and can help with license or capacity planning.'
-                )}
-                value={details?.total_number_of_unique_hosts ?? noDataString}
-                error={view.detailsError}
-                errorStateTitle={t('Error loading unique hosts')}
-                width={valueCardWidth}
-              ></DashboardValueCard>
-              <DashboardValueCard
-                id="automation-hours-card"
-                title={t('Hours of automation')}
-                help={t(
-                  'Sum of all job runtimes in the selected period. Reflects total automation workload and can inform capacity planning and resource allocation.'
-                )}
-                value={details?.total_hours_of_automation ?? noDataString}
-                valueSuffix={details?.total_hours_of_automation ? 'h' : undefined}
-                error={view.detailsError}
-                errorStateTitle={t('Error loading hours of automation')}
-                width={valueCardWidth}
-              ></DashboardValueCard>
-            </Grid>
-          </GridItem>
-          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
-            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
-              <DashboardTableCard
-                id="top-projects-card"
-                title={t('Top 5 projects')}
-                help={t(
-                  'Projects ranked by total job count in the selected period. Helps identify which projects are driving the most automation activity.'
-                )}
-                firstColumnHeader={t('Project name')}
-                errorStateTitle={t('Error loading projects')}
-                items={details?.top_projects ?? []}
-                error={view.detailsError}
-                loading={view.detailsLoading}
-                clearAllFilters={view.mainTableView.clearAllFilters}
-                filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
-                emptyStateTitle={
-                  view?.mainTableView?.itemCount
-                    ? t('No projects to rank')
-                    : t('No project data yet')
-                }
-                emptyStateDescription={
-                  view?.mainTableView?.itemCount
-                    ? t(
-                        'Automation data exists, but no runs are currently associated with projects.'
-                      )
-                    : t('Project data will appear after your first automation runs.')
-                }
-              ></DashboardTableCard>
-              <DashboardTableCard
-                id="top-users-card"
-                title={t('Top 5 users')}
-                help={t(
-                  'Users ranked by automation runs they triggered or that ran in their context in the selected period. Shows individual adoption and activity.'
-                )}
-                firstColumnHeader={t('User name')}
-                errorStateTitle={t('Error loading users')}
-                items={details?.top_users ?? []}
-                error={view.detailsError}
-                loading={view.detailsLoading}
-                clearAllFilters={view.mainTableView.clearAllFilters}
-                filterState={view.isFilterStateDefault ? undefined : view.mainTableView.filterState}
-                emptyStateTitle={
-                  view?.mainTableView?.itemCount ? t('No users to rank') : t('No user data yet')
-                }
-                emptyStateDescription={
-                  view?.mainTableView?.itemCount
-                    ? t(
-                        'Automation data exists, but no runs are currently attributed to individual users.'
-                      )
-                    : t('User data will appear after your first automation runs.')
-                }
-              ></DashboardTableCard>
-              <DashboardChartCard
-                id="host-chart-card"
-                title={t('Number of hosts jobs are running on')}
-                help={t(
-                  'Number of hosts that ran at least one job in the selected period. Complements run count by showing how broadly automation is applied across your inventory.'
-                )}
-                summaryValue={details?.total_number_of_host_job_runs ?? 0}
-                data={details?.host_chart ?? { kind: 'day', items: [] }}
-                variant={'lineChart'}
-                error={view.detailsError}
-                errorStateTitle={t('Error loading host chart')}
-                legendLabel={t('Hosts')}
-              ></DashboardChartCard>
-              <DashboardChartCard
-                id="job-chart-card"
-                title={t('Number of times jobs were run')}
-                help={t(
-                  'Total number of job executions in the selected period, regardless of success or failure. Use this to understand automation volume, trends, and adoption over time.'
-                )}
-                variant={'barChart'}
-                summaryValue={details?.total_number_of_job_runs ?? 0}
-                data={details?.job_chart ?? { kind: 'day', items: [] }}
-                errorStateTitle={t('Error loading job chart')}
-                error={view.detailsError}
-                legendLabel={t('Job runs')}
-              ></DashboardChartCard>
-            </Grid>
-          </GridItem>
-          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
-            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
-              <DashboardMainTableCard {...view} toolbarFilters={toolbarFilters} />
-            </Grid>
-          </GridItem>
-        </PageDashboard>
-      </PageLayout>
-    </AutomationDashboardWrapper>
+    <PageLayout>
+      {!isLoading && (
+        <>
+          <PageHeader
+            title={t('Automation Dashboard')}
+            titleHelpTitle={t('Automation Dashboard')}
+            titleHelp={description}
+            description={description}
+          />
+          <DashboardToolbar
+            toolbarFilters={toolbarFilters}
+            {...view.mainTableView}
+            keyFn={(item) => item.id}
+            registerClearCallback={view.registerClearCallback}
+          />
+        </>
+      )}
+      <PageDashboardContext.Provider value={pageDashboardContextValue}>
+        <Scrollable marginLeft={20} marginRight={20} marginBottom={16} marginTop={16}>
+          <div
+            ref={ref}
+            style={{
+              display: 'grid',
+              gap: 16,
+              gridTemplateColumns: `repeat(${gridColumns}, 1fr)`,
+            }}
+          >
+            {isLoading ? <LoadingState /> : dashboardContent}
+          </div>
+        </Scrollable>
+      </PageDashboardContext.Provider>
+    </PageLayout>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.tsx
@@ -29,6 +29,11 @@ const AutomationDashboardWrapper = styled.div`
   overflow: hidden;
 `;
 const Divisor = 1662 / 24;
+/** Horizontal padding subtracted from container width before computing grid columns. */
+const DASHBOARD_PADDING_PX = 40;
+/** Breakpoint range (in grid columns) where value cards switch from 'md' to 'xs' size. */
+const WIDE_LAYOUT_MIN_COLUMNS = 16;
+const WIDE_LAYOUT_MAX_COLUMNS = 31;
 
 export function AutomationDashboard() {
   const { t } = useTranslation();
@@ -49,13 +54,19 @@ export function AutomationDashboard() {
   const [gridColumns, setGridColumns] = useState(1);
 
   useLayoutEffect(() => {
-    const width = Math.max(1, Math.floor((ref.current?.clientWidth ?? 0) / Divisor));
-    setGridColumns(Math.min(25, width));
+    const width = Math.max(
+      1,
+      Math.floor(((ref.current?.clientWidth ?? 0) - DASHBOARD_PADDING_PX) / Divisor)
+    );
+    setGridColumns(width);
   }, []);
 
   useResizeObserver(ref, (entry) => {
-    const width = Math.max(1, Math.floor((entry.contentRect.width ?? 0) / Divisor));
-    setGridColumns(Math.min(25, width));
+    const width = Math.max(
+      1,
+      Math.floor(((entry.contentRect.width ?? 0) - DASHBOARD_PADDING_PX) / Divisor)
+    );
+    setGridColumns(width);
   });
 
   // Show loading state while checking collection status
@@ -66,6 +77,10 @@ export function AutomationDashboard() {
       </AutomationDashboardWrapper>
     );
   }
+
+  const isWideLayout =
+    WIDE_LAYOUT_MIN_COLUMNS <= gridColumns && gridColumns <= WIDE_LAYOUT_MAX_COLUMNS;
+  const valueCardWidth = isWideLayout ? 'xs' : ('md' as const);
 
   return (
     <AutomationDashboardWrapper ref={ref}>
@@ -96,6 +111,7 @@ export function AutomationDashboard() {
                 value={details?.total_number_of_successful_jobs ?? noDataString}
                 error={view.detailsError}
                 errorStateTitle={t('Error loading successful jobs')}
+                width={valueCardWidth}
               ></DashboardValueCard>
               <DashboardValueCard
                 id="failed-jobs-card"
@@ -108,6 +124,7 @@ export function AutomationDashboard() {
                 value={details?.total_number_of_failed_jobs ?? noDataString}
                 error={view.detailsError}
                 errorStateTitle={t('Error loading failed jobs')}
+                width={valueCardWidth}
               ></DashboardValueCard>
               <DashboardValueCard
                 id="unique-hosts-card"
@@ -118,6 +135,7 @@ export function AutomationDashboard() {
                 value={details?.total_number_of_unique_hosts ?? noDataString}
                 error={view.detailsError}
                 errorStateTitle={t('Error loading unique hosts')}
+                width={valueCardWidth}
               ></DashboardValueCard>
               <DashboardValueCard
                 id="automation-hours-card"
@@ -129,6 +147,7 @@ export function AutomationDashboard() {
                 valueSuffix={details?.total_hours_of_automation ? 'h' : undefined}
                 error={view.detailsError}
                 errorStateTitle={t('Error loading hours of automation')}
+                width={valueCardWidth}
               ></DashboardValueCard>
             </Grid>
           </GridItem>
@@ -184,10 +203,6 @@ export function AutomationDashboard() {
                     : t('User data will appear after your first automation runs.')
                 }
               ></DashboardTableCard>
-            </Grid>
-          </GridItem>
-          <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
-            <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
               <DashboardChartCard
                 id="host-chart-card"
                 title={t('Number of hosts jobs are running on')}
@@ -216,13 +231,9 @@ export function AutomationDashboard() {
               ></DashboardChartCard>
             </Grid>
           </GridItem>
-
           <GridItem style={{ gridColumn: `span ${gridColumns}` }}>
             <Grid hasGutter style={{ gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }}>
-              <DashboardMainTableCard
-                {...view}
-                toolbarFilters={toolbarFilters}
-              ></DashboardMainTableCard>
+              <DashboardMainTableCard {...view} toolbarFilters={toolbarFilters} />
             </Grid>
           </GridItem>
         </PageDashboard>

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -113,7 +113,7 @@ export function useAutomationDashboardToolbarActions(props: {
                   onClick: () => removeToolbarFilterSet(selectedFilterSet),
                   icon: TrashIcon,
                   isDisabled: superuserDeleteDisabledReason,
-                  variant: ButtonVariant.danger,
+                  isDanger: true,
                 },
               ],
             },

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.test.tsx
@@ -109,4 +109,22 @@ describe('DashboardChartCard', () => {
     expect(screen.getByText('Hosts')).toBeInTheDocument();
     expect(screen.queryByText('Count')).not.toBeInTheDocument();
   });
+
+  test('should format label with default locale string for an unrecognized kind', () => {
+    const unknownKindData = {
+      kind: 'week' as unknown as DashboardChartCardProps['data']['kind'],
+      items: [{ label: '2024-06-15T00:00:00', value: 10 }],
+    };
+    render(<DashboardChartCard {...defaultProps} data={unknownKindData} />);
+    expect(screen.getByText(expectedFormatted)).toBeInTheDocument();
+  });
+
+  test('should render with no crash when items is missing from data', () => {
+    const dataWithoutItems = {
+      kind: 'day' as const,
+      items: undefined as unknown as DashboardChartCardProps['data']['items'],
+    };
+    render(<DashboardChartCard {...defaultProps} data={dataWithoutItems} />);
+    expect(screen.getByText(expectedFormatted)).toBeInTheDocument();
+  });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardChartCard.tsx
@@ -3,6 +3,7 @@ import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import { DashboardChartCardProps, IDashboardChartItem } from '../types';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
 import { useTranslation } from 'react-i18next';
+import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
 
 export function DashboardChartCard(props: DashboardChartCardProps) {
   const { id, title, help, summaryValue, data, variant, error, errorStateTitle, legendLabel } =
@@ -39,19 +40,21 @@ export function DashboardChartCard(props: DashboardChartCardProps) {
     const value = chartItem.value;
     return { label, value };
   };
-  const usFormat = 'en-US';
+
   const values = data?.items?.map((item, index, array) => mapChartItem(item, index, array)) ?? [];
   const content = (
     <Flex direction={{ default: 'row' }} style={{ height: '100%' }}>
       <FlexItem>
-        <Title headingLevel="h2" style={{ fontSize: 'xxx-large', lineHeight: 1, fontWeight: 400 }}>
-          {summaryValue || summaryValue === 0 ? summaryValue.toLocaleString(usFormat) : '--'}
+        <Title headingLevel="h2" style={{ fontSize: 'xx-large', lineHeight: 1, fontWeight: 400 }}>
+          {summaryValue || summaryValue === 0
+            ? summaryValue.toLocaleString(DEFAULT_NUMBER_LOCALE)
+            : '--'}
         </Title>
       </FlexItem>
 
       <FlexItem style={{ height: '90%', width: '100%' }}>
         <PageDashboardChart
-          groups={[{ label: legendLabel ?? t('Count'), color: blueColor, values: values ?? [] }]}
+          groups={[{ label: legendLabel ?? t('Count'), color: blueColor, values }]}
           variant={variant}
           allowZero
           onlyIntegerTicks
@@ -62,7 +65,7 @@ export function DashboardChartCard(props: DashboardChartCardProps) {
     </Flex>
   );
   return (
-    <PageDashboardCard id={id} title={title} helpTitle={title} help={help} width="lg" height="lg">
+    <PageDashboardCard id={id} title={title} helpTitle={title} help={help} width="md" height="md">
       {error ? <EmptyStateError titleProp={errorStateTitle} message={error.message} /> : content}
     </PageDashboardCard>
   );

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -4,6 +4,7 @@ import {
   PageTable,
   usePageAlertToaster,
 } from '@ansible/ansible-ui-framework';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IAutomationDashboardView, IJobTemplate } from '../types';
 import { DashboardTableInputField } from './DashboardTableInputField';
@@ -11,7 +12,6 @@ import { DashboardTableToolbarRow } from './DashboardTableToolbarRow';
 import { DashboardValueCard } from './DashboardValueCard';
 import { usePutRequest } from '../../../../common/crud/usePutRequest';
 import { currencyFormatter } from '../../utilities/currencyFormatter';
-import { useLayoutEffect, useRef, useState } from 'react';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
@@ -27,6 +27,16 @@ interface IJobTemplateModify {
 // 24-column grid system for responsive layout
 // Uses 1625px instead of PageDashboard's 1662px to account for card padding
 const GRID_COLUMN_WIDTH = 1625 / 24; // ~67.7px per column
+
+/** Fixed width (px) for time-input columns to keep editable fields consistently sized. */
+const TIME_COLUMN_WIDTH = 212;
+
+/**
+ * The main table card always spans the full dashboard grid.
+ * 32 exceeds the maximum expected column count (~31) so `span 32`
+ * reliably fills the entire row on every viewport size.
+ */
+const MAIN_TABLE_FULL_SPAN = 32;
 
 const TdWrapper = styled.div`
   padding-block-start: var(--pf-t--global--spacer--control--vertical--default);
@@ -132,19 +142,23 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
   };
 
   const tableInputField = (columnKey: keyof IJobTemplateModify, item: IJobTemplate) => (
-    <DashboardTableInputField
-      id={`${columnKey}_${item.id}`}
-      min={1}
-      max={1000000}
-      type={'integer'}
-      value={item[columnKey]}
-      onChange={(value: number) => void onTableInputChange(item, columnKey, value)}
-      error={errors?.[item.id]?.[columnKey]}
-    />
+    <div style={{ width: `${TIME_COLUMN_WIDTH}px` }}>
+      <DashboardTableInputField
+        id={`${columnKey}_${item.id}`}
+        min={1}
+        max={1000000}
+        type={'integer'}
+        value={item[columnKey]}
+        onChange={(value: number) => void onTableInputChange(item, columnKey, value)}
+        error={errors?.[item.id]?.[columnKey]}
+      />
+    </div>
   );
 
   const timeTakenCreateAutomationColumn: ITableColumn<IJobTemplate> = {
     id: 'time_taken_create_automation',
+    maxWidth: TIME_COLUMN_WIDTH,
+    minWidth: TIME_COLUMN_WIDTH,
     header: t('Time taken to create automation (min)'),
     helpText: t(
       'Time taken to create the automation for the job template. This is used to calculate the total time spent on automation, which includes both the time taken to create the automation and the time taken to execute it.'
@@ -152,15 +166,26 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     cell: (item) =>
       activeAwxUser?.is_superuser
         ? tableInputField('time_taken_create_automation_minutes', item)
-        : tableCell('time_taken_create_automation_minutes', item),
+        : tableCell('time_taken_create_automation_minutes', item, TIME_COLUMN_WIDTH),
   };
   const currencyColumnKeys: Set<keyof IJobTemplate> = new Set([
     'automated_costs',
     'manual_costs',
     'savings',
   ]);
-  const tableCell = (columnKey: keyof IJobTemplate, item: IJobTemplate) => (
-    <TdWrapper>
+  const tableCell = (
+    columnKey: keyof IJobTemplate,
+    item: IJobTemplate,
+    maxWidth?: number | undefined
+  ) => (
+    <TdWrapper
+      style={{
+        maxWidth: maxWidth ?? 'unset',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
       {currencyColumnKeys.has(columnKey)
         ? currencyFormatter(item[columnKey] as number)
         : item[columnKey]}
@@ -171,24 +196,29 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     {
       id: 'template_name',
       header: t('Template Name'),
-      cell: (item) => tableCell('template_name', item),
+      cell: (item) => tableCell('template_name', item, 250),
       defaultSort: true,
       defaultSortDirection: 'asc',
       sort: 'template_name',
+      maxWidth: 250,
     },
     {
       id: 'num_job_executions',
       header: t('Number of job executions'),
       cell: (item) => tableCell('runs', item),
       sort: 'runs',
+      maxWidth: 190,
+      minWidth: 190,
     },
     {
       id: 'time_taken_manually_execute',
       header: t('Time taken to manually execute (min)'),
+      maxWidth: TIME_COLUMN_WIDTH,
+      minWidth: TIME_COLUMN_WIDTH,
       cell: (item) =>
         activeAwxUser?.is_superuser
           ? tableInputField('time_taken_manually_execute_minutes', item)
-          : tableCell('time_taken_manually_execute_minutes', item),
+          : tableCell('time_taken_manually_execute_minutes', item, TIME_COLUMN_WIDTH),
     },
     ...(costState?.include_template_creation_time_in_costs
       ? [timeTakenCreateAutomationColumn]
@@ -232,6 +262,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
       isCompact
       canCollapse={false}
       disableBodyPadding
+      style={{ gridColumn: `span ${MAIN_TABLE_FULL_SPAN}` }}
     >
       <CardBody>
         <DashboardTableToolbarRow

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -24,9 +24,8 @@ interface IJobTemplateModify {
   time_taken_create_automation_minutes: number;
 }
 
-// 24-column grid system for responsive layout
-// Uses 1625px instead of PageDashboard's 1662px to account for card padding
-const GRID_COLUMN_WIDTH = 1625 / 24; // ~67.7px per column
+// Uses 1625px instead of PageDashboard's 1610px to account for card padding
+const GRID_COLUMN_WIDTH = 1610 / 24; // ~67px per column
 
 /** Fixed width (px) for time-input columns to keep editable fields consistently sized. */
 const TIME_COLUMN_WIDTH = 212;
@@ -55,6 +54,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
     detailsError,
     isFilterStateDefault,
     toolbarFilters,
+    topCardsWidth,
   } = props;
   const { t } = useTranslation();
   const { activeAwxUser } = useAwxActiveUser();
@@ -287,6 +287,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             formatAsCurrency={true}
             error={detailsError}
             errorStateTitle={t('Error loading manual automation cost')}
+            width={topCardsWidth}
           ></DashboardValueCard>
           <DashboardValueCard
             id="cost-automated-execution-card"
@@ -296,6 +297,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             formatAsCurrency={true}
             error={detailsError}
             errorStateTitle={t('Error loading automated execution cost')}
+            width={topCardsWidth}
           ></DashboardValueCard>
           <DashboardValueCard
             id="total-savings-card"
@@ -305,6 +307,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             formatAsCurrency={true}
             error={detailsError}
             errorStateTitle={t('Error loading total savings')}
+            width={topCardsWidth}
           ></DashboardValueCard>
           <DashboardValueCard
             id="total-hours-saved-card"
@@ -314,6 +317,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             valueSuffix={details?.total_time_saving ? 'h' : undefined}
             error={detailsError}
             errorStateTitle={t('Error loading total hours saved')}
+            width={topCardsWidth}
           ></DashboardValueCard>
         </div>
       </CardBody>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.test.tsx
@@ -73,4 +73,12 @@ describe('DashboardTableCard', () => {
     // pageItems falls back to [] and itemCount to 0 — empty state is shown
     expect(screen.getByRole('heading', { name: 'No data' })).toBeInTheDocument();
   });
+
+  test('renders empty value cell when execution_count is undefined', () => {
+    const items = [{ id: 1, name: 'No Count Item' }] as IDashboardTableItem[];
+    render(<DashboardTableCard {...defaultProps} items={items} />);
+    const row = screen.getByText('No Count Item').closest('tr');
+    const valueCell = row?.querySelectorAll('td')[1];
+    expect(valueCell).toHaveTextContent('');
+  });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
@@ -3,6 +3,16 @@ import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 import { DashboardTableCardProps, IDashboardTableItem } from '../types';
 import { PageLoadingTable } from '../../../../../framework/PageTable/PageLoadingTable';
+import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
+
+const TRUNCATED_NAME_CELL_MAX_WIDTH = 320;
+
+const truncatedNameCellStyle: React.CSSProperties = {
+  maxWidth: `${TRUNCATED_NAME_CELL_MAX_WIDTH}px`,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
 
 export function DashboardTableCard(props: DashboardTableCardProps) {
   const {
@@ -24,14 +34,34 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
   const [perPage, setPerPage] = useState(5);
   const { t } = useTranslation();
 
+  const nameCell = (item: IDashboardTableItem) => {
+    return <div style={truncatedNameCellStyle}>{item.name}</div>;
+  };
+
+  const valueCell = (item: IDashboardTableItem) => {
+    return (
+      <div
+        style={{
+          textAlign: 'right',
+        }}
+      >
+        {item?.execution_count || item.execution_count === 0
+          ? item.execution_count.toLocaleString(DEFAULT_NUMBER_LOCALE)
+          : ''}
+      </div>
+    );
+  };
+
   const tableColumns: ITableColumn<IDashboardTableItem>[] = [
     {
       header: firstColumnHeader,
-      cell: (item) => item.name,
+      cell: nameCell,
     },
     {
       header: t('Total no. of jobs'),
-      cell: (item) => item.execution_count,
+      cell: valueCell,
+      maxWidth: 75,
+      minWidth: 75,
     },
   ];
 
@@ -41,7 +71,7 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
       title={title}
       helpTitle={title}
       help={help}
-      width="lg"
+      width="md"
       height="md"
       disableBodyPadding
     >

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableCard.tsx
@@ -5,7 +5,7 @@ import { DashboardTableCardProps, IDashboardTableItem } from '../types';
 import { PageLoadingTable } from '../../../../../framework/PageTable/PageLoadingTable';
 import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
 
-const TRUNCATED_NAME_CELL_MAX_WIDTH = 320;
+const TRUNCATED_NAME_CELL_MAX_WIDTH = 350;
 
 const truncatedNameCellStyle: React.CSSProperties = {
   maxWidth: `${TRUNCATED_NAME_CELL_MAX_WIDTH}px`,
@@ -56,12 +56,12 @@ export function DashboardTableCard(props: DashboardTableCardProps) {
     {
       header: firstColumnHeader,
       cell: nameCell,
+      maxWidth: TRUNCATED_NAME_CELL_MAX_WIDTH,
     },
     {
       header: t('Total no. of jobs'),
       cell: valueCell,
-      maxWidth: 75,
-      minWidth: 75,
+      maxWidth: 104,
     },
   ];
 

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
@@ -4,6 +4,7 @@ import { DashboardValueCardProps } from '../types';
 import { Link } from 'react-router-dom';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
 import { currencyFormatter } from '../../utilities/currencyFormatter';
+import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
 
 export function DashboardValueCard(props: DashboardValueCardProps) {
   const {
@@ -17,14 +18,13 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
     error,
     errorStateTitle,
     formatAsCurrency,
+    width,
   } = props;
-
-  const usFormat = 'en-US';
 
   const contentValue =
     typeof value === 'number' ? (
       <span style={{ fontSize: 'xx-large', fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
-        {formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(usFormat)}
+        {formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(DEFAULT_NUMBER_LOCALE)}
         {valueSuffix ? ` ${valueSuffix}` : ''}
       </span>
     ) : (
@@ -59,8 +59,7 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
       title={title}
       helpTitle={help ? title : undefined}
       help={help}
-      width="sm"
-      height="xs"
+      width={width ?? 'md'}
     >
       {error ? <EmptyStateError titleProp={errorStateTitle} message={error.message} /> : content}
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
@@ -23,7 +23,14 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
 
   const contentValue =
     typeof value === 'number' ? (
-      <span style={{ fontSize: 'xx-large', fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
+      <span
+        style={{
+          fontSize: width === 'xs' ? 'x-large' : 'xx-large',
+          fontWeight: '400',
+          lineHeight: 1,
+          marginTop: 'auto',
+        }}
+      >
         {formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(DEFAULT_NUMBER_LOCALE)}
         {valueSuffix ? ` ${valueSuffix}` : ''}
       </span>

--- a/frontend/awx/analytics/automation-dashboard/components/Toolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/Toolbar.tsx
@@ -37,6 +37,7 @@ export function useAutomationDashboardToolbar() {
       isPinned: true,
       isRequired: true,
       disableSortOptions: true,
+      defaultValue: AutomationDashboardDateRangeFilterPresets.last_7_days,
     }),
     [t]
   );

--- a/frontend/awx/analytics/automation-dashboard/constants/common.ts
+++ b/frontend/awx/analytics/automation-dashboard/constants/common.ts
@@ -1,0 +1,2 @@
+/** Locale identifier used for number formatting (e.g. `1,234.56`). */
+export const DEFAULT_NUMBER_LOCALE = 'en-US';

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -176,6 +176,7 @@ export type IAutomationDashboardView = {
   isFilterStateDefault: boolean;
   registerClearCallback: (callback: () => void) => void;
   toolbarFilters?: IToolbarFilter[];
+  topCardsWidth?: PageDashboardCardWidth;
 };
 
 // ─── Export Types ─────────────────────────────────────────────────────────────

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -1,5 +1,9 @@
 import { ComponentClass, Dispatch, SetStateAction } from 'react';
-import { IFilterState, IToolbarFilter } from '@ansible/ansible-ui-framework';
+import {
+  IFilterState,
+  IToolbarFilter,
+  PageDashboardCardWidth,
+} from '@ansible/ansible-ui-framework';
 import { IAutomationDashboardBaseView } from '../common/useAutomationDashboardBaseView';
 
 // ─── Dashboard Data Models (API shapes) ──────────────────────────────────────
@@ -101,6 +105,7 @@ type DashboardCommonCardProps = {
   help?: string;
   error?: Error;
   errorStateTitle: string;
+  width?: PageDashboardCardWidth;
 };
 
 export type DashboardValueCardProps = Readonly<


### PR DESCRIPTION
## Summary
[AAP-82394] Fix Automation Dashboard layout
<!-- What changed and why? -->
This pull request makes several improvements to the AWX Automation Dashboard, focusing on layout responsiveness, consistent number formatting, and improved table usability and accessibility. The changes ensure that dashboard cards and tables adapt better to different screen sizes, display numbers in a locale-aware format, and maintain consistent sizing for key table columns and input fields.

**Dashboard layout and responsiveness:**

* The dashboard grid calculation now subtracts horizontal padding before determining the number of columns, resulting in more accurate and responsive layouts (`AutomationDashboard.tsx`). [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R32-R36) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L52-R69)
* Value cards dynamically switch between 'md' and 'xs' sizes based on grid width, improving visual balance across different viewports (`AutomationDashboard.tsx`). [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R81-R84) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R114) [[3]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R127) [[4]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R138) [[5]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736R150)

**Consistent number formatting:**

* All dashboard cards and tables now use a shared `DEFAULT_NUMBER_LOCALE` for number formatting, ensuring numbers are displayed in a locale-aware manner throughout the UI (`DashboardChartCard.tsx`, `DashboardValueCard.tsx`, `DashboardTableCard.tsx`). [[1]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454R6) [[2]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454L42-R51) [[3]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8R7) [[4]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8R21-R27) [[5]](diffhunk://#diff-aa123f59e0a28666ed453a0e7a3901efb795e905fec2bfbee318e27f1caf643fR6-R15) [[6]](diffhunk://#diff-aa123f59e0a28666ed453a0e7a3901efb795e905fec2bfbee318e27f1caf643fR37-R64)

**Table and card sizing improvements:**

* Table columns for job templates have fixed widths, especially for editable time input fields, and template names are truncated with ellipsis to prevent overflow, enhancing readability and usability (`DashboardMainTableCard.tsx`, `DashboardTableCard.tsx`). [[1]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R31-R40) [[2]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R145) [[3]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R155-R188) [[4]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L174-R221) [[5]](diffhunk://#diff-aa123f59e0a28666ed453a0e7a3901efb795e905fec2bfbee318e27f1caf643fR6-R15) [[6]](diffhunk://#diff-aa123f59e0a28666ed453a0e7a3901efb795e905fec2bfbee318e27f1caf643fR37-R64)
* Dashboard cards now default to 'md' size for improved consistency and fit in the grid (`DashboardChartCard.tsx`, `DashboardTableCard.tsx`). [[1]](diffhunk://#diff-f51170189987505a26524d81d8ac7f657848c3697d920393ee9d02ccc0745454L65-R68) [[2]](diffhunk://#diff-aa123f59e0a28666ed453a0e7a3901efb795e905fec2bfbee318e27f1caf643fL44-R74)

**Toolbar date filter enhancements:**

* The date range filter now resets to its default value when the reset button is clicked, and does nothing if no default is set. Corresponding tests have been added for these behaviors (`ToolbarDateRangeFilter.tsx`, `ToolbarDateRangeFilter.test.tsx`). [[1]](diffhunk://#diff-4795b60277087ea2af7c9826cd978581998dc98e70d3763d9bc3525f2d0e517bL53-R58) [[2]](diffhunk://#diff-5b7f3e63b2fe162a7464713409644cf36b7ea87c3dddb8cac4b15b84ed7e1f92R70-R108)

**Minor code and layout cleanups:**

* Unused code and redundant grid wrappers have been removed for clarity and maintainability (`AutomationDashboard.tsx`). [[1]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L187-L190) [[2]](diffhunk://#diff-a569d1be17b5811a84a220c557e8ed7be19740d2e150b5fb326afb86bc45f736L219-R236)
* Minor import and code organization improvements (`DashboardMainTableCard.tsx`).

These changes collectively enhance the dashboard's usability, accessibility, and visual consistency across different devices and locales.
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="2557" height="1921" alt="image" src="https://github.com/user-attachments/assets/62dc1d58-3a2e-4e1a-8ca5-6b372be506e9" />

<img width="1747" height="1763" alt="image" src="https://github.com/user-attachments/assets/94278e04-6717-4d8e-983d-da58745771a3" />

