### PR TITLE
fix(ci): bump coverage pipeline bundle to fix clone-repo task

### DIFF
--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -26,7 +26,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:21d749e0ac1be16393b072222a2ce40b9d03ccc2158170c6694612516667ab0a
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:89a4d806d3c5e2aee3eb6207b5abf6e3dd602f0e2685386ea4af9dd61e1e06bf
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

The nightly coverage pipeline is failing because the `git-clone/0.1` task was removed from `konflux-ci/build-definitions`. Update the bundle digest in the coverage push template to match the fix Ryan applied to the e2e template in #3365.

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [x] **Low** — Bundle digest update only, same change as #3365 but for the coverage template.

Made with [Cursor](https://cursor.com)