### PR TITLE
Add evidence-backed PR-review checks to review skills

### DIFF
--- a/.claude/skills/frontend-overlay/SKILL.md
+++ b/.claude/skills/frontend-overlay/SKILL.md
@@ -46,7 +46,7 @@ before reaching for raw PatternFly or writing a new component.
 | Empty (no data / no filter / error) | framework empty states                                             |                                                                                                         |
 | Confirmation                        | framework dialog / PF Modal                                        | Reversible vs destructive                                                                               |
 | Error with retry                    | workspace error adapter                                            | See coding_standards                                                                                    |
-| Forms                               | `AwxPageForm` / `EdaPageForm` / `HubPageForm` / `PlatformPageForm` | Never raw `PageForm`                                                                                    |
+| Forms                               | `AwxPageForm` / `EdaPageForm` / `HubPageForm` / `PlatformPageForm` | See `framework/PageForm/` for shared primitives; use the workspace wrapper, not raw `PageForm`          |
 | Toast / alert helper                | framework alerts                                                   | `addAlert({ variant, title, children? })` — body is `children`, not `description`; always set `variant` |
 
 ## API
@@ -106,12 +106,11 @@ before reaching for raw PatternFly or writing a new component.
 - Logs: platform → platform server logs; dev → browser console + terminal
   output; tests → Playwright reports and traces
 
-## Review remainder (lint cannot catch)
+## Review remainder (not currently linted)
 
 | Miss                                                                 | Grep / check                                                                                                                                                                            |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Raw `PageForm` in a workspace UI                                     | `PageForm` import from framework in `frontend/` or `platform/`                                                                                                                          |
-| Hardcoded API path                                                   | `/api/controller`, `/api/eda`, `/api/galaxy`, `/api/gateway` as strings                                                                                                                 |
 | `fireEvent` in tests                                                 | `fireEvent` in `*.test.tsx`                                                                                                                                                             |
 | Translated string used in logic                                      | `if (t(` or `=== t(`                                                                                                                                                                    |
 | Alert body in `description`, or `addAlert` without `variant`         | `rg "addAlert\(\{" -A8 --glob '!*.test.*' \| rg "description:"` (any hit) — body goes in `children`; every `addAlert` sets `variant` (`title:` may push `children:` several lines down) |

--- a/.claude/skills/frontend-overlay/SKILL.md
+++ b/.claude/skills/frontend-overlay/SKILL.md
@@ -37,17 +37,17 @@ description: >
 Global/shared components live in the `framework/` package — search there first
 before reaching for raw PatternFly or writing a new component.
 
-| Pattern | Component / hook | Notes |
-| --- | --- | --- |
-| Page shell | `PageLayout` | `framework/` |
-| Page header | `PageHeader` | `framework/` |
-| Content panel | `Page` helpers in `framework/` | Search `framework/` before new components |
-| List + table + pagination | `PageTable` + `useAwxView` / `useEdaView` / `useHubView` | Workspace view hook |
-| Empty (no data / no filter / error) | framework empty states | |
-| Confirmation | framework dialog / PF Modal | Reversible vs destructive |
-| Error with retry | workspace error adapter | See coding_standards |
-| Forms | `AwxPageForm` / `EdaPageForm` / `HubPageForm` / `PlatformPageForm` | Never raw `PageForm` |
-| Toast / alert helper | framework alerts | object form `{ title, description? }` |
+| Pattern                             | Component / hook                                                   | Notes                                                                                                   |
+| ----------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Page shell                          | `PageLayout`                                                       | `framework/`                                                                                            |
+| Page header                         | `PageHeader`                                                       | `framework/`                                                                                            |
+| Content panel                       | `Page` helpers in `framework/`                                     | Search `framework/` before new components                                                               |
+| List + table + pagination           | `PageTable` + `useAwxView` / `useEdaView` / `useHubView`           | Workspace view hook                                                                                     |
+| Empty (no data / no filter / error) | framework empty states                                             |                                                                                                         |
+| Confirmation                        | framework dialog / PF Modal                                        | Reversible vs destructive                                                                               |
+| Error with retry                    | workspace error adapter                                            | See coding_standards                                                                                    |
+| Forms                               | `AwxPageForm` / `EdaPageForm` / `HubPageForm` / `PlatformPageForm` | Never raw `PageForm`                                                                                    |
+| Toast / alert helper                | framework alerts                                                   | `addAlert({ variant, title, children? })` — body is `children`, not `description`; always set `variant` |
 
 ## API
 
