### PR TITLE
fix(job-output): show <1%/>99% for statuses rounding to 0%/100%

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/StatusBar.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.test.tsx
@@ -50,6 +50,34 @@ describe('StatusBar', () => {
       render(<HostStatusBar counts={counts} />);
       expect(screen.getByTestId('status-bar')).toBeInTheDocument();
     });
+
+    it('should fall back to dark styling for counts keys absent from status', () => {
+      const counts = {
+        ok: 9,
+        skipped: 0,
+        changed: 0,
+        failures: 0,
+        dark: 0,
+        unknown: 1,
+      } as unknown as HostStatusCounts;
+      render(<HostStatusBar counts={counts} />);
+      // 'unknown' key is not in hostStatus, so legend falls back to the 'dark' (Unreachable) label
+      // Two "Unreachable" entries appear: one for dark=0 and one for the fallback unknown=1 (10%)
+      expect(screen.getAllByText(/Unreachable/)).toHaveLength(2);
+    });
+
+    it('should display <1% and >99% for minority/majority statuses that round to 0%/100%', () => {
+      const counts: HostStatusCounts = {
+        ok: 999,
+        skipped: 0,
+        changed: 0,
+        failures: 0,
+        dark: 1,
+      };
+      render(<HostStatusBar counts={counts} />);
+      expect(screen.getByText('Unreachable <1%')).toBeInTheDocument();
+      expect(screen.getByText('Success >99%')).toBeInTheDocument();
+    });
   });
 
   describe('WorkflowNodesStatusBar', () => {

--- a/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
@@ -161,8 +161,7 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
 
   const barSegments = Object.keys(status).map((key) => {
     const count = (counts[key as keyof T] as number) || 0;
-    const jobStatus =
-      (status[key as keyof K] as StatusProps) ?? (status as CommonStatusType)['dark'];
+    const jobStatus = status[key as keyof K] as StatusProps;
     return (
       <Tooltip
         key={key}
@@ -205,7 +204,9 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
               (status[key as keyof K] as StatusProps)?.label ??
               (status as CommonStatusType)['dark'].label
             }
-            percent={(((counts[key as keyof T] as number) ?? 0) / totalCounts) * 100}
+            percent={((counts[key as keyof T] as number) / totalCounts) * 100}
+            count={counts[key as keyof T] as number}
+            total={totalCounts}
           />
         ))}
       </Legend>
@@ -213,13 +214,23 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
   );
 }
 
-function LegendItem(props: { color: string; label: string; percent: number }) {
-  const { color, label, percent } = props;
+function LegendItem(
+  props: Readonly<{ color: string; label: string; percent: number; count: number; total: number }>
+) {
+  const { color, label, percent, count, total } = props;
+  let display: string;
+  if (count > 0 && Math.round(percent) === 0) {
+    display = '<1%';
+  } else if (count < total && Math.round(percent) === 100) {
+    display = '>99%';
+  } else {
+    display = `${Math.round(percent)}%`;
+  }
 
   return (
     <div>
       <LegendBox color={color} />
-      {label} {Math.round(percent)}%
+      {label} {display}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fix misleading percentage labels in the job output status bar legend. When a status has a non-zero count but rounds to 0%, it now displays `<1%` instead of `0%`. When a dominant status rounds to 100% but is not the only segment present, it displays `>99%` instead of `100%`. This prevents the legend from implying a status is absent or that it accounts for the entire run when neither is true.

Also removes the silent fallback that mapped unknown host status keys to the `dark` (Unreachable) style in bar segments, which was misattributing unrecognized statuses visually.

## Type of Change

- [X] Bug fix
- [ ] Enhancement
- [X] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [X] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

N/A

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

1. Run a job against an inventory with a large number of hosts where one status (e.g. Success) dominates and one (e.g. Unreachable) is a small minority.
2. Open the job output page and inspect the host status bar legend.
3. Verify the minority status shows `<1%` and the dominant status shows `>99%` instead of `0%` / `100%`.

### Screenshots

BEFORE

<img width="403" height="105" alt="Screenshot From 2026-08-15 12-40-36" src="https://github.com/user-attachments/assets/fe7da976-6ecd-498f-8071-54a46c01e85b" />


AFTER

<img width="403" height="105" alt="Screenshot From 2026-08-15 12-40-56" src="https://github.com/user-attachments/assets/a402df46-411e-4f0a-8e6c-1caaf3f3fe94" />