### PR TITLE
fix(hub): render GFM markdown in execution environment READMEs

### DIFF
--- a/frontend/hub/common/MarkdownEditor.test.tsx
+++ b/frontend/hub/common/MarkdownEditor.test.tsx
@@ -47,47 +47,78 @@ function renderEditor({
 }
 
 describe('MarkdownEditor', () => {
-  test('should render markdown headings as PatternFly Title components', () => {
+  test('should render markdown headings, paragraphs, lists, quotes, and thematic breaks', () => {
     renderEditor();
+
+    const preview = screen.getByTestId('readme');
+    expect(preview).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
 
     const levels = [1, 2, 3, 4, 5, 6] as const;
     for (const level of levels) {
       const heading = screen.getByRole('heading', { level, name: `heading${level}` });
-      expect(heading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
-      expect(heading).toHaveClass('pf-v6-c-title', `pf-m-h${level}`);
+      expect(heading.tagName).toBe(`H${level}`);
+      expect(preview).toContainElement(heading);
     }
-  });
 
-  test('should render paragraphs, blockquotes, lists, and thematic breaks as PatternFly Content', () => {
-    renderEditor();
-
-    const paragraph = screen.getByText('paragraph text');
-    expect(paragraph.tagName).toBe('P');
-    expect(paragraph).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
-
-    const quote = screen.getByText('quote text').closest('blockquote');
-    expect(quote).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(screen.getByText('paragraph text').tagName).toBe('P');
+    expect(screen.getByText('quote text').closest('blockquote')).toBeInTheDocument();
 
     const orderedItem = screen.getByText('ordered item');
     expect(orderedItem.tagName).toBe('LI');
-    expect(orderedItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
-    expect(orderedItem.closest('ol')).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(orderedItem.closest('ol')).toBeInTheDocument();
 
     const unorderedItem = screen.getByText('unordered item');
     expect(unorderedItem.tagName).toBe('LI');
-    expect(unorderedItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
-    expect(unorderedItem.closest('ul')).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(unorderedItem.closest('ul')).toBeInTheDocument();
 
     const separator = screen.getByRole('separator');
     expect(separator.tagName).toBe('HR');
-    expect(separator).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+  });
+
+  test('should preserve ordered list start when numbering does not begin at 1', () => {
+    renderEditor({ text: '5. fifth item' });
+
+    expect(screen.getByText('fifth item').closest('ol')).toHaveAttribute('start', '5');
+  });
+
+  test('should apply GFM task-list classes on lists and items', () => {
+    renderEditor({
+      text: ['- [ ] unchecked item', '- [x] checked item'].join('\n'),
+    });
+
+    const uncheckedItem = screen.getByText('unchecked item');
+    const checkedItem = screen.getByText('checked item');
+    const list = uncheckedItem.closest('ul');
+
+    expect(list).toHaveClass('contains-task-list');
+    expect(uncheckedItem).toHaveClass('task-list-item');
+    expect(checkedItem).toHaveClass('task-list-item');
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[0]).toBeDisabled();
+    expect(checkboxes[1]).toBeDisabled();
+  });
+
+  test('should apply GFM task-list class on ordered lists that contain tasks', () => {
+    renderEditor({
+      text: ['3. [ ] first task', '4. [x] second task'].join('\n'),
+    });
+
+    const list = screen.getByText('first task').closest('ol');
+    expect(list).toHaveAttribute('start', '3');
+    expect(list).toHaveClass('contains-task-list');
+    expect(screen.getByText('first task')).toHaveClass('task-list-item');
   });
 
   test('should render placeholder markdown when text is empty', () => {
     renderEditor({ text: '', placeholder: '# Placeholder heading' });
 
-    const heading = screen.getByRole('heading', { level: 1, name: 'Placeholder heading' });
-    expect(heading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+    expect(screen.getByRole('heading', { level: 1, name: 'Placeholder heading' }).tagName).toBe(
+      'H1'
+    );
   });
 
   test('should show the raw editor and preview while editing', async () => {

--- a/frontend/hub/common/MarkdownEditor.test.tsx
+++ b/frontend/hub/common/MarkdownEditor.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import { MarkdownEditor } from './MarkdownEditor';
+
+const markdownWithAllBlocks = [
+  '# heading1',
+  '## heading2',
+  '### heading3',
+  '#### heading4',
+  '##### heading5',
+  '###### heading6',
+  '',
+  'paragraph text',
+  '',
+  '> quote text',
+  '',
+  '---',
+  '',
+  '1. ordered item',
+  '',
+  '- unordered item',
+].join('\n');
+
+function renderEditor({
+  text = markdownWithAllBlocks,
+  placeholder = '',
+  updateText = vi.fn(),
+  helperText = '',
+  editing = false,
+}: {
+  text?: string;
+  placeholder?: string;
+  updateText?: (text: string) => void;
+  helperText?: string;
+  editing?: boolean;
+} = {}) {
+  return render(
+    <MarkdownEditor
+      text={text}
+      placeholder={placeholder}
+      updateText={updateText}
+      helperText={helperText}
+      editing={editing}
+    />
+  );
+}
+
+describe('MarkdownEditor', () => {
+  test('should render markdown headings as PatternFly Title components', () => {
+    renderEditor();
+
+    const levels = [1, 2, 3, 4, 5, 6] as const;
+    for (const level of levels) {
+      const heading = screen.getByRole('heading', { level, name: `heading${level}` });
+      expect(heading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+      expect(heading).toHaveClass('pf-v6-c-title', `pf-m-h${level}`);
+    }
+  });
+
+  test('should render paragraphs, blockquotes, lists, and thematic breaks as PatternFly Content', () => {
+    renderEditor();
+
+    const paragraph = screen.getByText('paragraph text');
+    expect(paragraph.tagName).toBe('P');
+    expect(paragraph).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+
+    const quote = screen.getByText('quote text').closest('blockquote');
+    expect(quote).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+
+    const orderedItem = screen.getByText('ordered item');
+    expect(orderedItem.tagName).toBe('LI');
+    expect(orderedItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(orderedItem.closest('ol')).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+
+    const unorderedItem = screen.getByText('unordered item');
+    expect(unorderedItem.tagName).toBe('LI');
+    expect(unorderedItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(unorderedItem.closest('ul')).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+
+    const separator = screen.getByRole('separator');
+    expect(separator.tagName).toBe('HR');
+    expect(separator).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+  });
+
+  test('should render placeholder markdown when text is empty', () => {
+    renderEditor({ text: '', placeholder: '# Placeholder heading' });
+
+    const heading = screen.getByRole('heading', { level: 1, name: 'Placeholder heading' });
+    expect(heading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+  });
+
+  test('should show the raw editor and preview while editing', async () => {
+    const user = userEvent.setup();
+    const updateText = vi.fn();
+
+    renderEditor({
+      text: '# heading1',
+      updateText,
+      helperText: 'Supports markdown',
+      editing: true,
+    });
+
+    expect(screen.getByText('Raw Markdown')).toBeInTheDocument();
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+    expect(screen.getByText('Supports markdown')).toBeInTheDocument();
+    expect(screen.getByTestId('readme')).toHaveClass('preview');
+
+    const textarea = screen.getByTestId('raw-markdown');
+    await user.type(textarea, 'x');
+
+    expect(updateText).toHaveBeenCalled();
+  });
+});

--- a/frontend/hub/common/MarkdownEditor.tsx
+++ b/frontend/hub/common/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
-import { TextArea } from '@patternfly/react-core';
+import { Content, TextArea } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import styled from 'styled-components';
 
 const MarkdownEditorWrapper = styled.div`
@@ -20,6 +21,19 @@ const RawMarkdown = styled.div`
 
 const ReactMarkdownWrapper = styled.div`
   flex-grow: 1;
+
+  td,
+  th {
+    padding: 2px 16px 2px 0;
+    vertical-align: top;
+  }
+
+  code {
+    display: inline-block;
+    background: var(--pf-t--global--background--color--secondary--default);
+    padding: 2px 6px;
+    border-radius: 6px;
+  }
 `;
 
 interface IProps {
@@ -54,8 +68,14 @@ export function MarkdownEditor(props: IProps) {
       )}
       <ReactMarkdownWrapper>
         {editing && t(`Preview`)}
-        <div className={editing ? 'pf-v6-c-content preview' : 'pf-v6-c-content'}>
-          <ReactMarkdown>{text || placeholder}</ReactMarkdown>
+        <div
+          data-cy="readme"
+          data-testid="readme"
+          className={editing ? 'pf-v6-c-content preview' : 'pf-v6-c-content'}
+        >
+          <Content>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{text || placeholder}</ReactMarkdown>
+          </Content>
         </div>
       </ReactMarkdownWrapper>
     </MarkdownEditorWrapper>

--- a/frontend/hub/common/MarkdownEditor.tsx
+++ b/frontend/hub/common/MarkdownEditor.tsx
@@ -1,7 +1,6 @@
-import { Content, TextArea, Title } from '@patternfly/react-core';
-import { ReactNode } from 'react';
+import { Content, TextArea } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import ReactMarkdown, { type Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import styled from 'styled-components';
 
@@ -35,6 +34,11 @@ const ReactMarkdownWrapper = styled.div`
     padding: 2px 6px;
     border-radius: 6px;
   }
+
+  /* remark-gfm / github-markdown-css: hide the list bullet so the checkbox is the marker */
+  li.task-list-item {
+    list-style-type: none;
+  }
 `;
 
 interface IProps {
@@ -44,40 +48,6 @@ interface IProps {
   helperText: string;
   editing: boolean;
 }
-
-function MarkdownHeading({
-  headingLevel,
-  children,
-}: Readonly<{ headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'; children?: ReactNode }>) {
-  return <Title headingLevel={headingLevel}>{children}</Title>;
-}
-
-function MarkdownContent({
-  component,
-  children,
-}: Readonly<{
-  component: 'p' | 'ul' | 'ol' | 'li' | 'blockquote' | 'hr';
-  children?: ReactNode;
-}>) {
-  return <Content component={component}>{children}</Content>;
-}
-
-const markdownComponents: Components = {
-  h1: ({ children }) => <MarkdownHeading headingLevel="h1">{children}</MarkdownHeading>,
-  h2: ({ children }) => <MarkdownHeading headingLevel="h2">{children}</MarkdownHeading>,
-  h3: ({ children }) => <MarkdownHeading headingLevel="h3">{children}</MarkdownHeading>,
-  h4: ({ children }) => <MarkdownHeading headingLevel="h4">{children}</MarkdownHeading>,
-  h5: ({ children }) => <MarkdownHeading headingLevel="h5">{children}</MarkdownHeading>,
-  h6: ({ children }) => <MarkdownHeading headingLevel="h6">{children}</MarkdownHeading>,
-  p: ({ children }) => <MarkdownContent component="p">{children}</MarkdownContent>,
-  ul: ({ children }) => <MarkdownContent component="ul">{children}</MarkdownContent>,
-  ol: ({ children }) => <MarkdownContent component="ol">{children}</MarkdownContent>,
-  li: ({ children }) => <MarkdownContent component="li">{children}</MarkdownContent>,
-  blockquote: ({ children }) => (
-    <MarkdownContent component="blockquote">{children}</MarkdownContent>
-  ),
-  hr: () => <MarkdownContent component="hr" />,
-};
 
 export function MarkdownEditor(props: Readonly<IProps>) {
   const { t } = useTranslation();
@@ -103,15 +73,9 @@ export function MarkdownEditor(props: Readonly<IProps>) {
       )}
       <ReactMarkdownWrapper>
         {editing && t(`Preview`)}
-        <div
-          data-cy="readme"
-          data-testid="readme"
-          className={editing ? 'pf-v6-c-content preview' : 'pf-v6-c-content'}
-        >
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-            {text || placeholder}
-          </ReactMarkdown>
-        </div>
+        <Content data-cy="readme" data-testid="readme" className={editing ? 'preview' : undefined}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{text || placeholder}</ReactMarkdown>
+        </Content>
       </ReactMarkdownWrapper>
     </MarkdownEditorWrapper>
   );

--- a/frontend/hub/common/MarkdownEditor.tsx
+++ b/frontend/hub/common/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
-import { Content, TextArea } from '@patternfly/react-core';
+import { Content, TextArea, Title } from '@patternfly/react-core';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import styled from 'styled-components';
 
@@ -44,7 +45,41 @@ interface IProps {
   editing: boolean;
 }
 
-export function MarkdownEditor(props: IProps) {
+function MarkdownHeading({
+  headingLevel,
+  children,
+}: Readonly<{ headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'; children?: ReactNode }>) {
+  return <Title headingLevel={headingLevel}>{children}</Title>;
+}
+
+function MarkdownContent({
+  component,
+  children,
+}: Readonly<{
+  component: 'p' | 'ul' | 'ol' | 'li' | 'blockquote' | 'hr';
+  children?: ReactNode;
+}>) {
+  return <Content component={component}>{children}</Content>;
+}
+
+const markdownComponents: Components = {
+  h1: ({ children }) => <MarkdownHeading headingLevel="h1">{children}</MarkdownHeading>,
+  h2: ({ children }) => <MarkdownHeading headingLevel="h2">{children}</MarkdownHeading>,
+  h3: ({ children }) => <MarkdownHeading headingLevel="h3">{children}</MarkdownHeading>,
+  h4: ({ children }) => <MarkdownHeading headingLevel="h4">{children}</MarkdownHeading>,
+  h5: ({ children }) => <MarkdownHeading headingLevel="h5">{children}</MarkdownHeading>,
+  h6: ({ children }) => <MarkdownHeading headingLevel="h6">{children}</MarkdownHeading>,
+  p: ({ children }) => <MarkdownContent component="p">{children}</MarkdownContent>,
+  ul: ({ children }) => <MarkdownContent component="ul">{children}</MarkdownContent>,
+  ol: ({ children }) => <MarkdownContent component="ol">{children}</MarkdownContent>,
+  li: ({ children }) => <MarkdownContent component="li">{children}</MarkdownContent>,
+  blockquote: ({ children }) => (
+    <MarkdownContent component="blockquote">{children}</MarkdownContent>
+  ),
+  hr: () => <MarkdownContent component="hr" />,
+};
+
+export function MarkdownEditor(props: Readonly<IProps>) {
   const { t } = useTranslation();
 
   const { text, placeholder, updateText, helperText, editing } = props;
@@ -73,9 +108,9 @@ export function MarkdownEditor(props: IProps) {
           data-testid="readme"
           className={editing ? 'pf-v6-c-content preview' : 'pf-v6-c-content'}
         >
-          <Content>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{text || placeholder}</ReactMarkdown>
-          </Content>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+            {text || placeholder}
+          </ReactMarkdown>
         </div>
       </ReactMarkdownWrapper>
     </MarkdownEditorWrapper>

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
@@ -115,13 +115,13 @@ describe('ExecutionEnvironmentDetails', () => {
     const heading1 = await screen.findByRole('heading', { level: 1, name: 'heading1' });
     const heading2 = screen.getByRole('heading', { level: 2, name: 'heading2' });
     const listItem = screen.getByRole('listitem');
+    const preview = heading1.closest('[data-ouia-component-type="PF6/Content"]');
 
-    expect(heading1).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
-    expect(heading1).toHaveClass('pf-v6-c-title', 'pf-m-h1');
-    expect(heading2).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
-    expect(heading2).toHaveClass('pf-v6-c-title', 'pf-m-h2');
-    expect(listItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
-    expect(listItem).toHaveClass('pf-v6-c-content--li');
+    expect(preview).toBeInTheDocument();
+    expect(heading1.tagName).toBe('H1');
+    expect(heading2.tagName).toBe('H2');
+    expect(preview).toContainElement(heading2);
+    expect(listItem.tagName).toBe('LI');
     expect(listItem).toHaveTextContent('list item');
     expect(screen.getByText('bold text').tagName).toBe('STRONG');
     expect(screen.getByText('italic text').tagName).toBe('EM');
@@ -139,9 +139,8 @@ describe('ExecutionEnvironmentDetails', () => {
 
     await waitFor(() => {
       const previewHeading = screen.getByRole('heading', { level: 1, name: 'New Heading' });
-      expect(previewHeading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
-      expect(previewHeading).toHaveClass('pf-v6-c-title');
-      expect(screen.getByText('new bold text')).toBeInTheDocument();
+      expect(previewHeading.tagName).toBe('H1');
+      expect(screen.getByText('new bold text').tagName).toBe('STRONG');
     });
 
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
@@ -25,6 +25,12 @@ const mockReadmeWithContent: ReadmeType = {
   text: '# Heading 1\n**bold text**',
 };
 
+const mockReadmeWithGfmTable: ReadmeType = {
+  updated_at: '2024-01-01T00:00:00Z',
+  created_at: '2024-01-01T00:00:00Z',
+  text: '| Col A | Col B |\n| ----- | ----- |\n| cell1 | cell2 |',
+};
+
 describe('ExecutionEnvironmentDetails', () => {
   let readmeMockData: ReadmeType = mockReadmeEmpty;
 
@@ -134,5 +140,16 @@ describe('ExecutionEnvironmentDetails', () => {
 
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  test('should render GFM tables in README', async () => {
+    readmeMockData = mockReadmeWithGfmTable;
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Col A')).toBeInTheDocument();
+      expect(screen.getByText('cell1')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
@@ -22,7 +22,7 @@ const mockReadmeEmpty: ReadmeType = {
 const mockReadmeWithContent: ReadmeType = {
   updated_at: '2024-01-01T00:00:00Z',
   created_at: '2024-01-01T00:00:00Z',
-  text: '# Heading 1\n**bold text**',
+  text: '# heading1\n## heading2\n**bold text**\n*italic text*\n- list item',
 };
 
 const mockReadmeWithGfmTable: ReadmeType = {
@@ -112,13 +112,19 @@ describe('ExecutionEnvironmentDetails', () => {
 
     renderWithFreshCache();
 
-    await waitFor(
-      () => {
-        expect(screen.getByText('Heading 1')).toBeInTheDocument();
-        expect(screen.getByText('bold text')).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
+    const heading1 = await screen.findByRole('heading', { level: 1, name: 'heading1' });
+    const heading2 = screen.getByRole('heading', { level: 2, name: 'heading2' });
+    const listItem = screen.getByRole('listitem');
+
+    expect(heading1).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+    expect(heading1).toHaveClass('pf-v6-c-title', 'pf-m-h1');
+    expect(heading2).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+    expect(heading2).toHaveClass('pf-v6-c-title', 'pf-m-h2');
+    expect(listItem).toHaveAttribute('data-ouia-component-type', 'PF6/Content');
+    expect(listItem).toHaveClass('pf-v6-c-content--li');
+    expect(listItem).toHaveTextContent('list item');
+    expect(screen.getByText('bold text').tagName).toBe('STRONG');
+    expect(screen.getByText('italic text').tagName).toBe('EM');
 
     const editButton = screen.getByRole('button', { name: /edit/i });
     await user.click(editButton);
@@ -129,13 +135,13 @@ describe('ExecutionEnvironmentDetails', () => {
     await user.clear(markdownTextarea);
     await user.type(markdownTextarea, '# New Heading\n**new bold text**');
 
-    const previewButton = screen.getByText('Preview');
-    await user.click(previewButton);
+    expect(screen.getByText('Preview')).toBeInTheDocument();
 
     await waitFor(() => {
-      const preview = screen.getByTestId('readme').querySelector('.preview');
-      expect(preview).toHaveTextContent('New Heading');
-      expect(preview).toHaveTextContent('new bold text');
+      const previewHeading = screen.getByRole('heading', { level: 1, name: 'New Heading' });
+      expect(previewHeading).toHaveAttribute('data-ouia-component-type', 'PF6/Title');
+      expect(previewHeading).toHaveClass('pf-v6-c-title');
+      expect(screen.getByText('new bold text')).toBeInTheDocument();
     });
 
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Execution environment README preview now renders GitHub-flavored markdown (headings, bold, and tables) instead of showing raw markdown syntax as plain text.

The Hub README editor was using `react-markdown` without `remark-gfm` and without PatternFly `Content`. Collection documentation already used that combination; this change aligns the EE README path with it.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

1. Open Hub → Execution Environments → any EE → Details.
2. Add or edit the README and paste:

```markdown
# Headings
## Heading 2
**Bold Text**

| Col A | Col B |
| ----- | ----- |
| cell  | cell  |
```

3. Save and confirm headings, bold, and the table render instead of raw `#` / `**` / `|` text.

Hub unit tests cover heading/bold rendering and GFM table output.


Made with [Cursor](https://cursor.com)