### PR TITLE
Reinstate Certified and Validated badges on collection cards (AAP-84503)

### DIFF
--- a/framework/PageCells/LabelsCell.test.tsx
+++ b/framework/PageCells/LabelsCell.test.tsx
@@ -32,6 +32,39 @@ describe('LabelsCell', () => {
     });
   });
 
+  describe('with rich LabelValue objects', () => {
+    it('should render labels with color and variant', () => {
+      render(
+        <LabelsCell
+          labels={[
+            { label: 'published', color: 'blue', variant: 'filled' },
+            { label: 'validated', color: 'purple', variant: 'filled' },
+          ]}
+        />
+      );
+
+      expect(screen.getByText('published')).toBeInTheDocument();
+      expect(screen.getByText('validated')).toBeInTheDocument();
+    });
+
+    it('should render labels with status prop', () => {
+      render(<LabelsCell labels={[{ label: 'Signed', status: 'success', variant: 'outline' }]} />);
+
+      expect(screen.getByText('Signed')).toBeInTheDocument();
+    });
+
+    it('should render mixed string and object labels', () => {
+      render(
+        <LabelsCell
+          labels={['plain-label', { label: 'colored-label', color: 'green', variant: 'filled' }]}
+        />
+      );
+
+      expect(screen.getByText('plain-label')).toBeInTheDocument();
+      expect(screen.getByText('colored-label')).toBeInTheDocument();
+    });
+  });
+
   describe('with labelsWithLinks', () => {
     const labelsWithLinks = [
       { name: 'Link1', link: '/path1' },

--- a/framework/PageCells/LabelsCell.tsx
+++ b/framework/PageCells/LabelsCell.tsx
@@ -32,9 +32,10 @@ export function LabelsCell(props: Readonly<LabelsProps | LabelsWithLinksProps>) 
             return (
               <Label
                 key={label.label}
-                color={label.color}
+                color={label.status ? undefined : label.color}
                 icon={label.icon}
                 variant={label.variant}
+                status={label.status}
               >
                 {label.label}
               </Label>

--- a/framework/PageCells/LabelsCell.tsx
+++ b/framework/PageCells/LabelsCell.tsx
@@ -1,5 +1,6 @@
 import { Label, LabelGroup } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
+import { LabelValue } from '../PageTable/PageTableColumn';
 
 type LabelWithLink = { name: string; link: string };
 
@@ -11,20 +12,34 @@ type LabelsWithLinksProps = {
 };
 
 type LabelsProps = {
-  labels: string[];
+  labels: LabelValue[];
   labelsWithLinks?: never;
   numLabels?: number;
   noWrap?: boolean;
 };
 
-export function LabelsCell(props: LabelsProps | LabelsWithLinksProps) {
+export function LabelsCell(props: Readonly<LabelsProps | LabelsWithLinksProps>) {
   return (
     <LabelGroup
       numLabels={props.numLabels ?? 999}
       style={props.noWrap ? { flexWrap: 'nowrap' } : undefined}
     >
       {props.labels
-        ? props.labels.map((label) => <Label key={label}>{label}</Label>)
+        ? props.labels.map((label) => {
+            if (typeof label === 'string') {
+              return <Label key={label}>{label}</Label>;
+            }
+            return (
+              <Label
+                key={label.label}
+                color={label.color}
+                icon={label.icon}
+                variant={label.variant}
+              >
+                {label.label}
+              </Label>
+            );
+          })
         : props.labelsWithLinks.map((labelWithLink) => (
             <Label
               color="blue"

--- a/framework/PageTable/PageTable.tsx
+++ b/framework/PageTable/PageTable.tsx
@@ -390,7 +390,7 @@ function PageTableView<T extends object>(props: PageTableProps<T>) {
       for (const descriptionColumn of descriptionColumns) {
         if ('value' in descriptionColumn) {
           expandedRowFunctions.push((item) => {
-            const value = descriptionColumn.value?.(item);
+            const value = descriptionColumn.value?.(item) as ReactNode;
             if (value) {
               return <div key={descriptionColumn.id ?? descriptionColumn.header}>{value}</div>;
             }

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -202,19 +202,24 @@ export function PageTableCard<T extends object>(props: {
               <Label color={card.badgeColor}>{card.badge}</Label>
             </FlexItem>
           )}
+          {card.labels && (
+            <FlexItem>
+              <LabelGroup numLabels={999}>
+                {card.labels.map((item) => (
+                  <Label
+                    key={item.label}
+                    color={item.color}
+                    icon={item.icon}
+                    variant={item.variant}
+                  >
+                    <Truncate content={item.label} style={{ minWidth: 0 }} />
+                  </Label>
+                ))}
+              </LabelGroup>
+            </FlexItem>
+          )}
         </CardHeaderDiv>
       </CardHeader>
-      {card.labels && (
-        <div style={{ paddingLeft: 32, paddingRight: 32, paddingTop: 8 }}>
-          <LabelGroup numLabels={999}>
-            {card.labels.map((item) => (
-              <Label key={item.label} color={item.color} icon={item.icon} variant={item.variant}>
-                <Truncate content={item.label} style={{ minWidth: 0 }} />
-              </Label>
-            ))}
-          </LabelGroup>
-        </div>
-      )}
       <div
         style={{
           overflow: 'hidden',

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -46,6 +46,7 @@ export interface IPageTableCard {
     color?: LabelColor;
     icon?: ReactNode;
     variant?: 'outline' | 'filled' | undefined;
+    status?: 'success' | 'warning' | 'danger' | 'info' | 'custom';
   }[]; // TODO - disable/enable auto generated filters
   badge?: string;
   badgeColor?: LabelColor;
@@ -72,6 +73,7 @@ const CardTopDiv = styled.div`
   align-items: center;
   gap: 16px;
   max-width: 100%;
+  flex: 1;
 `;
 
 const CardDiv = styled.div`
@@ -186,6 +188,24 @@ export function PageTableCard<T extends object>(props: {
                 )
               )}
             </CardDiv>
+            {card.labels && (
+              <>
+                <div style={{ flexGrow: 1 }} />
+                <LabelGroup numLabels={999}>
+                  {card.labels.map((item) => (
+                    <Label
+                      key={item.label}
+                      color={item.status ? undefined : item.color}
+                      icon={item.icon}
+                      variant={item.variant}
+                      status={item.status}
+                    >
+                      <Truncate content={item.label} style={{ minWidth: 0 }} />
+                    </Label>
+                  ))}
+                </LabelGroup>
+              </>
+            )}
           </CardTopDiv>
           {card.badge && card.badgeTooltip && (
             <FlexItem>
@@ -200,22 +220,6 @@ export function PageTableCard<T extends object>(props: {
           {card.badge && !card.badgeTooltip && (
             <FlexItem>
               <Label color={card.badgeColor}>{card.badge}</Label>
-            </FlexItem>
-          )}
-          {card.labels && (
-            <FlexItem>
-              <LabelGroup numLabels={999}>
-                {card.labels.map((item) => (
-                  <Label
-                    key={item.label}
-                    color={item.color}
-                    icon={item.icon}
-                    variant={item.variant}
-                  >
-                    <Truncate content={item.label} style={{ minWidth: 0 }} />
-                  </Label>
-                ))}
-              </LabelGroup>
             </FlexItem>
           )}
         </CardHeaderDiv>

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -89,10 +89,6 @@ const CardFooterDiv = styled.div`
   flex-wrap: wrap;
 `;
 
-const CardFooterLabelsDiv = styled.div`
-  flex-grow: 1;
-`;
-
 export const PageDetailDiv = styled.div`
   display: flex;
   gap: 16px;
@@ -208,6 +204,17 @@ export function PageTableCard<T extends object>(props: {
           )}
         </CardHeaderDiv>
       </CardHeader>
+      {card.labels && (
+        <div style={{ paddingLeft: 32, paddingRight: 32, paddingTop: 8 }}>
+          <LabelGroup numLabels={999}>
+            {card.labels.map((item) => (
+              <Label key={item.label} color={item.color} icon={item.icon} variant={item.variant}>
+                <Truncate content={item.label} style={{ minWidth: 0 }} />
+              </Label>
+            ))}
+          </LabelGroup>
+        </div>
+      )}
       <div
         style={{
           overflow: 'hidden',
@@ -218,37 +225,14 @@ export function PageTableCard<T extends object>(props: {
       >
         <Scrollable>{card.cardBody}</Scrollable>
       </div>
-      {card.labels || (itemActions && itemActions.length) ? (
+      {itemActions && itemActions.length ? (
         <CardFooter>
           <CardFooterDiv>
-            <CardFooterLabelsDiv>
-              {card.labels && (
-                <LabelGroup numLabels={999}>
-                  {card.labels.map((item) => (
-                    <Label
-                      key={item.label}
-                      color={item.color}
-                      icon={item.icon}
-                      variant={item.variant}
-                    >
-                      <Truncate content={item.label} style={{ minWidth: 0 }} />
-                    </Label>
-                  ))}
-                </LabelGroup>
-              )}
-            </CardFooterLabelsDiv>
-            {itemActions && itemActions.length ? (
-              <div
-                style={{ marginRight: -16, alignSelf: 'end', justifySelf: 'flex-end', flexGrow: 1 }}
-              >
-                <PageActions
-                  actions={itemActions}
-                  position={'right'}
-                  selectedItem={item}
-                  iconOnly
-                />
-              </div>
-            ) : null}
+            <div
+              style={{ marginRight: -16, alignSelf: 'end', justifySelf: 'flex-end', flexGrow: 1 }}
+            >
+              <PageActions actions={itemActions} position={'right'} selectedItem={item} iconOnly />
+            </div>
           </CardFooterDiv>
         </CardFooter>
       ) : null}

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -191,19 +191,21 @@ export function PageTableCard<T extends object>(props: {
             {card.labels && (
               <>
                 <div style={{ flexGrow: 1 }} />
-                <LabelGroup numLabels={999}>
-                  {card.labels.map((item) => (
-                    <Label
-                      key={item.label}
-                      color={item.status ? undefined : item.color}
-                      icon={item.icon}
-                      variant={item.variant}
-                      status={item.status}
-                    >
-                      <Truncate content={item.label} style={{ minWidth: 0 }} />
-                    </Label>
-                  ))}
-                </LabelGroup>
+                <div style={{ alignSelf: 'flex-start', marginTop: 2 }}>
+                  <LabelGroup numLabels={999}>
+                    {card.labels.map((item) => (
+                      <Label
+                        key={item.label}
+                        color={item.status ? undefined : item.color}
+                        icon={item.icon}
+                        variant={item.variant}
+                        status={item.status}
+                      >
+                        <Truncate content={item.label} style={{ minWidth: 0 }} />
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                </div>
               </>
             )}
           </CardTopDiv>

--- a/framework/PageTable/PageTableCard.tsx
+++ b/framework/PageTable/PageTableCard.tsx
@@ -329,7 +329,9 @@ export function useColumnsToTableCardFn<T extends object>(
 
       const to = nameColumn && 'to' in nameColumn ? nameColumn.to : undefined;
       let value: CellFn<T, ReactNode> | undefined =
-        nameColumn && 'value' in nameColumn ? nameColumn.value : undefined;
+        nameColumn && 'value' in nameColumn
+          ? (nameColumn.value as CellFn<T, ReactNode>)
+          : undefined;
       if (!value) {
         value = nameColumn && 'cell' in nameColumn ? nameColumn.cell : undefined;
       }
@@ -389,7 +391,9 @@ export function useColumnsToTableCardFn<T extends object>(
             )}
           </DescriptionList>
         ),
-        labels: labelColumn && labelColumn.value(item)?.map((label) => ({ label })),
+        labels: labelColumn
+          ?.value(item)
+          ?.map((label) => (typeof label === 'string' ? { label } : label)),
       };
       if (!hasDescription && visibleCardColumns.length === 0 && countColumns.length === 0) {
         pageTableCard.cardBody = <div style={{ flexGrow: 1 }} />;

--- a/framework/PageTable/PageTableColumn.test.tsx
+++ b/framework/PageTable/PageTableColumn.test.tsx
@@ -196,6 +196,22 @@ describe('TableColumnCell', () => {
     expect(screen.getByText('stable')).toBeInTheDocument();
   });
 
+  it('should render LabelsCell with rich LabelValue objects', () => {
+    const column: ITableColumn<TestItem> = {
+      header: 'Labels',
+      type: 'labels',
+      value: () => [
+        { label: 'published', color: 'blue', variant: 'filled' },
+        { label: 'Signed', status: 'success', variant: 'outline' },
+      ],
+    };
+
+    renderCell(column);
+
+    expect(screen.getByText('published')).toBeInTheDocument();
+    expect(screen.getByText('Signed')).toBeInTheDocument();
+  });
+
   it('should render LabelsCell with empty array when labels value is undefined', () => {
     const column: ITableColumn<TestItem> = {
       header: 'Labels',

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -7,7 +7,13 @@ import { PageTableViewTypeE } from '../PageToolbar/PageTableViewType';
 
 export type LabelValue =
   | string
-  | { label: string; color?: LabelColor; icon?: ReactNode; variant?: 'outline' | 'filled' };
+  | {
+      label: string;
+      color?: LabelColor;
+      icon?: ReactNode;
+      variant?: 'outline' | 'filled';
+      status?: 'success' | 'warning' | 'danger' | 'info' | 'custom';
+    };
 
 /** Column options for controlling how the column displays in a table. */
 export enum ColumnTableOption {

--- a/framework/PageTable/PageTableColumn.tsx
+++ b/framework/PageTable/PageTableColumn.tsx
@@ -1,8 +1,13 @@
 import { ReactNode, useMemo } from 'react';
+import { LabelColor } from '../components/pfcolors';
 import { DateTimeCell } from '../PageCells/DateTimeCell';
 import { LabelsCell } from '../PageCells/LabelsCell';
 import { TextCell } from '../PageCells/TextCell';
 import { PageTableViewTypeE } from '../PageToolbar/PageTableViewType';
+
+export type LabelValue =
+  | string
+  | { label: string; color?: LabelColor; icon?: ReactNode; variant?: 'outline' | 'filled' };
 
 /** Column options for controlling how the column displays in a table. */
 export enum ColumnTableOption {
@@ -160,11 +165,12 @@ export interface ITableColumnTypeCount<T extends object> extends ITableColumnCom
   // TODO options for formatting number. i.e. should number be error/warning color if not 0?
 }
 
-/** Table column that shows a count. In a card, this shows up in a count section at the bottom of the card. */
+/** Table column that shows labels. In a card, this shows up in the footer label area. */
 export interface ITableColumnTypeLabels<T extends object> extends ITableColumnCommon<T> {
   type: 'labels';
-  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists. */
-  value: CellFn<T, string[] | undefined>;
+  /** if value returns undefined, this column will be hidden from expanded rows, cards, and lists.
+   *  Values can be plain strings or rich objects with color, icon, and variant. */
+  value: CellFn<T, LabelValue[] | undefined>;
   // TODO add use option indicating how many labels to show by default
 }
 

--- a/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
@@ -50,7 +50,7 @@ function getBadgesColumn(): ITableColumn<CollectionVersionSearch> | undefined {
 
 function getBadgeValues(repoName: string, isSigned: boolean): LabelValue[] | undefined {
   const col = getBadgesColumn();
-  if (!col || col.type !== 'labels') return undefined;
+  if (col?.type !== 'labels') return undefined;
   return col.value(makeCollection(repoName, isSigned));
 }
 

--- a/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { LabelValue } from '@ansible/ansible-ui-framework';
+import { ITableColumn, LabelValue } from '@ansible/ansible-ui-framework';
 import { useCollectionColumns } from './useCollectionColumns';
 import { CollectionVersionSearch } from '../Collection';
 
@@ -43,18 +43,18 @@ function makeCollection(repoName: string, isSigned: boolean): CollectionVersionS
   } as CollectionVersionSearch;
 }
 
+function getBadgesColumn(): ITableColumn<CollectionVersionSearch> | undefined {
+  const { result } = renderHook(() => useCollectionColumns());
+  return result.current.find((col) => col.header === 'Badges');
+}
+
+function getBadgeValues(repoName: string, isSigned: boolean): LabelValue[] | undefined {
+  const col = getBadgesColumn();
+  if (!col || col.type !== 'labels') return undefined;
+  return col.value(makeCollection(repoName, isSigned));
+}
+
 describe('useCollectionColumns badges column', () => {
-  function getBadgesColumn() {
-    const { result } = renderHook(() => useCollectionColumns());
-    return result.current.find((col) => col.header === 'Badges');
-  }
-
-  function getBadgeValues(repoName: string, isSigned: boolean): LabelValue[] | undefined {
-    const col = getBadgesColumn();
-    if (!col || !('value' in col)) return undefined;
-    return col.value(makeCollection(repoName, isSigned)) as LabelValue[] | undefined;
-  }
-
   it('should return blue filled label for rh-certified repository', () => {
     const labels = getBadgeValues('rh-certified', false);
     expect(labels).toBeDefined();

--- a/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
@@ -1,181 +1,126 @@
 /* eslint-disable i18next/no-literal-string */
 import { renderHook } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
+import { LabelValue } from '@ansible/ansible-ui-framework';
 import { useCollectionColumns } from './useCollectionColumns';
 import { CollectionVersionSearch } from '../Collection';
 
-// Mock useHubContext
+vi.mock('@ansible/ansible-ui-framework', async () => {
+  const actual = await vi.importActual('@ansible/ansible-ui-framework');
+  return {
+    ...actual,
+    useGetPageUrl: () => () => '/mock-url',
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({}),
+  };
+});
+
 vi.mock('../../common/useHubContext', () => ({
-  useHubContext: () => ({
-    featureFlags: {
-      display_signatures: true,
-    },
-    settings: {},
-    user: null,
-    hasPermission: () => false,
-  }),
+  useHubContext: () => ({ featureFlags: { display_signatures: true } }),
 }));
 
-const mockCollection: CollectionVersionSearch = {
-  collection_version: {
-    namespace: 'amazon',
-    name: 'aws',
-    version: '1.0.0',
-    pulp_created: '2024-01-01T00:00:00Z',
-    pulp_href: '/test/',
-    description: 'AWS collection',
-    requires_ansible: '>=2.9',
-    require_ansible: '>=2.9',
-    contents: [
-      { name: 'ec2', description: '', content_type: 'module' },
-      { name: 'iam_role', description: '', content_type: 'role' },
-      { name: 's3_plugin', description: '', content_type: 'inventory' },
-    ],
-    dependencies: { 'ansible.utils': '>=2.0.0' },
-  },
-  repository: {
-    name: 'published',
-    pulp_href: '/test/',
-    description: '',
-    pulp_id: '1',
-    pulp_last_updated: '',
-    content_count: 0,
-    gpgkey: '',
-    latest_version_href: '',
-  },
-  namespace_metadata: {
-    pulp_href: '/test/',
-    name: 'amazon',
-    company: 'Amazon Web Services',
-    description: '',
-    avatar_url: '',
-  },
-  repository_version: '1',
-  is_highest: true,
-  is_signed: true,
-  is_deprecated: false,
-};
-
-function renderUseCollectionColumns() {
-  return renderHook(() => useCollectionColumns(), {
-    wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
-  });
+function makeCollection(repoName: string, isSigned: boolean): CollectionVersionSearch {
+  return {
+    repository: {
+      name: repoName,
+      description: '',
+      pulp_id: '1',
+      pulp_last_updated: '',
+      content_count: 0,
+      gpgkey: '',
+    },
+    collection_version: { name: 'test-col', namespace: 'test-ns', version: '1.0.0' },
+    repository_version: '1',
+    is_highest: true,
+    is_deprecated: false,
+    is_signed: isSigned,
+  } as CollectionVersionSearch;
 }
 
-describe('useCollectionColumns', () => {
-  it('should return an array of table columns', () => {
-    const { result } = renderUseCollectionColumns();
-    expect(Array.isArray(result.current)).toBe(true);
-    expect(result.current.length).toBeGreaterThan(0);
-  });
+describe('useCollectionColumns badges column', () => {
+  function getBadgesColumn() {
+    const { result } = renderHook(() => useCollectionColumns());
+    return result.current.find((col) => col.header === 'Badges');
+  }
 
-  it('should have a Name column', () => {
-    const { result } = renderUseCollectionColumns();
-    const nameColumn = result.current.find((col) => col.header === 'Name');
-    expect(nameColumn).toBeDefined();
-  });
+  function getBadgeValues(repoName: string, isSigned: boolean): LabelValue[] | undefined {
+    const col = getBadgesColumn();
+    if (!col || !('value' in col)) return undefined;
+    return col.value(makeCollection(repoName, isSigned)) as LabelValue[] | undefined;
+  }
 
-  it('should have a "Provided by" column that uses namespaceTitle', () => {
-    const { result } = renderUseCollectionColumns();
-    const providedByColumn = result.current.find((col) => col.header === 'Provided by');
-    expect(providedByColumn).toBeDefined();
-
-    // The value function should use namespaceTitle
-    // In non-insights mode, it falls back to namespace name
-    if (providedByColumn && 'value' in providedByColumn) {
-      const value = providedByColumn.value!(mockCollection);
-      // In non-insights mode, namespaceTitle returns the name, not company
-      expect(value).toContain('amazon');
+  it('should return blue filled label for rh-certified repository', () => {
+    const labels = getBadgeValues('rh-certified', false);
+    expect(labels).toBeDefined();
+    const repoLabel = labels![0];
+    expect(typeof repoLabel).not.toBe('string');
+    if (typeof repoLabel !== 'string') {
+      expect(repoLabel.label).toBe('rh-certified');
+      expect(repoLabel.color).toBe('blue');
+      expect(repoLabel.variant).toBe('filled');
     }
   });
 
-  it('should display "Provided by" with namespace name when no company', () => {
-    const { result } = renderUseCollectionColumns();
-    const providedByColumn = result.current.find((col) => col.header === 'Provided by');
-    const collectionNoCompany = {
-      ...mockCollection,
-      namespace_metadata: { ...mockCollection.namespace_metadata!, company: '' },
-    };
-    if (providedByColumn && 'value' in providedByColumn) {
-      const value = providedByColumn.value!(collectionNoCompany);
-      expect(value).toContain('amazon');
+  it('should return purple filled label for validated repository', () => {
+    const labels = getBadgeValues('validated', false);
+    const repoLabel = labels![0];
+    if (typeof repoLabel !== 'string') {
+      expect(repoLabel.label).toBe('validated');
+      expect(repoLabel.color).toBe('purple');
+      expect(repoLabel.variant).toBe('filled');
     }
   });
 
-  it('should have Repository column', () => {
-    const { result } = renderUseCollectionColumns();
-    const repoColumn = result.current.find((col) => col.header === 'Repository');
-    expect(repoColumn).toBeDefined();
-    if (repoColumn && 'value' in repoColumn) {
-      expect(repoColumn.value!(mockCollection)).toBe('published');
+  it('should return grey filled label for published repository', () => {
+    const labels = getBadgeValues('published', false);
+    const repoLabel = labels![0];
+    if (typeof repoLabel !== 'string') {
+      expect(repoLabel.label).toBe('published');
+      expect(repoLabel.color).toBe('grey');
+      expect(repoLabel.variant).toBe('filled');
     }
   });
 
-  it('should have Namespace column', () => {
-    const { result } = renderUseCollectionColumns();
-    const nsColumn = result.current.find((col) => col.header === 'Namespace');
-    expect(nsColumn).toBeDefined();
-    if (nsColumn && 'value' in nsColumn) {
-      expect(nsColumn.value!(mockCollection)).toBe('amazon');
+  it('should return grey filled label for community repository', () => {
+    const labels = getBadgeValues('community', false);
+    const repoLabel = labels![0];
+    if (typeof repoLabel !== 'string') {
+      expect(repoLabel.label).toBe('community');
+      expect(repoLabel.color).toBe('grey');
     }
   });
 
-  it('should count modules correctly', () => {
-    const { result } = renderUseCollectionColumns();
-    const modulesColumn = result.current.find((col) => col.header === 'Modules');
-    expect(modulesColumn).toBeDefined();
-    if (modulesColumn && 'value' in modulesColumn) {
-      expect(modulesColumn.value!(mockCollection)).toBe(1);
+  it('should include Signed status label when collection is signed', () => {
+    const labels = getBadgeValues('published', true);
+    expect(labels).toHaveLength(2);
+    const signedLabel = labels![1];
+    if (typeof signedLabel !== 'string') {
+      expect(signedLabel.label).toBe('Signed');
+      expect(signedLabel.status).toBe('success');
+      expect(signedLabel.variant).toBe('outline');
     }
   });
 
-  it('should count roles correctly', () => {
-    const { result } = renderUseCollectionColumns();
-    const rolesColumn = result.current.find((col) => col.header === 'Roles');
-    expect(rolesColumn).toBeDefined();
-    if (rolesColumn && 'value' in rolesColumn) {
-      expect(rolesColumn.value!(mockCollection)).toBe(1);
+  it('should include Unsigned status label when collection is not signed', () => {
+    const labels = getBadgeValues('published', false);
+    expect(labels).toHaveLength(2);
+    const unsignedLabel = labels![1];
+    if (typeof unsignedLabel !== 'string') {
+      expect(unsignedLabel.label).toBe('Unsigned');
+      expect(unsignedLabel.status).toBe('warning');
+      expect(unsignedLabel.variant).toBe('outline');
     }
   });
 
-  it('should count plugins correctly', () => {
-    const { result } = renderUseCollectionColumns();
-    const pluginsColumn = result.current.find((col) => col.header === 'Plugins');
-    expect(pluginsColumn).toBeDefined();
-    if (pluginsColumn && 'value' in pluginsColumn) {
-      expect(pluginsColumn.value!(mockCollection)).toBe(1);
-    }
-  });
-
-  it('should count dependencies correctly', () => {
-    const { result } = renderUseCollectionColumns();
-    const depsColumn = result.current.find((col) => col.header === 'Dependencies');
-    expect(depsColumn).toBeDefined();
-    if (depsColumn && 'value' in depsColumn) {
-      expect(depsColumn.value!(mockCollection)).toBe(1);
-    }
-  });
-
-  it('should have Signed state column', () => {
-    const { result } = renderUseCollectionColumns();
-    const signedColumn = result.current.find((col) => col.header === 'Signed state');
-    expect(signedColumn).toBeDefined();
-  });
-
-  it('should have Version column', () => {
-    const { result } = renderUseCollectionColumns();
-    const versionColumn = result.current.find((col) => col.header === 'Version');
-    expect(versionColumn).toBeDefined();
-    if (versionColumn && 'value' in versionColumn) {
-      expect(versionColumn.value!(mockCollection)).toBe('1.0.0');
-    }
-  });
-
-  it('should show Deprecated badge when collection is deprecated', () => {
-    const { result } = renderUseCollectionColumns();
-    const nameColumn = result.current.find((col) => col.header === 'Name');
-    expect(nameColumn).toBeDefined();
-    // The name column cell renderer handles deprecated state but we test value
+  it('should hide badges column from table and list views', () => {
+    const col = getBadgesColumn();
+    expect(col?.table).toBe('hidden');
+    expect(col?.list).toBe('hidden');
   });
 });

--- a/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
@@ -67,12 +67,12 @@ describe('useCollectionColumns badges column', () => {
     }
   });
 
-  it('should return Certified blue filled label for published repository', () => {
+  it('should return raw grey label for published repository in standalone mode', () => {
     const labels = getBadgeValues('published', false);
     const repoLabel = labels![0];
     if (typeof repoLabel !== 'string') {
-      expect(repoLabel.label).toBe('Certified');
-      expect(repoLabel.color).toBe('blue');
+      expect(repoLabel.label).toBe('published');
+      expect(repoLabel.color).toBe('grey');
       expect(repoLabel.variant).toBe('filled');
     }
   });

--- a/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.test.tsx
@@ -55,34 +55,34 @@ function getBadgeValues(repoName: string, isSigned: boolean): LabelValue[] | und
 }
 
 describe('useCollectionColumns badges column', () => {
-  it('should return blue filled label for rh-certified repository', () => {
+  it('should return Certified blue filled label for rh-certified repository', () => {
     const labels = getBadgeValues('rh-certified', false);
     expect(labels).toBeDefined();
     const repoLabel = labels![0];
     expect(typeof repoLabel).not.toBe('string');
     if (typeof repoLabel !== 'string') {
-      expect(repoLabel.label).toBe('rh-certified');
+      expect(repoLabel.label).toBe('Certified');
       expect(repoLabel.color).toBe('blue');
       expect(repoLabel.variant).toBe('filled');
     }
   });
 
-  it('should return purple filled label for validated repository', () => {
-    const labels = getBadgeValues('validated', false);
+  it('should return Certified blue filled label for published repository', () => {
+    const labels = getBadgeValues('published', false);
     const repoLabel = labels![0];
     if (typeof repoLabel !== 'string') {
-      expect(repoLabel.label).toBe('validated');
-      expect(repoLabel.color).toBe('purple');
+      expect(repoLabel.label).toBe('Certified');
+      expect(repoLabel.color).toBe('blue');
       expect(repoLabel.variant).toBe('filled');
     }
   });
 
-  it('should return grey filled label for published repository', () => {
-    const labels = getBadgeValues('published', false);
+  it('should return Validated purple filled label for validated repository', () => {
+    const labels = getBadgeValues('validated', false);
     const repoLabel = labels![0];
     if (typeof repoLabel !== 'string') {
-      expect(repoLabel.label).toBe('published');
-      expect(repoLabel.color).toBe('grey');
+      expect(repoLabel.label).toBe('Validated');
+      expect(repoLabel.color).toBe('purple');
       expect(repoLabel.variant).toBe('filled');
     }
   });

--- a/frontend/hub/collections/hooks/useCollectionColumns.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.tsx
@@ -1,18 +1,18 @@
 import {
   ColumnCardOption,
+  ColumnListOption,
   ColumnTableOption,
   ITableColumn,
+  LabelColor,
   LabelValue,
   PFColorE,
   TextCell,
   useGetPageUrl,
 } from '@ansible/ansible-ui-framework';
-import { Label, Truncate } from '@patternfly/react-core';
 import { BanIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { CollectionLogo } from '../../common/Logo';
 import { namespaceTitle } from '../../common/namespaceTitle';
 import { useHubContext } from '../../common/useHubContext';
@@ -79,16 +79,17 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
       {
         header: t('Repository'),
         value: (collection) => collection.repository?.name,
-        cell: (collection) => {
-          const badge = getCollectionBadge(collection.repository?.name, t);
-          return (
-            <Label color={badge.color} icon={badge.icon} variant={badge.variant}>
-              <Truncate content={badge.label} style={{ minWidth: 0 }} />
-            </Label>
-          );
-        },
-        card: 'hidden',
-        list: 'hidden',
+        cell: (collection) => (
+          <TextCell
+            text={collection.repository?.name}
+            to={getPageUrl(HubRoute.RepositoryDetails, {
+              params: {
+                id: collection.repository?.name,
+              },
+            })}
+          />
+        ),
+        card: ColumnCardOption.hidden,
       },
       {
         header: t('Namespace'),
@@ -189,19 +190,30 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
         header: t('Badges'),
         type: 'labels',
         value: (collection) => {
-          const badge = getCollectionBadge(collection.repository?.name, t);
-          const labels: LabelValue[] = [badge];
-          if (display_signatures && collection.is_signed) {
+          const labels: LabelValue[] = [];
+          if (collection.repository?.name) {
+            const repoName = collection.repository.name;
+            const repoColorMap: Record<string, LabelColor> = {
+              'rh-certified': 'blue',
+              validated: 'purple',
+            };
             labels.push({
-              label: t('Signed'),
-              color: 'green',
-              icon: <CheckCircleIcon />,
-              variant: 'outline',
+              label: repoName,
+              color: repoColorMap[repoName] ?? 'grey',
+              variant: 'filled',
             });
+          }
+          if (display_signatures) {
+            labels.push(
+              collection.is_signed
+                ? { label: t('Signed'), status: 'success' as const, variant: 'outline' as const }
+                : { label: t('Unsigned'), status: 'warning' as const, variant: 'outline' as const }
+            );
           }
           return labels;
         },
         table: ColumnTableOption.hidden,
+        list: ColumnListOption.hidden,
       },
     ],
     [getPageUrl, t, display_signatures, name, namespace, repository]

--- a/frontend/hub/collections/hooks/useCollectionColumns.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.tsx
@@ -3,7 +3,6 @@ import {
   ColumnListOption,
   ColumnTableOption,
   ITableColumn,
-  LabelColor,
   LabelValue,
   PFColorE,
   TextCell,
@@ -13,6 +12,7 @@ import { BanIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/r
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { CollectionLogo } from '../../common/Logo';
 import { namespaceTitle } from '../../common/namespaceTitle';
 import { useHubContext } from '../../common/useHubContext';
@@ -192,16 +192,7 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
         value: (collection) => {
           const labels: LabelValue[] = [];
           if (collection.repository?.name) {
-            const repoName = collection.repository.name;
-            const repoColorMap: Record<string, LabelColor> = {
-              'rh-certified': 'blue',
-              validated: 'purple',
-            };
-            labels.push({
-              label: repoName,
-              color: repoColorMap[repoName] ?? 'grey',
-              variant: 'filled',
-            });
+            labels.push(getCollectionBadge(collection.repository.name, t));
           }
           if (display_signatures) {
             labels.push(

--- a/frontend/hub/collections/hooks/useCollectionColumns.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.tsx
@@ -2,6 +2,7 @@ import {
   ColumnCardOption,
   ColumnTableOption,
   ITableColumn,
+  LabelValue,
   PFColorE,
   TextCell,
   useGetPageUrl,
@@ -86,6 +87,8 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
             </Label>
           );
         },
+        card: 'hidden',
+        list: 'hidden',
       },
       {
         header: t('Namespace'),
@@ -179,8 +182,26 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
         },
         list: 'secondary',
         value: (collection) => !collection.is_signed || collection.is_signed,
-        card: display_signatures ? undefined : ColumnCardOption.hidden,
+        card: ColumnCardOption.hidden,
         table: display_signatures ? undefined : ColumnTableOption.hidden,
+      },
+      {
+        header: t('Badges'),
+        type: 'labels',
+        value: (collection) => {
+          const badge = getCollectionBadge(collection.repository?.name, t);
+          const labels: LabelValue[] = [badge];
+          if (display_signatures && collection.is_signed) {
+            labels.push({
+              label: t('Signed'),
+              color: 'green',
+              icon: <CheckCircleIcon />,
+              variant: 'outline',
+            });
+          }
+          return labels;
+        },
+        table: ColumnTableOption.hidden,
       },
     ],
     [getPageUrl, t, display_signatures, name, namespace, repository]

--- a/frontend/hub/collections/hooks/useCollectionColumns.tsx
+++ b/frontend/hub/collections/hooks/useCollectionColumns.tsx
@@ -6,10 +6,12 @@ import {
   TextCell,
   useGetPageUrl,
 } from '@ansible/ansible-ui-framework';
+import { Label, Truncate } from '@patternfly/react-core';
 import { BanIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { CollectionLogo } from '../../common/Logo';
 import { namespaceTitle } from '../../common/namespaceTitle';
 import { useHubContext } from '../../common/useHubContext';
@@ -76,16 +78,14 @@ export function useCollectionColumns(_options?: { disableSort?: boolean; disable
       {
         header: t('Repository'),
         value: (collection) => collection.repository?.name,
-        cell: (collection) => (
-          <TextCell
-            text={collection.repository?.name}
-            to={getPageUrl(HubRoute.RepositoryDetails, {
-              params: {
-                id: collection.repository?.name,
-              },
-            })}
-          />
-        ),
+        cell: (collection) => {
+          const badge = getCollectionBadge(collection.repository?.name, t);
+          return (
+            <Label color={badge.color} icon={badge.icon} variant={badge.variant}>
+              <Truncate content={badge.label} style={{ minWidth: 0 }} />
+            </Label>
+          );
+        },
       },
       {
         header: t('Namespace'),

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -25,10 +25,6 @@ function CollectionRepositoryCell(props: Readonly<{ collection: CollectionVersio
   );
 }
 
-function renderRepositoryCell(collection: CollectionVersionSearch) {
-  return <CollectionRepositoryCell collection={collection} />;
-}
-
 export function CollectionMultiSelectDialog(props: {
   title: string;
   description: string;
@@ -65,7 +61,9 @@ export function CollectionMultiSelectDialog(props: {
       },
       {
         header: t('Repository'),
-        cell: renderRepositoryCell,
+        cell: (collection: CollectionVersionSearch) => (
+          <CollectionRepositoryCell collection={collection} />
+        ),
       },
     ],
     [t]

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -25,6 +25,10 @@ function CollectionRepositoryCell(props: Readonly<{ collection: CollectionVersio
   );
 }
 
+function renderRepositoryCell(collection: CollectionVersionSearch) {
+  return <CollectionRepositoryCell collection={collection} />;
+}
+
 export function CollectionMultiSelectDialog(props: {
   title: string;
   description: string;
@@ -61,9 +65,7 @@ export function CollectionMultiSelectDialog(props: {
       },
       {
         header: t('Repository'),
-        cell: (collection: CollectionVersionSearch) => (
-          <CollectionRepositoryCell collection={collection} />
-        ),
+        cell: renderRepositoryCell,
       },
     ],
     [t]

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -10,15 +10,17 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hubAPI } from '../../common/api/formatPath';
 import { collectionKeyFn } from '../../common/api/hub-api-utils';
-import { CollectionBadge, getCollectionBadge } from '../../common/collectionBadgeUtils';
+import { getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { useHubView } from '../../common/useHubView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionFilters } from './useCollectionFilters';
 
-function CollectionRepositoryLabel(props: Readonly<{ badge: CollectionBadge }>) {
+function CollectionRepositoryCell(props: Readonly<{ collection: CollectionVersionSearch }>) {
+  const { t } = useTranslation();
+  const badge = getCollectionBadge(props.collection.repository?.name, t);
   return (
-    <Label color={props.badge.color} icon={props.badge.icon} variant={props.badge.variant}>
-      <Truncate content={props.badge.label} style={{ minWidth: 0 }} />
+    <Label color={badge.color} icon={badge.icon} variant={badge.variant}>
+      <Truncate content={badge.label} style={{ minWidth: 0 }} />
     </Label>
   );
 }
@@ -60,7 +62,7 @@ export function CollectionMultiSelectDialog(props: {
       {
         header: t('Repository'),
         cell: (collection: CollectionVersionSearch) => (
-          <CollectionRepositoryLabel badge={getCollectionBadge(collection.repository?.name, t)} />
+          <CollectionRepositoryCell collection={collection} />
         ),
       },
     ],

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -25,6 +25,10 @@ function CollectionRepositoryCell(props: Readonly<{ collection: CollectionVersio
   );
 }
 
+function repositoryCell(collection: CollectionVersionSearch) {
+  return <CollectionRepositoryCell collection={collection} />;
+}
+
 export function CollectionMultiSelectDialog(props: {
   title: string;
   description: string;
@@ -61,9 +65,7 @@ export function CollectionMultiSelectDialog(props: {
       },
       {
         header: t('Repository'),
-        cell: (collection: CollectionVersionSearch) => (
-          <CollectionRepositoryCell collection={collection} />
-        ),
+        cell: repositoryCell,
       },
     ],
     [t]

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -10,10 +10,18 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hubAPI } from '../../common/api/formatPath';
 import { collectionKeyFn } from '../../common/api/hub-api-utils';
-import { getCollectionBadge } from '../../common/collectionBadgeUtils';
+import { CollectionBadge, getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { useHubView } from '../../common/useHubView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionFilters } from './useCollectionFilters';
+
+function CollectionRepositoryLabel(props: Readonly<{ badge: CollectionBadge }>) {
+  return (
+    <Label color={props.badge.color} icon={props.badge.icon} variant={props.badge.variant}>
+      <Truncate content={props.badge.label} style={{ minWidth: 0 }} />
+    </Label>
+  );
+}
 
 export function CollectionMultiSelectDialog(props: {
   title: string;
@@ -51,14 +59,9 @@ export function CollectionMultiSelectDialog(props: {
       },
       {
         header: t('Repository'),
-        cell: (collection: CollectionVersionSearch) => {
-          const badge = getCollectionBadge(collection.repository?.name, t);
-          return (
-            <Label color={badge.color} icon={badge.icon} variant={badge.variant}>
-              <Truncate content={badge.label} style={{ minWidth: 0 }} />
-            </Label>
-          );
-        },
+        cell: (collection: CollectionVersionSearch) => (
+          <CollectionRepositoryLabel badge={getCollectionBadge(collection.repository?.name, t)} />
+        ),
       },
     ],
     [t]

--- a/frontend/hub/collections/hooks/useSelectCollections.tsx
+++ b/frontend/hub/collections/hooks/useSelectCollections.tsx
@@ -10,16 +10,10 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hubAPI } from '../../common/api/formatPath';
 import { collectionKeyFn } from '../../common/api/hub-api-utils';
-import { isInsightsMode } from '../../common/isInsights';
+import { getCollectionBadge } from '../../common/collectionBadgeUtils';
 import { useHubView } from '../../common/useHubView';
 import { CollectionVersionSearch } from '../Collection';
 import { useCollectionFilters } from './useCollectionFilters';
-
-const CERTIFIED_REPO = isInsightsMode() ? 'published' : 'rh-certified';
-
-function CertifiedIcon() {
-  return <i className="fas fa-certificate"></i>;
-}
 
 export function CollectionMultiSelectDialog(props: {
   title: string;
@@ -57,16 +51,14 @@ export function CollectionMultiSelectDialog(props: {
       },
       {
         header: t('Repository'),
-        cell: (collection: CollectionVersionSearch) =>
-          collection.repository?.name === CERTIFIED_REPO ? (
-            <Label color="blue" icon={<CertifiedIcon />} variant="outline">
-              <Truncate content={t('Certified')} style={{ minWidth: 0 }} />
+        cell: (collection: CollectionVersionSearch) => {
+          const badge = getCollectionBadge(collection.repository?.name, t);
+          return (
+            <Label color={badge.color} icon={badge.icon} variant={badge.variant}>
+              <Truncate content={badge.label} style={{ minWidth: 0 }} />
             </Label>
-          ) : (
-            <Label color="blue" variant="outline">
-              <Truncate content={collection.repository?.name || ''} style={{ minWidth: 0 }} />
-            </Label>
-          ),
+          );
+        },
       },
     ],
     [t]

--- a/frontend/hub/common/collectionBadgeUtils.test.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.test.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable i18next/no-literal-string */
+import { describe, expect, it } from 'vitest';
+import { getCollectionBadge } from './collectionBadgeUtils';
+
+const t = (key: string) => key;
+
+describe('getCollectionBadge', () => {
+  it('should return Certified badge for "published" repository', () => {
+    const badge = getCollectionBadge('published', t);
+    expect(badge.label).toBe('Certified');
+    expect(badge.color).toBe('blue');
+    expect(badge.variant).toBe('filled');
+    expect(badge.icon).toBeDefined();
+  });
+
+  it('should return Certified badge for "rh-certified" repository', () => {
+    const badge = getCollectionBadge('rh-certified', t);
+    expect(badge.label).toBe('Certified');
+    expect(badge.color).toBe('blue');
+    expect(badge.variant).toBe('filled');
+    expect(badge.icon).toBeDefined();
+  });
+
+  it('should return Validated badge for "validated" repository', () => {
+    const badge = getCollectionBadge('validated', t);
+    expect(badge.label).toBe('Validated');
+    expect(badge.color).toBe('purple');
+    expect(badge.variant).toBe('filled');
+    expect(badge.icon).toBeUndefined();
+  });
+
+  it('should return raw name with blue color for unknown repository', () => {
+    const badge = getCollectionBadge('community', t);
+    expect(badge.label).toBe('community');
+    expect(badge.color).toBe('blue');
+    expect(badge.variant).toBe('filled');
+  });
+
+  it('should return empty label for undefined repository', () => {
+    const badge = getCollectionBadge(undefined, t);
+    expect(badge.label).toBe('');
+    expect(badge.color).toBe('blue');
+    expect(badge.variant).toBe('filled');
+  });
+});

--- a/frontend/hub/common/collectionBadgeUtils.test.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.test.tsx
@@ -29,17 +29,17 @@ describe('getCollectionBadge', () => {
     expect(badge.icon).toBeUndefined();
   });
 
-  it('should return raw name with blue color for unknown repository', () => {
+  it('should return raw name with grey color for unknown repository', () => {
     const badge = getCollectionBadge('community', t);
     expect(badge.label).toBe('community');
-    expect(badge.color).toBe('blue');
+    expect(badge.color).toBe('grey');
     expect(badge.variant).toBe('filled');
   });
 
   it('should return empty label for undefined repository', () => {
     const badge = getCollectionBadge(undefined, t);
     expect(badge.label).toBe('');
-    expect(badge.color).toBe('blue');
+    expect(badge.color).toBe('grey');
     expect(badge.variant).toBe('filled');
   });
 });

--- a/frontend/hub/common/collectionBadgeUtils.test.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.test.tsx
@@ -5,20 +5,19 @@ import { getCollectionBadge } from './collectionBadgeUtils';
 const t = (key: string) => key;
 
 describe('getCollectionBadge', () => {
-  it('should return Certified badge for "published" repository', () => {
-    const badge = getCollectionBadge('published', t);
+  it('should return Certified badge for "rh-certified" repository in standalone mode', () => {
+    const badge = getCollectionBadge('rh-certified', t);
     expect(badge.label).toBe('Certified');
     expect(badge.color).toBe('blue');
     expect(badge.variant).toBe('filled');
     expect(badge.icon).toBeDefined();
   });
 
-  it('should return Certified badge for "rh-certified" repository', () => {
-    const badge = getCollectionBadge('rh-certified', t);
-    expect(badge.label).toBe('Certified');
-    expect(badge.color).toBe('blue');
+  it('should return raw name for "published" repository in standalone mode', () => {
+    const badge = getCollectionBadge('published', t);
+    expect(badge.label).toBe('published');
+    expect(badge.color).toBe('grey');
     expect(badge.variant).toBe('filled');
-    expect(badge.icon).toBeDefined();
   });
 
   it('should return Validated badge for "validated" repository', () => {

--- a/frontend/hub/common/collectionBadgeUtils.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.tsx
@@ -1,0 +1,45 @@
+import { LabelColor } from '@ansible/ansible-ui-framework';
+import { ReactNode } from 'react';
+import { isInsightsMode } from './isInsights';
+
+const CERTIFIED_REPO = isInsightsMode() ? 'published' : 'rh-certified';
+const VALIDATED_REPO = 'validated';
+
+export interface CollectionBadge {
+  label: string;
+  color: LabelColor;
+  icon?: ReactNode;
+  variant: 'filled' | 'outline';
+}
+
+export function CertifiedIcon() {
+  return <i className="fas fa-certificate"></i>;
+}
+
+export function getCollectionBadge(
+  repositoryName: string | undefined,
+  t: (key: string) => string
+): CollectionBadge {
+  if (repositoryName === CERTIFIED_REPO) {
+    return {
+      label: t('Certified'),
+      color: 'blue',
+      icon: <CertifiedIcon />,
+      variant: 'filled',
+    };
+  }
+
+  if (repositoryName === VALIDATED_REPO) {
+    return {
+      label: t('Validated'),
+      color: 'purple',
+      variant: 'filled',
+    };
+  }
+
+  return {
+    label: repositoryName || '',
+    color: 'blue',
+    variant: 'filled',
+  };
+}

--- a/frontend/hub/common/collectionBadgeUtils.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.tsx
@@ -1,8 +1,7 @@
 import { LabelColor } from '@ansible/ansible-ui-framework';
 import { ReactNode } from 'react';
-import { isInsightsMode } from './isInsights';
 
-const CERTIFIED_REPO = isInsightsMode() ? 'published' : 'rh-certified';
+const CERTIFIED_REPOS = ['published', 'rh-certified'];
 const VALIDATED_REPO = 'validated';
 
 export interface CollectionBadge {
@@ -20,7 +19,7 @@ export function getCollectionBadge(
   repositoryName: string | undefined,
   t: (key: string) => string
 ): CollectionBadge {
-  if (repositoryName === CERTIFIED_REPO) {
+  if (repositoryName && CERTIFIED_REPOS.includes(repositoryName)) {
     return {
       label: t('Certified'),
       color: 'blue',

--- a/frontend/hub/common/collectionBadgeUtils.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.tsx
@@ -1,7 +1,8 @@
 import { LabelColor } from '@ansible/ansible-ui-framework';
 import { ReactNode } from 'react';
+import { isInsightsMode } from './isInsights';
 
-const CERTIFIED_REPOS = new Set(['published', 'rh-certified']);
+const CERTIFIED_REPOS = isInsightsMode() ? new Set(['published']) : new Set(['rh-certified']);
 const VALIDATED_REPO = 'validated';
 
 export interface CollectionBadge {

--- a/frontend/hub/common/collectionBadgeUtils.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.tsx
@@ -38,7 +38,7 @@ export function getCollectionBadge(
 
   return {
     label: repositoryName || '',
-    color: 'blue',
+    color: 'grey',
     variant: 'filled',
   };
 }

--- a/frontend/hub/common/collectionBadgeUtils.tsx
+++ b/frontend/hub/common/collectionBadgeUtils.tsx
@@ -1,7 +1,7 @@
 import { LabelColor } from '@ansible/ansible-ui-framework';
 import { ReactNode } from 'react';
 
-const CERTIFIED_REPOS = ['published', 'rh-certified'];
+const CERTIFIED_REPOS = new Set(['published', 'rh-certified']);
 const VALIDATED_REPO = 'validated';
 
 export interface CollectionBadge {
@@ -19,7 +19,7 @@ export function getCollectionBadge(
   repositoryName: string | undefined,
   t: (key: string) => string
 ): CollectionBadge {
-  if (repositoryName && CERTIFIED_REPOS.includes(repositoryName)) {
+  if (repositoryName && CERTIFIED_REPOS.has(repositoryName)) {
     return {
       label: t('Certified'),
       color: 'blue',

--- a/frontend/hub/overview/CollectionCard.tsx
+++ b/frontend/hub/overview/CollectionCard.tsx
@@ -11,7 +11,7 @@ import { ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled, { CSSProperties } from 'styled-components';
 import { CollectionVersionSearch } from '../collections/Collection';
-import { isInsightsMode } from '../common/isInsights';
+import { getCollectionBadge } from '../common/collectionBadgeUtils';
 import { CollectionLogo } from '../common/Logo';
 import { namespaceTitle } from '../common/namespaceTitle';
 import { HubRoute } from '../main/HubRoutes';
@@ -22,8 +22,6 @@ export const ColumnsDiv = styled.div`
   align-items: baseline;
 `;
 
-const CERTIFIED_REPO = isInsightsMode() ? 'published' : 'rh-certified';
-
 type Labels =
   | {
       label: string;
@@ -32,10 +30,6 @@ type Labels =
       variant?: 'outline' | 'filled' | undefined;
     }[]
   | undefined;
-
-function CertifiedIcon() {
-  return <i className="fas fa-certificate"></i>;
-}
 
 export function CollectionCard(props: { collection: CollectionVersionSearch }) {
   const { t } = useTranslation();
@@ -55,23 +49,8 @@ export function CollectionCard(props: { collection: CollectionVersionSearch }) {
 
   const getLabels = useCallback(
     (item: CollectionVersionSearch) => {
-      const cardLabels: Labels =
-        item.repository?.name === CERTIFIED_REPO
-          ? [
-              {
-                label: t('Certified'),
-                color: 'blue',
-                icon: <CertifiedIcon />,
-                variant: 'outline',
-              },
-            ]
-          : [
-              {
-                label: item.repository?.name || '',
-                color: 'blue',
-                variant: 'outline',
-              },
-            ];
+      const badge = getCollectionBadge(item.repository?.name, t);
+      const cardLabels: Labels = [badge];
       if (item.is_signed) {
         cardLabels?.push({
           label: t('Signed'),


### PR DESCRIPTION
## Summary

- Replaces the plain-text "Repository" field on Hub collection cards with PatternFly **filled Label** badges: **blue** for Certified, **purple** for Validated ([AAP-84503](https://redhat.atlassian.net/browse/AAP-84503))
- Centralizes the repository-to-badge mapping in a new shared utility (`collectionBadgeUtils.tsx`) to eliminate duplicated logic across `CollectionCard`, `useCollectionColumns`, and `useSelectCollections`
- Applies consistently to the overview carousel cards, the collections list/card/table views, and the collection multi-select dialog

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Navigate to Hub > Collections in card/list view
2. Verify collections from the `published`/`rh-certified` repository show a **blue filled "Certified"** badge with a certificate icon
3. Verify collections from the `validated` repository show a **purple filled "Validated"** badge
4. Verify the overview carousel cards show the same badges
5. Open any collection multi-select dialog and verify badges render correctly

### Screenshots

Before
<img width="1888" height="881" alt="image" src="https://github.com/user-attachments/assets/b4267370-0085-4301-bb38-c0026ed27bd6" />


After
<img width="1888" height="881" alt="image" src="https://github.com/user-attachments/assets/c8126a94-f65e-467c-8063-b3549fbfdfdf" />





Made with [Cursor](https://cursor.com)