### PR TITLE
fix(deps): pin @playwright/test to 1.57.0 to match CI runner image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "@babel/preset-react": "7.26.3",
         "@babel/preset-typescript": "7.26.0",
         "@cypress/code-coverage": "3.13.11",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.57.0",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
         "@svgr/webpack": "8.1.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -6701,19 +6701,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.1"
+        "playwright": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -23470,35 +23470,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@babel/preset-react": "7.26.3",
     "@babel/preset-typescript": "7.26.0",
     "@cypress/code-coverage": "3.13.11",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.57.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
     "@svgr/webpack": "8.1.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

- Pin `@playwright/test` to exact `1.57.0` (drop the `^`) so `npm ci` cannot float to 1.62.1.
- Restore `playwright` / `playwright-core` in the lockfile to 1.57.0 to match the Konflux `playwright-runner` image (`mcr.microsoft.com/playwright:v1.57.0-noble`).
- #3506 regenerated `package-lock.json` with `rm package-lock.json && npm install`, which resolved `^1.57.0` to 1.62.1 and broke every live-chromium test ([Currents run](https://app.currents.dev/run/03c797c16ce7631c)). The brace-expansion 5.0.9 override is unchanged.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

The failing run that this restores compatibility for: https://app.currents.dev/run/03c797c16ce7631c

### Manual Testing

- `npm ci` installs `@playwright/test@1.57.0`
- Lockfile only changes the three Playwright packages; `brace-expansion` remains 5.0.9


Made with [Cursor](https://cursor.com)