### PR TITLE
fix(test): replace Monaco editor .fill() with keyboard-based helper

### DIFF
--- a/playwright/commands/fillMonacoEditor.ts
+++ b/playwright/commands/fillMonacoEditor.ts
@@ -1,0 +1,21 @@
+import { Locator, Page } from '@playwright/test';
+
+/**
+ * Fill a Monaco editor with the given text.
+ *
+ * Monaco 0.56+ uses a `native-edit-context` element that is NOT a standard
+ * `<textarea>` or `[contenteditable]`. Playwright's `.fill()` only works on
+ * `<input>`, `<textarea>`, or `[contenteditable]` elements, so we use the
+ * keyboard to select-all and type instead.
+ *
+ * @param page  - The Playwright Page object
+ * @param text  - The text to enter into the editor
+ * @param editorLocator - Optional locator for the editor element. Defaults to
+ *                        `page.getByRole('textbox', { name: 'Editor content' })`.
+ */
+export async function fillMonacoEditor(page: Page, text: string, editorLocator?: Locator) {
+  const editor = editorLocator ?? page.getByRole('textbox', { name: 'Editor content' });
+  await editor.click({ force: true });
+  await page.keyboard.press('Control+a');
+  await page.keyboard.type(text);
+}

--- a/playwright/tests/integration/automation-content/remotes/remotes.spec.ts
+++ b/playwright/tests/integration/automation-content/remotes/remotes.spec.ts
@@ -2,6 +2,7 @@ import { TOPOLOGY_AZURE, TOPOLOGY_SAAS } from '@ansible/playwright/commands/cons
 import { isTopology } from '@ansible/playwright/commands/getTopologyType';
 import { clearTableFilters } from '@ansible/playwright/commands/clearTableFilters';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { filterTable } from '@ansible/playwright/commands/filterTable';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
