### PR TITLE
AAP-85859 XLAB Update KPI cards title in Cost calculation card

### DIFF
--- a/framework/PageDashboard/PageDashboardCard.test.tsx
+++ b/framework/PageDashboard/PageDashboardCard.test.tsx
@@ -63,4 +63,29 @@ describe('PageDashboardCard', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should default the title size to xl when titleSize is not provided', () => {
+    renderCard({ title: 'Inventories' });
+
+    expect(screen.getByTestId('card-title')).toHaveClass('pf-m-xl');
+  });
+
+  it('should render the title at the provided titleSize', () => {
+    renderCard({ title: 'Inventories', titleSize: 'md' });
+
+    expect(screen.getByTestId('card-title')).toHaveClass('pf-m-md');
+    expect(screen.getByTestId('card-title')).not.toHaveClass('pf-m-xl');
+  });
+
+  it('should not apply compact styling when isCompact is not provided', () => {
+    renderCard({ id: 'compact-card-test', title: 'Inventories' });
+
+    expect(screen.getByTestId('compact-card-test')).not.toHaveClass('pf-m-compact');
+  });
+
+  it('should apply compact styling when isCompact is true', () => {
+    renderCard({ id: 'compact-card-test', title: 'Inventories', isCompact: true });
+
+    expect(screen.getByTestId('compact-card-test')).toHaveClass('pf-m-compact');
+  });
 });

