### PR TITLE
Stabilize inventory util timeout

### DIFF
--- a/playwright/utils/inventory.ts
+++ b/playwright/utils/inventory.ts
@@ -342,7 +342,11 @@ export const Inventory = {
       await page.getByRole('button', { name: 'Select source' }).click();
       await page.getByRole('option', { name: 'Sourced from a Project' }).click();
       await page.locator('#project-select').click();
+      const inventoryPathsResponsePromise = page.waitForResponse((response) =>
+        /\/projects\/\d+\/inventories\//.test(response.url())
+      );
       await page.getByRole('option', { name: projectName }).click();
+      await inventoryPathsResponsePromise;
       await page.getByPlaceholder('Select inventory path').click();
       await page.getByRole('option', { name: '. (project root)' }).click();
       await page.getByRole('button', { name: 'Create source' }).click();


### PR DESCRIPTION
## Summary

Stabilizes Workflow Vis tests failing in CI

Addressing test failure: FAILED test (workflow-visualizer.spec.ts → "Can delete one single node…"): root cause was in the shared helper playwright/utils/inventory.ts (Inventory.ui.createSource). Selecting a project fires an async GET `projects/{id}/inventories/` to populate the "Select inventory path" field, but the test clicked that field immediately, so it hung until the request resolved (took the full 300s test timeout under slow conditions). Fixed by explicitly waiting for that response before interacting with the field — this helper is shared, so it also fixes any other test using createSource.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
