### PR TITLE
chore: update tekton pipeline bundle for e2e tests

### DIFF
--- a/.tekton/aap-ui-e2e-coverage-push.yaml
+++ b/.tekton/aap-ui-e2e-coverage-push.yaml
@@ -26,7 +26,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:89a4d806d3c5e2aee3eb6207b5abf6e3dd602f0e2685386ea4af9dd61e1e06bf
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:bb3822cfc26a33f00f314a7a4cedf7472d5c4638b5c928056c15c120cad7e6c6
       - name: kind
         value: pipeline
       - name: secret

--- a/.tekton/aap-ui-e2e.yaml
+++ b/.tekton/aap-ui-e2e.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-ui-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:89a4d806d3c5e2aee3eb6207b5abf6e3dd602f0e2685386ea4af9dd61e1e06bf
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-ui-tests:0.1@sha256:bb3822cfc26a33f00f314a7a4cedf7472d5c4638b5c928056c15c120cad7e6c6
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->
The latest pipeline bundle resolves the failure when trying to deploy aap-dev.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [X] Other (please specify) - CI

## Risk Analysis - REQUIRED

- [x] **Low** — 
