### PR TITLE
AAP-85025 XLAB Clarify report management actions

### DIFF
--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.test.tsx
@@ -1,8 +1,29 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { ToolbarDateRangeFilter } from './ToolbarDateRangeFilter';
+import {
+  ToolbarDateRangeFilter,
+  type IToolbarDateRangeFilterProps,
+} from './ToolbarDateRangeFilter';
+
+/** Stateful wrapper — real components own filterValues in state, unlike the vi.fn() mock used elsewhere in this file. */
+function StatefulToolbarDateRangeFilter(
+  props: Omit<IToolbarDateRangeFilterProps, 'filterValues' | 'setFilterValues'> & {
+    initialFilterValues?: string[];
+  }
+) {
+  const { initialFilterValues, ...rest } = props;
+  const [filterValues, setFilterValues] = useState<string[] | undefined>(initialFilterValues);
+  return (
+    <ToolbarDateRangeFilter
+      {...rest}
+      filterValues={filterValues}
+      setFilterValues={(setter) => setFilterValues((prev) => setter(prev))}
+    />
+  );
+}
 
 const defaultOptions = [
   { label: 'Last 7 days', value: 'last7days' },
@@ -118,5 +139,257 @@ describe('ToolbarDateRangeFilter', () => {
 
     expect(screen.getByLabelText('Start date')).toBeInTheDocument();
     expect(screen.getByLabelText('End date')).toBeInTheDocument();
+  });
+
+  it('should show the start and end date already present in filterValues on mount', () => {
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01', '2024-01-31']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-01-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-01-31');
+  });
+
+  it('should show the current custom range after filterValues is set externally post-mount', () => {
+    const { rerender } = render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['last7days']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Start date')).not.toBeInTheDocument();
+
+    // Simulates loading a saved report whose filters set a custom range on an
+    // already-mounted toolbar — the date pickers must pick up the new values.
+    rerender(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-02-01', '2024-02-15']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-02-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-02-15');
+  });
+
+  it('should update the displayed range when filterValues changes to a different custom range', () => {
+    const { rerender } = render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01', '2024-01-31']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-01-01');
+
+    rerender(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-03-01', '2024-03-10']}
+        setFilterValues={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-03-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-03-10');
+  });
+
+  it('should call setFilterValues with the start date when it is entered', () => {
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2024-01-01' } });
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom', '2024-01-01']);
+  });
+
+  it('should call setFilterValues with both dates when the end date is entered after the start date', () => {
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2024-01-31' } });
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom', '2024-01-01', '2024-01-31']);
+  });
+
+  it('should preserve the existing end date when the start date is changed', () => {
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01', '2024-01-31']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2024-01-05' } });
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom', '2024-01-05', '2024-01-31']);
+  });
+
+  it('should drop the start date but keep the end date when the start date is cleared', () => {
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01', '2024-01-31']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '' } });
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom', '', '2024-01-31']);
+  });
+
+  it('should drop both dates when the start date is cleared and there was no end date', () => {
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '' } });
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom']);
+  });
+
+  it('should make the end date field read-only but keep showing its value when the start date is cleared', () => {
+    render(
+      <StatefulToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        initialFilterValues={['custom', '2024-01-01', '2024-01-31']}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '' } });
+
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-01-31');
+    expect(screen.getByLabelText('End date')).toBeDisabled();
+  });
+
+  it('should clear only the end date when the reset button next to it is clicked', async () => {
+    const user = userEvent.setup();
+    const setFilterValues = vi.fn();
+    render(
+      <ToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        filterValues={['custom', '2024-01-01', '2024-01-31']}
+        setFilterValues={setFilterValues}
+      />
+    );
+
+    await user.click(screen.getByTestId('toolbar-date-picker-clear-end-date'));
+
+    const setterFn = setFilterValues.mock.calls.at(-1)?.[0] as () => string[];
+    expect(setterFn()).toEqual(['custom', '2024-01-01']);
+  });
+
+  it('should restore the previously entered custom range when switching to a preset and back to Custom', async () => {
+    const user = userEvent.setup();
+    render(
+      <StatefulToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        initialFilterValues={['custom']}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2024-01-01' } });
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2024-01-31' } });
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-01-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-01-31');
+
+    // Switch away to a preset — the date pickers disappear.
+    await user.click(screen.getByRole('button', { name: 'Custom' }));
+    await user.click(screen.getByRole('option', { name: 'Last 7 days' }));
+    expect(screen.queryByLabelText('Start date')).not.toBeInTheDocument();
+
+    // Switch back to Custom — the previously entered dates should reappear.
+    await user.click(screen.getByRole('button', { name: 'Last 7 days' }));
+    await user.click(screen.getByRole('option', { name: 'Custom' }));
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-01-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2024-01-31');
+  });
+
+  it('should select Custom with no dates pre-filled the first time it is chosen', async () => {
+    const user = userEvent.setup();
+    render(
+      <StatefulToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        initialFilterValues={['last7days']}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Last 7 days' }));
+    await user.click(screen.getByRole('option', { name: 'Custom' }));
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('');
+    expect(screen.getByLabelText('End date')).toHaveValue('');
+  });
+
+  it('should restore only the start date when switching back to Custom with a partial remembered range', async () => {
+    const user = userEvent.setup();
+    render(
+      <StatefulToolbarDateRangeFilter
+        placeholder="Select range"
+        options={defaultOptions}
+        initialFilterValues={['custom']}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2024-01-01' } });
+    expect(screen.getByLabelText('End date')).toHaveValue('');
+
+    await user.click(screen.getByRole('button', { name: 'Custom' }));
+    await user.click(screen.getByRole('option', { name: 'Last 7 days' }));
+
+    await user.click(screen.getByRole('button', { name: 'Last 7 days' }));
+    await user.click(screen.getByRole('option', { name: 'Custom' }));
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2024-01-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('');
   });
 });

--- a/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
+++ b/framework/PageToolbar/PageToolbarFilters/ToolbarDateRangeFilter.tsx
@@ -1,6 +1,6 @@
 import { Button, DatePicker, ToolbarItem, isValidDate } from '@patternfly/react-core';
 import { TimesCircleIcon } from '@patternfly/react-icons';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PageSingleSelect } from '../../PageInputs/PageSingleSelect';
 import { ToolbarFilterType } from '../PageToolbarFilter';
