### PR TITLE
fix(awx): fix workflow node prompt string fields not clearing when saved

### DIFF
--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
@@ -826,6 +826,216 @@ describe('useSaveVisualizer', () => {
     expect(payload.extra_data).toEqual(expect.objectContaining({ survey_key: 'survey_value' }));
   });
 
+  test('should send null to API when scm_branch prompt field is cleared on a new node', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-scm',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'scm-clear',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          scm_branch: '',
+          limit: '',
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: true,
+              ask_limit_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).toHaveProperty('scm_branch', null);
+    expect(payload).toHaveProperty('limit', null);
+  });
+
+  test('should not send cleared scm_branch when ask_scm_branch_on_launch is false on a new node', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-scm2',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'scm-no-prompt',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          scm_branch: '',
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('scm_branch');
+  });
+
+  test('should send null to API when scm_branch prompt field is cleared on an existing node', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          scm_branch: '',
+          limit: '',
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: true,
+              ask_limit_on_launch: true,
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const nodePatchCall = mockPatchFn.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/42/')
+    );
+    expect(nodePatchCall).toBeDefined();
+    const payload = (nodePatchCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).toHaveProperty('scm_branch', null);
+    expect(payload).toHaveProperty('limit', null);
+  });
+
+  test('should not send cleared scm_branch when ask_scm_branch_on_launch is false on an existing node', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          scm_branch: '',
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: false,
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const nodePatchCall = mockPatchFn.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/42/')
+    );
+    expect(nodePatchCall).toBeDefined();
+    const payload = (nodePatchCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('scm_branch');
+  });
+
   test('should propagate errors from updateExistingNodes', async () => {
     mockPatchFn.mockRejectedValueOnce(new Error('PATCH failed'));
     const editedNode = makeGraphNode({

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.test.ts
@@ -1127,4 +1127,204 @@ describe('useSaveVisualizer', () => {
     const payload = (nodePatch as unknown[])[1] as { extra_data?: object };
     expect(payload.extra_data).toEqual(expect.objectContaining({ survey_answer: 42 }));
   });
+
+  test('should not include undefined prompt field in payload for new node (value === undefined early return)', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-undef-prompt',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: 'undef-prompt',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          // scm_branch intentionally absent — launch_data?.scm_branch is undefined
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: true,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('scm_branch');
+  });
+
+  test('should not include empty non-prompt field in payload for new node (!isPrompt early return)', async () => {
+    const newNode = makeGraphNode({
+      id: 'unsavedNode-empty-identifier',
+      visible: true,
+      modified: false,
+      nodeData: {
+        resource: {
+          id: 0,
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 5,
+              name: 'Deploy',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [newNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const workflowNodeCall = mockPostFn.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/workflow_nodes/')
+    );
+    expect(workflowNodeCall).toBeDefined();
+    const payload = (workflowNodeCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('identifier');
+  });
+
+  test('should not include undefined prompt field in payload for existing node (value === undefined early return)', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: 'test-node',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          // scm_branch intentionally absent — launch_data?.scm_branch is undefined
+          original: {
+            launch_config: {
+              ask_scm_branch_on_launch: true,
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const nodePatchCall = mockPatchFn.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/42/')
+    );
+    expect(nodePatchCall).toBeDefined();
+    const payload = (nodePatchCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('scm_branch');
+  });
+
+  test('should not include empty non-prompt field in payload for existing node (!isPrompt early return)', async () => {
+    const editedNode = makeGraphNode({
+      id: '42',
+      visible: true,
+      modified: true,
+      nodeData: {
+        resource: {
+          id: 42,
+          identifier: '',
+          all_parents_must_converge: false,
+          extra_data: {},
+          always_nodes: [],
+          failure_nodes: [],
+          success_nodes: [],
+          summary_fields: {
+            unified_job_template: {
+              id: 1,
+              name: 'Test Template',
+              unified_job_type: RESOURCE_TYPE.job,
+            },
+          },
+        },
+        launch_data: {
+          original: {
+            launch_config: {
+              ask_labels_on_launch: false,
+              ask_instance_groups_on_launch: false,
+              ask_credential_on_launch: false,
+              defaults: { credentials: [] },
+            },
+            labels: [],
+            instance_groups: [],
+            credentials: [],
+          },
+        },
+        survey_data: undefined,
+      } as unknown as Partial<GraphNodeData>,
+    });
+    mockGraphNodes = [editedNode];
+    const { result } = renderHook(() => useSaveVisualizer('123'));
+    await result.current();
+
+    const nodePatchCall = mockPatchFn.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && c[0].includes('/workflow_job_template_nodes/42/')
+    );
+    expect(nodePatchCall).toBeDefined();
+    const payload = (nodePatchCall as unknown[])[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('identifier');
+  });
 });

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -200,7 +200,15 @@ export function useSaveVisualizer(templateId: string) {
             }
           }
 
-          if (typeof value === 'undefined' || value === null || value === '') {
+          if (typeof value === 'undefined') {
+            return;
+          }
+          if (value === null || value === '') {
+            if (!isPrompt) {
+              return;
+            }
+            // Prompt field explicitly cleared; send null to the API to remove the node override
+            createNodePayload[key] = null as unknown as CreateWorkflowNodePayload[K];
             return;
           }
 
@@ -301,7 +309,15 @@ export function useSaveVisualizer(templateId: string) {
               }
             }
 
-            if (typeof value === 'undefined' || value === null || value === '') {
+            if (typeof value === 'undefined') {
+              return;
+            }
+            if (value === null || value === '') {
+              if (!isPrompt) {
+                return;
+              }
+              // Prompt field explicitly cleared; send null to the API to remove the node override
+              updatedNodePayload[key] = null as unknown as CreateWorkflowNodePayload[K];
               return;
             }
 

--- a/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/hooks/useSaveVisualizer.tsx
@@ -200,7 +200,7 @@ export function useSaveVisualizer(templateId: string) {
             }
           }
 
-          if (typeof value === 'undefined') {
+          if (value === undefined) {
             return;
           }
           if (value === null || value === '') {
@@ -309,7 +309,7 @@ export function useSaveVisualizer(templateId: string) {
               }
             }
 
-            if (typeof value === 'undefined') {
+            if (value === undefined) {
               return;
             }
             if (value === null || value === '') {
@@ -625,7 +625,7 @@ export function toKeyedObject(
   key: string,
   value: string | number | undefined | null
 ): { [key: string]: string | number } | object {
-  if ((typeof value === 'string' && value !== '') || typeof value === 'number') {
+  if (value !== null && value !== undefined && value !== '') {
     return { [key]: value };
   } else {
     return {};

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
@@ -468,6 +468,48 @@ describe('NodeTypeStep', () => {
 
     expect(capturedPrompt).toMatchObject({ scm_branch: '' });
   });
+
+  it('should use launch config scm_branch as fallback when step data has no scm_branch override', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: true,
+          ask_scm_branch_on_launch: true,
+          survey_enabled: false,
+          defaults: { credentials: [], inventory: null, scm_branch: 'release' },
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+    });
+
+    // Step state without scm_branch — prompts?.scm_branch is undefined, so fallback to launchConfigValue
+    const stepStateWithoutBranch = {
+      nodePromptsStep: {
+        prompt: { ...mockStepState.nodePromptsStep.prompt },
+      },
+    };
+
+    let capturedPrompt: unknown;
+    mockSetStepData.mockImplementation((updater: unknown) => {
+      if (typeof updater === 'function') {
+        const result = (
+          updater as (prev: typeof stepStateWithoutBranch) => {
+            nodePromptsStep?: { prompt?: unknown };
+          }
+        )(stepStateWithoutBranch);
+        capturedPrompt = result?.nodePromptsStep?.prompt;
+      }
+    });
+
+    render(<TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job, resourceId: 1 }} />);
+
+    await waitFor(() => expect(mockSetStepData).toHaveBeenCalled(), { timeout: 5000 });
+
+    expect(capturedPrompt).toMatchObject({ scm_branch: 'release' });
+  });
 });
 
 function TestWrapperWithSourceNode({

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.test.tsx
@@ -426,6 +426,48 @@ describe('NodeTypeStep', () => {
     );
     expect(container.firstChild).not.toBeNull();
   });
+
+  it('should preserve empty scm_branch from step data over launch config default when template has not changed', async () => {
+    mockRequestGet.mockImplementation((url: string): Promise<Record<string, unknown>> => {
+      if (url.includes('/launch/')) {
+        return Promise.resolve({
+          ask_credential_on_launch: true,
+          ask_scm_branch_on_launch: true,
+          survey_enabled: false,
+          defaults: { credentials: [], inventory: null, scm_branch: 'test' },
+        });
+      }
+      if (url.includes('/credentials/')) {
+        return Promise.resolve({ count: 0, results: [] });
+      }
+      return Promise.resolve({ id: 1, name: 'Demo Template', type: 'job_template' });
+    });
+
+    // Simulate step state where scm_branch = '' (node override cleared, resolvePromptField returns '')
+    const stepStateWithClearedBranch = {
+      nodePromptsStep: {
+        prompt: { ...mockStepState.nodePromptsStep.prompt, scm_branch: '' },
+      },
+    };
+
+    let capturedPrompt: unknown;
+    mockSetStepData.mockImplementation((updater: unknown) => {
+      if (typeof updater === 'function') {
+        const result = (
+          updater as (prev: typeof stepStateWithClearedBranch) => {
+            nodePromptsStep?: { prompt?: unknown };
+          }
+        )(stepStateWithClearedBranch);
+        capturedPrompt = result?.nodePromptsStep?.prompt;
+      }
+    });
+
+    render(<TestWrapper defaultValues={{ node_type: RESOURCE_TYPE.job, resourceId: 1 }} />);
+
+    await waitFor(() => expect(mockSetStepData).toHaveBeenCalled(), { timeout: 5000 });
+
+    expect(capturedPrompt).toMatchObject({ scm_branch: '' });
+  });
 });
 
 function TestWrapperWithSourceNode({

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodeTypeStep.tsx
@@ -199,6 +199,7 @@ export function NodeTypeStep(props: Readonly<{ hasSourceNode?: boolean }>) {
                 diff_mode: prompts?.diff_mode ?? launchConfigValue?.diff_mode,
                 forks: prompts?.forks ?? launchConfigValue?.forks,
                 limit: prompts?.limit ?? launchConfigValue?.limit,
+                scm_branch: prompts?.scm_branch ?? launchConfigValue?.scm_branch,
                 verbosity: prompts?.verbosity ?? launchConfigValue?.verbosity,
                 job_slice_count: prompts?.job_slice_count ?? launchConfigValue?.job_slice_count,
                 timeout: prompts?.timeout ?? launchConfigValue?.timeout,


### PR DESCRIPTION
## Summary

- **Write path fix**: `useSaveVisualizer` was silently dropping cleared string prompt fields (`value === ''`) from PATCH/POST payloads. Now sends `null` to the API when a prompt field (e.g. `scm_branch`, `limit`) is explicitly cleared, properly removing the node override.
- **Read path fix**: `NodeTypeStep.setLaunchToWizardData` was spreading `launchConfigValue` (which contains `defaults.scm_branch` from the job template's launch config) into step data without including `scm_branch` in `preservedPromptOverrides`. This caused the wizard to always show the template's default (e.g. `"test"`) even after the user had cleared the field and saved. Added `scm_branch` to `preservedPromptOverrides` with the same nullish-coalescing pattern used for `limit`, `forks`, and other string prompt fields.

Fixes AAP-65196.

## Test plan

- [ ] Open a workflow job template node wizard for a job template with `ask_scm_branch_on_launch: true`
- [ ] Enter a value in Source control branch, click Finish, and save the WFT
- [ ] Reopen the node wizard — verify the entered value appears
- [ ] Clear the Source control branch field, click Finish, and save the WFT
- [ ] Reopen the node wizard — verify the field is now **empty** (not showing the template default or previous value)
- [ ] Verify PATCH payload in network tab contains `"scm_branch": null` when field is cleared
- [ ] Unit tests: `useSaveVisualizer.test.ts` (4 new tests) and `NodeTypeStep.test.tsx` (1 new test)
## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)