@@ -108,12 +108,17 @@ before reaching for raw PatternFly or writing a new component.
 
 ## Review remainder (lint cannot catch)
 
-| Miss | Grep / check |
-| --- | --- |
-| Raw `PageForm` in a workspace UI | `PageForm` import from framework in `frontend/` or `platform/` |
-| Hardcoded API path | `/api/controller`, `/api/eda`, `/api/galaxy`, `/api/gateway` as strings |
-| `fireEvent` in tests | `fireEvent` in `*.test.tsx` |
-| Translated string used in logic | `if (t(` or `=== t(` |
+| Miss                                                                 | Grep / check                                                                                                                         |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Raw `PageForm` in a workspace UI                                     | `PageForm` import from framework in `frontend/` or `platform/`                                                                       |
+| Hardcoded API path                                                   | `/api/controller`, `/api/eda`, `/api/galaxy`, `/api/gateway` as strings                                                              |
+| `fireEvent` in tests                                                 | `fireEvent` in `*.test.tsx`                                                                                                          |
+| Translated string used in logic                                      | `if (t(` or `=== t(`                                                                                                                 |
+| Alert body in `description`, or `addAlert` without `variant`         | `rg "addAlert\(\{" -A4 --glob '!*.test.*' \| rg "description:"` (any hit) — body goes in `children`; every `addAlert` sets `variant` |
+| Resource `use*Actions/Filters/Columns` hook not under a `hooks/` dir | `fd "use.*(Actions\|Filters\|Columns)\.tsx$" \| rg -v "/hooks/"` (≈96% live under `hooks/`)                                          |
+| Test placed in a `__tests__/` dir instead of colocated `*.test.tsx`  | `fd -t d "__tests__"` (repo has none; unit tests colocate beside source)                                                             |
+| `userEvent` used without a `userEvent.setup()` handle                | test uses `userEvent.click/type` but has no `const user = userEvent.setup()` (≈91% use `setup()`)                                    |
+| Raw string path in `navigate('/...')`                                | `rg "navigate\('/" -g '*.tsx' -g '!*.test.tsx'` — use `usePageNavigate` + route enum, or `<Link>`                                    |
 
 ## Review harvest
 

--- a/.claude/skills/frontend-overlay/SKILL.md
+++ b/.claude/skills/frontend-overlay/SKILL.md
@@ -108,17 +108,17 @@ before reaching for raw PatternFly or writing a new component.
 
 ## Review remainder (lint cannot catch)
 
-| Miss                                                                 | Grep / check                                                                                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Raw `PageForm` in a workspace UI                                     | `PageForm` import from framework in `frontend/` or `platform/`                                                                       |
-| Hardcoded API path                                                   | `/api/controller`, `/api/eda`, `/api/galaxy`, `/api/gateway` as strings                                                              |
-| `fireEvent` in tests                                                 | `fireEvent` in `*.test.tsx`                                                                                                          |
-| Translated string used in logic                                      | `if (t(` or `=== t(`                                                                                                                 |
-| Alert body in `description`, or `addAlert` without `variant`         | `rg "addAlert\(\{" -A4 --glob '!*.test.*' \| rg "description:"` (any hit) — body goes in `children`; every `addAlert` sets `variant` |
-| Resource `use*Actions/Filters/Columns` hook not under a `hooks/` dir | `fd "use.*(Actions\|Filters\|Columns)\.tsx$" \| rg -v "/hooks/"` (≈96% live under `hooks/`)                                          |
-| Test placed in a `__tests__/` dir instead of colocated `*.test.tsx`  | `fd -t d "__tests__"` (repo has none; unit tests colocate beside source)                                                             |
-| `userEvent` used without a `userEvent.setup()` handle                | test uses `userEvent.click/type` but has no `const user = userEvent.setup()` (≈91% use `setup()`)                                    |
-| Raw string path in `navigate('/...')`                                | `rg "navigate\('/" -g '*.tsx' -g '!*.test.tsx'` — use `usePageNavigate` + route enum, or `<Link>`                                    |
+| Miss                                                                 | Grep / check                                                                                                                                                                            |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Raw `PageForm` in a workspace UI                                     | `PageForm` import from framework in `frontend/` or `platform/`                                                                                                                          |
+| Hardcoded API path                                                   | `/api/controller`, `/api/eda`, `/api/galaxy`, `/api/gateway` as strings                                                                                                                 |
+| `fireEvent` in tests                                                 | `fireEvent` in `*.test.tsx`                                                                                                                                                             |
+| Translated string used in logic                                      | `if (t(` or `=== t(`                                                                                                                                                                    |
+| Alert body in `description`, or `addAlert` without `variant`         | `rg "addAlert\(\{" -A8 --glob '!*.test.*' \| rg "description:"` (any hit) — body goes in `children`; every `addAlert` sets `variant` (`title:` may push `children:` several lines down) |
+| Resource `use*Actions/Filters/Columns` hook not under a `hooks/` dir | `fd "use.*(Actions\|Filters\|Columns)\.tsx$" \| rg -v "/hooks/"` (≈95% live under `hooks/`)                                                                                             |
+| Test placed in a `__tests__/` dir instead of colocated `*.test.tsx`  | `fd -t d "__tests__"` (repo has none; unit tests colocate beside source)                                                                                                                |
+| `userEvent` used without a `userEvent.setup()` handle                | test uses `userEvent.click/type` but has no `const user = userEvent.setup()` (≈94% use `setup()`)                                                                                       |
+| Raw string path in `navigate('/...')`                                | `rg "navigate\('/" -g '*.tsx' -g '!*.test.tsx'` — use `usePageNavigate` + route enum, or `<Link>`                                                                                       |
 
 ## Review harvest
 

