### PR TITLE
fix(test): reset SWR cache between tests in all workspaces

### DIFF
--- a/framework/vitest.setup.ts
+++ b/framework/vitest.setup.ts
@@ -1,7 +1,13 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import './vitest.i18n';
 import './vitest.monaco';
 import { enablePreview } from './vitest.preview';
+import { resetTestSwrCache } from './test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/frontend/awx/vitest.setup.ts
+++ b/frontend/awx/vitest.setup.ts
@@ -1,7 +1,13 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.i18n';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/frontend/chatbot/vitest.setup.ts
+++ b/frontend/chatbot/vitest.setup.ts
@@ -1,6 +1,12 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/frontend/common/vitest.setup.ts
+++ b/frontend/common/vitest.setup.ts
@@ -1,7 +1,13 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.i18n';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/frontend/eda/vitest.setup.ts
+++ b/frontend/eda/vitest.setup.ts
@@ -1,9 +1,10 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach, vi } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.i18n';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
-import { vi } from 'vitest';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 // Mock localStorage for MSW compatibility
 const localStorageMock = {
@@ -17,3 +18,7 @@ const localStorageMock = {
 globalThis.localStorage = localStorageMock as Storage;
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/frontend/hub/vitest.setup.ts
+++ b/frontend/hub/vitest.setup.ts
@@ -1,7 +1,13 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.i18n';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});

--- a/platform/vitest.setup.ts
+++ b/platform/vitest.setup.ts
@@ -1,11 +1,17 @@
 // vitest.setup.ts
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 import '@ansible/ansible-ui-framework/vitest.i18n';
 import '@ansible/ansible-ui-framework/vitest.monaco';
 import { Window } from 'happy-dom';
 import { enablePreview } from '@ansible/ansible-ui-framework/vitest.preview';
+import { resetTestSwrCache } from '@ansible/ansible-ui-framework/test-utils/swrTestWrapper';
 
 enablePreview();
+
+beforeEach(() => {
+  resetTestSwrCache();
+});
 
 const window = global.window as unknown as Window;
 window.HTMLCanvasElement.prototype.getContext = function (


### PR DESCRIPTION
## Summary

Fixes flaky test failures caused by SWR cache leaking between tests (e.g., TemplateLaunchWizard Unable to find [data-testid="wizard-next"]).

  Root cause: A prior change added a @testing-library/react alias that wraps every render() call in an SWRConfig with a shared cache Map. However, resetTestSwrCache() was exported but never
  called between tests. The shared Map accumulated cached API responses, and SWR's dedupingInterval could serve stale data from a previous test — e.g., a launch config with
  ask_labels_on_launch: true leaking into a test that expected it to be false.

  Fix: Added a global beforeEach(resetTestSwrCache) to every workspace's vitest.setup.ts (framework, awx, eda, hub, platform, common, chatbot). Each test now starts with a fresh SWR cache
  automatically.

  Test plan

  - [x] TemplateLaunchWizard.test.tsx — all 19 tests pass (no manual SWRConfig wrappers needed)
  - [x] ESLint clean on all 7 changed setup files
  - [x] No test file changes required — the fix is purely in setup infrastructure

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