--- a/framework/PageDashboard/PageDashboardCard.test.tsx
+++ b/framework/PageDashboard/PageDashboardCard.test.tsx
@@ -64,19 +64,6 @@ describe('PageDashboardCard', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should default the title size to xl when titleSize is not provided', () => {
-    renderCard({ title: 'Inventories' });
-
-    expect(screen.getByTestId('card-title')).toHaveClass('pf-m-xl');
-  });
-
-  it('should render the title at the provided titleSize', () => {
-    renderCard({ title: 'Inventories', titleSize: 'md' });
-
-    expect(screen.getByTestId('card-title')).toHaveClass('pf-m-md');
-    expect(screen.getByTestId('card-title')).not.toHaveClass('pf-m-xl');
-  });
-
   it('should not apply compact styling when isCompact is not provided', () => {
     renderCard({ id: 'compact-card-test', title: 'Inventories' });
 

--- a/framework/PageDashboard/PageDashboardCard.tsx
+++ b/framework/PageDashboard/PageDashboardCard.tsx
@@ -66,6 +66,7 @@ export function PageDashboardCard(props: {
   canCollapse?: boolean;
 
   disableBodyPadding?: boolean;
+  titleSize?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 }) {
   const id = useID(props);
 
@@ -161,7 +162,7 @@ export function PageDashboardCard(props: {
                   data-cy="card-title"
                   data-testid="card-title"
                   headingLevel="h3"
-                  size="xl"
+                  size={props.titleSize ?? 'xl'}
                   style={{ display: 'inline-block', verticalAlign: '-0.15em', lineHeight: '1.2' }}
                 >
                   {props.title}

--- a/framework/PageDashboard/PageDashboardCard.tsx
+++ b/framework/PageDashboard/PageDashboardCard.tsx
@@ -66,7 +66,6 @@ export function PageDashboardCard(props: {
   canCollapse?: boolean;
 
   disableBodyPadding?: boolean;
-  titleSize?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 }) {
   const id = useID(props);
 
@@ -162,7 +161,7 @@ export function PageDashboardCard(props: {
                   data-cy="card-title"
                   data-testid="card-title"
                   headingLevel="h3"
-                  size={props.titleSize ?? 'xl'}
+                  size="xl"
                   style={{ display: 'inline-block', verticalAlign: '-0.15em', lineHeight: '1.2' }}
                 >
                   {props.title}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardCardValue.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardCardValue.tsx
@@ -1,0 +1,39 @@
+import { PageDashboardCardWidth } from '@ansible/ansible-ui-framework';
+import { currencyFormatter } from '../../utilities/currencyFormatter';
+import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
+
+export function getDashboardCardValueFontSize(
+  value: string | number,
+  width: PageDashboardCardWidth | undefined,
+  sizes: { compact: string; expanded: string }
+): string {
+  if (typeof value !== 'number') {
+    return 'large';
+  }
+  return width === 'xs' ? sizes.compact : sizes.expanded;
+}
+
+type DashboardCardValueDisplayProps = Readonly<{
+  value: string | number;
+  valueSuffix?: string;
+  formatAsCurrency?: boolean;
+  fontSize: string;
+}>;
+
+export function DashboardCardValueDisplay(props: DashboardCardValueDisplayProps) {
+  const { value, valueSuffix, formatAsCurrency, fontSize } = props;
+
+  let displayValue: string | number = value;
+  if (typeof value === 'number') {
+    displayValue = formatAsCurrency
+      ? currencyFormatter(value)
+      : value.toLocaleString(DEFAULT_NUMBER_LOCALE);
+  }
+
+  return (
+    <span style={{ fontSize, fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
+      {displayValue}
+      {valueSuffix ? ` ${valueSuffix}` : ''}
+    </span>
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { DashboardDetailsCard } from './DashboardDetailsCard';
+import { DashboardDetailsCardProps } from '../types';
+
+const defaultProps: DashboardDetailsCardProps = {
+  id: 'test-card',
+  title: 'Test Title',
+  help: 'Help text',
+  value: 12345,
+  valueSuffix: 'EUR',
+  errorStateTitle: 'Card Error',
+};
+
+describe('DashboardDetailsCard', () => {
+  test('should render title, value, and suffix', () => {
+    render(<DashboardDetailsCard {...defaultProps} />);
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('12,345', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/EUR/)).toBeInTheDocument();
+  });
+
+  test('should render help text when help button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DashboardDetailsCard {...defaultProps} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('Help text')).toBeInTheDocument();
+  }, 10000);
+
+  test('should not render a help button when help is not provided', () => {
+    render(<DashboardDetailsCard {...defaultProps} help={undefined} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('should render value as string when value is not a number', () => {
+    render(<DashboardDetailsCard {...defaultProps} value="Test value" valueSuffix={undefined} />);
+    expect(screen.getByText('Test value')).toBeInTheDocument();
+  });
+
+  test('should not render valueSuffix when valueSuffix is not provided', () => {
+    render(<DashboardDetailsCard {...defaultProps} valueSuffix={undefined} />);
+    expect(screen.queryByText(/EUR/)).not.toBeInTheDocument();
+  });
+
+  test('should render error state with errorStateTitle and error message when error is provided', () => {
+    render(<DashboardDetailsCard {...defaultProps} error={new Error('Something failed')} />);
+    expect(screen.getByText('Card Error')).toBeInTheDocument();
+    expect(screen.getByText('Something failed')).toBeInTheDocument();
+    expect(screen.queryByText((12345).toLocaleString('en-US'))).not.toBeInTheDocument();
+  });
+
+  test('should not render error state when error is not provided', () => {
+    render(<DashboardDetailsCard {...defaultProps} />);
+    expect(screen.queryByText('Card Error')).not.toBeInTheDocument();
+    expect(screen.getByText('12,345', { exact: false })).toBeInTheDocument();
+  });
+
+  describe('formatAsCurrency', () => {
+    test('should format numeric value as USD currency when formatAsCurrency is true', () => {
+      render(
+        <DashboardDetailsCard
+          {...defaultProps}
+          value={2500}
+          valueSuffix={undefined}
+          formatAsCurrency={true}
+        />
+      );
+      expect(screen.getByText('$2,500.00')).toBeInTheDocument();
+    });
+
+    test('should use toLocaleString when formatAsCurrency is false', () => {
+      render(
+        <DashboardDetailsCard
+          {...defaultProps}
+          value={2500}
+          valueSuffix={undefined}
+          formatAsCurrency={false}
+        />
+      );
+      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
+      expect(screen.getByText('2,500')).toBeInTheDocument();
+    });
+
+    test('should use toLocaleString when formatAsCurrency is omitted', () => {
+      render(<DashboardDetailsCard {...defaultProps} value={2500} valueSuffix={undefined} />);
+      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
+      expect(screen.getByText('2,500')).toBeInTheDocument();
+    });
+
+    test('should still render valueSuffix alongside currency-formatted value', () => {
+      render(
+        <DashboardDetailsCard
+          {...defaultProps}
+          value={1000}
+          valueSuffix="*"
+          formatAsCurrency={true}
+        />
+      );
+      expect(screen.getByText(/\$1,000\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/\*/)).toBeInTheDocument();
+    });
+  });
+
+  describe('font size', () => {
+    test('should render value at x-large font size by default (no width)', () => {
+      render(<DashboardDetailsCard {...defaultProps} />);
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'x-large' });
+    });
+
+    test('should render value at large font size when width is xs', () => {
+      render(<DashboardDetailsCard {...defaultProps} width="xs" />);
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'large' });
+    });
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.tsx
@@ -1,0 +1,33 @@
+import { PageDashboardCard, PageDetail, PageDetails } from '@ansible/ansible-ui-framework';
+import { DashboardDetailsCardProps } from '../types';
+import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
+import { DashboardCardValueDisplay, getDashboardCardValueFontSize } from './DashboardCardValue';
+
+export function DashboardDetailsCard(props: DashboardDetailsCardProps) {
+  const { id, title, help, value, valueSuffix, error, errorStateTitle, formatAsCurrency, width } =
+    props;
+
+  const fontSize = getDashboardCardValueFontSize(value, width, {
+    compact: 'large',
+    expanded: 'x-large',
+  });
+
+  return (
+    <PageDashboardCard id={id} width={width ?? 'md'}>
+      <PageDetails disablePadding disableScroll>
+        <PageDetail helpText={help} label={title}>
+          {error ? (
+            <EmptyStateError titleProp={errorStateTitle} message={error.message} />
+          ) : (
+            <DashboardCardValueDisplay
+              value={value}
+              valueSuffix={valueSuffix}
+              formatAsCurrency={formatAsCurrency}
+              fontSize={fontSize}
+            />
+          )}
+        </PageDetail>
+      </PageDetails>
+    </PageDashboardCard>
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -205,19 +205,16 @@ describe('DashboardMainTableCard', () => {
     ).toBeInTheDocument();
   });
 
-  test('should render parent title at xl size and nested KPI titles at md size', () => {
+  test('should render parent title in the card header at xl size', () => {
     renderCard();
     expect(screen.getByText('Cost calculation')).toHaveClass('pf-m-xl');
-    expect(screen.getByText('Cost of manual automation')).toHaveClass('pf-m-md');
-    expect(screen.getByText('Cost of automated execution')).toHaveClass('pf-m-md');
-    expect(screen.getByText('Total savings/cost avoided')).toHaveClass('pf-m-md');
-    expect(screen.getByText('Total hours saved/avoided')).toHaveClass('pf-m-md');
   });
 
-  test('should apply compact card styling to nested KPI cards but not to the parent card', () => {
+  test('should render nested KPI titles as description list labels rather than card headers', () => {
     renderCard();
-    expect(screen.getByTestId('cost-manual-automation-card')).toHaveClass('pf-m-compact');
-    expect(screen.getByTestId('ad-main-table-card')).not.toHaveClass('pf-m-compact');
+    // Only the parent card renders a PageDashboardCard header title.
+    expect(screen.getAllByTestId('card-title')).toHaveLength(1);
+    expect(screen.getByText('Cost of manual automation')).not.toHaveClass('pf-m-xl');
   });
 
   test('should display 0 in value cards when details has zero values', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -205,6 +205,21 @@ describe('DashboardMainTableCard', () => {
     ).toBeInTheDocument();
   });
 
+  test('should render parent title at xl size and nested KPI titles at md size', () => {
+    renderCard();
+    expect(screen.getByText('Cost calculation')).toHaveClass('pf-m-xl');
+    expect(screen.getByText('Cost of manual automation')).toHaveClass('pf-m-md');
+    expect(screen.getByText('Cost of automated execution')).toHaveClass('pf-m-md');
+    expect(screen.getByText('Total savings/cost avoided')).toHaveClass('pf-m-md');
+    expect(screen.getByText('Total hours saved/avoided')).toHaveClass('pf-m-md');
+  });
+
+  test('should apply compact card styling to nested KPI cards but not to the parent card', () => {
+    renderCard();
+    expect(screen.getByTestId('cost-manual-automation-card')).toHaveClass('pf-m-compact');
+    expect(screen.getByTestId('ad-main-table-card')).not.toHaveClass('pf-m-compact');
+  });
+
   test('should display 0 in value cards when details has zero values', () => {
     renderCard(
       buildProps({

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -297,6 +297,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading manual automation cost')}
             width={topCardsWidth}
+            isNested
           ></DashboardValueCard>
           <DashboardValueCard
             id="cost-automated-execution-card"
@@ -307,6 +308,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading automated execution cost')}
             width={topCardsWidth}
+            isNested
           ></DashboardValueCard>
           <DashboardValueCard
             id="total-savings-card"
@@ -317,6 +319,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading total savings')}
             width={topCardsWidth}
+            isNested
           ></DashboardValueCard>
           <DashboardValueCard
             id="total-hours-saved-card"
@@ -327,6 +330,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading total hours saved')}
             width={topCardsWidth}
+            isNested
           ></DashboardValueCard>
         </div>
       </CardBody>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { IAutomationDashboardView, IJobTemplate } from '../types';
 import { DashboardTableInputField } from './DashboardTableInputField';
 import { DashboardTableToolbarRow } from './DashboardTableToolbarRow';
-import { DashboardValueCard } from './DashboardValueCard';
 import { usePutRequest } from '../../../../common/crud/usePutRequest';
 import { currencyFormatter } from '../../utilities/currencyFormatter';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
@@ -21,6 +20,7 @@ import styled from 'styled-components';
 import { ExportIcon } from '@patternfly/react-icons';
 import { DashboardExportButton } from './DashboardExportButton';
 import { hasValidRequiredFilters } from '../utils/queryString';
+import { DashboardDetailsCard } from './DashboardDetailsCard';
 
 interface IJobTemplateModify {
   time_taken_manually_execute_minutes: number;
@@ -288,7 +288,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
           ref={ref}
           style={{ display: 'grid', gap: 16, gridTemplateColumns: `repeat(${columns}, 1fr)` }}
         >
-          <DashboardValueCard
+          <DashboardDetailsCard
             id="cost-manual-automation-card"
             title={t('Cost of manual automation')}
             help={t('Total cost if all jobs were run manually')}
@@ -297,9 +297,8 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading manual automation cost')}
             width={topCardsWidth}
-            isNested
-          ></DashboardValueCard>
-          <DashboardValueCard
+          ></DashboardDetailsCard>
+          <DashboardDetailsCard
             id="cost-automated-execution-card"
             title={t('Cost of automated execution')}
             help={t('Total cost of running jobs on AAP')}
@@ -308,9 +307,8 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading automated execution cost')}
             width={topCardsWidth}
-            isNested
-          ></DashboardValueCard>
-          <DashboardValueCard
+          ></DashboardDetailsCard>
+          <DashboardDetailsCard
             id="total-savings-card"
             title={t('Total savings/cost avoided')}
             help={t('Difference between manual and automated cost')}
@@ -319,9 +317,8 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading total savings')}
             width={topCardsWidth}
-            isNested
-          ></DashboardValueCard>
-          <DashboardValueCard
+          ></DashboardDetailsCard>
+          <DashboardDetailsCard
             id="total-hours-saved-card"
             title={t('Total hours saved/avoided')}
             help={t('Time saved by automation vs manual execution')}
@@ -330,8 +327,7 @@ export function DashboardMainTableCard(props: IAutomationDashboardView) {
             error={detailsError}
             errorStateTitle={t('Error loading total hours saved')}
             width={topCardsWidth}
-            isNested
-          ></DashboardValueCard>
+          ></DashboardDetailsCard>
         </div>
       </CardBody>
       <CardBody>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
@@ -98,85 +98,17 @@ describe('DashboardValueCard', () => {
     expect(screen.getByText('12,345', { exact: false })).toBeInTheDocument();
   });
 
-  describe('formatAsCurrency', () => {
-    test('should format numeric value as USD currency when formatAsCurrency is true', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard
-            {...defaultProps}
-            value={2500}
-            valueSuffix={undefined}
-            formatAsCurrency={true}
-          />
-        </MemoryRouter>
-      );
-      expect(screen.getByText('$2,500.00')).toBeInTheDocument();
-    });
-
-    test('should use toLocaleString when formatAsCurrency is false', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard
-            {...defaultProps}
-            value={2500}
-            valueSuffix={undefined}
-            formatAsCurrency={false}
-          />
-        </MemoryRouter>
-      );
-      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
-      expect(screen.getByText('2,500')).toBeInTheDocument();
-    });
-
-    test('should use toLocaleString when formatAsCurrency is omitted', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard {...defaultProps} value={2500} valueSuffix={undefined} />
-        </MemoryRouter>
-      );
-      expect(screen.queryByText('$2,500.00')).not.toBeInTheDocument();
-      expect(screen.getByText('2,500')).toBeInTheDocument();
-    });
-
-    test('should still render valueSuffix alongside currency-formatted value', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard
-            {...defaultProps}
-            value={1000}
-            valueSuffix="*"
-            formatAsCurrency={true}
-          />
-        </MemoryRouter>
-      );
-      expect(screen.getByText(/\$1,000\.00/)).toBeInTheDocument();
-      expect(screen.getByText(/\*/)).toBeInTheDocument();
-    });
-  });
-
-  describe('isNested', () => {
-    test('should render title at xl size and card without compact styling when isNested is not provided', () => {
+  describe('font size', () => {
+    test('should render title at xl size', () => {
       render(
         <MemoryRouter>
           <DashboardValueCard {...defaultProps} />
         </MemoryRouter>
       );
       expect(screen.getByTestId('card-title')).toHaveClass('pf-m-xl');
-      expect(screen.getByTestId('test-card')).not.toHaveClass('pf-m-compact');
     });
 
-    test('should render title at md size and card with compact styling when isNested is true', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard {...defaultProps} isNested />
-        </MemoryRouter>
-      );
-      expect(screen.getByTestId('card-title')).toHaveClass('pf-m-md');
-      expect(screen.getByTestId('card-title')).not.toHaveClass('pf-m-xl');
-      expect(screen.getByTestId('test-card')).toHaveClass('pf-m-compact');
-    });
-
-    test('should render value at xx-large font size by default (not nested, no width)', () => {
+    test('should render value at xx-large font size by default (no width)', () => {
       render(
         <MemoryRouter>
           <DashboardValueCard {...defaultProps} />
@@ -185,31 +117,13 @@ describe('DashboardValueCard', () => {
       expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'xx-large' });
     });
 
-    test('should render value at x-large font size when not nested and width is xs', () => {
+    test('should render value at x-large font size when width is xs', () => {
       render(
         <MemoryRouter>
           <DashboardValueCard {...defaultProps} width="xs" />
         </MemoryRouter>
       );
       expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'x-large' });
-    });
-
-    test('should render value at x-large font size when nested and width is not xs', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard {...defaultProps} isNested width="md" />
-        </MemoryRouter>
-      );
-      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'x-large' });
-    });
-
-    test('should render value at large font size when nested and width is xs', () => {
-      render(
-        <MemoryRouter>
-          <DashboardValueCard {...defaultProps} isNested width="xs" />
-        </MemoryRouter>
-      );
-      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'large' });
     });
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx
@@ -153,4 +153,63 @@ describe('DashboardValueCard', () => {
       expect(screen.getByText(/\*/)).toBeInTheDocument();
     });
   });
+
+  describe('isNested', () => {
+    test('should render title at xl size and card without compact styling when isNested is not provided', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('card-title')).toHaveClass('pf-m-xl');
+      expect(screen.getByTestId('test-card')).not.toHaveClass('pf-m-compact');
+    });
+
+    test('should render title at md size and card with compact styling when isNested is true', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} isNested />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('card-title')).toHaveClass('pf-m-md');
+      expect(screen.getByTestId('card-title')).not.toHaveClass('pf-m-xl');
+      expect(screen.getByTestId('test-card')).toHaveClass('pf-m-compact');
+    });
+
+    test('should render value at xx-large font size by default (not nested, no width)', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'xx-large' });
+    });
+
+    test('should render value at x-large font size when not nested and width is xs', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} width="xs" />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'x-large' });
+    });
+
+    test('should render value at x-large font size when nested and width is not xs', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} isNested width="md" />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'x-large' });
+    });
+
+    test('should render value at large font size when nested and width is xs', () => {
+      render(
+        <MemoryRouter>
+          <DashboardValueCard {...defaultProps} isNested width="xs" />
+        </MemoryRouter>
+      );
+      expect(screen.getByText('12,345', { exact: false })).toHaveStyle({ fontSize: 'large' });
+    });
+  });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
@@ -6,6 +6,26 @@ import { EmptyStateError } from '../../../../../framework/components/EmptyStateE
 import { currencyFormatter } from '../../utilities/currencyFormatter';
 import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
 
