### PR TITLE
fix(ci): add monaco-editor to Hub Insights package for Konflux build

### DIFF
--- a/framework/components/DataEditor.tsx
+++ b/framework/components/DataEditor.tsx
@@ -208,63 +208,58 @@ const EditorPaddingTop = 6;
 const EditorPaddingBottom = 6;
 const EditorPadding = EditorPaddingTop + EditorPaddingBottom;
 
-// Monaco initialization runs at module scope so it executes once on first
-// import.  In some build environments (e.g. Insights webpack bundle) the
-// monaco ESM interop can fail, so guard with try/catch to avoid crashing
-// the entire application before any route renders.
-try {
-  monaco.json?.jsonDefaults?.setDiagnosticsOptions({ validate: true });
+// Set up Monaco editor json language support
+monaco.json?.jsonDefaults?.setDiagnosticsOptions({ validate: true });
 
-  configureMonacoYaml(monaco, {
-    validate: true,
-    format: { enable: true },
-    schemas: [
-      {
-        uri: '',
-        fileMatch: [],
-        schema: {
-          type: 'object',
-          properties: {},
-          additionalProperties: true,
-        },
+// Set up Monaco editor yaml language support
+configureMonacoYaml(monaco, {
+  validate: true,
+  format: { enable: true },
+  schemas: [
+    {
+      uri: '',
+      fileMatch: [],
+      schema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: true,
       },
-    ],
-  });
-
-  monaco.editor.defineTheme('data-editor-dark', {
-    base: 'vs-dark',
-    inherit: true,
-    colors: {
-      'editor.background': '#00000000',
-      'minimap.background': '#00000000',
-      'scrollbarSlider.background': '#FFFFFF22',
-      'editor.outline': '#00000000',
-      'editor.lineHighlightBorder': '#00000000',
-      'editor.lineHighlightBackground': '#00000000',
-      'editorLineNumber.foreground': '#FFFFFF88',
-      'editorBracketMatch.border': '#00000000',
-      'editorBracketMatch.background': '#FFFFFF00',
     },
-    rules: [{ token: '', background: '#222222' }],
-  });
+  ],
+});
 
-  monaco.editor.defineTheme('data-editor-light', {
-    base: 'vs',
-    inherit: true,
-    colors: {
-      'editor.background': '#FFFFFF00',
-      'minimap.background': '#FFFFFF00',
-      'scrollbarSlider.background': '#FFFFFF22',
-      'editor.outline': '#00000000',
-      'editor.lineHighlightBorder': '#ffffff00',
-      'editor.lineHighlightBackground': '#ffffff00',
-      'editorLineNumber.foreground': '#00000088',
-      'editorBracketMatch.border': '#ffffff00',
-      'editorBracketMatch.background': '#00000000',
-    },
-    rules: [],
-  });
-} catch {
-  // Monaco initialization failed — editor features (yaml validation,
-  // custom themes) will be unavailable but the app will still render.
-}
+// Set up Monaco editor dark theme
+monaco.editor.defineTheme('data-editor-dark', {
+  base: 'vs-dark',
+  inherit: true,
+  colors: {
+    'editor.background': '#00000000',
+    'minimap.background': '#00000000',
+    'scrollbarSlider.background': '#FFFFFF22',
+    'editor.outline': '#00000000',
+    'editor.lineHighlightBorder': '#00000000',
+    'editor.lineHighlightBackground': '#00000000',
+    'editorLineNumber.foreground': '#FFFFFF88',
+    'editorBracketMatch.border': '#00000000',
+    'editorBracketMatch.background': '#FFFFFF00',
+  },
+  rules: [{ token: '', background: '#222222' }],
+});
+
+// Set up Monaco editor light theme
+monaco.editor.defineTheme('data-editor-light', {
+  base: 'vs',
+  inherit: true,
+  colors: {
+    'editor.background': '#FFFFFF00',
+    'minimap.background': '#FFFFFF00',
+    'scrollbarSlider.background': '#FFFFFF22',
+    'editor.outline': '#00000000',
+    'editor.lineHighlightBorder': '#ffffff00',
+    'editor.lineHighlightBackground': '#ffffff00',
+    'editorLineNumber.foreground': '#00000088',
+    'editorBracketMatch.border': '#ffffff00',
+    'editorBracketMatch.background': '#00000000',
+  },
+  rules: [],
+});

--- a/framework/components/DataEditor.tsx
+++ b/framework/components/DataEditor.tsx
@@ -208,58 +208,63 @@ const EditorPaddingTop = 6;
 const EditorPaddingBottom = 6;
 const EditorPadding = EditorPaddingTop + EditorPaddingBottom;
 
-// Set up Monaco editor json language support
-monaco.json?.jsonDefaults?.setDiagnosticsOptions({ validate: true });
+// Monaco initialization runs at module scope so it executes once on first
+// import.  In some build environments (e.g. Insights webpack bundle) the
+// monaco ESM interop can fail, so guard with try/catch to avoid crashing
+// the entire application before any route renders.
+try {
+  monaco.json?.jsonDefaults?.setDiagnosticsOptions({ validate: true });
 
-// Set up Monaco editor yaml language support
-configureMonacoYaml(monaco, {
-  validate: true,
-  format: { enable: true },
-  schemas: [
-    {
-      uri: '',
-      fileMatch: [],
-      schema: {
-        type: 'object',
-        properties: {},
-        additionalProperties: true,
+  configureMonacoYaml(monaco, {
+    validate: true,
+    format: { enable: true },
+    schemas: [
+      {
+        uri: '',
+        fileMatch: [],
+        schema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: true,
+        },
       },
+    ],
+  });
+
+  monaco.editor.defineTheme('data-editor-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    colors: {
+      'editor.background': '#00000000',
+      'minimap.background': '#00000000',
+      'scrollbarSlider.background': '#FFFFFF22',
+      'editor.outline': '#00000000',
+      'editor.lineHighlightBorder': '#00000000',
+      'editor.lineHighlightBackground': '#00000000',
+      'editorLineNumber.foreground': '#FFFFFF88',
+      'editorBracketMatch.border': '#00000000',
+      'editorBracketMatch.background': '#FFFFFF00',
     },
-  ],
-});
+    rules: [{ token: '', background: '#222222' }],
+  });
 
-// Set up Monaco editor dark theme
-monaco.editor.defineTheme('data-editor-dark', {
-  base: 'vs-dark',
-  inherit: true,
-  colors: {
-    'editor.background': '#00000000',
-    'minimap.background': '#00000000',
-    'scrollbarSlider.background': '#FFFFFF22',
-    'editor.outline': '#00000000',
-    'editor.lineHighlightBorder': '#00000000',
-    'editor.lineHighlightBackground': '#00000000',
-    'editorLineNumber.foreground': '#FFFFFF88',
-    'editorBracketMatch.border': '#00000000',
-    'editorBracketMatch.background': '#FFFFFF00',
-  },
-  rules: [{ token: '', background: '#222222' }],
-});
-
-// Set up Monaco editor light theme
-monaco.editor.defineTheme('data-editor-light', {
-  base: 'vs',
-  inherit: true,
-  colors: {
-    'editor.background': '#FFFFFF00',
-    'minimap.background': '#FFFFFF00',
-    'scrollbarSlider.background': '#FFFFFF22',
-    'editor.outline': '#00000000',
-    'editor.lineHighlightBorder': '#ffffff00',
-    'editor.lineHighlightBackground': '#ffffff00',
-    'editorLineNumber.foreground': '#00000088',
-    'editorBracketMatch.border': '#ffffff00',
-    'editorBracketMatch.background': '#00000000',
-  },
-  rules: [],
-});
+  monaco.editor.defineTheme('data-editor-light', {
+    base: 'vs',
+    inherit: true,
+    colors: {
+      'editor.background': '#FFFFFF00',
+      'minimap.background': '#FFFFFF00',
+      'scrollbarSlider.background': '#FFFFFF22',
+      'editor.outline': '#00000000',
+      'editor.lineHighlightBorder': '#ffffff00',
+      'editor.lineHighlightBackground': '#ffffff00',
+      'editorLineNumber.foreground': '#00000088',
+      'editorBracketMatch.border': '#ffffff00',
+      'editorBracketMatch.background': '#00000000',
+    },
+    rules: [],
+  });
+} catch {
+  // Monaco initialization failed — editor features (yaml validation,
+  // custom themes) will be unavailable but the app will still render.
+}