@@ -49,6 +49,22 @@ export function ToolbarDateRangeFilter(props: IToolbarDateRangeFilterProps) {
     setFilterValues(() => [defaultValue ?? props.options[0].value]);
   }
 
+  // `from`/`to` are derived directly from filterValues (not local state) so that
+  // externally-set values — e.g. loading a saved report with a custom range —
+  // are always reflected, not just the value present when this component first mounted.
+  const from = filterValues && filterValues.length > 1 ? filterValues[1] : undefined;
+  const to = filterValues && filterValues.length > 2 ? filterValues[2] : undefined;
+
+  // Remembers the last custom range entered so it can be restored if the user
+  // switches to a preset and back to Custom, without controlling the displayed
+  // from/to values itself (those stay solely derived from filterValues above).
+  const lastCustomRangeRef = useRef<{ from?: string; to?: string }>({});
+  useEffect(() => {
+    if (selectedOption?.isCustom && (from || to)) {
+      lastCustomRangeRef.current = { from, to };
+    }
+  }, [selectedOption, from, to]);
+
   function onSelectChange(value: string | null) {
     if (value === null) {
       if (defaultValue) {
@@ -57,33 +73,43 @@ export function ToolbarDateRangeFilter(props: IToolbarDateRangeFilterProps) {
       return;
     }
     const option = props.options.find((option) => option.value === value);
-    if (option) {
+    if (!option) return;
+    if (!option.isCustom) {
       setFilterValues(() => [value]);
+      return;
     }
+    const remembered = lastCustomRangeRef.current;
+    const newValues = [value];
+    if (remembered.from) {
+      newValues.push(remembered.from);
+      if (remembered.to) newValues.push(remembered.to);
+    }
+    setFilterValues(() => newValues);
   }
 
-  const [from, setFrom] = useState<string | undefined>(() => {
-    if (filterValues && filterValues.length > 1) return filterValues[1];
-    return undefined;
-  });
-
-  const [to, setTo] = useState<string | undefined>(() => {
-    if (filterValues && filterValues.length > 2) return filterValues[2];
-    return undefined;
-  });
-
-  useEffect(() => {
-    if (selectedOption && selectedOption.isCustom) {
-      const newValues = [selectedOption.value];
-      if (from) {
-        newValues.push(from);
-        if (to) {
-          newValues.push(to);
-        }
-      }
+  function setFrom(value?: string) {
+    if (!selectedOption) return;
+    if (!value) {
+      // Keep "to" as-is when "from" is cleared — the "to" DatePicker becomes
+      // read-only (see DateRange below) rather than losing its value.
+      const newValues = to ? [selectedOption.value, '', to] : [selectedOption.value];
       setFilterValues(() => newValues);
+      return;
     }
-  }, [selectedOption, from, to, setFilterValues]);
+    const newValues = to ? [selectedOption.value, value, to] : [selectedOption.value, value];
+    setFilterValues(() => newValues);
+  }
+
+  function setTo(value?: string) {
+    // The "to" DatePicker is disabled until "from" is set (see DateRange below),
+    // so `from` is always defined here.
+    if (!selectedOption || !from) return;
+    if (value) {
+      setFilterValues(() => [selectedOption.value, from, value]);
+      return;
+    }
+    setFilterValues(() => [selectedOption.value, from]);
+  }
 
   return (
     <ToolbarItem>
@@ -155,6 +181,8 @@ export function DateRange(props: {
           variant="control"
           style={{ alignSelf: 'flex-start' }}
           onClick={() => setTo(undefined)}
+          aria-label={t('Clear end date')}
+          data-testid="toolbar-date-picker-clear-end-date"
         ></Button>
       )}
     </>

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
@@ -223,35 +223,35 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should keep "Edit report" enabled when filter state equals the default', () => {
+    test('should keep "Update report" enabled when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should keep "Edit report" enabled when filter state differs from the default', () => {
+    test('should keep "Update report" enabled when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Edit report" with an invalid-filter message when a required custom date range is invalid', () => {
+    test('should disable "Update report" with an invalid-filter message when a required custom date range is invalid', () => {
       const action = renderActions(
         invalidCustomRangeFilterState,
         filterSet,
         requiredDateRangeToolbarFilters
       )[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
-      expect(subAction?.isDisabled).toBe('Enter a valid custom date range before saving');
+      const subAction = getDropdownSubAction(action, 'Update report');
+      expect(subAction?.isDisabled).toBe('Enter a valid custom date range before updating');
     });
 
-    test('should enable "Edit report" once the required custom date range becomes valid', () => {
+    test('should enable "Update report" once the required custom date range becomes valid', () => {
       const action = renderActions(
         validCustomRangeFilterState,
         filterSet,
         requiredDateRangeToolbarFilters
       )[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
@@ -285,17 +285,17 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
-    test('should disable "Edit report" with admin-only message when user is not a superuser', () => {
+    test('should disable "Update report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
-    test('should disable "Edit report" with admin-only message even when the filter state is default', () => {
+    test('should disable "Update report" with admin-only message even when the filter state is default', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
@@ -305,7 +305,7 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(action.actions).toHaveLength(3);
     });
 
-    test('should include "Create new report", "Edit report", "Delete report" sub-actions', () => {
+    test('should include "Create new report", "Update report", "Delete report" sub-actions', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
       expect(action.type).toBe(PageActionType.Dropdown);
 
@@ -313,7 +313,7 @@ describe('useAutomationDashboardToolbarActions', () => {
         a.type === PageActionType.Seperator ? [] : [a.label]
       );
       expect(labels).toContain('Create new report');
-      expect(labels).toContain('Edit report');
+      expect(labels).toContain('Update report');
       expect(labels).toContain('Delete report');
     });
 
@@ -324,16 +324,16 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
     });
 
-    test('should call updateToolbarFilterSet when "Edit report" is clicked', () => {
+    test('should call updateToolbarFilterSet when "Update report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       subAction?.onClick();
       expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, nonDefaultFilterState);
     });
 
-    test('should call updateToolbarFilterSet when "Edit report" is clicked on the default filter state', () => {
+    test('should call updateToolbarFilterSet when "Update report" is clicked on the default filter state', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Edit report');
+      const subAction = getDropdownSubAction(action, 'Update report');
       subAction?.onClick();
       expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, defaultFilterState);
     });

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.test.tsx
@@ -124,10 +124,10 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(actions[0].type).toBe(PageActionType.Button);
     });
 
-    test('should label the button "Save as report"', () => {
+    test('should label the button "Create new report"', () => {
       const action = renderActions(defaultFilterState, undefined)[0] as IPageActionButton;
 
-      expect(action.label).toBe('Save as report');
+      expect(action.label).toBe('Create new report');
     });
 
     test('should have None selection', () => {
@@ -199,10 +199,10 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(actions[0].type).toBe(PageActionType.Dropdown);
     });
 
-    test('should label the dropdown "Save as report"', () => {
+    test('should label the dropdown "Report actions"', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
 
-      expect(action.label).toBe('Save as report');
+      expect(action.label).toBe('Report actions');
     });
 
     test('should never disable the dropdown itself', () => {
@@ -211,27 +211,47 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(action.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Save report" when filter state equals the default', () => {
+    test('should disable "Create new report" when filter state equals the default', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Save report');
+      const subAction = getDropdownSubAction(action, 'Create new report');
       expect(subAction?.isDisabled).toBeTruthy();
     });
 
-    test('should disable "Rename report" when filter state equals the default', () => {
-      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Rename report');
-      expect(subAction?.isDisabled).toBeTruthy();
-    });
-
-    test('should enable "Save report" when filter state differs from the default', () => {
+    test('should enable "Create new report" when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Save report');
+      const subAction = getDropdownSubAction(action, 'Create new report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should enable "Rename report" when filter state differs from the default', () => {
+    test('should keep "Edit report" enabled when filter state equals the default', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Edit report');
+      expect(subAction?.isDisabled).toBeFalsy();
+    });
+
+    test('should keep "Edit report" enabled when filter state differs from the default', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Rename report');
+      const subAction = getDropdownSubAction(action, 'Edit report');
+      expect(subAction?.isDisabled).toBeFalsy();
+    });
+
+    test('should disable "Edit report" with an invalid-filter message when a required custom date range is invalid', () => {
+      const action = renderActions(
+        invalidCustomRangeFilterState,
+        filterSet,
+        requiredDateRangeToolbarFilters
+      )[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Edit report');
+      expect(subAction?.isDisabled).toBe('Enter a valid custom date range before saving');
+    });
+
+    test('should enable "Edit report" once the required custom date range becomes valid', () => {
+      const action = renderActions(
+        validCustomRangeFilterState,
+        filterSet,
+        requiredDateRangeToolbarFilters
+      )[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Edit report');
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
@@ -248,17 +268,34 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(subAction?.isDisabled).toBeFalsy();
     });
 
-    test('should disable "Save report" with admin-only message when user is not a superuser', () => {
+    test('should keep "Delete report" enabled when a required custom date range is invalid', () => {
+      const action = renderActions(
+        invalidCustomRangeFilterState,
+        filterSet,
+        requiredDateRangeToolbarFilters
+      )[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Delete report');
+      expect(subAction?.isDisabled).toBeFalsy();
+    });
+
+    test('should disable "Create new report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Save report');
+      const subAction = getDropdownSubAction(action, 'Create new report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
-    test('should disable "Rename report" with admin-only message when user is not a superuser', () => {
+    test('should disable "Edit report" with admin-only message when user is not a superuser', () => {
       mockActiveAwxUser.is_superuser = false;
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Rename report');
+      const subAction = getDropdownSubAction(action, 'Edit report');
+      expect(subAction?.isDisabled).toBe('Only administrators can save reports');
+    });
+
+    test('should disable "Edit report" with admin-only message even when the filter state is default', () => {
+      mockActiveAwxUser.is_superuser = false;
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Edit report');
       expect(subAction?.isDisabled).toBe('Only administrators can save reports');
     });
 
@@ -268,30 +305,37 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(action.actions).toHaveLength(3);
     });
 
-    test('should include "Save report", "Rename report", "Delete report" sub-actions', () => {
+    test('should include "Create new report", "Edit report", "Delete report" sub-actions', () => {
       const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
       expect(action.type).toBe(PageActionType.Dropdown);
 
       const labels = action.actions.flatMap((a) =>
         a.type === PageActionType.Seperator ? [] : [a.label]
       );
-      expect(labels).toContain('Save report');
-      expect(labels).toContain('Rename report');
+      expect(labels).toContain('Create new report');
+      expect(labels).toContain('Edit report');
       expect(labels).toContain('Delete report');
     });
 
-    test('should call createToolbarFilterSet when "Save report" is clicked', () => {
+    test('should call createToolbarFilterSet when "Create new report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Save report');
+      const subAction = getDropdownSubAction(action, 'Create new report');
       subAction?.onClick();
       expect(mockCreateFn).toHaveBeenCalledWith(nonDefaultFilterState);
     });
 
-    test('should call updateToolbarFilterSet when "Rename report" is clicked', () => {
+    test('should call updateToolbarFilterSet when "Edit report" is clicked', () => {
       const action = renderActions(nonDefaultFilterState, filterSet)[0] as Dropdown;
-      const subAction = getDropdownSubAction(action, 'Rename report');
+      const subAction = getDropdownSubAction(action, 'Edit report');
       subAction?.onClick();
       expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, nonDefaultFilterState);
+    });
+
+    test('should call updateToolbarFilterSet when "Edit report" is clicked on the default filter state', () => {
+      const action = renderActions(defaultFilterState, filterSet)[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Edit report');
+      subAction?.onClick();
+      expect(mockUpdateFn).toHaveBeenCalledWith(filterSet, defaultFilterState);
     });
 
     test('should call removeToolbarFilterSet when "Delete report" is clicked', () => {
@@ -301,34 +345,36 @@ describe('useAutomationDashboardToolbarActions', () => {
       expect(mockRemoveFn).toHaveBeenCalledWith(filterSet);
     });
 
-    test('should fall back to a single Button when the required custom date range is invalid', () => {
+    test('should still return the Dropdown (not fall back to a single Button) when the required custom date range is invalid', () => {
       const action = renderActions(
         invalidCustomRangeFilterState,
-        filterSet,
-        requiredDateRangeToolbarFilters
-      )[0];
-
-      expect(action.type).toBe(PageActionType.Button);
-    });
-
-    test('should disable the fallback button with an invalid-filter message', () => {
-      const action = renderActions(
-        invalidCustomRangeFilterState,
-        filterSet,
-        requiredDateRangeToolbarFilters
-      )[0] as IPageActionButton;
-
-      expect(action.isDisabled).toBe('Enter a valid custom date range before saving');
-    });
-
-    test('should return the Dropdown again once the required custom date range becomes valid', () => {
-      const action = renderActions(
-        validCustomRangeFilterState,
         filterSet,
         requiredDateRangeToolbarFilters
       )[0];
 
       expect(action.type).toBe(PageActionType.Dropdown);
+    });
+
+    test('should disable "Create new report" with an invalid-filter message when the required custom date range is invalid', () => {
+      const action = renderActions(
+        invalidCustomRangeFilterState,
+        filterSet,
+        requiredDateRangeToolbarFilters
+      )[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Create new report');
+
+      expect(subAction?.isDisabled).toBe('Enter a valid custom date range before saving');
+    });
+
+    test('should enable "Create new report" once the required custom date range becomes valid', () => {
+      const action = renderActions(
+        validCustomRangeFilterState,
+        filterSet,
+        requiredDateRangeToolbarFilters
+      )[0] as Dropdown;
+      const subAction = getDropdownSubAction(action, 'Create new report');
+
+      expect(subAction?.isDisabled).toBeFalsy();
     });
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -49,7 +49,7 @@ function getEditDisabledReason(
   t: (key: string) => string
 ): string | undefined {
   if (superuserDisabledReason) return superuserDisabledReason;
-  if (!validFilters) return t('Enter a valid custom date range before saving');
+  if (!validFilters) return t('Enter a valid custom date range before updating');
   return undefined;
 }
 
@@ -114,7 +114,7 @@ export function useAutomationDashboardToolbarActions(props: {
                   type: PageActionType.Button,
                   icon: PencilAltIcon,
                   selection: PageActionSelection.None,
-                  label: t('Edit report'),
+                  label: t('Update report'),
                   isDisabled: editDisabledReason,
                   onClick: () =>
                     filterState && selectedFilterSet

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardToolbarActions.tsx
@@ -43,6 +43,16 @@ function getSaveDisabledReason(
   return undefined;
 }
 
+function getEditDisabledReason(
+  superuserDisabledReason: string | undefined,
+  validFilters: boolean,
+  t: (key: string) => string
+): string | undefined {
+  if (superuserDisabledReason) return superuserDisabledReason;
+  if (!validFilters) return t('Enter a valid custom date range before saving');
+  return undefined;
+}
+
 export function useAutomationDashboardToolbarActions(props: {
   filterState?: IFilterState;
   toolbarFilters?: IToolbarFilter[];
@@ -75,9 +85,14 @@ export function useAutomationDashboardToolbarActions(props: {
     t
   );
 
+  // Editing a report's name and/or persisting the current filter state to it is
+  // valid regardless of the default/non-default filter state, but the current
+  // filter state must still be valid to be persisted.
+  const editDisabledReason = getEditDisabledReason(superuserDisabledReason, validFilters, t);
+
   return useMemo<IPageAction<IJobTemplate>[]>(
     () =>
-      selectedFilterSet && validFilters
+      selectedFilterSet
         ? [
             {
               type: PageActionType.Dropdown,
@@ -85,13 +100,13 @@ export function useAutomationDashboardToolbarActions(props: {
               variant: ButtonVariant.primary,
               isPinned: true,
               selection: PageActionSelection.None,
-              label: t('Save as report'),
+              label: t('Report actions'),
               actions: [
                 {
                   type: PageActionType.Button,
                   icon: PlusCircleIcon,
                   selection: PageActionSelection.None,
-                  label: t('Save report'),
+                  label: t('Create new report'),
                   isDisabled: saveDisabledReason,
                   onClick: () => (filterState ? createToolbarFilterSet(filterState) : {}),
                 },
@@ -99,8 +114,8 @@ export function useAutomationDashboardToolbarActions(props: {
                   type: PageActionType.Button,
                   icon: PencilAltIcon,
                   selection: PageActionSelection.None,
-                  label: t('Rename report'),
-                  isDisabled: saveDisabledReason,
+                  label: t('Edit report'),
+                  isDisabled: editDisabledReason,
                   onClick: () =>
                     filterState && selectedFilterSet
                       ? updateToolbarFilterSet(selectedFilterSet, filterState)
@@ -125,7 +140,7 @@ export function useAutomationDashboardToolbarActions(props: {
               variant: ButtonVariant.primary,
               isPinned: true,
               selection: PageActionSelection.None,
-              label: t('Save as report'),
+              label: t('Create new report'),
               isDisabled: saveDisabledReason,
               onClick: () => (filterState ? createToolbarFilterSet(filterState) : {}),
             },
@@ -134,12 +149,12 @@ export function useAutomationDashboardToolbarActions(props: {
       selectedFilterSet,
       t,
       saveDisabledReason,
+      editDisabledReason,
       superuserDeleteDisabledReason,
       filterState,
       createToolbarFilterSet,
       updateToolbarFilterSet,
       removeToolbarFilterSet,
-      validFilters,
     ]
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -100,7 +100,7 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
       expect(screen.getByRole('heading', { name: 'Create new report' })).toBeInTheDocument();
     });
 
-    test('should show "Edit report" title when editing an existing filter set', async () => {
+    test('should show "Update report" title when editing an existing filter set', async () => {
       const user = userEvent.setup();
       render(
         <Wrapper>
@@ -110,7 +110,7 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
-      expect(screen.getByText('Edit report')).toBeInTheDocument();
+      expect(screen.getByText('Update report')).toBeInTheDocument();
     });
 
     test('should communicate that both name and filter state will be saved when editing', async () => {

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.test.tsx
@@ -70,12 +70,12 @@ function OpenDialogButton({
   return <button onClick={() => openDialog(filterState, filterSet)}>Open dialog</button>;
 }
 
-/** Opens the dialog, fills the name field, and clicks Save. */
+/** Opens the dialog, fills the name field, and clicks the submit button. */
 async function openAndSubmit(user: ReturnType<typeof userEvent.setup>, name: string) {
   await user.click(screen.getByRole('button', { name: 'Open dialog' }));
   await user.clear(screen.getByRole('textbox', { name: /name/i }));
   await user.type(screen.getByRole('textbox', { name: /name/i }), name);
-  await user.click(screen.getByRole('button', { name: /save/i }));
+  await user.click(screen.getByRole('button', { name: /create report|save changes/i }));
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -97,10 +97,10 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
       expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(screen.getByRole('heading', { name: 'Save report' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Create new report' })).toBeInTheDocument();
     });
 
-    test('should show "Rename report" title when editing an existing filter set', async () => {
+    test('should show "Edit report" title when editing an existing filter set', async () => {
       const user = userEvent.setup();
       render(
         <Wrapper>
@@ -110,7 +110,24 @@ describe('useCreateEditToolbarFilterSetDialog', () => {
 
       await user.click(screen.getByRole('button', { name: 'Open dialog' }));
 
-      expect(screen.getByText('Rename report')).toBeInTheDocument();
+      expect(screen.getByText('Edit report')).toBeInTheDocument();
+    });
+
+    test('should communicate that both name and filter state will be saved when editing', async () => {
+      const user = userEvent.setup();
+      render(
+        <Wrapper>
+          <OpenDialogButton filterSet={existingFilterSet} onComplete={vi.fn()} />
+        </Wrapper>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+      expect(
+        screen.getByText(
+          'This will update the report with the current name and filter configuration.'
+        )
+      ).toBeInTheDocument();
     });
 
     test('should render the Name input', async () => {

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -107,7 +107,7 @@ export function useCreateEditToolbarFilterSetDialog(
     (filterState: IFilterState, filterSet: IDashboardFilterSet) => {
       const newFilterSet = { ...filterSet, filters: JSON.stringify(filterState) };
       const isCreate = filterSet.id === undefined;
-      const title = isCreate ? t('Create new report') : t('Edit report');
+      const title = isCreate ? t('Create new report') : t('Update report');
       const description = isCreate
         ? t('Save the current filter configuration as a new report.')
         : t('This will update the report with the current name and filter configuration.');

--- a/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
+++ b/frontend/awx/analytics/automation-dashboard/common/useCreateEditToolbarFilterSetDialog.tsx
@@ -76,7 +76,7 @@ function CreateEditToolbarFilterSetDialog(
           singleColumn
           disablePadding
           disableSubmitOnEnter
-          submitText={t('Save report')}
+          submitText={filterSet.id === undefined ? t('Create report') : t('Save changes')}
           onSubmit={onSubmit}
           cancelText={t('Cancel')}
           onCancel={onClose}
@@ -106,10 +106,15 @@ export function useCreateEditToolbarFilterSetDialog(
   return useCallback(
     (filterState: IFilterState, filterSet: IDashboardFilterSet) => {
       const newFilterSet = { ...filterSet, filters: JSON.stringify(filterState) };
-      const title = filterSet.id === undefined ? t('Save report') : t('Rename report');
+      const isCreate = filterSet.id === undefined;
+      const title = isCreate ? t('Create new report') : t('Edit report');
+      const description = isCreate
+        ? t('Save the current filter configuration as a new report.')
+        : t('This will update the report with the current name and filter configuration.');
       setDialog(
         <CreateEditToolbarFilterSetDialog
           title={title}
+          description={description}
           filterSet={newFilterSet}
           onComplete={onComplete}
           onSuccess={(message) =>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { PageAlertToasterProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
-import type { PageToolbarProps } from '@ansible/ansible-ui-framework';
+import type { IFilterState, PageToolbarProps } from '@ansible/ansible-ui-framework';
 import type { IDashboardFilterSet, IJobTemplate } from '../types';
 import { DashboardToolbar } from './DashboardToolbar';
 
@@ -268,6 +268,71 @@ describe('DashboardToolbar', () => {
           </Wrapper>
         );
       }).not.toThrow();
+    });
+  });
+
+  describe('custom period default start date', () => {
+    test('should seed the start date to 7 days ago when switching to Custom with no dates', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+      try {
+        const { rerender } = render(
+          <Wrapper>
+            <DashboardToolbar {...buildProps({ filterState: { period: ['last_7_days'] } })} />
+          </Wrapper>
+        );
+
+        rerender(
+          <Wrapper>
+            <DashboardToolbar {...buildProps({ filterState: { period: ['custom'] } })} />
+          </Wrapper>
+        );
+
+        expect(mockSetFilterState).toHaveBeenCalled();
+        const updater = mockSetFilterState.mock.calls.at(-1)?.[0] as (
+          prev: IFilterState
+        ) => IFilterState;
+        expect(updater({ period: ['custom'] })).toEqual({ period: ['custom', '2024-06-08'] });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test('should not seed a start date when Custom already has one', () => {
+      const { rerender } = render(
+        <Wrapper>
+          <DashboardToolbar {...buildProps({ filterState: { period: ['last_7_days'] } })} />
+        </Wrapper>
+      );
+
+      rerender(
+        <Wrapper>
+          <DashboardToolbar
+            {...buildProps({ filterState: { period: ['custom', '2024-01-01'] } })}
+          />
+        </Wrapper>
+      );
+
+      expect(mockSetFilterState).not.toHaveBeenCalled();
+    });
+
+    test('should not re-seed the start date when it is cleared while already on Custom', () => {
+      const { rerender } = render(
+        <Wrapper>
+          <DashboardToolbar
+            {...buildProps({ filterState: { period: ['custom', '2024-01-01'] } })}
+          />
+        </Wrapper>
+      );
+      mockSetFilterState.mockClear();
+
+      rerender(
+        <Wrapper>
+          <DashboardToolbar {...buildProps({ filterState: { period: ['custom'] } })} />
+        </Wrapper>
+      );
+
+      expect(mockSetFilterState).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardToolbar.tsx
@@ -6,8 +6,14 @@ import {
   useBreakpoint,
 } from '@ansible/ansible-ui-framework';
 import { PageAsyncSingleSelect } from '@ansible/ansible-ui-framework/PageInputs/PageAsyncSingleSelect';
-import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import React, { useCallback, useEffect } from 'react';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  yyyyMMddFormat,
+} from '@patternfly/react-core';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAutomationDashboardToolbarActions } from '../common/useAutomationDashboardToolbarActions';
 import { AutomationDashboardDateRangeFilterPresets } from '../constants';
@@ -17,6 +23,14 @@ import { useFilterSetView } from '../views/useFilterSetView';
 const DEFAULT_FILTER_STATE: IFilterState = {
   period: [AutomationDashboardDateRangeFilterPresets.last_7_days],
 };
+
+const CUSTOM_RANGE_DEFAULT_FROM_DAYS = 7;
+
+function getDefaultCustomFrom(): string {
+  const date = new Date();
+  date.setDate(date.getDate() - CUSTOM_RANGE_DEFAULT_FROM_DAYS);
+  return yyyyMMddFormat(date);
+}
 
 function parseFilterState(raw: string): IFilterState {
   try {
@@ -67,6 +81,27 @@ export function DashboardToolbar(
       setSelectedFilterSet(undefined);
     });
   }, [registerClearCallback, setValue, setSelectedFilterSet]);
+
+  // When the user switches the period filter to Custom with no dates yet, seed the
+  // start date to 7 days ago (matching "Last 7 days") instead of leaving it empty.
+  // Only fires on the transition into Custom, so manually clearing the start date
+  // afterwards isn't immediately overwritten.
+  const previousPeriodPresetRef = useRef<string | undefined>(filterState?.period?.[0]);
+  useEffect(() => {
+    const period = filterState?.period;
+    const currentPreset = period?.[0];
+    const enteringCustom =
+      currentPreset === AutomationDashboardDateRangeFilterPresets.custom &&
+      previousPeriodPresetRef.current !== AutomationDashboardDateRangeFilterPresets.custom;
+    previousPeriodPresetRef.current = currentPreset;
+
+    if (enteringCustom && period?.length === 1) {
+      setFilterState?.((prev) => ({
+        ...prev,
+        period: [AutomationDashboardDateRangeFilterPresets.custom, getDefaultCustomFrom()],
+      }));
+    }
+  }, [filterState?.period, setFilterState]);
 
   const applyFilterSet = useCallback(
     (filterSet: IDashboardFilterSet) => {

--- a/frontend/awx/analytics/automation-dashboard/utils/queryString.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/utils/queryString.test.ts
@@ -607,6 +607,46 @@ describe('queryString', () => {
       ).toBe(false);
     });
 
+    test('should return false when start date is after end date', () => {
+      expect(
+        isRequiredFilterValid(requiredDateRangeFilter, {
+          period: ['custom', '2024-01-31', '2024-01-01'],
+        })
+      ).toBe(false);
+    });
+
+    test('should return true when start date equals end date', () => {
+      expect(
+        isRequiredFilterValid(requiredDateRangeFilter, {
+          period: ['custom', '2024-01-15', '2024-01-15'],
+        })
+      ).toBe(true);
+    });
+
+    test('should return false when only a start date after today is provided (end defaults to today)', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+      try {
+        expect(
+          isRequiredFilterValid(requiredDateRangeFilter, { period: ['custom', '2024-06-16'] })
+        ).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test('should return true when only a start date of today is provided (end defaults to today)', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+      try {
+        expect(
+          isRequiredFilterValid(requiredDateRangeFilter, { period: ['custom', '2024-06-15'] })
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     describe('timezones west of UTC', () => {
       const originalTz = process.env.TZ;
 

--- a/frontend/awx/analytics/automation-dashboard/utils/queryString.ts
+++ b/frontend/awx/analytics/automation-dashboard/utils/queryString.ts
@@ -42,9 +42,17 @@ export function isRequiredFilterValid(filter: IToolbarFilter, filterState: IFilt
   // Custom date range requires 2 values: ['custom', 'start_date']
   // (end_date will default to the current date)
   // or 3 values: ['custom', 'start_date', 'end_date']
+  // In both cases, start_date must not be after end_date — ISO date strings
+  // compare correctly with simple string comparison.
   if (filter.type === ToolbarFilterType.DateRange && values[0] === 'custom') {
-    if (values.length === 2) return isIsoDateString(values[1]);
-    if (values.length === 3) return isIsoDateString(values[1]) && isIsoDateString(values[2]);
+    if (values.length === 2) {
+      if (!isIsoDateString(values[1])) return false;
+      return values[1] <= yyyyMMddFormat(new Date());
+    }
+    if (values.length === 3) {
+      if (!isIsoDateString(values[1]) || !isIsoDateString(values[2])) return false;
+      return values[1] <= values[2];
+    }
     return false;
   }
 


### PR DESCRIPTION
## Summary
[AAP-85025] Clarify report management actions

This pull request introduces several improvements and updates to the automation dashboard's toolbar actions and the date range filter component. The main focus is on enhancing the handling and validation of custom date ranges, refining the report management actions (including permissions and labels), and ensuring the UI and tests accurately reflect these changes.

**Toolbar Actions and Report Management:**

* The dropdown menu for report actions now uses clearer labels: "Create new report", "Edit report", and "Delete report" instead of the previous "Save report" and "Rename report". The main dropdown is labeled "Report actions" instead of "Save as report". [[1]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078R88-R118) [[2]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078L128-R143) [[3]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L127-R130) [[4]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L202-R205) [[5]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L271-R377)
* The "Edit report" action is now always available (regardless of whether the filter state is default or not), but is disabled with a clear message if the user is not a superuser or if required custom date ranges are invalid. [[1]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078R46-R55) [[2]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L214-R254) [[3]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L251-R298)
* The logic for enabling/disabling actions is refactored: "Create new report" is disabled for non-superusers or invalid filters, and "Edit report" has its own validation logic. [[1]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078R46-R55) [[2]](diffhunk://#diff-93b1c36dae73e96b23a1678442a7bc9ad4d988b0f2a9eb439a5d22a8bcc27078R88-R118) [[3]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L214-R254)
* All relevant tests are updated to match the new labels, behaviors, and validation logic, including edge cases for permissions and filter validity. [[1]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L127-R130) [[2]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L202-R205) [[3]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L214-R254) [[4]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L251-R298) [[5]](diffhunk://#diff-8558f7cc46bfea894c32b5ee672739c65d3d473b440daccffc1a89420a05ec28L271-R377)

**Date Range Filter Improvements:**

* The `ToolbarDateRangeFilter` component now derives the start and end dates directly from `filterValues` (props), ensuring the UI always reflects externally-set values (such as when loading a saved report), not just the values present on mount.
* Local state for the date range is removed in favor of prop-driven state, and setter functions for start/end dates update `filterValues` accordingly.
* Added a clear button for the end date with accessible labeling and test ID for improved testability and accessibility.
* Tests are added and updated to verify correct behavior when filter values are set externally, changed, or cleared, and when the user interacts with the date pickers. [[1]](diffhunk://#diff-5b7f3e63b2fe162a7464713409644cf36b7ea87c3dddb8cac4b15b84ed7e1f92R122-R256) [[2]](diffhunk://#diff-5b7f3e63b2fe162a7464713409644cf36b7ea87c3dddb8cac4b15b84ed7e1f92L2-R2)

These changes improve the reliability, clarity, and accessibility of the report management UI and custom date range handling, while ensuring that permissions and validation are consistently enforced across the application.

## Type of Change

- [x] Bug fix
- [x] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->

<img width="1231" height="257" alt="image" src="https://github.com/user-attachments/assets/e547f23f-efd8-4df2-b9cc-d4045856434d" />

<img width="747" height="335" alt="image" src="https://github.com/user-attachments/assets/1e97349f-c8c6-4caa-bf8d-c208e56b9ba8" />


<img width="777" height="399" alt="image" src="https://github.com/user-attachments/assets/3fbf6c85-9b60-46b6-b3f3-89f304edade4" />

<img width="747" height="335" alt="image" src="https://github.com/user-attachments/assets/f15ce355-461b-4318-92d0-e93ff707e3a8" />

