### PR TITLE
Fix blank labels in Workflow Jobs dropdown for sliced job runs

### DIFF
--- a/frontend/awx/views/jobs/WorkflowOutputNavigation.test.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutputNavigation.test.tsx
@@ -188,4 +188,76 @@ describe('WorkflowOutputNavigation', () => {
 
     expect(screen.getByText(/Workflow Job 1\/0/)).toBeInTheDocument();
   });
+
+  it('should display job name for sliced job nodes with UUID identifiers', async () => {
+    const user = userEvent.setup();
+    const slicedNode = createWorkflowNode({
+      id: 10,
+      identifier: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      job: '200',
+      summary_fields: {
+        ...createWorkflowNode().summary_fields,
+        job: {
+          id: 200,
+          name: 'Slice Job [1/3]',
+          type: 'job',
+          status: 'successful',
+          description: '',
+          elapsed: 30,
+          failed: false,
+        },
+        unified_job_template:
+          undefined as unknown as WorkflowJobNode['summary_fields']['unified_job_template'],
+      },
+    });
+
+    renderWithRouter([slicedNode]);
+    await user.click(screen.getByRole('button', { name: /Workflow Job 1\/1/ }));
+
+    expect(screen.getByText('Slice Job [1/3]')).toBeInTheDocument();
+  });
+
+  it('should fallback to unified_job_template name when job name is missing on sliced nodes', async () => {
+    const user = userEvent.setup();
+    const slicedNode = createWorkflowNode({
+      id: 11,
+      identifier: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      job: '201',
+      summary_fields: {
+        ...createWorkflowNode().summary_fields,
+        job: undefined,
+        unified_job_template: {
+          id: 7,
+          name: 'Demo Job Template',
+          description: '',
+          unified_job_type: 'job',
+        },
+      },
+    });
+
+    renderWithRouter([slicedNode]);
+    await user.click(screen.getByRole('button', { name: /Workflow Job 1\/1/ }));
+
+    expect(screen.getByText('Demo Job Template')).toBeInTheDocument();
+  });
+
+  it('should fallback to node id when both job and template names are missing', async () => {
+    const user = userEvent.setup();
+    const slicedNode = createWorkflowNode({
+      id: 12,
+      identifier: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      job: '202',
+      summary_fields: {
+        ...createWorkflowNode().summary_fields,
+        job: undefined,
+        unified_job_template:
+          undefined as unknown as WorkflowJobNode['summary_fields']['unified_job_template'],
+      },
+    });
+
+    renderWithRouter([slicedNode]);
+    await user.click(screen.getByRole('button', { name: /Workflow Job 1\/1/ }));
+
+    expect(screen.getByText('Node 12')).toBeInTheDocument();
+  });
 });

--- a/frontend/awx/views/jobs/WorkflowOutputNavigation.tsx
+++ b/frontend/awx/views/jobs/WorkflowOutputNavigation.tsx
@@ -20,6 +20,17 @@ interface WorkflowOutputNavigationProps {
   workflowNodes: WorkflowJobNode[];
 }
 
+function getWorkflowNodeLabel(node: WorkflowJobNode): string {
+  if (!stringIsUUID(node.identifier) && node.identifier !== '') {
+    return node.identifier;
+  }
+  return (
+    node.summary_fields?.job?.name ||
+    node.summary_fields?.unified_job_template?.name ||
+    `Node ${node.id.toString()}`
+  );
+}
+
 export function WorkflowOutputNavigation(props: WorkflowOutputNavigationProps) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
@@ -142,9 +153,9 @@ export function WorkflowOutputNavigation(props: WorkflowOutputNavigationProps) {
                 },
               })}
               component={Link}
-              value={node.summary_fields?.job?.name}
+              value={getWorkflowNodeLabel(node)}
             >
-              {stringIsUUID(node.identifier) ? node.summary_fields?.job?.name : node.identifier}
+              {getWorkflowNodeLabel(node)}
             </SelectOption>
           ))}
         </SelectList>


### PR DESCRIPTION
## Summary

  Fixes the Workflow Jobs dropdown rendering blank/empty text labels when viewing
  jobs spawned by dynamically generated workflows (e.g., Job Slices).

  Root Cause: In WorkflowOutputNavigation.tsx, the dropdown label logic used
  node.summary_fields?.job?.name for nodes with UUID identifiers (auto-generated
  by job slicing). When the node's template topology is unresolved,
  summary_fields.job may not carry a name, resulting in undefined → blank text.

  Fix: Extracted a getWorkflowNodeLabel() helper with a fallback chain:
  1. Human-readable identifier (non-UUID alias) — existing behavior preserved
  2. summary_fields.job.name — the job's actual name
  3. summary_fields.unified_job_template.name — the backing template name
  4. Node {id} — last-resort fallback using the node's numeric ID

  Test plan

  - [x] Added regression test: sliced node with UUID identifier + job name present → displays job name
  - [x] Added regression test: sliced node with missing job → falls back to template name
  - [x] Added regression test: sliced node with no job or template → falls back to node ID
  - [x] All 9 tests pass (6 existing + 3 new)
  - [x] ESLint passes
  - [x] TypeScript passes
  - [x] Manual verification against a live AAP instance with sliced workflow jobs
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Screenshots

 
<img width="754" height="569" alt="Screenshot 2026-08-13 at 12 22 26 PM" src="https://github.com/user-attachments/assets/69e77c7c-9073-4fb1-9b06-304277704769" />