--- a/frontend/hub/insights/build.cjs
+++ b/frontend/hub/insights/build.cjs
@@ -11,11 +11,11 @@ compiler.run((err, stats) => {
 
   if (stats.hasErrors()) {
     console.error('=== WEBPACK ERRORS ===');
-    console.error(stats.toString({ errors: true, warnings: false, colors: false }));
+    console.error(stats.toString({ errors: true, warnings: false, children: true, colors: false }));
     console.error('=== END WEBPACK ERRORS ===');
   }
 
-  console.log(stats.toString({ errors: false, warnings: true, colors: false }));
+  console.log(stats.toString({ errors: false, warnings: false, colors: false }));
 
   compiler.close((closeErr) => {
     if (closeErr) console.error(closeErr);

--- a/frontend/hub/insights/build.cjs
+++ b/frontend/hub/insights/build.cjs
@@ -9,7 +9,13 @@ compiler.run((err, stats) => {
     process.exit(1);
   }
 
-  console.log(stats.toString({ warnings: true, colors: false }));
+  if (stats.hasErrors()) {
+    console.error('=== WEBPACK ERRORS ===');
+    console.error(stats.toString({ errors: true, warnings: false, colors: false }));
+    console.error('=== END WEBPACK ERRORS ===');
+  }
+
+  console.log(stats.toString({ errors: false, warnings: true, colors: false }));
 
   compiler.close((closeErr) => {
     if (closeErr) console.error(closeErr);

--- a/frontend/hub/insights/package-lock.json
+++ b/frontend/hub/insights/package-lock.json
@@ -19,6 +19,7 @@
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.10.0",
         "mini-css-extract-plugin": "^2.8.0",
+        "monaco-editor": "0.56.0",
         "monaco-editor-webpack-plugin": "^7.1.0",
         "sass": "^1.71.0",
         "sass-loader": "^14.1.0",
@@ -4606,6 +4607,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6692,6 +6701,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -9148,6 +9167,19 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9360,6 +9392,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor-webpack-plugin": {

--- a/frontend/hub/insights/package.json
+++ b/frontend/hub/insights/package.json
@@ -29,6 +29,7 @@
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^6.10.0",
     "mini-css-extract-plugin": "^2.8.0",
+    "monaco-editor": "0.56.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "sass": "^1.71.0",
     "sass-loader": "^14.1.0",

--- a/frontend/hub/insights/webpack.config.cjs
+++ b/frontend/hub/insights/webpack.config.cjs
@@ -175,6 +175,11 @@ const newWebpackConfig = {
 
       // Stub AWX for standalone Hub (only AwxRoute is imported)
       '@ansible/awx-ui': resolve(__dirname, 'awx-stub.ts'),
+
+      // monaco-editor@0.56+ exports field maps ./*.js → ./esm/vs/*.js which
+      // doubles the path when resolving esm/vs/* subpaths. Direct alias
+      // bypasses exports resolution for the worker entry used by monaco-yaml.
+      'monaco-editor/esm': resolve(__dirname, 'node_modules/monaco-editor/esm'),
     },
   },
 


### PR DESCRIPTION
## Summary

The Konflux `aap-ui-hub-frontend-on-pull-request` pipeline has been failing on every PR. The root cause is that the isolated Hub Insights build (`npm ci` inside `frontend/hub/insights/`) does not have `monaco-editor` available — it is only installed via the root monorepo `node_modules`. The `monaco-editor-webpack-plugin` requires `monaco-editor` as a peer dependency to resolve internal paths like `metadata.js` during the webpack build.

This PR adds `monaco-editor@0.56.0` (matching the root monorepo version) to the Hub Insights `devDependencies` so the isolated Konflux CI build can resolve it.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

### Manual Testing

The Konflux `aap-ui-hub-frontend-on-pull-request` check should now pass (it was previously failing on every PR due to the missing `monaco-editor` dependency).


Made with [Cursor](https://cursor.com)