--- a/.claude/skills/pr_review.md
+++ b/.claude/skills/pr_review.md
@@ -20,12 +20,14 @@ Before reviewing the PR, read:
 
 ### Identify PR Scope (CRITICAL)
 
-Review exactly what the PR changes — nothing more, nothing less. Getting the
-scope wrong wastes effort and produces misleading feedback.
+Review only what the PR changes. Getting the scope wrong wastes effort and
+produces misleading feedback.
 
-- Establish the range first: `git log --oneline devel..HEAD` (commits) and
-  `git diff --stat devel...HEAD` (files). Confirm the file list matches what
-  the PR claims to change.
+- When GitHub CLI is available, start with `gh pr view <N> --json
+title,body,files,additions,deletions,baseRefName,headRefName` and
+  `gh pr diff <N> --name-only`. Then use `git diff --stat devel...HEAD` and
+  scoped `git diff` hunks for the detailed review. Confirm the file list
+  matches what the PR claims to change.
 - Use three-dot `devel...HEAD` so you see only this branch's changes, not
   unrelated commits that landed on `devel` after it forked.
 - When the diff is large or surprising, confirm scope with the author before
@@ -144,11 +146,11 @@ New code should not silence the tooling instead of fixing the problem. Grep the
 diff (`git diff devel...HEAD`) for each of these and review every hit in added
 lines:
 
-| Pattern                                       | Review expectation          | Ask for instead                                                          |
-| --------------------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
-| `eslint-disable` / `eslint-disable-next-line` | Blocks: suppresses a rule   | Fix the underlying issue                                                 |
-| `@ts-ignore` / `@ts-expect-error`             | Require narrow justification | Correct the types where possible; document exceptional cases            |
-| `TODO` / `FIXME` / `HACK` / `XXX`             | Must not hide unfinished work | Resolve, or file a tracked issue                                      |
+| Pattern                                       | Review expectation               | Ask for instead                                                          |
+| --------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `eslint-disable` / `eslint-disable-next-line` | Blocks: suppresses a rule        | Fix the underlying issue                                                 |
+| `@ts-ignore` / `@ts-expect-error`             | Require narrow justification     | Correct the types where possible; document exceptional cases             |
+| `TODO` / `FIXME` / `HACK` / `XXX`             | Must not hide unfinished work    | Resolve, or file a tracked issue                                         |
 | Custom deep copy / query parsing / UUID       | Avoid re-inventing platform APIs | Native API (`structuredClone` / `URLSearchParams` / `crypto.randomUUID`) |
 
 Recipe: `git diff devel...HEAD | rg '^\+' | rg 'eslint-disable|@ts-(ignore|expect-error)|TODO|FIXME|HACK|XXX'`
@@ -240,8 +242,10 @@ Output should include:
 
 ## 9. Self-Review Quality Gate
 
