### PR TITLE
fix: increase Playwright globalTimeout default from 90 to 120 minutes

### DIFF
--- a/.github/workflows/playwright-currents.yml
+++ b/.github/workflows/playwright-currents.yml
@@ -37,7 +37,7 @@ on:
       TIMEOUT_MINUTES:
         type: string
         required: false
-        default: '90'
+        default: '120'
       AAP_TOPOLOGY_TYPE:
         description: 'AAP topology type (saas, ocp-a, man-b, or empty)'
         type: string
@@ -73,7 +73,7 @@ jobs:
           echo "Generated matrix for $PARALLEL_TESTS parallel tests: $matrix"
 
   playwright-tests:
-    timeout-minutes: ${{ fromJSON(inputs.TIMEOUT_MINUTES || '90') }}
+    timeout-minutes: ${{ fromJSON(inputs.TIMEOUT_MINUTES || '120') }}
     runs-on: ubuntu-latest
     needs: generate-matrix
     strategy:
@@ -145,7 +145,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PROJECT: ${{ inputs.PROJECT || 'live chromium' }}
         SHARD: ${{ matrix.shard }}/${{ inputs.PARALLEL_TESTS || '4' }}
-        TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES || '90' }}
+        TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES || '120' }}
       run: |
         npx pwc \
           --key="${CURRENTS_RECORD_KEY}" \

--- a/.github/workflows/run-playwright-currents.yml
+++ b/.github/workflows/run-playwright-currents.yml
@@ -31,8 +31,8 @@ on:
       TIMEOUT_MINUTES:
         type: number
         required: false
-        description: "Job timeout in minutes (default: 90)"
-        default: 90
+        description: "Job timeout in minutes (default: 120)"
+        default: 120
       AAP_TOPOLOGY_TYPE:
         type: choice
         required: false

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -15,7 +15,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env'), override: true });
  */
 // Use verbose configuration by default for better debugging
 const isCI = !!process.env.CI;
-const jobTimeoutMinutes = Number(process.env.TIMEOUT_MINUTES) || 90;
+const jobTimeoutMinutes = Number(process.env.TIMEOUT_MINUTES) || 120;
 const config: PlaywrightTestConfig = {
   testDir: '.',
   fullyParallel: false,


### PR DESCRIPTION
## Summary

- Increases the default `TIMEOUT_MINUTES` from 90 to 120 in `playwright.config.ts` (effective `globalTimeout` 85 → 115 minutes)
- Aligns GitHub Actions Playwright/Currents workflow defaults to 120 so the GHA job timeout does not kill the run first

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Problem

Jenkins `@tier1` Playwright jobs (for example `tier1-cont-b.fresh-install.ui-playwright`) hit Playwright `globalTimeout` at 5100s (85 minutes) and report the remaining tests as skipped. Chatbot/Lightspeed never start; they are queued after the cap. This is the same failure mode as #3220.

The `@tier1` tagging wave finished on 19 June with 180 tags. A full run is ~93 minutes (build 89). Nothing new has been tagged since, so 90 was already too tight once that initiative completed.

## Risk Details

| Risk | Assessment |
|---|---|
| **Functional impact** | None — CI timeout ceiling only |
| **Hung run exposure** | Increases from 85 min to 115 min before Playwright kills a hung suite |
| **Override capability** | `TIMEOUT_MINUTES` still wins when set |
| **Scope** | CI only (`isCI` guard). Local runs unchanged |

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

- [ ] Confirm Jenkins `@tier1` runs no longer skip chatbot/Lightspeed due to `Timed out waiting 5100s`
- [ ] Confirm `TIMEOUT_MINUTES` still overrides the default when set


Made with [Cursor](https://cursor.com)