@@ -223,10 +224,7 @@ test.describe('Hub - Remotes', () => {
           await page.getByTestId('tls_validation').uncheck();
 
           // Update requirements file (using the code editor textbox)
-          const requirementsEditor = page.getByRole('textbox', { name: 'Editor content' });
-          await requirementsEditor.click({ force: true });
-          await requirementsEditor.clear();
-          await requirementsEditor.fill('collections:\n  - name: community.general');
+          await fillMonacoEditor(page, 'collections:\n  - name: community.general');
 
           await page.getByRole('button', { name: 'Save remote', exact: true }).click();
 
@@ -285,9 +283,7 @@ test.describe('Hub - Remotes', () => {
           await page.getByTestId('sync_dependencies').check();
 
           // Clear requirements file (using the code editor textbox)
-          const requirementsEditor = page.getByRole('textbox', { name: 'Editor content' });
-          await requirementsEditor.click({ force: true });
-          await requirementsEditor.clear();
+          await fillMonacoEditor(page, '');
 
           await page.getByTestId('Submit').click();
 

--- a/playwright/tests/integration/automation-decisions/credential-types/credential-types-crud.spec.ts
+++ b/playwright/tests/integration/automation-decisions/credential-types/credential-types-crud.spec.ts
@@ -1,6 +1,7 @@
 import type { PlatformOrganization } from '@ansible/platform-ui/interfaces/PlatformOrganization';
 import { isSaaS } from '@ansible/playwright/commands/getTopologyType';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { filterTable } from '@ansible/playwright/commands/filterTable';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
@@ -32,11 +33,11 @@ test.describe('EDA Credential Types - CRUD Operations', () => {
       await test.step('Verify error on invalid input configuration', async () => {
         await page.getByPlaceholder('Enter credential type name').fill(name);
         await page.getByPlaceholder('Enter description').fill('temp');
-        await page.locator('.view-lines').first().click();
-        await page
-          .locator('#inputs')
-          .getByRole('textbox', { name: 'Editor content' })
-          .fill('random');
+        await fillMonacoEditor(
+          page,
+          'random',
+          page.locator('#inputs').getByRole('textbox', { name: 'Editor content' })
+        );
         await page.getByRole('button', { name: 'Create credential type' }).click();
         await expect(page.getByText('schema must be in dict format')).toBeVisible();
       });
@@ -46,16 +47,12 @@ test.describe('EDA Credential Types - CRUD Operations', () => {
         await page.getByPlaceholder('Enter credential type name').fill(name);
         await page.getByPlaceholder('Enter description').clear();
         await page.getByPlaceholder('Enter description').fill('This is a custom Credential Type.');
-        const inputsEditor = page
-          .locator('#inputs')
-          .getByRole('textbox', { name: 'Editor content' });
-        await page.locator('#inputs').locator('.view-lines').first().click();
-        await inputsEditor.press('ControlOrMeta+a');
-        await inputsEditor.press('Delete');
-        await inputsEditor.fill(
+        await fillMonacoEditor(
+          page,
           JSON.stringify({
             fields: [{ id: 'username', type: 'string', label: 'Username' }],
-          })
+          }),
+          page.locator('#inputs').getByRole('textbox', { name: 'Editor content' })
         );
       });
 

--- a/playwright/tests/integration/automation-execution/infrastructure/credential-types/credential-types.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/credential-types/credential-types.spec.ts
@@ -4,6 +4,7 @@ import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
 import { clickTableRowAction } from '@ansible/playwright/commands/clickTableRowAction';
 import { confirmAndAssertDeletion } from '@ansible/playwright/commands/confirmAndAssertDeletion';
 import { deleteResourceFromDetailsPage } from '@ansible/playwright/commands/deleteResourceFromDetailsPage';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { filterTable } from '@ansible/playwright/commands/filterTable';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
 import { selectTableRow } from '@ansible/playwright/commands/selectTableRow';
@@ -283,9 +284,11 @@ test.describe('Credential Types', { tag: ['@not_mock', '@local_debug'] }, () => 
           fields: [{ id: 'api_key', type: 'string', label: 'API Key' }],
         });
 
-        await page.locator('.view-lines').first().click();
-        const inputEditor = page.locator('.monaco-editor').first().getByRole('textbox');
-        await inputEditor.fill(inputConfig);
+        await fillMonacoEditor(
+          page,
+          inputConfig,
+          page.locator('.monaco-editor').first().getByRole('textbox')
+        );
 
         await page.getByRole('button', { name: 'Save credential type' }).click();
 

--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/constructed/constructed-inventory-crud.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/constructed/constructed-inventory-crud.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test';
 import { clickPageAction } from '../../../../../../commands/clickPageAction';
 import { confirmAndAssertDeletion } from '../../../../../../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../../../../../../commands/createE2EName';
+import { fillMonacoEditor } from '../../../../../../commands/fillMonacoEditor';
 import { filterTableByText } from '../../../../../../commands/filterTableByText';
 import { navigateTo } from '../../../../../../commands/navigateTo';
 import { setupAfter, setupBefore } from '../../../../../../commands/setup';
@@ -112,9 +113,7 @@ test.describe('Constructed Inventory', () => {
         // Edit description and source vars
         await page.getByPlaceholder('Enter description').clear();
         await page.getByPlaceholder('Enter description').fill(description);
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).clear();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill('plugin: constructed');
+        await fillMonacoEditor(page, 'plugin: constructed');
         await page.getByRole('button', { name: 'Save inventory' }).click();
 
         // Verify changes were saved

--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/regular/regular-inventory-crud.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/regular/regular-inventory-crud.spec.ts
@@ -4,6 +4,7 @@ import { clickTableRowAction } from '../../../../../../commands/clickTableRowAct
 import { clearTableFilters } from '../../../../../../commands/clearTableFilters';
 import { confirmAndAssertDeletion } from '../../../../../../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../../../../../../commands/createE2EName';
+import { fillMonacoEditor } from '../../../../../../commands/fillMonacoEditor';
 import { setupAfter, setupBefore } from '../../../../../../commands/setup';
 import { Organization, Inventory, InstanceGroup } from '@ansible/playwright/utils';
 
@@ -73,8 +74,7 @@ test.describe('Regular Inventory', () => {
           page.getByRole('heading', { name: `Edit ${inventoryName}`, exact: true })
         ).toBeVisible();
 
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(TEST_VAR_EDITED);
+        await fillMonacoEditor(page, TEST_VAR_EDITED);
         await page.getByRole('button', { name: 'Save inventory' }).click();
 
         await expect(page.getByTestId('name')).toHaveText(inventoryName);

--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-groups.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-groups.spec.ts
@@ -4,6 +4,7 @@ import { clickPageAction } from '../../../../../../commands/clickPageAction';
 import { clickTableRow } from '../../../../../../commands/clickTableRow';
 import { clickTableRowAction } from '../../../../../../commands/clickTableRowAction';
 import { createE2EName } from '../../../../../../commands/createE2EName';
+import { fillMonacoEditor } from '../../../../../../commands/fillMonacoEditor';
 import { getTableRow } from '../../../../../../commands/getTableRow';
 import { navigateTo } from '../../../../../../commands/navigateTo';
 import { runAdHocCommandWizard } from '../../../../../../commands/runAdHocCommandWizard';
@@ -35,7 +36,7 @@ test.describe('Inventory Groups - List View', () => {
 
       await page.getByRole('textbox', { name: 'Name', exact: true }).fill(groupName);
       await page.getByRole('textbox', { name: 'Description' }).fill('This is a description');
-      await page.getByRole('textbox', { name: 'Editor content' }).fill(variablesText);
+      await fillMonacoEditor(page, variablesText);
 
       await page.getByRole('button', { name: 'Create group' }).click();
       await page.waitForURL(/\/groups\/\d+\/details/);

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
 import { awxAPI } from '@ansible/playwright/commands/apiClient';
 import { Credential, JobTemplate, WorkflowVisualizer } from '@ansible/playwright/utils';
@@ -285,7 +286,7 @@ test.describe('Workflow Visualizer - Template Switch', () => {
       await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
 
       await page.getByRole('button', { name: 'Prompts' }).click();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('my_var: test_value');
+      await fillMonacoEditor(page, 'my_var: test_value');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.waitForTimeout(500);
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -372,7 +373,7 @@ test.describe('Workflow Visualizer - Template Switch', () => {
       await page.getByRole('checkbox', { name: credentialName }).check();
       await page.getByRole('button', { name: 'Credentials' }).click();
       // Set extra_vars
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('stale_var: old_value');
+      await fillMonacoEditor(page, 'stale_var: old_value');
       // Set skip_tags
       await page.getByRole('textbox', { name: 'Type to filter' }).last().click();
       await page.getByRole('textbox', { name: 'Type to filter' }).last().fill('stale_tag');
@@ -545,7 +546,7 @@ test.describe('Workflow Visualizer - Template Switch', () => {
       await page.getByRole('button', { name: 'Next' }).nth(0).click({ force: true });
 
       await page.getByRole('button', { name: 'Prompts' }).click();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('old_var: stale_value');
+      await fillMonacoEditor(page, 'old_var: stale_value');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.waitForTimeout(500);
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -645,7 +646,7 @@ test.describe('Workflow Visualizer - Template Switch', () => {
       await page.getByRole('textbox', { name: 'Search input' }).fill(oldCredName);
       await page.getByRole('checkbox', { name: oldCredName }).check();
       await page.getByRole('button', { name: 'Credentials' }).click();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('old_var: old');
+      await fillMonacoEditor(page, 'old_var: old');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.waitForTimeout(500);
       await page.getByRole('button', { name: 'Finish' }).click();
@@ -670,7 +671,7 @@ test.describe('Workflow Visualizer - Template Switch', () => {
       await page.getByRole('textbox', { name: 'Search input' }).fill(newCredName);
       await page.getByRole('checkbox', { name: newCredName }).check();
       await page.getByRole('button', { name: 'Credentials' }).click();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('new_var: fresh');
+      await fillMonacoEditor(page, 'new_var: fresh');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.waitForTimeout(500);
       await page.getByRole('button', { name: 'Finish' }).click();

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
 import { toggleNodeKebab } from '@ansible/playwright/commands/toggleNodeKebab';
 import { awxAPI } from '@ansible/playwright/commands/apiClient';
@@ -569,7 +570,7 @@ test.describe('Workflow Viz', () => {
       await page.getByRole('textbox', { name: 'Search input' }).fill(instanceGroup);
       await page.getByRole('checkbox', { name: instanceGroup }).check();
       await page.getByRole('button', { name: 'Instance groups' }).click();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('var: test');
+      await fillMonacoEditor(page, 'var: test');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.getByRole('button', { name: 'Finish' }).click();
       await page.getByRole('button', { name: 'Legend' }).click();
@@ -593,7 +594,7 @@ test.describe('Workflow Viz', () => {
       await expect(
         page.getByRole('code').locator('div').filter({ hasText: 'var: test' }).nth(4)
       ).toBeVisible();
-      await page.getByRole('textbox', { name: 'Editor content' }).fill('newvar: newtest');
+      await fillMonacoEditor(page, 'newvar: newtest');
       await page.getByRole('button', { name: 'Next' }).click();
       await page.getByRole('button', { name: 'Finish' }).click();
       await page.getByRole('button', { name: 'Legend' }).click();

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflowVisualizerOutput.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflowVisualizerOutput.spec.ts
@@ -7,6 +7,7 @@ import type { WorkflowNode } from '@ansible/awx-ui/interfaces/WorkflowNode';
 import { awxAPI } from '@ansible/playwright/commands/apiClient';
 import { clickTableRowAction } from '@ansible/playwright/commands/clickTableRowAction';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { filterTable } from '@ansible/playwright/commands/filterTable';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
@@ -241,7 +242,7 @@ test.describe('Workflow Visualizer - Job Output', () => {
         await page.getByRole('button', { name: 'Next' }).click();
 
         // Add extra variables
-        await page.getByRole('textbox', { name: 'Editor content' }).fill('foo: bar');
+        await fillMonacoEditor(page, 'foo: bar');
         await page.getByRole('button', { name: 'Next' }).click();
 
         // Verify extra vars are shown in review step

--- a/playwright/utils/authentication.ts
+++ b/playwright/utils/authentication.ts
@@ -3,6 +3,7 @@ import { clickPageAction } from '../commands/clickPageAction';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { navigateTo } from '../commands/navigateTo';
 
 export interface CreateAuthenticationMethodOptions {
@@ -52,18 +53,16 @@ export const Authentication = {
             .fill('ldap://ldap.example.com:389');
           await page.getByRole('button', { name: 'Select a value' }).click();
           await page.getByRole('option', { name: 'MemberDNGroupType', exact: true }).click();
-          await page
-            .locator(
-              '#configuration-editor-GROUP_TYPE_PARAMS > .monaco-editor > .overflow-guard > div:nth-child(2) > .lines-content > .view-lines > .view-line'
-            )
-            .click();
-          await page.keyboard.type(`{name_attr: "cn", member_attr: "member"}`);
-          await page
-            .locator(
-              '#configuration-editor-USER_ATTR_MAP > .monaco-editor > .overflow-guard > div:nth-child(2) > .lines-content > .view-lines > .view-line'
-            )
-            .click();
-          await page.keyboard.type('email: "mail"');
+          await fillMonacoEditor(
+            page,
+            `{name_attr: "cn", member_attr: "member"}`,
+            page.locator('#configuration-editor-GROUP_TYPE_PARAMS').getByRole('textbox')
+          );
+          await fillMonacoEditor(
+            page,
+            'email: "mail"',
+            page.locator('#configuration-editor-USER_ATTR_MAP').getByRole('textbox')
+          );
           break;
         case 'TACACS+':
           await page

--- a/playwright/utils/credentialType.ts
+++ b/playwright/utils/credentialType.ts
@@ -3,6 +3,7 @@ import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
 import { navigateTo } from '../commands/navigateTo';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { selectTableRow } from '../commands/selectTableRow';
 
 export interface CredentialTypeOptions {
@@ -26,15 +27,19 @@ export const CredentialType = {
       await page.getByPlaceholder('Enter description').fill(description);
 
       if (options.inputConfiguration) {
-        await page.locator('.view-lines').first().click();
-        const inputEditor = page.locator('.monaco-editor').first().getByRole('textbox');
-        await inputEditor.fill(options.inputConfiguration);
+        await fillMonacoEditor(
+          page,
+          options.inputConfiguration,
+          page.locator('.monaco-editor').first().getByRole('textbox')
+        );
       }
 
       if (options.injectorConfiguration) {
-        await page.locator('.view-lines').nth(1).click();
-        const injectorEditor = page.locator('.monaco-editor').nth(1).getByRole('textbox');
-        await injectorEditor.fill(options.injectorConfiguration);
+        await fillMonacoEditor(
+          page,
+          options.injectorConfiguration,
+          page.locator('.monaco-editor').nth(1).getByRole('textbox')
+        );
       }
 
       await page.getByRole('button', { name: 'Create credential type' }).click();

--- a/playwright/utils/edaCredentialType.ts
+++ b/playwright/utils/edaCredentialType.ts
@@ -4,6 +4,7 @@ import { clickPageAction } from '../commands/clickPageAction';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { navigateTo } from '../commands/navigateTo';
 
 export interface CreateEdaCredentialTypeOptions {
@@ -84,37 +85,35 @@ export const EdaCredentialType = {
       await page.getByText('Create credential type').click();
       const credentialTypeName = options.credentialTypeName ?? createE2EName('credential_type');
       await page.getByPlaceholder('Enter credential type name').fill(credentialTypeName);
-      await page.locator('.view-lines').first().click();
-      await page
-        .locator('#inputs')
-        .getByRole('textbox', { name: 'Editor content' })
-        .fill(
-          options?.inputType ??
-            JSON.stringify({
-              fields: [
-                {
-                  id: 'auth_type',
-                  type: 'string',
-                  label: 'Event Stream Authentication Type',
-                  hidden: true,
-                  default: 'basic',
-                },
-                {
-                  id: 'username',
-                  type: 'string',
-                  label: 'Username',
-                  help_text: 'The username used to authenticate the incoming event stream',
-                },
-                {
-                  id: 'password',
-                  type: 'string',
-                  label: 'Password',
-                  secret: true,
-                  help_text: 'The password used to authenticate the incoming event stream',
-                },
-              ],
-            })
-        );
+      await fillMonacoEditor(
+        page,
+        options?.inputType ??
+          JSON.stringify({
+            fields: [
+              {
+                id: 'auth_type',
+                type: 'string',
+                label: 'Event Stream Authentication Type',
+                hidden: true,
+                default: 'basic',
+              },
+              {
+                id: 'username',
+                type: 'string',
+                label: 'Username',
+                help_text: 'The username used to authenticate the incoming event stream',
+              },
+              {
+                id: 'password',
+                type: 'string',
+                label: 'Password',
+                secret: true,
+                help_text: 'The password used to authenticate the incoming event stream',
+              },
+            ],
+          }),
+        page.locator('#inputs').getByRole('textbox', { name: 'Editor content' })
+      );
       await page.getByRole('button', { name: 'Create credential type' }).click();
       await expect(
         page.getByRole('heading', { name: credentialTypeName, exact: true })

--- a/playwright/utils/host.ts
+++ b/playwright/utils/host.ts
@@ -4,6 +4,7 @@ import { clickPageAction } from '../commands/clickPageAction';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { navigateTo } from '../commands/navigateTo';
 import { AwxHost as HostType } from '@ansible/awx-ui/interfaces/AwxHost';
 
@@ -58,8 +59,7 @@ export const Host = {
         await page.getByRole('textbox', { name: 'Description' }).fill(options.description);
       }
       if (options.variables) {
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(options.variables);
+        await fillMonacoEditor(page, options.variables);
       }
       await page.getByRole('button', { name: 'Create host' }).click();
 

--- a/playwright/utils/inventory.ts
+++ b/playwright/utils/inventory.ts
@@ -9,6 +9,7 @@ import { clickPageAction } from '../commands/clickPageAction';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { navigateTo } from '../commands/navigateTo';
 import { singleSelectByLabel } from '../commands/singleSelectByLabel';
 
@@ -207,8 +208,7 @@ export const Inventory = {
 
       // Variables
       if (options.variables) {
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(options.variables);
+        await fillMonacoEditor(page, options.variables);
       }
 
       // Prevent instance group fallback
@@ -298,8 +298,7 @@ export const Inventory = {
 
       // source vars
       if (options.sourceVars) {
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(options.sourceVars);
+        await fillMonacoEditor(page, options.sourceVars);
       }
 
       // label

--- a/playwright/utils/inventoryGroup.ts
+++ b/playwright/utils/inventoryGroup.ts
@@ -2,6 +2,7 @@ import { Page, expect } from '@playwright/test';
 import { awxAPI } from '../commands/apiClient';
 import { clickTableRow } from '../commands/clickTableRow';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { getTableRow } from '../commands/getTableRow';
 import { navigateTo } from '../commands/navigateTo';
 import { InventoryGroup as InventoryGroupType } from '@ansible/awx-ui/interfaces/InventoryGroup';
@@ -62,7 +63,7 @@ export const InventoryGroup = {
         await page.getByRole('textbox', { name: 'Description' }).fill(options.description);
       }
       if (options.variables) {
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(options.variables);
+        await fillMonacoEditor(page, options.variables);
       }
       await page.getByRole('button', { name: 'Create group' }).click();
       await expect(page.getByRole('heading', { name: groupName, exact: true })).toBeVisible();

--- a/playwright/utils/inventoryHost.ts
+++ b/playwright/utils/inventoryHost.ts
@@ -4,6 +4,7 @@ import { awxAPI } from '../commands/apiClient';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { getTableRow } from '../commands/getTableRow';
 import { navigateTo } from '../commands/navigateTo';
 
@@ -119,8 +120,7 @@ export const InventoryHost = {
       }
 
       if (options.variables) {
-        await page.locator('.view-line').click();
-        await page.getByRole('textbox', { name: 'Editor content' }).fill(options.variables);
+        await fillMonacoEditor(page, options.variables);
       }
 
       await page.getByRole('button', { name: 'Create host', exact: true }).click();

--- a/playwright/utils/schedule.ts
+++ b/playwright/utils/schedule.ts
@@ -3,6 +3,7 @@ import { clickPageAction } from '../commands/clickPageAction';
 import { clickTableRow } from '../commands/clickTableRow';
 import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
 import { navigateTo } from '../commands/navigateTo';
 import { Inventory } from './inventory';
 import { JobTemplate } from './jobTemplate';
@@ -76,9 +77,11 @@ export const Schedule = {
         }
         if (options.extraVars) {
           await expect(page.getByText('Variables')).toBeVisible();
-          await page.locator('.view-lines').first().click();
-          const varsEditor = page.locator('.monaco-editor').first().getByRole('textbox');
-          await varsEditor.fill(options.extraVars);
+          await fillMonacoEditor(
+            page,
+            options.extraVars,
+            page.locator('.monaco-editor').first().getByRole('textbox')
+          );
         }
         await page.getByRole('button', { name: 'Next' }).click();
       }


### PR DESCRIPTION
## Summary

Monaco 0.56.0 (upgraded in #3444) introduced `native-edit-context` which changes the editor element from a standard `contenteditable` `<textarea>` to a `<div>`. Playwright's `.fill()` only works on `<input>`, `<textarea>`, or `[contenteditable]` elements, so all tests that fill Monaco editors broke with:

> `Error: Element is not an <input>, <textarea> or [contenteditable] element`

This was causing **~20 ephemeral e2e test failures** across multiple test suites.

### Changes

1. **New shared command** `playwright/commands/fillMonacoEditor.ts` — uses `Ctrl+A` + `keyboard.type()` instead of `.fill()`
2. **Updated 8 utility files** that wrap Monaco interactions:
   - `credentialType.ts`, `edaCredentialType.ts`, `inventory.ts`, `inventoryHost.ts`, `inventoryGroup.ts`, `host.ts`, `schedule.ts`, `authentication.ts`
3. **Updated 9 spec files** with direct Monaco usage:
   - `credential-types.spec.ts`, `credential-types-crud.spec.ts`, `inventory-groups.spec.ts`, `regular-inventory-crud.spec.ts`, `constructed-inventory-crud.spec.ts`, `workflowVisualizerOutput.spec.ts`, `workflow-visualizer.spec.ts`, `workflow-visualizer-template-switch.spec.ts`, `remotes.spec.ts`

## Type of Change

- [x] Bug fix
- [x] Tests

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped

## Testing

### Ephemeral E2E Tests

These changes fix the ~20 Monaco-related failures seen in [Currents run c650f70d21c2db13](https://app.currents.dev/run/c650f70d21c2db13). Trigger `/run-playwright` to validate.