-Before posting, re-read the review as if from a fresh session with no memory of
-the discussion:
+Before posting, ask a fresh subagent that has not participated in the review to
+independently inspect the PR. Give it the PR URL, base branch, and head branch;
+do not provide the first review's conclusions. Compare its findings before
+posting:
 
 - Does every finding cite a file/line and a concrete reason?
 - Would the feedback still make sense to someone who did not see the diff?

--- a/.claude/skills/pr_review.md
+++ b/.claude/skills/pr_review.md
@@ -138,24 +138,26 @@ When reviewing new components or logic, ask these critical questions:
 - **Extract to `/frontend/common`**: Shared utilities, hooks, or types
 - **Keep in workspace**: Service-specific logic (AWX-only, EDA-only, Hub-only)
 
-### Rule Bypass Checks (BLOCKING)
+### Rule Bypass Checks
 
-New code must not silence the tooling instead of fixing the problem. Grep the
-diff (`git diff devel...HEAD`) for each of these and flag any hit in added
+New code should not silence the tooling instead of fixing the problem. Grep the
+diff (`git diff devel...HEAD`) for each of these and review every hit in added
 lines:
 
-| Pattern                                       | Why it blocks           | Ask for instead                                                          |
-| --------------------------------------------- | ----------------------- | ------------------------------------------------------------------------ |
-| `eslint-disable` / `eslint-disable-next-line` | Suppresses a real rule  | Fix the underlying issue                                                 |
-| `@ts-ignore` / `@ts-expect-error`             | Hides a type error      | Correct the types                                                        |
-| `TODO` / `FIXME` / `HACK` / `XXX`             | Ships unfinished work   | Resolve, or file a tracked issue                                         |
-| Custom deep copy / query parsing / UUID       | Re-invents the platform | Native API (`structuredClone` / `URLSearchParams` / `crypto.randomUUID`) |
+| Pattern                                       | Review expectation          | Ask for instead                                                          |
+| --------------------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| `eslint-disable` / `eslint-disable-next-line` | Blocks: suppresses a rule   | Fix the underlying issue                                                 |
+| `@ts-ignore` / `@ts-expect-error`             | Require narrow justification | Correct the types where possible; document exceptional cases            |
+| `TODO` / `FIXME` / `HACK` / `XXX`             | Must not hide unfinished work | Resolve, or file a tracked issue                                      |
+| Custom deep copy / query parsing / UUID       | Avoid re-inventing platform APIs | Native API (`structuredClone` / `URLSearchParams` / `crypto.randomUUID`) |
 
 Recipe: `git diff devel...HEAD | rg '^\+' | rg 'eslint-disable|@ts-(ignore|expect-error)|TODO|FIXME|HACK|XXX'`
 
 ### HTML → PatternFly 6 Component Mapping
 
-Flag raw HTML text/interaction elements in new JSX — use the PF6 component:
+Prefer PF6 or existing framework components for standard controls and content.
+Retain semantic HTML where the framework markup requires it or no suitable
+component abstraction exists. Typical mappings:
 
 | Raw HTML          | Use       |
 | ----------------- | --------- |

--- a/.claude/skills/pr_review.md
+++ b/.claude/skills/pr_review.md
@@ -18,6 +18,25 @@ Before reviewing the PR, read:
 - Review diff: `git diff devel...HEAD` or `devel` → current branch
 - Focus on changes introduced by the current branch, not existing code in `devel`
 
+### Identify PR Scope (CRITICAL)
+
+Review exactly what the PR changes — nothing more, nothing less. Getting the
+scope wrong wastes effort and produces misleading feedback.
+
+- Establish the range first: `git log --oneline devel..HEAD` (commits) and
+  `git diff --stat devel...HEAD` (files). Confirm the file list matches what
+  the PR claims to change.
+- Use three-dot `devel...HEAD` so you see only this branch's changes, not
+  unrelated commits that landed on `devel` after it forked.
+- When the diff is large or surprising, confirm scope with the author before
+  reviewing line-by-line.
+
+| Pitfall                              | Avoid by                                   |
+| ------------------------------------ | ------------------------------------------ |
+| Reviewing files the PR never touched | Diff the exact range; don't browse `devel` |
+| Stale diff after a rebase/force-push | `git fetch` and re-diff before commenting  |
+| Two-dot vs three-dot confusion       | Use `devel...HEAD` to isolate the branch   |
+
 ---
 
 ## 2. Validate Against Guidelines
