### PR TITLE
fix(eda,awx): fix flaky vitest timeouts in useDeleteUser and WorkflowApprovals

### DIFF
--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovals.test.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovals.test.tsx
@@ -139,13 +139,14 @@ describe('WorkflowApprovals WebSocket handler', () => {
     });
 
     await renderAndWait();
+    await new Promise((r) => setTimeout(r, 100));
     const initialFetchCount = fetchCount;
 
     act(() => {
       capturedOnMessage!({ group_name: 'jobs', type: 'job' });
     });
 
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, 300));
 
     expect(fetchCount).toBe(initialFetchCount);
     server.events.removeAllListeners();
@@ -161,13 +162,14 @@ describe('WorkflowApprovals WebSocket handler', () => {
     });
 
     await renderAndWait();
+    await new Promise((r) => setTimeout(r, 100));
     const initialFetchCount = fetchCount;
 
     act(() => {
       capturedOnMessage!({ group_name: 'inventories', type: 'workflow_approval' });
     });
 
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, 300));
 
     expect(fetchCount).toBe(initialFetchCount);
     server.events.removeAllListeners();

--- a/frontend/eda/access/users/hooks/useDeleteUser.test.tsx
+++ b/frontend/eda/access/users/hooks/useDeleteUser.test.tsx
@@ -95,8 +95,11 @@ describe('useDeleteUsers', () => {
     const submitButton = screen.getByRole('button', { name: 'Delete users' });
     await user.click(submitButton);
 
-    await waitFor(() => {
-      expect(onComplete).toHaveBeenCalled();
-    });
+    await waitFor(
+      () => {
+        expect(onComplete).toHaveBeenCalled();
+      },
+      { timeout: 10000 }
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fix two flaky vitest failures that intermittently block CI across multiple PRs.

### 1. `useDeleteUser.test.tsx` (EDA)
The `should call onComplete after confirming deletion` test exercises a multi-step async chain (confirmation dialog → bulk action dialog → HTTP DELETE → `onComplete` callback). The default `waitFor` timeout of 1000ms is insufficient on slower CI runners.

**Fix**: Increase `waitFor` timeout to 10000ms.

### 2. `WorkflowApprovals.test.tsx` (AWX)
The `should ignore WS messages with non-matching group_name` test captures `initialFetchCount` right after `renderAndWait()`, but SWR may trigger a background revalidation fetch that arrives after the snapshot, making `fetchCount` appear to increment unexpectedly.

**Fix**: Add a 100ms settling delay after render before capturing `initialFetchCount`, and increase the post-message wait from 200ms to 300ms.

**Affected CI jobs**:
- [Vitest (eda)](https://github.com/ansible/ansible-ui/actions/runs/30656935528/job/91243640733)
- [Vitest (awx) / administration](https://github.com/ansible/ansible-ui/actions/runs/30657835572/job/91246664149)

These failures affect multiple unrelated PRs.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped (test timing fixes only)

## Testing

### Manual Testing

```bash
cd frontend/eda && npx vitest run access/users/hooks/useDeleteUser.test.tsx
# Test Files  1 passed (1)
# Tests  2 passed (2)

cd frontend/awx && npx vitest run administration/workflow-approvals/WorkflowApprovals.test.tsx
# Test Files  1 passed (1)
# Tests  6 passed (6)
```