+function getSpanFontSize(
+  isNested: DashboardValueCardProps['isNested'],
+  width: DashboardValueCardProps['width']
+): string {
+  if (isNested) {
+    return width === 'xs' ? 'large' : 'x-large';
+  }
+  return width === 'xs' ? 'x-large' : 'xx-large';
+}
+
+function getDisplayValue(
+  value: DashboardValueCardProps['value'],
+  formatAsCurrency: DashboardValueCardProps['formatAsCurrency']
+): string | number {
+  if (typeof value !== 'number') {
+    return value;
+  }
+  return formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(DEFAULT_NUMBER_LOCALE);
+}
+
 export function DashboardValueCard(props: DashboardValueCardProps) {
   const {
     id,
@@ -19,31 +39,25 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
     errorStateTitle,
     formatAsCurrency,
     width,
+    isNested,
   } = props;
 
-  const contentValue =
-    typeof value === 'number' ? (
-      <span
-        style={{
-          fontSize: width === 'xs' ? 'x-large' : 'xx-large',
-          fontWeight: '400',
-          lineHeight: 1,
-          marginTop: 'auto',
-        }}
-      >
-        {formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(DEFAULT_NUMBER_LOCALE)}
-        {valueSuffix ? ` ${valueSuffix}` : ''}
-      </span>
-    ) : (
-      <span style={{ fontSize: 'large', fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
-        {value}
-        {valueSuffix ? ` ${valueSuffix}` : ''}
-      </span>
-    );
+  const fontSize = typeof value === 'number' ? getSpanFontSize(isNested, width) : 'large';
+  const displayValue = getDisplayValue(value, formatAsCurrency);
+
+  const contentValue = (
+    <span style={{ fontSize, fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
+      {displayValue}
+      {valueSuffix ? ` ${valueSuffix}` : ''}
+    </span>
+  );
 
   const content = (
     <Flex
-      style={{ height: '100%' }}
+      style={{
+        height: '100%',
+        paddingTop: isNested ? 'var(--pf-t--global--spacer--md)' : undefined,
+      }}
       spaceItems={{ default: 'spaceItemsLg' }}
       alignItems={{ default: 'alignItemsFlexStart' }}
       justifyContent={{ default: 'justifyContentFlexStart' }}
@@ -56,7 +70,6 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
           </Content>
         </FlexItem>
       )}
-
       {contentValue}
     </Flex>
   );
@@ -67,6 +80,8 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
       helpTitle={help ? title : undefined}
       help={help}
       width={width ?? 'md'}
+      titleSize={isNested ? 'md' : 'xl'}
+      isCompact={isNested}
     >
       {error ? <EmptyStateError titleProp={errorStateTitle} message={error.message} /> : content}
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx
@@ -3,60 +3,21 @@ import { Content, Flex, FlexItem } from '@patternfly/react-core';
 import { DashboardValueCardProps } from '../types';
 import { Link } from 'react-router-dom';
 import { EmptyStateError } from '../../../../../framework/components/EmptyStateError';
-import { currencyFormatter } from '../../utilities/currencyFormatter';
-import { DEFAULT_NUMBER_LOCALE } from '../constants/common';
-
-function getSpanFontSize(
-  isNested: DashboardValueCardProps['isNested'],
-  width: DashboardValueCardProps['width']
-): string {
-  if (isNested) {
-    return width === 'xs' ? 'large' : 'x-large';
-  }
-  return width === 'xs' ? 'x-large' : 'xx-large';
-}
-
-function getDisplayValue(
-  value: DashboardValueCardProps['value'],
-  formatAsCurrency: DashboardValueCardProps['formatAsCurrency']
-): string | number {
-  if (typeof value !== 'number') {
-    return value;
-  }
-  return formatAsCurrency ? currencyFormatter(value) : value.toLocaleString(DEFAULT_NUMBER_LOCALE);
-}
+import { DashboardCardValueDisplay, getDashboardCardValueFontSize } from './DashboardCardValue';
 
 export function DashboardValueCard(props: DashboardValueCardProps) {
-  const {
-    id,
-    title,
-    help,
-    value,
-    linkText,
-    to,
-    valueSuffix,
-    error,
-    errorStateTitle,
-    formatAsCurrency,
-    width,
-    isNested,
-  } = props;
+  const { id, title, help, value, linkText, to, valueSuffix, error, errorStateTitle, width } =
+    props;
 
-  const fontSize = typeof value === 'number' ? getSpanFontSize(isNested, width) : 'large';
-  const displayValue = getDisplayValue(value, formatAsCurrency);
-
-  const contentValue = (
-    <span style={{ fontSize, fontWeight: '400', lineHeight: 1, marginTop: 'auto' }}>
-      {displayValue}
-      {valueSuffix ? ` ${valueSuffix}` : ''}
-    </span>
-  );
+  const fontSize = getDashboardCardValueFontSize(value, width, {
+    compact: 'x-large',
+    expanded: 'xx-large',
+  });
 
   const content = (
     <Flex
       style={{
         height: '100%',
-        paddingTop: isNested ? 'var(--pf-t--global--spacer--md)' : undefined,
       }}
       spaceItems={{ default: 'spaceItemsLg' }}
       alignItems={{ default: 'alignItemsFlexStart' }}
@@ -70,7 +31,7 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
           </Content>
         </FlexItem>
       )}
-      {contentValue}
+      <DashboardCardValueDisplay value={value} valueSuffix={valueSuffix} fontSize={fontSize} />
     </Flex>
   );
   return (
@@ -80,8 +41,6 @@ export function DashboardValueCard(props: DashboardValueCardProps) {
       helpTitle={help ? title : undefined}
       help={help}
       width={width ?? 'md'}
-      titleSize={isNested ? 'md' : 'xl'}
-      isCompact={isNested}
     >
       {error ? <EmptyStateError titleProp={errorStateTitle} message={error.message} /> : content}
     </PageDashboardCard>

--- a/frontend/awx/analytics/automation-dashboard/components/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Toolbar';
 export * from './DashboardValueCard';
+export * from './DashboardDetailsCard';
 export * from './DashboardTableCard';
 export * from './DashboardChartCard';
 export * from './DashboardMainTableCard';

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -108,15 +108,24 @@ type DashboardCommonCardProps = {
   width?: PageDashboardCardWidth;
 };
 
+type DashboardCardValueProps = {
+  value: string | number;
+  valueSuffix?: string;
+};
+
 export type DashboardValueCardProps = Readonly<
-  DashboardCommonCardProps & {
-    value: string | number;
-    valueSuffix?: string;
-    formatAsCurrency?: boolean;
-    linkText?: string;
-    to?: string;
-    isNested?: boolean;
-  }
+  DashboardCommonCardProps &
+    DashboardCardValueProps & {
+      linkText?: string;
+      to?: string;
+    }
+>;
+
+export type DashboardDetailsCardProps = Readonly<
+  DashboardCommonCardProps &
+    DashboardCardValueProps & {
+      formatAsCurrency?: boolean;
+    }
 >;
 
 export type DashboardTableCardProps = DashboardCommonCardProps & {

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -115,6 +115,7 @@ export type DashboardValueCardProps = Readonly<
     formatAsCurrency?: boolean;
     linkText?: string;
     to?: string;
+    isNested?: boolean;
   }
 >;
 


### PR DESCRIPTION
## Summary
[AAP-85859]

This pull request refactors and enhances the automation dashboard's card components, focusing on improving code reuse, test coverage, and value formatting consistency. The main change is the introduction of a new `DashboardDetailsCard` component, which consolidates and standardizes the display logic for dashboard card values, including formatting and error handling. This new component replaces the previous usage of `DashboardValueCard` in key dashboard locations. Additionally, utility functions and tests have been added or updated to ensure proper formatting and styling across different scenarios.

**Component Refactoring and Consolidation**
- Introduced a new `DashboardDetailsCard` component that encapsulates value display logic, error handling, and formatting, and replaced multiple usages of `DashboardValueCard` in the main dashboard view for improved consistency and maintainability. (`frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.tsx`, `frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.tsx`, `frontend/awx/analytics/automation-dashboard/components/index.ts`, `frontend/awx/analytics/automation-dashboard/types/index.ts`) [[1]](diffhunk://#diff-e273f4d0655922eb12350b68a90916acd4844f44cc543b308cda41d4769ed17eR1-R33) [[2]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2R23) [[3]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L291-R291) [[4]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L300-R301) [[5]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L310-R311) [[6]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L320-R321) [[7]](diffhunk://#diff-1578f7fcd69d2e26a8bf98a2bef24fc53081bdb199cf5cefade390d56793b2d2L330-R330) [[8]](diffhunk://#diff-0af55395d1685543b3ef7baa76c75f38d35af182d9e4b4af84e1f346f57c9e6cR3) [[9]](diffhunk://#diff-d05e212d7a2ec1b5d1cb032cd15b62af8941dc11a7c26eccd21941acfdf1c7dbL111-R130)

**Value Formatting and Display Enhancements**
- Added utility functions (`DashboardCardValueDisplay`, `getDashboardCardValueFontSize`) to handle value formatting (including currency and locale-aware numbers) and font sizing based on card width, ensuring a consistent look and feel. (`frontend/awx/analytics/automation-dashboard/components/DashboardCardValue.tsx`, `frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx`) [[1]](diffhunk://#diff-de58407be99cad24a9391ccd769c5de3e20000703e91d13317b36d00338381a2R1-R39) [[2]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8L6-R21) [[3]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8L59-R34)
- Updated `DashboardValueCard` to use the new value display utilities and adjusted font size logic for better visual hierarchy. (`frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.tsx`) [[1]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8L6-R21) [[2]](diffhunk://#diff-a7c8feb040f35bf56ff9a1b04db27dde5ec4a023df51d94482c0fabac24bfdf8L59-R34)

**Test Coverage Improvements**
- Added comprehensive tests for `DashboardDetailsCard`, covering rendering, value formatting, error handling, and font sizing. (`frontend/awx/analytics/automation-dashboard/components/DashboardDetailsCard.test.tsx`)
- Updated tests for `DashboardValueCard` and `DashboardMainTableCard` to reflect changes in font sizing and header rendering, and to ensure correct application of new display logic. (`frontend/awx/analytics/automation-dashboard/components/DashboardValueCard.test.tsx`, `frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx`) [[1]](diffhunk://#diff-75ba12bdd16f3b6d794771faefbadfee6cc8639281c8fc6aa1c94230e307009bL101-R126) [[2]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806R208-R219)

**Styling and UI Consistency**
- Improved test coverage for compact styling in `PageDashboardCard`, ensuring correct CSS class application based on the `isCompact` prop. (`framework/PageDashboard/PageDashboardCard.test.tsx`)

These changes collectively improve the maintainability, consistency, and testability of the dashboard card components.

<!-- What changed and why? -->

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="2549" height="677" alt="image" src="https://github.com/user-attachments/assets/5bde6f42-5f10-442e-b8b0-f5d88e42d3b1" />