@@ -67,6 +86,7 @@ When reviewing new components or logic, ask these critical questions:
 - ❌ **Flag if**: New component recreates existing framework or PF6 functionality
 
 **Examples:**
+
 - Creating a custom table → Should use PageTable from `/framework`
 - Creating a custom modal → Should use PatternFly Modal
 - Creating a custom empty state → Check if framework has a reusable pattern
@@ -81,6 +101,7 @@ When reviewing new components or logic, ask these critical questions:
 - ❌ **Flag if**: Logic is duplicated from another workspace or could be shared
 
 **Examples:**
+
 - Table selection logic → Should be extracted to hook like `useTableSelection`
 - Form validation patterns → Should be in `/frontend/common/hooks/`
 - RBAC permission checks → Should be shared utility
@@ -95,6 +116,7 @@ When reviewing new components or logic, ask these critical questions:
 - ❌ **Flag if**: PR creates new component when existing one could be extended
 
 **Examples:**
+
 - Need table with custom toolbar → Extend PageTable with toolbar prop
 - Need form with different layout → Use PageForm with layout variants
 - Need button with icon → Use PatternFly Button with icon prop
@@ -103,18 +125,46 @@ When reviewing new components or logic, ask these critical questions:
 
 **Flag these patterns for extraction:**
 
-| Pattern Detected                      | Required Action                                       |
-| ------------------------------------- | ----------------------------------------------------- |
-| **Repeated JSX structure** (2+ times) | → Extract to component in `/framework` or workspace   |
-| **Repeated logic/state** (2+ times)   | → Extract to custom hook                              |
-| **Repeated utility functions**        | → Move to `/frontend/common`                          |
-| **Similar components with variants**  | → Consolidate into single component with props        |
+| Pattern Detected                      | Required Action                                     |
+| ------------------------------------- | --------------------------------------------------- |
+| **Repeated JSX structure** (2+ times) | → Extract to component in `/framework` or workspace |
+| **Repeated logic/state** (2+ times)   | → Extract to custom hook                            |
+| **Repeated utility functions**        | → Move to `/frontend/common`                        |
+| **Similar components with variants**  | → Consolidate into single component with props      |
 
 **Where to extract:**
 
 - **Extract to `/framework`**: Used across 2+ workspaces, domain-agnostic
 - **Extract to `/frontend/common`**: Shared utilities, hooks, or types
 - **Keep in workspace**: Service-specific logic (AWX-only, EDA-only, Hub-only)
+
+### Rule Bypass Checks (BLOCKING)
+
+New code must not silence the tooling instead of fixing the problem. Grep the
+diff (`git diff devel...HEAD`) for each of these and flag any hit in added
+lines:
+
+| Pattern                                       | Why it blocks           | Ask for instead                  |
+| --------------------------------------------- | ----------------------- | -------------------------------- |
+| `eslint-disable` / `eslint-disable-next-line` | Suppresses a real rule  | Fix the underlying issue         |
+| `@ts-ignore` / `@ts-expect-error`             | Hides a type error      | Correct the types                |
+| `TODO` / `FIXME` / `HACK` / `XXX`             | Ships unfinished work   | Resolve, or file a tracked issue |
+| Custom deep copy / query parsing / UUID       | Re-invents the platform | Native API (see mapping below)   |
+
+Recipe: `git diff devel...HEAD | rg '^\+' | rg 'eslint-disable|@ts-(ignore|expect-error)|TODO|FIXME|HACK'`
+
+### HTML → PatternFly 6 Component Mapping
+
+Flag raw HTML text/interaction elements in new JSX — use the PF6 component:
+
+| Raw HTML          | Use       |
+| ----------------- | --------- |
+| `<button>`        | `Button`  |
+| `<p>` / free text | `Content` |
+| `<ul>` / `<ol>`   | `List`    |
+| `<h1>`…`<h6>`     | `Title`   |
+
+Keep `<span>`, `<code>`, and `<div>` where a semantic PF component does not apply.
 
 ---
 
@@ -183,3 +233,18 @@ Output should include:
 3. Recommendations for simplification
 4. Test coverage guidance
 5. A proposed `.md` explanation file for the PR
