### PR TITLE
fix(test): use page-title testid to avoid strict mode violation in event stream test

### DIFF
--- a/playwright/tests/integration/automation-decisions/event-streams/event-stream-activations.spec.ts
+++ b/playwright/tests/integration/automation-decisions/event-streams/event-stream-activations.spec.ts
@@ -241,7 +241,7 @@ test.describe('Event Stream and Rulebook Activation Integration', () => {
 
       await test.step('Navigate to event stream details', async () => {
         await navigateTo(page, 'Automation Decisions', 'Event Streams');
-        await expect(page.getByRole('heading', { name: 'Event Streams' })).toBeVisible();
+        await expect(page.getByTestId('page-title')).toContainText('Event Streams');
         await clickTableRow(
           {
             text: eventStream.name,


### PR DESCRIPTION
## Summary

The event stream activation test failed with a strict mode violation because `getByRole('heading', { name: 'Event Streams' })` matched **two** elements — the page title and the empty state heading. Changed to `getByTestId('page-title')` which uniquely targets the page title.

**Verified locally:** all event stream tests pass.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped

## Testing

### Ephemeral E2E Tests

Single test fix — verified locally. Depends on [PR #3458](https://github.com/ansible/ansible-ui/pull/3458) for full Monaco coverage.