### PR TITLE
Credentials test flake

### DIFF
--- a/playwright/commands/waitForPageTableLoad.ts
+++ b/playwright/commands/waitForPageTableLoad.ts
@@ -1,0 +1,23 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Waits for a PageTable's initial data fetch to resolve by waiting for its
+ * loading skeleton rows (`PageLoadingTable`) to disappear.
+ *
+ * `PageTable` renders a skeleton-row `<tbody>` while `pageItems` is
+ * `undefined`, so `tbody`-visibility checks alone are satisfied by the
+ * loading state. If the fetch resolves to zero items, the toolbar is also
+ * swapped out entirely for a separate empty-state tree with its own actions.
+ * Waiting here avoids interacting with toolbar actions or rows while that
+ * initial swap is still in flight.
+ *
+ * @example
+ * ```typescript
+ * await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+ * await waitForPageTableLoad(page);
+ * await page.getByText('Create credential', { exact: true }).click();
+ * ```
+ */
+export async function waitForPageTableLoad(page: Page, timeout = 30000) {
+  await expect(page.locator('.pf-v6-c-skeleton')).toHaveCount(0, { timeout });
+}

--- a/playwright/tests/integration/automation-execution/infrastructure/credentials/credentials.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/credentials/credentials.spec.ts
@@ -11,653 +11,859 @@ import { Credential } from '@ansible/playwright/utils';
 test.beforeEach(setupBefore({ path: '/execution/infrastructure/credentials' }));
 test.afterEach(setupAfter);
 