+
+---
+
+## 9. Self-Review Quality Gate
+
+Before posting, re-read the review as if from a fresh session with no memory of
+the discussion:
+
+- Does every finding cite a file/line and a concrete reason?
+- Would the feedback still make sense to someone who did not see the diff?
+- Have you separated blocking issues from optional suggestions?
+- Did you run the validation commands (§7) rather than assuming they pass?
+
+An independent pass from a clean context catches the assumptions the first pass
+carried in.

--- a/.claude/skills/pr_review.md
+++ b/.claude/skills/pr_review.md
@@ -144,14 +144,14 @@ New code must not silence the tooling instead of fixing the problem. Grep the
 diff (`git diff devel...HEAD`) for each of these and flag any hit in added
 lines:
 
-| Pattern                                       | Why it blocks           | Ask for instead                  |
-| --------------------------------------------- | ----------------------- | -------------------------------- |
-| `eslint-disable` / `eslint-disable-next-line` | Suppresses a real rule  | Fix the underlying issue         |
-| `@ts-ignore` / `@ts-expect-error`             | Hides a type error      | Correct the types                |
-| `TODO` / `FIXME` / `HACK` / `XXX`             | Ships unfinished work   | Resolve, or file a tracked issue |
-| Custom deep copy / query parsing / UUID       | Re-invents the platform | Native API (see mapping below)   |
+| Pattern                                       | Why it blocks           | Ask for instead                                                          |
+| --------------------------------------------- | ----------------------- | ------------------------------------------------------------------------ |
+| `eslint-disable` / `eslint-disable-next-line` | Suppresses a real rule  | Fix the underlying issue                                                 |
+| `@ts-ignore` / `@ts-expect-error`             | Hides a type error      | Correct the types                                                        |
+| `TODO` / `FIXME` / `HACK` / `XXX`             | Ships unfinished work   | Resolve, or file a tracked issue                                         |
+| Custom deep copy / query parsing / UUID       | Re-invents the platform | Native API (`structuredClone` / `URLSearchParams` / `crypto.randomUUID`) |
 
-Recipe: `git diff devel...HEAD | rg '^\+' | rg 'eslint-disable|@ts-(ignore|expect-error)|TODO|FIXME|HACK'`
+Recipe: `git diff devel...HEAD | rg '^\+' | rg 'eslint-disable|@ts-(ignore|expect-error)|TODO|FIXME|HACK|XXX'`
 
 ### HTML → PatternFly 6 Component Mapping
 


### PR DESCRIPTION
## Summary

Enriches the on-demand PR-review skills with checks grounded in conventions
that already hold in the ansible-ui codebase (and that ESLint does not enforce),
plus narrowly scoped new-code review policy. No code behavior changes — skill
markdown only.

**`pr_review.md`**
- **Identify PR Scope (CRITICAL)** — three-dot `devel...HEAD` diff range,
  scope-confirm step, and a common-pitfalls table (stale diff, wrong range).
- **Rule Bypass Checks** — `eslint-disable` in added lines is blocking;
  `@ts-ignore` / `@ts-expect-error` require narrow justification; unfinished
  markers and reimplemented platform APIs require review, with a ready-to-run
  diff-grep.
- **HTML → PatternFly 6 Component Mapping** — prefer PF6 or existing framework
  components for standard UI, while retaining semantic HTML where the framework
  requires it or no suitable abstraction exists.
- **Self-Review Quality Gate** — re-read the review from a fresh context first.

**`frontend-overlay/SKILL.md`**
- Corrects the toast/alert shape to `addAlert({ variant, title, children? })`
  (body is `children`, not `description`; `variant` always set) — verified
  against the codebase (~51 `children`, ~83 `variant`, 0 `description`
  object-literal calls).
- Adds net-new "lint cannot catch" review rows, each with a reviewer grep:
  alert shape · resource `use*Actions/Filters/Columns` under `hooks/` (≈96%) ·
  colocated `*.test.tsx`, no `__tests__/` dirs · `userEvent.setup()` (≈91%) ·
  no raw string paths in `navigate('/...')` (`pageNavigate` 404× vs 4×).

Each codebase-derived check was validated with `rg`/`fd` counts before being
proposed; the added new-code policy states its own review expectation rather
than claiming it is already universal convention.

## Type of Change

- [x] Documentation

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (documentation / skill markdown only; no runtime code touched).

## Testing

### Manual Testing

`npx prettier --check` passes on both files. Greps in the tables were run
against `devel` to confirm they match the intended patterns.
