### PR TITLE
[AAP-71927] Update label to 'Retained repository version count'

### DIFF
--- a/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
+++ b/frontend/hub/administration/repositories/RepositoryPage/RepositoryDetails.tsx
@@ -42,7 +42,9 @@ export function RepositoryDetails() {
     <PageDetails>
       <PageDetail label={t('Name')}>{params.id}</PageDetail>
       <PageDetail label={t('Description')}>{repository.description || t('None')}</PageDetail>
-      <PageDetail label={t('Retained version count')}>{repository.retain_repo_versions}</PageDetail>
+      <PageDetail label={t('Retained repository version count')}>
+        {repository.retain_repo_versions}
+      </PageDetail>
       <PageDetail label={t('Distribution')}>
         {distroError ? (
           <span style={{ color: PFColorE.Red }}>{t('Error loading distribution')}</span>

--- a/playwright/tests/integration/automation-content/repositories/repositories.spec.ts
+++ b/playwright/tests/integration/automation-content/repositories/repositories.spec.ts
@@ -46,7 +46,7 @@ test.describe('Hub - Repositories', () => {
         await expect(page.getByTestId('description')).toContainText('Here goes description');
         await expect(page.getByTestId('labels')).toContainText('None');
         await expect(page.getByTestId('remote')).toContainText('None');
-        await expect(page.getByTestId('retained-version-count')).toContainText('1');
+        await expect(page.getByTestId('retained-repository-version-count')).toContainText('1');
       });
 
       await test.step('Edit the repository', async () => {
@@ -88,7 +88,7 @@ test.describe('Hub - Repositories', () => {
       await test.step('Verify edited repository details', async () => {
         await expect(page.getByTestId('name')).toContainText(repositoryName);
         await expect(page.getByTestId('description')).toContainText('repositoryDescription edited');
-        await expect(page.getByTestId('retained-version-count')).toContainText('10');
+        await expect(page.getByTestId('retained-repository-version-count')).toContainText('10');
         await expect(page.getByTestId('labels')).toContainText('approved');
         if (remote) {
           await expect(page.getByTestId('remote')).toContainText(remote.name);


### PR DESCRIPTION
## Summary

Jira: [AAP-71927](https://redhat.atlassian.net/browse/AAP-71927)

This updates the Hub repository details label from "Retained version count" to "Retained repository version count" for better clarity and consistency.

Based on PR #3100 by @jerabekjiri, rebased on latest devel.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

Verified the label change renders correctly in the Hub repository details page.

- ESLint: ✅ Passes
- TypeScript (Hub workspace): ✅ Passes