-test.describe('Credentials - List View', () => {
-  test(
-    'can edit machine credential from the list row action',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
+test.describe('Credentials', () => {
+  test.describe('List View', () => {
+    test(
+      'can edit machine credential from the list row action',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
+        const row = page.getByRole('row').filter({ hasText: credentialName });
+        await row.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
+        const editedName = `${credentialName}-edited`;
+
+        await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
+        await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible({
+          timeout: 10000,
+        });
+        await filterTable({ filterLabel: 'Name', filterValue: editedName }, page);
+        await expect(page.getByRole('link', { name: editedName })).toBeVisible();
+      }
+    );
+
+    test(
+      'can delete machine credential from the list row action',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+
+    test(
+      'can delete machine credential from the list toolbar',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
+        const row = page.getByRole('row').filter({ hasText: credentialName });
+
+        await row.getByRole('checkbox').check();
+        await page.getByRole('button', { name: 'toolbar actions' }).click();
+        await page.getByRole('menuitem', { name: 'Delete credentials' }).click();
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
+
+    test(
+      'copies a credential from the list row action',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
+        await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
+
+        // Set up API interception before clicking the duplicate button
+        const copyResponsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes('/credentials/') &&
+            response.url().includes('/copy/') &&
+            response.status() === 201
+        );
+
+        // Click the duplicate credential button
+        const credentialLink = page.getByRole('link', { name: credentialName, exact: true });
+        const row = page.getByRole('row').filter({ has: credentialLink });
+        await row.getByRole('button', { name: 'Duplicate credential' }).click();
+
+        // Get the exact copied credential name from the API response
+        const copyResponse = await copyResponsePromise;
+        const copiedCredential = (await copyResponse.json()) as { name: string; id: number };
+        const copiedCredentialName = copiedCredential.name;
+
+        // Filter for the copied credential
+        await filterTable(
+          { filterLabel: 'Name', filterValue: copiedCredentialName, clearFilters: true },
+          page
+        );
+        await expect(
+          page.getByRole('link', { name: copiedCredentialName, exact: true })
+        ).toBeVisible();
+
+        // Delete the copied credential
+        const copiedLink = page.getByRole('link', {
+          name: new RegExp(`^${credentialName} @`),
+          exact: false,
+        });
+        const copiedRow = page.getByRole('row').filter({ has: copiedLink });
+        await copiedRow.getByRole('checkbox').check();
+        await page.getByRole('button', { name: 'toolbar actions' }).click();
+        await page.getByRole('menuitem', { name: 'Delete credentials' }).click();
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+
+        // Filter for the original credential
+        await filterTable(
+          { filterLabel: 'Name', filterValue: credentialName, clearFilters: true },
+          page
+        );
+
+        // Delete the original credential
+        const originalLink = page.getByRole('link', { name: credentialName, exact: true });
+        const originalRow = page.getByRole('row').filter({ has: originalLink });
+        await originalRow.getByRole('button', { name: 'kebab dropdown toggle' }).click();
+        await page.getByRole('menuitem', { name: 'Delete credential' }).click();
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
+  });
+
+  test.describe('Details View', () => {
+    test('details page should render boolean field', { tag: ['@not_mock'] }, async ({ page }) => {
       const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
 
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
-      await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
-      const row = page.getByRole('row').filter({ hasText: credentialName });
-      await row.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
-      const editedName = `${credentialName}-edited`;
-
-      await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
-      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible({
-        timeout: 10000,
-      });
-      await filterTable({ filterLabel: 'Name', filterValue: editedName }, page);
-      await expect(page.getByRole('link', { name: editedName })).toBeVisible();
-    }
-  );
-
-  test(
-    'can delete machine credential from the list row action',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
+      await expect(page.getByText('Machine')).toBeVisible();
+      await expect(page.getByText('Username').first()).toBeVisible();
+      await expect(page.getByText('Encrypted').first()).toBeVisible();
       await Credential.ui.delete(page, credentialName);
-    }
-  );
-
-  test(
-    'can delete machine credential from the list toolbar',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
-      await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
-      const row = page.getByRole('row').filter({ hasText: credentialName });
-
-      await row.getByRole('checkbox').check();
-      await page.getByRole('button', { name: 'toolbar actions' }).click();
-      await page.getByRole('menuitem', { name: 'Delete credentials' }).click();
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
-
-  test('copies a credential from the list row action', { tag: ['@not_mock'] }, async ({ page }) => {
-    const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-
-    await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-    await filterTable({ filterLabel: 'Name', filterValue: credentialName }, page);
-    await expect(page.locator('tbody')).toBeVisible({ timeout: 5000 });
-
-    // Set up API interception before clicking the duplicate button
-    const copyResponsePromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/credentials/') &&
-        response.url().includes('/copy/') &&
-        response.status() === 201
-    );
-
-    // Click the duplicate credential button
-    const credentialLink = page.getByRole('link', { name: credentialName, exact: true });
-    const row = page.getByRole('row').filter({ has: credentialLink });
-    await row.getByRole('button', { name: 'Duplicate credential' }).click();
-
-    // Get the exact copied credential name from the API response
-    const copyResponse = await copyResponsePromise;
-    const copiedCredential = (await copyResponse.json()) as { name: string; id: number };
-    const copiedCredentialName = copiedCredential.name;
-
-    // Filter for the copied credential
-    await filterTable(
-      { filterLabel: 'Name', filterValue: copiedCredentialName, clearFilters: true },
-      page
-    );
-    await expect(page.getByRole('link', { name: copiedCredentialName, exact: true })).toBeVisible();
-
-    // Delete the copied credential
-    const copiedLink = page.getByRole('link', {
-      name: new RegExp(`^${credentialName} @`),
-      exact: false,
     });
-    const copiedRow = page.getByRole('row').filter({ has: copiedLink });
-    await copiedRow.getByRole('checkbox').check();
-    await page.getByRole('button', { name: 'toolbar actions' }).click();
-    await page.getByRole('menuitem', { name: 'Delete credentials' }).click();
-    await page.locator('#confirm').click();
-    await page.getByRole('button', { name: 'Delete credential' }).click();
 
-    // Filter for the original credential
-    await filterTable(
-      { filterLabel: 'Name', filterValue: credentialName, clearFilters: true },
-      page
+    test(
+      'can edit machine credential from the details page',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
+        const editedName = `${credentialName}-edited`;
+
+        await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
+        await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(page.getByRole('heading', { name: editedName })).toBeVisible();
+        await Credential.ui.delete(page, editedName);
+      }
     );
 
-    // Delete the original credential
-    const originalLink = page.getByRole('link', { name: credentialName, exact: true });
-    const originalRow = page.getByRole('row').filter({ has: originalLink });
-    await originalRow.getByRole('button', { name: 'kebab dropdown toggle' }).click();
-    await page.getByRole('menuitem', { name: 'Delete credential' }).click();
-    await page.locator('#confirm').click();
-    await page.getByRole('button', { name: 'Delete credential' }).click();
-    await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-  });
-});
+    test(
+      'can delete a machine credential from the details page',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
 
-test.describe('Credentials - Details View', () => {
-  test('details page should render boolean field', { tag: ['@not_mock'] }, async ({ page }) => {
-    const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-
-    await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-    await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-    await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-    await expect(page.getByText('Machine')).toBeVisible();
-    await expect(page.getByText('Username').first()).toBeVisible();
-    await expect(page.getByText('Encrypted').first()).toBeVisible();
-    await Credential.ui.delete(page, credentialName);
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await clickPageAction('Delete credential', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
   });
 
-  test(
-    'can edit machine credential from the details page',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+  test.describe('Create - External test modal', () => {
+    test(
+      'can display error toast message when running a test from the create credential form',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill('foo');
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
+        await page.getByRole('option', { name: 'Machine' }).click();
+        await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
+        await page.getByRole('textbox', { name: 'Password', exact: true }).fill('testpass');
+        await expect(page.getByRole('button', { name: 'Create credential' })).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+      }
+    );
+  });
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
-      const editedName = `${credentialName}-edited`;
+  test.describe('Edit - External test modal', () => {
+    test(
+      'can display error toast message when running a test from the edit credential form',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, {
+          credentialType: 'Machine',
+        });
 
-      await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
-      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(editedName);
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(page.getByRole('heading', { name: editedName })).toBeVisible();
-      await Credential.ui.delete(page, editedName);
-    }
-  );
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+  });
 
-  test(
-    'can delete a machine credential from the details page',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+  test.describe('Credential Types', () => {
+    test(
+      'cannot edit vault id for Vault credential type',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = createE2EName('credential');
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await clickPageAction('Delete credential', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
-});
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill(credentialName);
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Vault');
+        await page.getByRole('option', { name: 'Vault', exact: true }).click();
+        await page.getByRole('textbox', { name: 'Vault identifier' }).fill('test-vault-id');
+        await page.getByRole('textbox', { name: 'Vault password' }).fill('test-password');
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await expect(page.getByText('Vault identifier')).toBeVisible();
+        await expect(page.getByText('test-vault-id')).toBeVisible();
+        await expect(page.getByText('Vault password')).toBeVisible();
+        await expect(page.getByText('Encrypted')).toBeVisible();
+        await clickPageAction('Delete credential', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
 
-test.describe('Credentials Create - External test modal', () => {
-  test(
-    'can display error toast message when running a test from the create credential form',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill('foo');
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
-      await page.getByRole('option', { name: 'Machine' }).click();
-      await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
-      await page.getByRole('textbox', { name: 'Password', exact: true }).fill('testpass');
-      await expect(page.getByRole('button', { name: 'Create credential' })).toBeVisible();
-      await page.getByRole('button', { name: 'Cancel', exact: true }).click();
-    }
-  );
-});
+    test(
+      'can create, edit and delete a credential that renders a sub form',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = createE2EName('credential');
 
-test.describe('Credentials Edit - External test modal', () => {
-  test(
-    'can display error toast message when running a test from the edit credential form',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, {
-        credentialType: 'Machine',
-      });
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill(credentialName);
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Amazon Web Services');
+        await page.getByRole('option', { name: 'Amazon Web Services' }).click();
+        await page.getByRole('textbox', { name: 'Access Key' }).fill('access-key');
+        await page.getByRole('textbox', { name: 'Secret Key' }).fill('password');
+        await page.getByRole('textbox', { name: 'STS Token' }).fill('security-token');
+        await page.getByRole('textbox', { name: 'Description' }).fill('description');
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await expect(
+          page.getByTestId('label-credential-type').getByText('Credential type')
+        ).toBeVisible();
+        await expect(page.getByText('Amazon Web Services')).toBeVisible();
+        await expect(page.getByText('Access Key')).toBeVisible();
+        await expect(page.getByText('Secret Key')).toBeVisible();
+        await expect(page.getByText('Encrypted').first()).toBeVisible();
+        await expect(page.getByTestId('label-description').getByText('Description')).toBeVisible();
+        await expect(page.getByTestId('description').getByText('description')).toBeVisible();
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
+        const modifiedCredentialName = `${credentialName} - edited`;
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
-      await page.getByRole('button', { name: 'Cancel', exact: true }).click();
-      await Credential.ui.delete(page, credentialName);
-    }
-  );
-});
+        await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
+        await page.getByRole('textbox', { name: 'Name', exact: true }).fill(modifiedCredentialName);
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(page.getByRole('heading', { name: modifiedCredentialName })).toBeVisible();
+        await expect(
+          page.getByTestId('label-credential-type').getByText('Credential type')
+        ).toBeVisible();
+        await expect(page.getByText('Amazon Web Services')).toBeVisible();
+        await expect(page.getByText('Access Key')).toBeVisible();
+        await expect(page.getByText('Secret Key')).toBeVisible();
+        await expect(page.getByText('Encrypted').first()).toBeVisible();
+        await expect(page.getByTestId('label-description').getByText('Description')).toBeVisible();
+        await expect(page.getByTestId('description').getByText('description')).toBeVisible();
+        await Credential.ui.delete(page, modifiedCredentialName);
+      }
+    );
 
-test.describe('Credentials - Credential Types Tests', () => {
-  test(
-    'cannot edit vault id for Vault credential type',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = createE2EName('credential');
+    test(
+      'create/edit a credential using prompt on launch',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = createE2EName('credential');
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill(credentialName);
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
+        await page.getByRole('option', { name: 'Machine', exact: true }).click();
+        await expect(page.getByText('Type Details')).toBeVisible();
+        await expect(page.getByText('Privilege Escalation Method')).toBeVisible();
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
+        await page.getByRole('checkbox', { name: 'Prompt on launch', exact: true }).first().check();
+        await page.getByRole('checkbox', { name: 'Prompt on launch', exact: true }).nth(1).check();
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await expect(page.getByText('Password', { exact: true })).toBeVisible();
+        await expect(page.getByText('Private Key Passphrase')).toBeVisible();
+        await expect(page.getByText('Prompt on launch').first()).toBeVisible();
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill(credentialName);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Vault');
-      await page.getByRole('option', { name: 'Vault', exact: true }).click();
-      await page.getByRole('textbox', { name: 'Vault identifier' }).fill('test-vault-id');
-      await page.getByRole('textbox', { name: 'Vault password' }).fill('test-password');
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await expect(page.getByText('Vault identifier')).toBeVisible();
-      await expect(page.getByText('test-vault-id')).toBeVisible();
-      await expect(page.getByText('Vault password')).toBeVisible();
-      await expect(page.getByText('Encrypted')).toBeVisible();
-      await clickPageAction('Delete credential', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
+    test(
+      'machine credential type should render privilege escalation',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = createE2EName('credential');
 
-  test(
-    'can create, edit and delete a credential that renders a sub form',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = createE2EName('credential');
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill(credentialName);
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
+        await page.getByRole('option', { name: 'Machine', exact: true }).click();
+        await expect(page.getByText('Type Details')).toBeVisible();
+        await expect(page.getByText('Privilege Escalation Method')).toBeVisible();
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await clickPageAction('Delete credential', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill(credentialName);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Amazon Web Services');
-      await page.getByRole('option', { name: 'Amazon Web Services' }).click();
-      await page.getByRole('textbox', { name: 'Access Key' }).fill('access-key');
-      await page.getByRole('textbox', { name: 'Secret Key' }).fill('password');
-      await page.getByRole('textbox', { name: 'STS Token' }).fill('security-token');
-      await page.getByRole('textbox', { name: 'Description' }).fill('description');
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await expect(
-        page.getByTestId('label-credential-type').getByText('Credential type')
-      ).toBeVisible();
-      await expect(page.getByText('Amazon Web Services')).toBeVisible();
-      await expect(page.getByText('Access Key')).toBeVisible();
-      await expect(page.getByText('Secret Key')).toBeVisible();
-      await expect(page.getByText('Encrypted').first()).toBeVisible();
-      await expect(page.getByTestId('label-description').getByText('Description')).toBeVisible();
-      await expect(page.getByTestId('description').getByText('description')).toBeVisible();
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
-      const modifiedCredentialName = `${credentialName} - edited`;
+    test(
+      'can create credential using custom credential type',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = createE2EName('credential');
 
-      await page.getByRole('textbox', { name: 'Name', exact: true }).clear();
-      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(modifiedCredentialName);
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(page.getByRole('heading', { name: modifiedCredentialName })).toBeVisible();
-      await expect(
-        page.getByTestId('label-credential-type').getByText('Credential type')
-      ).toBeVisible();
-      await expect(page.getByText('Amazon Web Services')).toBeVisible();
-      await expect(page.getByText('Access Key')).toBeVisible();
-      await expect(page.getByText('Secret Key')).toBeVisible();
-      await expect(page.getByText('Encrypted').first()).toBeVisible();
-      await expect(page.getByTestId('label-description').getByText('Description')).toBeVisible();
-      await expect(page.getByTestId('description').getByText('description')).toBeVisible();
-      await Credential.ui.delete(page, modifiedCredentialName);
-    }
-  );
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        await page.getByPlaceholder('Enter credential name').fill(credentialName);
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
+        await page.getByRole('option', { name: 'Machine' }).click();
+        await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
+        await page.getByRole('textbox', { name: 'Password', exact: true }).fill('testpass');
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: credentialName, exact: true })
+        ).toBeVisible();
+        await clickPageAction('Delete credential', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete credential' }).click();
+        await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
+      }
+    );
+  });
 
-  test(
-    'create/edit a credential using prompt on launch',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = createE2EName('credential');
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill(credentialName);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
-      await page.getByRole('option', { name: 'Machine', exact: true }).click();
-      await expect(page.getByText('Type Details')).toBeVisible();
-      await expect(page.getByText('Privilege Escalation Method')).toBeVisible();
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(page.getByRole('heading', { name: `Edit ${credentialName}` })).toBeVisible();
-      await page.getByRole('checkbox', { name: 'Prompt on launch', exact: true }).first().check();
-      await page.getByRole('checkbox', { name: 'Prompt on launch', exact: true }).nth(1).check();
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await expect(page.getByText('Password', { exact: true })).toBeVisible();
-      await expect(page.getByText('Private Key Passphrase')).toBeVisible();
-      await expect(page.getByText('Prompt on launch').first()).toBeVisible();
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
+  test.describe('Job Templates Tab', () => {
+    test(
+      'can create a job template within the context of credential job template tab',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
 
-  test(
-    'machine credential type should render privilege escalation',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = createE2EName('credential');
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('tab', { name: 'Job Templates' }).click();
+        await expect(page.getByRole('tab', { name: 'Job Templates' })).toBeVisible();
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+  });
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill(credentialName);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
-      await page.getByRole('option', { name: 'Machine', exact: true }).click();
-      await expect(page.getByText('Type Details')).toBeVisible();
-      await expect(page.getByText('Privilege Escalation Method')).toBeVisible();
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await clickPageAction('Delete credential', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
+  test.describe('External Credential Plugins (AAP-44813)', () => {
+    test(
+      'should not re-POST existing credential input sources when editing a credential',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(180000);
 
-  test(
-    'can create credential using custom credential type',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = createE2EName('credential');
+        // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        const externalCredentialName = createE2EName('external-cred');
+        await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
+        await page.getByPlaceholder('Enter credential name').fill(externalCredentialName);
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      await page.getByPlaceholder('Enter credential name').fill(credentialName);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
-      await page.getByRole('option', { name: 'Machine' }).click();
-      await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
-      await page.getByRole('textbox', { name: 'Password', exact: true }).fill('testpass');
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(page.getByRole('heading', { name: credentialName, exact: true })).toBeVisible();
-      await clickPageAction('Delete credential', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete credential' }).click();
-      await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
-    }
-  );
-});
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await expect(page.getByRole('textbox', { name: 'Search input' })).toBeVisible();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('HashiCorp Vault Secret');
+        await page
+          .getByRole('option', { name: 'HashiCorp Vault Secret Lookup', exact: true })
+          .click();
 
-test.describe('Credentials - Job Templates Tab', () => {
-  test(
-    'can create a job template within the context of credential job template tab',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+        await expect(page.getByRole('textbox', { name: 'Server URL' })).toBeVisible();
+        await page
+          .getByRole('textbox', { name: 'Server URL' })
+          .fill('https://vault.example.com:8200');
+        await page.getByRole('textbox', { name: 'Token' }).fill('test-token');
 
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('tab', { name: 'Job Templates' }).click();
-      await expect(page.getByRole('tab', { name: 'Job Templates' })).toBeVisible();
-      await Credential.ui.delete(page, credentialName);
-    }
-  );
-});
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: externalCredentialName, exact: true })
+        ).toBeVisible();
 
-test.describe('Credentials - External Credential Plugins (AAP-44813)', () => {
-  test(
-    'should not re-POST existing credential input sources when editing a credential',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
+        // Step 2: Create a Machine credential and link its password to the external credential
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        const machineCredentialName = createE2EName('machine-cred-linked');
+        await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
+        await page.getByPlaceholder('Enter credential name').fill(machineCredentialName);
+
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
+        await page.getByRole('option', { name: 'Machine', exact: true }).click();
+
+        await expect(page.getByText('Type Details')).toBeVisible();
+        await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
+
+        // Click the secret management button for password field
+        const passwordFormGroup = page.locator('#password-form-group');
+        await passwordFormGroup.getByTestId('secret-management-input').click();
+
+        // The Secret Management System modal should appear
+        await expect(page.getByRole('heading', { name: 'Secret Management System' })).toBeVisible();
+
+        // Select the external credential from the dropdown
+        await page.getByRole('button', { name: 'Credential' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill(externalCredentialName);
+        await page.getByRole('option', { name: externalCredentialName }).click();
+
+        // Fill in the metadata fields required by HashiCorp Vault Secret Lookup
+        await expect(page.getByRole('textbox', { name: 'Path to Secret' })).toBeVisible();
+        await page.getByRole('textbox', { name: 'Path to Secret' }).fill('secret/data/test');
+        await page.getByRole('textbox', { name: 'Key Name' }).fill('password');
+
+        // Click Finish to complete the external credential link
+        await page.getByRole('button', { name: 'Finish' }).click();
+        await expect(
+          page.getByRole('heading', { name: 'Secret Management System' })
+        ).not.toBeVisible();
+
+        // Create the credential
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: machineCredentialName, exact: true })
+        ).toBeVisible();
+
+        // Verify the credential was created - the Password field should show the external credential link
+        // The link displays as a label with the credential type and name (e.g., "Hashivault: credname")
+        await expect(page.getByText('Password').first()).toBeVisible();
+        await expect(page.getByText(externalCredentialName).first()).toBeVisible();
+
+        // Step 3: Edit the credential and verify no duplicate input sources are created
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: `Edit ${machineCredentialName}` })
+        ).toBeVisible();
+
+        // Set up network request interception to track POST requests to credential_input_sources
+        const inputSourcePostRequests: string[] = [];
+        page.on('request', (request) => {
+          if (request.method() === 'POST' && request.url().includes('/credential_input_sources/')) {
+            inputSourcePostRequests.push(request.url());
+          }
+        });
+
+        // Make a simple change (just update the description)
+        await page.getByRole('textbox', { name: 'Description' }).fill('Updated description');
+
+        // Save the credential
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: machineCredentialName, exact: true })
+        ).toBeVisible();
+
+        // Verify no POST requests were made to credential_input_sources
+        // (the fix ensures existing input sources are not re-POSTed)
+        expect(inputSourcePostRequests.length).toBe(0);
+
+        // Verify the credential still shows the external credential link
+        await expect(page.getByText('Password').first()).toBeVisible();
+        await expect(page.getByText(externalCredentialName).first()).toBeVisible();
+
+        // Cleanup: Delete both credentials
+        await Credential.ui.delete(page, machineCredentialName);
+        await Credential.ui.delete(page, externalCredentialName);
+      }
+    );
+
+    test(
+      'should POST new credential input sources when adding a new link during edit',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(180000);
+
+        // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create credential', { exact: true }).click();
+        const externalCredentialName = createE2EName('external-cred');
+        await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
+        await page.getByPlaceholder('Enter credential name').fill(externalCredentialName);
+
+        await page.getByRole('button', { name: 'Credential type' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('HashiCorp Vault Secret');
+        await page
+          .getByRole('option', { name: 'HashiCorp Vault Secret Lookup', exact: true })
+          .click();
+
+        await expect(page.getByRole('textbox', { name: 'Server URL' })).toBeVisible();
+        await page
+          .getByRole('textbox', { name: 'Server URL' })
+          .fill('https://vault.example.com:8200');
+        await page.getByRole('textbox', { name: 'Token' }).fill('test-token');
+
+        await page.getByRole('button', { name: 'Create credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: externalCredentialName, exact: true })
+        ).toBeVisible();
+
+        // Step 2: Create a simple Machine credential WITHOUT any external links
+        const machineCredentialName = await Credential.ui.create(page, {
+          credentialType: 'Machine',
+        });
+
+        // Step 3: Edit the credential and add an external credential link
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: machineCredentialName }, page);
+        await page.getByRole('button', { name: 'Edit credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: `Edit ${machineCredentialName}` })
+        ).toBeVisible();
+
+        // Set up network request interception to track POST requests to credential_input_sources
+        let inputSourcePostCount = 0;
+        page.on('request', (request) => {
+          if (request.method() === 'POST' && request.url().includes('/credential_input_sources/')) {
+            inputSourcePostCount++;
+          }
+        });
+
+        // The password field has an encrypted value, so click Replace button first to enable editing
+        const passwordFormGroup = page.locator('#password-form-group');
+        await passwordFormGroup
+          .getByRole('button', { name: 'Replace field with new value' })
+          .click();
+
+        // Now click the secret management button for password field
+        await passwordFormGroup.getByTestId('secret-management-input').click();
+
+        await expect(page.getByRole('heading', { name: 'Secret Management System' })).toBeVisible();
+
+        // Select the external credential from the dropdown
+        await page.getByRole('button', { name: 'Credential' }).click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill(externalCredentialName);
+        await page.getByRole('option', { name: externalCredentialName }).click();
+
+        // Fill in the metadata fields
+        await expect(page.getByRole('textbox', { name: 'Path to Secret' })).toBeVisible();
+        await page.getByRole('textbox', { name: 'Path to Secret' }).fill('secret/data/test');
+        await page.getByRole('textbox', { name: 'Key Name' }).fill('password');
+
+        await page.getByRole('button', { name: 'Finish' }).click();
+        await expect(
+          page.getByRole('heading', { name: 'Secret Management System' })
+        ).not.toBeVisible();
+
+        // Save the credential
+        await page.getByRole('button', { name: 'Save credential' }).click();
+        await expect(
+          page.getByRole('heading', { name: machineCredentialName, exact: true })
+        ).toBeVisible();
+
+        // Verify exactly 1 POST request was made for the new input source
+        expect(inputSourcePostCount).toBe(1);
+
+        // Verify the credential shows the external credential link
+        await expect(page.getByText('Password').first()).toBeVisible();
+        await expect(page.getByText(externalCredentialName).first()).toBeVisible();
+
+        // Cleanup: Delete both credentials
+        await Credential.ui.delete(page, machineCredentialName);
+        await Credential.ui.delete(page, externalCredentialName);
+      }
+    );
+  });
+
+  test.describe('Team and User Access', () => {
+    test(
+      'can assign a team to credential and apply roles',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(120000);
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+        const teamName = createE2EName('team');
+
+        await navigateTo(page, 'Access Management', 'Teams');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create team', { exact: true }).click();
+        await page.getByPlaceholder('Enter team name').fill(teamName);
+        await page.getByLabel('Organization').click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Default');
+        await page.getByRole('option', { name: 'Default' }).click();
+        await page.getByRole('button', { name: 'Create team' }).click();
+        await expect(page.getByRole('heading', { name: teamName, exact: true })).toBeVisible();
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('tab', { name: 'Team Access' }).click();
+        await expect(page.getByText('No teams are assigned to this credential.')).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByRole('link', { name: 'Assign teams' }).click();
+        await expect(page.getByRole('heading', { name: 'Assign teams' })).toBeVisible();
+        await filterTable({ filterLabel: 'Name', filterValue: teamName }, page);
+        await page
+          .getByRole('row', { name: new RegExp(teamName) })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page
+          .getByRole('row', { name: /Credential Admin/ })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page.getByRole('button', { name: 'Finish', exact: true }).click();
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
+        await navigateTo(page, 'Access Management', 'Teams');
+        await clickTableRow({ filterLabel: 'Name', text: teamName }, page);
+        await clickPageAction('Delete team', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete team' }).click();
+        await expect(page.getByTestId('page-title')).toHaveText('Teams');
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+
+    test(
+      'can assign a user to credential and apply roles',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(120000);
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+        const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
+
+        await navigateTo(page, 'Access', 'Users');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create user', { exact: true }).click();
+        await page.getByRole('textbox', { name: 'Username' }).fill(userName);
+        await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
+        await page
+          .getByRole('textbox', { name: 'Confirm password', exact: true })
+          .fill('TestPassword123!');
+        await page.getByRole('button', { name: 'Create user' }).click();
+        await expect(page.getByRole('heading', { name: userName, exact: true })).toBeVisible();
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('tab', { name: 'User Access' }).click();
+        await page.getByRole('link', { name: 'Assign users' }).click();
+        await expect(page.getByRole('heading', { name: 'Assign users' })).toBeVisible();
+        await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
+        await page
+          .getByRole('row', { name: new RegExp(userName) })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page
+          .getByRole('row', { name: /Credential Admin/ })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page.getByRole('button', { name: 'Finish' }).click();
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
+        await navigateTo(page, 'Access', 'Users');
+        await clickTableRow({ filterLabel: 'Username', text: userName }, page);
+        await clickPageAction('Delete user', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete user' }).click();
+        await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+
+    test(
+      'can remove team role from credential Team Access tab',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(120000);
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+        const teamName = createE2EName('team');
+
+        await navigateTo(page, 'Access Management', 'Teams');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create team', { exact: true }).click();
+        await page.getByPlaceholder('Enter team name').fill(teamName);
+        await page.getByLabel('Organization').click();
+        await page.getByRole('textbox', { name: 'Search input' }).fill('Default');
+        await page.getByRole('option', { name: 'Default' }).click();
+        await page.getByRole('button', { name: 'Create team' }).click();
+        await expect(page.getByRole('heading', { name: teamName, exact: true })).toBeVisible();
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('tab', { name: 'Team Access' }).click();
+        await expect(page.getByText('No teams are assigned to this credential.')).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByRole('link', { name: 'Assign teams' }).click();
+        await expect(page.getByRole('heading', { name: 'Assign teams' })).toBeVisible();
+        await filterTable({ filterLabel: 'Name', filterValue: teamName }, page);
+        await page
+          .getByRole('row', { name: new RegExp(teamName) })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page
+          .getByRole('row', { name: /Credential Admin/ })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page.getByRole('button', { name: 'Finish', exact: true }).click();
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
+
+        await expect(page.getByRole('link', { name: teamName })).toBeVisible({ timeout: 10000 });
+        await filterTable({ filterLabel: 'Team name', filterValue: teamName }, page);
+        const teamRow = page.getByRole('row').filter({ hasText: teamName });
+        await teamRow.getByRole('checkbox').check();
+        await page.getByRole('button', { name: 'Remove role' }).click();
+        await expect(page.getByRole('heading', { name: 'Remove role' })).toBeVisible();
+        await page.getByRole('checkbox', { name: 'Yes, I confirm that I want to' }).check();
+        await page.getByRole('button', { name: 'Remove role' }).click();
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible({
+          timeout: 10000,
+        });
+        await navigateTo(page, 'Access Management', 'Teams');
+        await clickTableRow({ filterLabel: 'Name', text: teamName }, page);
+        await clickPageAction('Delete team', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete team' }).click();
+        await expect(page.getByTestId('page-title')).toHaveText('Teams');
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+
+    test(
+      'can remove user role from credential User Access tab',
+      { tag: ['@not_mock'] },
+      async ({ page }) => {
+        test.setTimeout(180000);
+        const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
+        const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
+
+        await navigateTo(page, 'Access', 'Users');
+        await waitForPageTableLoad(page);
+        await page.getByText('Create user', { exact: true }).click();
+        await page.getByRole('textbox', { name: 'Username' }).fill(userName);
+        await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
+        await page
+          .getByRole('textbox', { name: 'Confirm password', exact: true })
+          .fill('TestPassword123!');
+        await page.getByRole('button', { name: 'Create user' }).click();
+        await expect(page.getByRole('heading', { name: userName, exact: true })).toBeVisible();
+
+        await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+        await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
+        await page.getByRole('tab', { name: 'User Access' }).click();
+        await page.getByRole('link', { name: 'Assign users' }).click();
+        await expect(page.getByRole('heading', { name: 'Assign users' })).toBeVisible();
+        await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
+        await page
+          .getByRole('row', { name: new RegExp(userName) })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page
+          .getByRole('row', { name: /Credential Admin/ })
+          .getByRole('checkbox')
+          .check();
+        await page.getByRole('button', { name: 'Next', exact: true }).click();
+        await page.getByRole('button', { name: 'Finish' }).click();
+        await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
+
+        // Wait for user to appear in the list
+        await expect(page.getByRole('link', { name: userName })).toBeVisible({ timeout: 10000 });
+
+        // Filter for the user
+        await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
+
+        // Click the "Manage roles" button
+        const userRow = page.getByRole('row').filter({ hasText: userName });
+        await userRow.getByRole('button', { name: 'Manage roles' }).click();
+
+        // Verify we're on the manage roles page
+        await expect(
+          page.getByRole('heading', {
+            name: new RegExp(`Manage roles directly assigned to ${userName}`),
+          })
+        ).toBeVisible();
+
+        // Uncheck the Credential Admin role
+        const credentialAdminRow = page.getByRole('row', { name: /Credential Admin/ });
+        await credentialAdminRow.getByRole('checkbox').uncheck();
+
+        // Save the changes
+        await page.getByRole('button', { name: 'Save roles' }).click();
+
+        // Verify we're back on the User Access tab
+        await expect(page.getByRole('tab', { name: 'User Access' })).toBeVisible();
+
+        // Verify the role has been removed (user should no longer appear or have no roles)
+        await page.waitForTimeout(1000);
+
+        await navigateTo(page, 'Access', 'Users');
+        await clickTableRow({ filterLabel: 'Username', text: userName }, page);
+        await clickPageAction('Delete user', page);
+        await page.locator('#confirm').click();
+        await page.getByRole('button', { name: 'Delete user' }).click();
+        await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+        await Credential.ui.delete(page, credentialName);
+      }
+    );
+
+    test('can manage user roles from User Access tab', { tag: ['@not_mock'] }, async ({ page }) => {
       test.setTimeout(180000);
-
-      // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      const externalCredentialName = createE2EName('external-cred');
-      await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
-      await page.getByPlaceholder('Enter credential name').fill(externalCredentialName);
-
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await expect(page.getByRole('textbox', { name: 'Search input' })).toBeVisible();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('HashiCorp Vault Secret');
-      await page
-        .getByRole('option', { name: 'HashiCorp Vault Secret Lookup', exact: true })
-        .click();
-
-      await expect(page.getByRole('textbox', { name: 'Server URL' })).toBeVisible();
-      await page
-        .getByRole('textbox', { name: 'Server URL' })
-        .fill('https://vault.example.com:8200');
-      await page.getByRole('textbox', { name: 'Token' }).fill('test-token');
-
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: externalCredentialName, exact: true })
-      ).toBeVisible();
-
-      // Step 2: Create a Machine credential and link its password to the external credential
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      const machineCredentialName = createE2EName('machine-cred-linked');
-      await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
-      await page.getByPlaceholder('Enter credential name').fill(machineCredentialName);
-
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Machine');
-      await page.getByRole('option', { name: 'Machine', exact: true }).click();
-
-      await expect(page.getByText('Type Details')).toBeVisible();
-      await page.getByRole('textbox', { name: 'Username', exact: true }).fill('testuser');
-
-      // Click the secret management button for password field
-      const passwordFormGroup = page.locator('#password-form-group');
-      await passwordFormGroup.getByTestId('secret-management-input').click();
-
-      // The Secret Management System modal should appear
-      await expect(page.getByRole('heading', { name: 'Secret Management System' })).toBeVisible();
-
-      // Select the external credential from the dropdown
-      await page.getByRole('button', { name: 'Credential' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill(externalCredentialName);
-      await page.getByRole('option', { name: externalCredentialName }).click();
-
-      // Fill in the metadata fields required by HashiCorp Vault Secret Lookup
-      await expect(page.getByRole('textbox', { name: 'Path to Secret' })).toBeVisible();
-      await page.getByRole('textbox', { name: 'Path to Secret' }).fill('secret/data/test');
-      await page.getByRole('textbox', { name: 'Key Name' }).fill('password');
-
-      // Click Finish to complete the external credential link
-      await page.getByRole('button', { name: 'Finish' }).click();
-      await expect(
-        page.getByRole('heading', { name: 'Secret Management System' })
-      ).not.toBeVisible();
-
-      // Create the credential
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: machineCredentialName, exact: true })
-      ).toBeVisible();
-
-      // Verify the credential was created - the Password field should show the external credential link
-      // The link displays as a label with the credential type and name (e.g., "Hashivault: credname")
-      await expect(page.getByText('Password').first()).toBeVisible();
-      await expect(page.getByText(externalCredentialName).first()).toBeVisible();
-
-      // Step 3: Edit the credential and verify no duplicate input sources are created
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: `Edit ${machineCredentialName}` })
-      ).toBeVisible();
-
-      // Set up network request interception to track POST requests to credential_input_sources
-      const inputSourcePostRequests: string[] = [];
-      page.on('request', (request) => {
-        if (request.method() === 'POST' && request.url().includes('/credential_input_sources/')) {
-          inputSourcePostRequests.push(request.url());
-        }
-      });
-
-      // Make a simple change (just update the description)
-      await page.getByRole('textbox', { name: 'Description' }).fill('Updated description');
-
-      // Save the credential
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: machineCredentialName, exact: true })
-      ).toBeVisible();
-
-      // Verify no POST requests were made to credential_input_sources
-      // (the fix ensures existing input sources are not re-POSTed)
-      expect(inputSourcePostRequests.length).toBe(0);
-
-      // Verify the credential still shows the external credential link
-      await expect(page.getByText('Password').first()).toBeVisible();
-      await expect(page.getByText(externalCredentialName).first()).toBeVisible();
-
-      // Cleanup: Delete both credentials
-      await Credential.ui.delete(page, machineCredentialName);
-      await Credential.ui.delete(page, externalCredentialName);
-    }
-  );
-
-  test(
-    'should POST new credential input sources when adding a new link during edit',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      test.setTimeout(180000);
-
-      // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create credential', { exact: true }).click();
-      const externalCredentialName = createE2EName('external-cred');
-      await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
-      await page.getByPlaceholder('Enter credential name').fill(externalCredentialName);
-
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('HashiCorp Vault Secret');
-      await page
-        .getByRole('option', { name: 'HashiCorp Vault Secret Lookup', exact: true })
-        .click();
-
-      await expect(page.getByRole('textbox', { name: 'Server URL' })).toBeVisible();
-      await page
-        .getByRole('textbox', { name: 'Server URL' })
-        .fill('https://vault.example.com:8200');
-      await page.getByRole('textbox', { name: 'Token' }).fill('test-token');
-
-      await page.getByRole('button', { name: 'Create credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: externalCredentialName, exact: true })
-      ).toBeVisible();
-
-      // Step 2: Create a simple Machine credential WITHOUT any external links
-      const machineCredentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-
-      // Step 3: Edit the credential and add an external credential link
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: machineCredentialName }, page);
-      await page.getByRole('button', { name: 'Edit credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: `Edit ${machineCredentialName}` })
-      ).toBeVisible();
-
-      // Set up network request interception to track POST requests to credential_input_sources
-      let inputSourcePostCount = 0;
-      page.on('request', (request) => {
-        if (request.method() === 'POST' && request.url().includes('/credential_input_sources/')) {
-          inputSourcePostCount++;
-        }
-      });
-
-      // The password field has an encrypted value, so click Replace button first to enable editing
-      const passwordFormGroup = page.locator('#password-form-group');
-      await passwordFormGroup.getByRole('button', { name: 'Replace field with new value' }).click();
-
-      // Now click the secret management button for password field
-      await passwordFormGroup.getByTestId('secret-management-input').click();
-
-      await expect(page.getByRole('heading', { name: 'Secret Management System' })).toBeVisible();
-
-      // Select the external credential from the dropdown
-      await page.getByRole('button', { name: 'Credential' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill(externalCredentialName);
-      await page.getByRole('option', { name: externalCredentialName }).click();
-
-      // Fill in the metadata fields
-      await expect(page.getByRole('textbox', { name: 'Path to Secret' })).toBeVisible();
-      await page.getByRole('textbox', { name: 'Path to Secret' }).fill('secret/data/test');
-      await page.getByRole('textbox', { name: 'Key Name' }).fill('password');
-
-      await page.getByRole('button', { name: 'Finish' }).click();
-      await expect(
-        page.getByRole('heading', { name: 'Secret Management System' })
-      ).not.toBeVisible();
-
-      // Save the credential
-      await page.getByRole('button', { name: 'Save credential' }).click();
-      await expect(
-        page.getByRole('heading', { name: machineCredentialName, exact: true })
-      ).toBeVisible();
-
-      // Verify exactly 1 POST request was made for the new input source
-      expect(inputSourcePostCount).toBe(1);
-
-      // Verify the credential shows the external credential link
-      await expect(page.getByText('Password').first()).toBeVisible();
-      await expect(page.getByText(externalCredentialName).first()).toBeVisible();
-
-      // Cleanup: Delete both credentials
-      await Credential.ui.delete(page, machineCredentialName);
-      await Credential.ui.delete(page, externalCredentialName);
-    }
-  );
-});
-
-test.describe('Credentials - Team and User Access', () => {
-  test(
-    'can assign a team to credential and apply roles',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      test.setTimeout(120000);
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-      const teamName = createE2EName('team');
-
-      await navigateTo(page, 'Access Management', 'Teams');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create team', { exact: true }).click();
-      await page.getByPlaceholder('Enter team name').fill(teamName);
-      await page.getByLabel('Organization').click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Default');
-      await page.getByRole('option', { name: 'Default' }).click();
-      await page.getByRole('button', { name: 'Create team' }).click();
-      await expect(page.getByRole('heading', { name: teamName, exact: true })).toBeVisible();
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('tab', { name: 'Team Access' }).click();
-      await expect(page.getByText('No teams are assigned to this credential.')).toBeVisible({
-        timeout: 10000,
-      });
-      await page.getByRole('link', { name: 'Assign teams' }).click();
-      await expect(page.getByRole('heading', { name: 'Assign teams' })).toBeVisible();
-      await filterTable({ filterLabel: 'Name', filterValue: teamName }, page);
-      await page
-        .getByRole('row', { name: new RegExp(teamName) })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page
-        .getByRole('row', { name: /Credential Admin/ })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page.getByRole('button', { name: 'Finish', exact: true }).click();
-      await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
-      await navigateTo(page, 'Access Management', 'Teams');
-      await clickTableRow({ filterLabel: 'Name', text: teamName }, page);
-      await clickPageAction('Delete team', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete team' }).click();
-      await expect(page.getByTestId('page-title')).toHaveText('Teams');
-      await Credential.ui.delete(page, credentialName);
-    }
-  );
-
-  test(
-    'can assign a user to credential and apply roles',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      test.setTimeout(120000);
       const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
       const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
 
@@ -671,6 +877,7 @@ test.describe('Credentials - Team and User Access', () => {
         .fill('TestPassword123!');
       await page.getByRole('button', { name: 'Create user' }).click();
       await expect(page.getByRole('heading', { name: userName, exact: true })).toBeVisible();
+
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
       await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
       await page.getByRole('tab', { name: 'User Access' }).click();
@@ -689,143 +896,29 @@ test.describe('Credentials - Team and User Access', () => {
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await page.getByRole('button', { name: 'Finish' }).click();
       await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
-      await navigateTo(page, 'Access', 'Users');
-      await clickTableRow({ filterLabel: 'Username', text: userName }, page);
-      await clickPageAction('Delete user', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete user' }).click();
-      await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
-      await Credential.ui.delete(page, credentialName);
-    }
-  );
 
-  test(
-    'can remove team role from credential Team Access tab',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      test.setTimeout(120000);
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-      const teamName = createE2EName('team');
-
-      await navigateTo(page, 'Access Management', 'Teams');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create team', { exact: true }).click();
-      await page.getByPlaceholder('Enter team name').fill(teamName);
-      await page.getByLabel('Organization').click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Default');
-      await page.getByRole('option', { name: 'Default' }).click();
-      await page.getByRole('button', { name: 'Create team' }).click();
-      await expect(page.getByRole('heading', { name: teamName, exact: true })).toBeVisible();
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('tab', { name: 'Team Access' }).click();
-      await expect(page.getByText('No teams are assigned to this credential.')).toBeVisible({
-        timeout: 10000,
-      });
-      await page.getByRole('link', { name: 'Assign teams' }).click();
-      await expect(page.getByRole('heading', { name: 'Assign teams' })).toBeVisible();
-      await filterTable({ filterLabel: 'Name', filterValue: teamName }, page);
-      await page
-        .getByRole('row', { name: new RegExp(teamName) })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page
-        .getByRole('row', { name: /Credential Admin/ })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page.getByRole('button', { name: 'Finish', exact: true }).click();
-      await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
-
-      await expect(page.getByRole('link', { name: teamName })).toBeVisible({ timeout: 10000 });
-      await filterTable({ filterLabel: 'Team name', filterValue: teamName }, page);
-      const teamRow = page.getByRole('row').filter({ hasText: teamName });
-      await teamRow.getByRole('checkbox').check();
-      await page.getByRole('button', { name: 'Remove role' }).click();
-      await expect(page.getByRole('heading', { name: 'Remove role' })).toBeVisible();
-      await page.getByRole('checkbox', { name: 'Yes, I confirm that I want to' }).check();
-      await page.getByRole('button', { name: 'Remove role' }).click();
-      await expect(page.getByText('Success', { exact: true }).first()).toBeVisible({
-        timeout: 10000,
-      });
-      await navigateTo(page, 'Access Management', 'Teams');
-      await clickTableRow({ filterLabel: 'Name', text: teamName }, page);
-      await clickPageAction('Delete team', page);
-      await page.locator('#confirm').click();
-      await page.getByRole('button', { name: 'Delete team' }).click();
-      await expect(page.getByTestId('page-title')).toHaveText('Teams');
-      await Credential.ui.delete(page, credentialName);
-    }
-  );
-
-  test(
-    'can remove user role from credential User Access tab',
-    { tag: ['@not_mock'] },
-    async ({ page }) => {
-      test.setTimeout(180000);
-      const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-      const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
-
-      await navigateTo(page, 'Access', 'Users');
-      await waitForPageTableLoad(page);
-      await page.getByText('Create user', { exact: true }).click();
-      await page.getByRole('textbox', { name: 'Username' }).fill(userName);
-      await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
-      await page
-        .getByRole('textbox', { name: 'Confirm password', exact: true })
-        .fill('TestPassword123!');
-      await page.getByRole('button', { name: 'Create user' }).click();
-      await expect(page.getByRole('heading', { name: userName, exact: true })).toBeVisible();
-
-      await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-      await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-      await page.getByRole('tab', { name: 'User Access' }).click();
-      await page.getByRole('link', { name: 'Assign users' }).click();
-      await expect(page.getByRole('heading', { name: 'Assign users' })).toBeVisible();
-      await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
-      await page
-        .getByRole('row', { name: new RegExp(userName) })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page
-        .getByRole('row', { name: /Credential Admin/ })
-        .getByRole('checkbox')
-        .check();
-      await page.getByRole('button', { name: 'Next', exact: true }).click();
-      await page.getByRole('button', { name: 'Finish' }).click();
-      await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
-
-      // Wait for user to appear in the list
       await expect(page.getByRole('link', { name: userName })).toBeVisible({ timeout: 10000 });
-
-      // Filter for the user
       await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
 
-      // Click the "Manage roles" button
+      // Find the user row and click the Manage roles button (pencil icon)
       const userRow = page.getByRole('row').filter({ hasText: userName });
-      await userRow.getByRole('button', { name: 'Manage roles' }).click();
 
-      // Verify we're on the manage roles page
+      // Click the Manage roles button (pencil icon) - it's an ARIA button with label
+      await userRow.getByLabel('Manage roles').click();
+
+      // Verify we're on the manage roles page with the longer heading format
       await expect(
         page.getByRole('heading', {
           name: new RegExp(`Manage roles directly assigned to ${userName}`),
         })
       ).toBeVisible();
 
-      // Uncheck the Credential Admin role
-      const credentialAdminRow = page.getByRole('row', { name: /Credential Admin/ });
-      await credentialAdminRow.getByRole('checkbox').uncheck();
+      // Verify the role is displayed in the table
+      await expect(page.getByRole('row', { name: /Credential Admin/ })).toBeVisible();
+      await expect(page.getByText('Has all permissions to a single credential')).toBeVisible();
 
-      // Save the changes
-      await page.getByRole('button', { name: 'Save roles' }).click();
-
-      // Verify we're back on the User Access tab
-      await expect(page.getByRole('tab', { name: 'User Access' })).toBeVisible();
-
-      // Verify the role has been removed (user should no longer appear or have no roles)
-      await page.waitForTimeout(1000);
+      // Click Cancel to go back
+      await page.getByRole('button', { name: 'Cancel' }).click();
 
       await navigateTo(page, 'Access', 'Users');
       await clickTableRow({ filterLabel: 'Username', text: userName }, page);
@@ -834,73 +927,6 @@ test.describe('Credentials - Team and User Access', () => {
       await page.getByRole('button', { name: 'Delete user' }).click();
       await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
       await Credential.ui.delete(page, credentialName);
-    }
-  );
-
-  test('can manage user roles from User Access tab', { tag: ['@not_mock'] }, async ({ page }) => {
-    test.setTimeout(180000);
-    const credentialName = await Credential.ui.create(page, { credentialType: 'Machine' });
-    const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
-
-    await navigateTo(page, 'Access', 'Users');
-    await waitForPageTableLoad(page);
-    await page.getByText('Create user', { exact: true }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill(userName);
-    await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
-    await page
-      .getByRole('textbox', { name: 'Confirm password', exact: true })
-      .fill('TestPassword123!');
-    await page.getByRole('button', { name: 'Create user' }).click();
-    await expect(page.getByRole('heading', { name: userName, exact: true })).toBeVisible();
-
-    await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
-    await clickTableRow({ filterLabel: 'Name', text: credentialName }, page);
-    await page.getByRole('tab', { name: 'User Access' }).click();
-    await page.getByRole('link', { name: 'Assign users' }).click();
-    await expect(page.getByRole('heading', { name: 'Assign users' })).toBeVisible();
-    await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
-    await page
-      .getByRole('row', { name: new RegExp(userName) })
-      .getByRole('checkbox')
-      .check();
-    await page.getByRole('button', { name: 'Next', exact: true }).click();
-    await page
-      .getByRole('row', { name: /Credential Admin/ })
-      .getByRole('checkbox')
-      .check();
-    await page.getByRole('button', { name: 'Next', exact: true }).click();
-    await page.getByRole('button', { name: 'Finish' }).click();
-    await expect(page.getByText('Success', { exact: true }).first()).toBeVisible();
-
-    await expect(page.getByRole('link', { name: userName })).toBeVisible({ timeout: 10000 });
-    await filterTable({ filterLabel: 'Username', filterValue: userName }, page);
-
-    // Find the user row and click the Manage roles button (pencil icon)
-    const userRow = page.getByRole('row').filter({ hasText: userName });
-
-    // Click the Manage roles button (pencil icon) - it's an ARIA button with label
-    await userRow.getByLabel('Manage roles').click();
-
-    // Verify we're on the manage roles page with the longer heading format
-    await expect(
-      page.getByRole('heading', {
-        name: new RegExp(`Manage roles directly assigned to ${userName}`),
-      })
-    ).toBeVisible();
-
-    // Verify the role is displayed in the table
-    await expect(page.getByRole('row', { name: /Credential Admin/ })).toBeVisible();
-    await expect(page.getByText('Has all permissions to a single credential')).toBeVisible();
-
-    // Click Cancel to go back
-    await page.getByRole('button', { name: 'Cancel' }).click();
-
-    await navigateTo(page, 'Access', 'Users');
-    await clickTableRow({ filterLabel: 'Username', text: userName }, page);
-    await clickPageAction('Delete user', page);
-    await page.locator('#confirm').click();
-    await page.getByRole('button', { name: 'Delete user' }).click();
-    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
-    await Credential.ui.delete(page, credentialName);
+    });
   });
 });

--- a/playwright/tests/integration/automation-execution/infrastructure/credentials/credentials.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/credentials/credentials.spec.ts
@@ -5,6 +5,7 @@ import { createE2EName } from '../../../../../commands/createE2EName';
 import { filterTable } from '../../../../../commands/filterTable';
 import { navigateTo } from '../../../../../commands/navigateTo';
 import { setupAfter, setupBefore } from '../../../../../commands/setup';
+import { waitForPageTableLoad } from '../../../../../commands/waitForPageTableLoad';
 import { Credential } from '@ansible/playwright/utils';
 
 test.beforeEach(setupBefore({ path: '/execution/infrastructure/credentials' }));
@@ -183,6 +184,7 @@ test.describe('Credentials Create - External test modal', () => {
     { tag: ['@not_mock'] },
     async ({ page }) => {
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill('foo');
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -223,6 +225,7 @@ test.describe('Credentials - Credential Types Tests', () => {
       const credentialName = createE2EName('credential');
 
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill(credentialName);
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -250,6 +253,7 @@ test.describe('Credentials - Credential Types Tests', () => {
       const credentialName = createE2EName('credential');
 
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill(credentialName);
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -297,6 +301,7 @@ test.describe('Credentials - Credential Types Tests', () => {
     async ({ page }) => {
       const credentialName = createE2EName('credential');
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill(credentialName);
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -327,6 +332,7 @@ test.describe('Credentials - Credential Types Tests', () => {
       const credentialName = createE2EName('credential');
 
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill(credentialName);
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -351,6 +357,7 @@ test.describe('Credentials - Credential Types Tests', () => {
       const credentialName = createE2EName('credential');
 
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       await page.getByPlaceholder('Enter credential name').fill(credentialName);
       await page.getByRole('button', { name: 'Credential type' }).click();
@@ -393,6 +400,7 @@ test.describe('Credentials - External Credential Plugins (AAP-44813)', () => {
 
       // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       const externalCredentialName = createE2EName('external-cred');
       await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
@@ -418,6 +426,7 @@ test.describe('Credentials - External Credential Plugins (AAP-44813)', () => {
 
       // Step 2: Create a Machine credential and link its password to the external credential
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       const machineCredentialName = createE2EName('machine-cred-linked');
       await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
@@ -509,6 +518,7 @@ test.describe('Credentials - External Credential Plugins (AAP-44813)', () => {
 
       // Step 1: Create an external credential (HashiCorp Vault Secret Lookup)
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       const externalCredentialName = createE2EName('external-cred');
       await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();
@@ -604,6 +614,7 @@ test.describe('Credentials - Team and User Access', () => {
       const teamName = createE2EName('team');
 
       await navigateTo(page, 'Access Management', 'Teams');
+      await waitForPageTableLoad(page);
       await page.getByText('Create team', { exact: true }).click();
       await page.getByPlaceholder('Enter team name').fill(teamName);
       await page.getByLabel('Organization').click();
@@ -651,6 +662,7 @@ test.describe('Credentials - Team and User Access', () => {
       const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
 
       await navigateTo(page, 'Access', 'Users');
+      await waitForPageTableLoad(page);
       await page.getByText('Create user', { exact: true }).click();
       await page.getByRole('textbox', { name: 'Username' }).fill(userName);
       await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
@@ -696,6 +708,7 @@ test.describe('Credentials - Team and User Access', () => {
       const teamName = createE2EName('team');
 
       await navigateTo(page, 'Access Management', 'Teams');
+      await waitForPageTableLoad(page);
       await page.getByText('Create team', { exact: true }).click();
       await page.getByPlaceholder('Enter team name').fill(teamName);
       await page.getByLabel('Organization').click();
@@ -755,6 +768,7 @@ test.describe('Credentials - Team and User Access', () => {
       const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
 
       await navigateTo(page, 'Access', 'Users');
+      await waitForPageTableLoad(page);
       await page.getByText('Create user', { exact: true }).click();
       await page.getByRole('textbox', { name: 'Username' }).fill(userName);
       await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');
@@ -829,6 +843,7 @@ test.describe('Credentials - Team and User Access', () => {
     const userName = `E2E-user-${createE2EName('').replaceAll(/\s+/g, '')}`;
 
     await navigateTo(page, 'Access', 'Users');
+    await waitForPageTableLoad(page);
     await page.getByText('Create user', { exact: true }).click();
     await page.getByRole('textbox', { name: 'Username' }).fill(userName);
     await page.getByRole('textbox', { name: 'Password', exact: true }).fill('TestPassword123!');

--- a/playwright/utils/credential.ts
+++ b/playwright/utils/credential.ts
@@ -5,6 +5,7 @@ import { confirmAndAssertDeletion } from '../commands/confirmAndAssertDeletion';
 import { createE2EName } from '../commands/createE2EName';
 import { navigateTo } from '../commands/navigateTo';
 import { filterTable } from '../commands/filterTable';
+import { waitForPageTableLoad } from '../commands/waitForPageTableLoad';
 
 export interface CreateCredentialOptions {
   credentialName?: string;
@@ -40,6 +41,7 @@ export const Credential = {
     create: async (page: Page, options: CreateCredentialOptions = {}): Promise<string> => {
       const testToken = createE2EName('test-token');
       await navigateTo(page, 'Automation Execution', 'Infrastructure', 'Credentials');
+      await waitForPageTableLoad(page);
       await page.getByText('Create credential', { exact: true }).click();
       const credentialName = options.credentialName ?? createE2EName('credential');
       await expect(page.getByPlaceholder('Enter credential name')).toBeVisible();


### PR DESCRIPTION
## Summary

Fixing flaky credentials tests.

I did some restructuring of the `describe` blocks, which changes indentation of the entire file. It will be easier to review the actual changes in the first two commits.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
