### PR TITLE
Add React/TS, a11y, and Playwright guidance to skills

### DIFF
--- a/.claude/skills/coding_standards.md
+++ b/.claude/skills/coding_standards.md
@@ -638,22 +638,23 @@ rows.filter((r) => selected.has(r.id));
 
 Defining a component inside another component's body gives it a new identity
 every render, so React unmounts/remounts its subtree (state loss, flicker).
-Hoist it to module scope. The same applies to render props passed to framework
-components (`PageTable` cell renderers, `PageForm` inputs) — keep the function
-reference stable (module scope or `useCallback`), never an inline arrow that
-closes over changing values it does not need.
+Hoist it to module scope. (Inline `cell:` render functions in an
+`ITableColumn[]` are fine — those are render callbacks, not component
+definitions; the rule is about declaring a `function`/`const` component within
+render.)
 
-### CSS Modules over inline style objects
+### Avoid inline style objects
 
 An inline `style={{ ... }}` object is a new object every render (breaks
-memoization and PatternFly's own bailouts) and cannot be cached by the browser.
-Prefer a CSS Module class; when a dynamic inline style is unavoidable, memoize
-the object with `useMemo`.
+memoization and PatternFly's own bailouts). Prefer PatternFly layout components
+and utility classes, or a `styled-components` style — the repo's styling
+approach (see `library_references.md`); when a dynamic inline style is
+unavoidable, memoize the object with `useMemo`.
 
 ### Never `eslint-disable` in new or modified code
 
 Disabling a rule ships the problem plus a suppression to maintain. Fix the
-cause. (This repo forbids it outright — see the overlay skill.)
+cause. (This repo forbids it outright — see `CLAUDE.md`.)
 
 ### Build `ReactNode` lists, not joined strings
 

--- a/.claude/skills/coding_standards.md
+++ b/.claude/skills/coding_standards.md
@@ -13,22 +13,23 @@ API paths like `/api/v2/...` or `/api/eda/v1/...` are errors.
 ```typescript
 // AWX — /api/v2/...
 import { awxAPI } from '../../common/api/awx-utils';
-awxAPI`/users/${id}/`               // → /api/v2/users/42/
+awxAPI`/users/${id}/`; // → /api/v2/users/42/
 
 // EDA — /api/eda/v1/...
 import { edaAPI } from '../../common/eda-utils';
-edaAPI`/activations/`               // → /api/eda/v1/activations/
+edaAPI`/activations/`; // → /api/eda/v1/activations/
 
 // Hub — /api/galaxy/...
 import { hubAPI } from '../../common/api/formatPath';
-hubAPI`/v3/collections/`            // → /api/galaxy/v3/collections/
+hubAPI`/v3/collections/`; // → /api/galaxy/v3/collections/
 
 // Platform (Gateway) — /api/gateway/v1/...
 import { gatewayAPI } from '../../utils/gateway-api-utils';
-gatewayAPI`/authenticators/`        // → /api/gateway/v1/authenticators/
+gatewayAPI`/authenticators/`; // → /api/gateway/v1/authenticators/
 ```
 
 Source files:
+
 - `frontend/awx/common/api/awx-utils.tsx`
 - `frontend/eda/common/eda-utils.tsx`
 - `frontend/hub/common/api/formatPath.tsx`
@@ -53,16 +54,22 @@ const putRequest = usePutRequest<RequestBody, ResponseBody>();
 const patchRequest = usePatchRequest<RequestBody, ResponseBody>();
 const deleteRequest = useDeleteRequest();
 
-await postRequest(url, body);   // POST — auto-clears SWR cache for url
-await putRequest(url, body);    // PUT — auto-clears cache
-await patchRequest(url, body);  // PATCH — auto-clears cache
-await deleteRequest(url);       // DELETE — auto-clears cache
+await postRequest(url, body); // POST — auto-clears SWR cache for url
+await putRequest(url, body); // PUT — auto-clears cache
+await patchRequest(url, body); // PATCH — auto-clears cache
+await deleteRequest(url); // DELETE — auto-clears cache
 ```
 
 ### Function-based (for use outside components or in SWR fetchers)
 
 ```typescript
-import { requestGet, postRequest, requestPatch, requestPut, requestDelete } from '@ansible/common-ui/crud/Data';
+import {
+  requestGet,
+  postRequest,
+  requestPatch,
+  requestPut,
+  requestDelete,
+} from '@ansible/common-ui/crud/Data';
 
 const data = await requestGet<User>(url, signal);
 await postRequest<ResponseBody, RequestBody>(url, body, signal);
@@ -109,7 +116,7 @@ const { data: allCredentialTypes } = useAwxGetAllPages<CredentialType>(awxAPI`/c
 import { useClearCache } from '@ansible/common-ui/useInvalidateCache/useInvalidateCache';
 
 const { clearCacheByKey, clearAllCache } = useClearCache();
-clearCacheByKey(awxAPI`/users/`);  // Smart: clears all SWR keys containing this URL base
+clearCacheByKey(awxAPI`/users/`); // Smart: clears all SWR keys containing this URL base
 ```
 
 Source: `frontend/common/crud/`
@@ -121,12 +128,12 @@ Source: `frontend/common/crud/`
 Never use the raw `PageForm` from the framework. Each workspace wraps it with
 its error adapter:
 
-| Workspace    | Wrapper              | Error Adapter        | Source                                    |
-| ------------ | -------------------- | -------------------- | ----------------------------------------- |
-| **AWX**      | `AwxPageForm`        | `awxErrorAdapter`    | `frontend/awx/common/AwxPageForm.tsx`     |
-| **EDA**      | `EdaPageForm`        | `edaErrorAdapter`    | `frontend/eda/common/EdaPageForm.tsx`     |
-| **Hub**      | `HubPageForm`        | `hubErrorAdapter`    | `frontend/hub/common/HubPageForm.tsx`     |
-| **Platform** | `PlatformPageForm`   | `awxErrorAdapter`*   | `platform/common/PlatformPageForm.tsx`    |
+| Workspace    | Wrapper            | Error Adapter      | Source                                 |
+| ------------ | ------------------ | ------------------ | -------------------------------------- |
+| **AWX**      | `AwxPageForm`      | `awxErrorAdapter`  | `frontend/awx/common/AwxPageForm.tsx`  |
+| **EDA**      | `EdaPageForm`      | `edaErrorAdapter`  | `frontend/eda/common/EdaPageForm.tsx`  |
+| **Hub**      | `HubPageForm`      | `hubErrorAdapter`  | `frontend/hub/common/HubPageForm.tsx`  |
+| **Platform** | `PlatformPageForm` | `awxErrorAdapter`* | `platform/common/PlatformPageForm.tsx` |
 
 *Platform defaults to AWX's error adapter but accepts an override prop.
 
@@ -150,13 +157,14 @@ import { AwxPageForm } from '../../common/AwxPageForm';
 Each workspace API returns errors in different formats. The error adapters
 normalize them to `{ genericErrors[], fieldErrors[] }`.
 
-| Workspace | Error formats handled                                                      |
-| --------- | -------------------------------------------------------------------------- |
-| **AWX**   | `detail`, `__all__`, `inputs` (credentials), `module_args`, `error`, field-by-field |
-| **EDA**   | `detail` (string/array), `non_field_errors`, field-by-field               |
+| Workspace | Error formats handled                                                                              |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| **AWX**   | `detail`, `__all__`, `inputs` (credentials), `module_args`, `error`, field-by-field                |
+| **EDA**   | `detail` (string/array), `non_field_errors`, field-by-field                                        |
 | **Hub**   | Galaxy format (`{ errors: [{ code, detail, source }] }`), Pulp format (field objects), 500 strings |
 
 Each also exports a message parser hook:
+
 - `useAwxErrorMessageParser()` — from `frontend/awx/common/adapters/awxErrorAdapter.tsx`
 - `useEdaErrorMessageParser()` — from `frontend/eda/common/edaErrorAdapter.tsx`
 - `useHubErrorMessageParser()` — from `frontend/hub/common/adapters/hubErrorAdapter.tsx`
@@ -169,28 +177,29 @@ Use these parsers when displaying errors outside of PageForm (e.g., toast alerts
 
 Use the framework's PageForm inputs from `framework/PageForm/Inputs/`:
 
-| Component                     | Use for                                   |
-| ----------------------------- | ----------------------------------------- |
-| `PageFormTextInput`           | Text, email, password, number fields      |
-| `PageFormTextArea`            | Multiline text                            |
-| `PageFormSelect`              | Static dropdown                           |
-| `PageFormSingleSelect`        | Single-select with search                 |
-| `PageFormMultiSelect`         | Multi-select dropdown                     |
-| `PageFormAsyncSingleSelect`   | Async-loading single select (API-backed)  |
-| `PageFormAsyncMultiSelect`    | Async-loading multi select (API-backed)   |
-| `PageFormCreatableSelect`     | User can type new options                 |
-| `PageFormCheckbox`            | Boolean toggle (checkbox)                 |
-| `PageFormSwitch`              | Boolean toggle (switch)                   |
-| `PageFormDataEditor`          | JSON/YAML code editor (Monaco)            |
-| `PageFormSecret`              | Password with show/hide toggle            |
-| `PageFormDateTimePicker`      | Date and time picker                      |
-| `PageFormFileUpload`          | File upload                               |
-| `PageFormSlider`              | Numeric slider                            |
-| `PageFormToggleGroup`         | Toggle button group                       |
-| `PageFormMarkdown`            | Markdown editor                           |
-| `PageFormMultiInput`          | Multi-value text input                    |
+| Component                   | Use for                                  |
+| --------------------------- | ---------------------------------------- |
+| `PageFormTextInput`         | Text, email, password, number fields     |
+| `PageFormTextArea`          | Multiline text                           |
+| `PageFormSelect`            | Static dropdown                          |
+| `PageFormSingleSelect`      | Single-select with search                |
+| `PageFormMultiSelect`       | Multi-select dropdown                    |
+| `PageFormAsyncSingleSelect` | Async-loading single select (API-backed) |
+| `PageFormAsyncMultiSelect`  | Async-loading multi select (API-backed)  |
+| `PageFormCreatableSelect`   | User can type new options                |
+| `PageFormCheckbox`          | Boolean toggle (checkbox)                |
+| `PageFormSwitch`            | Boolean toggle (switch)                  |
+| `PageFormDataEditor`        | JSON/YAML code editor (Monaco)           |
+| `PageFormSecret`            | Password with show/hide toggle           |
+| `PageFormDateTimePicker`    | Date and time picker                     |
+| `PageFormFileUpload`        | File upload                              |
+| `PageFormSlider`            | Numeric slider                           |
+| `PageFormToggleGroup`       | Toggle button group                      |
+| `PageFormMarkdown`          | Markdown editor                          |
+| `PageFormMultiInput`        | Multi-value text input                   |
 
 Workspace-specific resource selectors also exist:
+
 - `PageFormSingleSelectAwxResource` / `PageFormMultiSelectAwxResource`
 - `PageFormSingleSelectEdaResource` / `PageFormMultiSelectEdaResource`
 - `PageFormSelectOrganization`, `PageFormLabelSelect`, etc.
@@ -237,6 +246,7 @@ export function EditUser() {
 ```
 
 Key points:
+
 - `PageFormSubmitHandler<T>` receives `(data, setError, setFieldError)`
 - Form data type may include extra fields not in the API type
   (e.g., `confirmPassword`, `userType`)
@@ -253,11 +263,11 @@ Source: `frontend/awx/access/users/UserForm.tsx`
 Each workspace has its own view hook. They differ in type constraints and
 response format handling.
 
-| Workspace | Hook               | Type constraint           | Response format                                   |
-| --------- | ------------------ | ------------------------- | ------------------------------------------------- |
-| **AWX**   | `useAwxView<T>`    | `T extends { id: number }`| `{ count, results, next, previous }`              |
-| **EDA**   | `useEdaView<T>`    | `T extends { id: number \| string }` | `{ count, results }`               |
-| **Hub**   | `useHubView<T>`    | `T extends object` (requires `keyFn`) | Galaxy: `{ meta: { count }, data, links }` or Pulp: `{ count, results }` |
+| Workspace | Hook            | Type constraint                       | Response format                                                          |
+| --------- | --------------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| **AWX**   | `useAwxView<T>` | `T extends { id: number }`            | `{ count, results, next, previous }`                                     |
+| **EDA**   | `useEdaView<T>` | `T extends { id: number \| string }`  | `{ count, results }`                                                     |
+| **Hub**   | `useHubView<T>` | `T extends object` (requires `keyFn`) | Galaxy: `{ meta: { count }, data, links }` or Pulp: `{ count, results }` |
 
 ```typescript
 // AWX
@@ -266,7 +276,7 @@ const view = useAwxView<Credential>({
   toolbarFilters,
   tableColumns,
   queryParams,
-  disableQueryString,  // Use in modals/details
+  disableQueryString, // Use in modals/details
 });
 
 // EDA
@@ -281,7 +291,7 @@ const view = useHubView<HubNamespace>({
   url: hubAPI`/v3/namespaces/`,
   toolbarFilters,
   tableColumns,
-  keyFn: (item) => item.name,  // Required for Hub
+  keyFn: (item) => item.name, // Required for Hub
 });
 ```
 
@@ -289,6 +299,7 @@ All return: `pageItems`, `itemCount`, `error`, `refresh()`, `updateItem()`,
 plus pagination, sorting, filtering, and selection state.
 
 Source files:
+
 - `frontend/awx/common/useAwxView.tsx`
 - `frontend/eda/common/useEventDrivenView.tsx`
 - `frontend/hub/common/useHubView.tsx`
@@ -393,50 +404,62 @@ These check `resource.summary_fields.user_capabilities.edit/delete/copy`.
 The framework exports 79+ components. Before creating anything new, check here:
 
 ### Page Structure
+
 `PageLayout`, `PageBody`, `PageHeader`, `PageMasthead`, `PageNavigation`,
 `PageApp`, `PageFramework`, `PageTabs`, `PageTitle`
 
 ### Data Display
+
 `PageTable`, `PageDetails`, `PageDetailsFromColumns`, `PageDashboard`,
 `PageDashboardCard`, `PageDashboardChart`, `PageDashboardCount`
 
 ### Forms
+
 `PageForm`, `GenericForm`, `PageFormCheckbox`, `PageFormSelect`,
 `PageFormSwitch`, `PageFormTextArea`, `PageFormTextInput`,
 `PageFormDataEditor`, `PageFormAsyncSingleSelect`, `PageFormAsyncMultiSelect`
 
 ### Dialogs
+
 `PageDialog`, `BulkActionDialog`, `BulkConfirmationDialog`,
 `MultiSelectDialog`, `useSelectDialog`
 
 ### Wizards
+
 `PageWizard`, `PageWizardStep`, `usePageWizard()`
 
 ### Actions
+
 `PageAction`, `PageActions` (with `PageActionType` and `PageActionSelection`)
 
 ### Toolbar & Filtering
+
 `PageToolbar`, `ToolbarTextFilter`, `ToolbarSingleSelectFilter`,
 `ToolbarMultiSelectFilter`, `ToolbarAsyncSingleSelectFilter`,
 `ToolbarAsyncMultiSelectFilter`, `ToolbarDateRangeFilter`
 
 ### Empty States
+
 `PageNotFound`, `PageNotImplemented`, `EmptyStateError`, `EmptyStateNoData`,
 `EmptyStateFilter`, `EmptyStateUnauthorized`
 
 ### Notifications
+
 `PageAlertToaster`, `usePageAlertToaster()`, `PageNotificationsIcon`
 
 ### Cell Renderers
+
 `TextCell`, `DateTimeCell`, `BytesCell`, `ElapsedTimeCell`, `LabelsCell`,
 `CopyCell`
 
 ### Hooks
+
 `useView`, `useInMemoryView`, `usePageSettings`, `usePageNavigate`,
 `useGetPageUrl`, `usePageDialogs`, `usePageAlertToaster`, `useBreakPoint`,
 `useID`, `useClipboard`, `useAbortController`
 
 ### Utilities
+
 `LoadingPage`, `Scrollable`, `ErrorBoundary`, `Collapse`, `Help`,
 `StandardPopover`, `BulkSelector`, `RunningIcon`, `pfcolors`
 
@@ -462,6 +485,7 @@ const url = getPageUrl(AwxRoute.Users);
 ```
 
 Route enum naming convention: `WorkspaceRoute.ResourceAction`
+
 - `AwxRoute.Users`, `AwxRoute.CreateUser`, `AwxRoute.EditUser`, `AwxRoute.UserDetails`
 - `EdaRoute.RulebookActivations`, `EdaRoute.CreateRulebookActivation`
 - Route enum values use kebab-case: `'awx-users'`, `'eda-rulebook-activations'`
@@ -473,31 +497,39 @@ Source: `frontend/awx/main/AwxRoutes.tsx`, `frontend/eda/main/EdaRoutes.tsx`
 ## 12. Common Utilities
 
 ### Shared Columns (`frontend/common/columns.tsx`)
+
 `useIdColumn<T>()`, `useNameColumn<T>()`, `useDescriptionColumn<T>()`,
 `useLastRanColumn()`
 
 ### Key Functions (`frontend/common/utils/nameKeyFn.tsx`)
+
 `nameKeyFn(item)` — returns `item.name`
 `idKeyFn(item)` — returns `item.id`
 
 ### Polling (`frontend/common/poll.ts`)
+
 `poll<T>(fn, check, interval?, maxAttempts?)` — poll until condition met
 
 ### Virtual Scrolling (`frontend/common/utils/useVirtualized.tsx`)
+
 `useVirtualizedList<T>(containerRef, items)` — virtual list rendering
 
 ### URL Validation (`frontend/common/validation/useIsValidUrl.tsx`)
+
 `useIsValidUrl()` — returns validator for HTTP/HTTPS URLs
 
 ### String Utilities (`frontend/awx/common/util/strings.ts`)
+
 `toTitleCase()`, `truncateString()`, `stringIsUUID()`, `arrayToString()`,
 `stringToArray()`
 
 ### Hub Task Polling (`frontend/hub/common/api/hub-api-utils.tsx`)
+
 `waitForTask(taskHref, signal, minDelay, multiplier, retries)` — exponential
 backoff for async Hub operations (returns 202 with task reference)
 
 ### Request Error (`frontend/common/crud/RequestError.ts`)
+
 `RequestError` class with `statusCode`, `body`, `json`, `details`
 `createRequestError(response)` — factory from HTTP response
 `isRequestError(error)` — type guard
@@ -589,8 +621,10 @@ This is enforced by SonarCloud rule S6759.
 
 ## 19. React & TypeScript Patterns
 
-§15 lists the ESLint rules; this section covers patterns lint does not catch,
-each with the reason and the fix.
+§15 lists the ESLint rules; this section covers patterns the current lint
+configuration does not enforce, each with the reason and the fix. Although
+`eslint-plugin-react-hooks` provides `set-state-in-effect`, enabling it needs a
+separate warning-first evaluation because it may be noisy in this codebase.
 
 ### You might not need an Effect
 
@@ -599,7 +633,7 @@ non-React widgets, the network). Do not use it to react to React itself — it
 adds an extra render, is easy to desync, and hides the data flow. Five common
 misuses:
 
-```typescript
+```tsx
 // ❌ Syncing derived state
 const [full, setFull] = useState('');
 useEffect(() => {
@@ -607,12 +641,12 @@ useEffect(() => {
 }, [first, last]);
 ```
 
-```typescript
+```tsx
 // ✅ Derive during render
 const full = `${first} ${last}`;
 ```
 
-```typescript
+```tsx
 // ❌ Effect to transform props for rendering → compute inline (memoize only if expensive)
 const visible = useMemo(() => rows.filter((r) => r.active), [rows]);
 

--- a/.claude/skills/coding_standards.md
+++ b/.claude/skills/coding_standards.md
@@ -587,3 +587,110 @@ This is enforced by SonarCloud rule S6759.
 - Utility files: camelCase (e.g. `apiHelpers.ts`)
 - Constants: UPPER_SNAKE_CASE
 
+## 19. React & TypeScript Patterns
+
+§15 lists the ESLint rules; this section covers patterns lint does not catch,
+each with the reason and the fix.
+
+### You might not need an Effect
+
+`useEffect` is for synchronizing with external systems (subscriptions,
+non-React widgets, the network). Do not use it to react to React itself — it
+adds an extra render, is easy to desync, and hides the data flow. Five common
+misuses:
+
+```typescript
+// ❌ Syncing derived state          // ✅ Derive during render
+const [full, setFull] = useState('');
+useEffect(() => {
+  setFull(`${first} ${last}`);
+}, [first, last]);
+const full = `${first} ${last}`;
+
+// ❌ Effect to transform props for rendering → compute inline (memoize only if expensive)
+const visible = useMemo(() => rows.filter((r) => r.active), [rows]);
+
+// ❌ Effect to reset state when a prop changes → remount with a key instead
+<UserForm key={userId} userId={userId} />;
+
+// ❌ Effect that runs on a user action → put the logic in the event handler
+function onSubmit() {
+  postUser(data); // not: setSubmitted(true) + useEffect(...)
+}
+
+// ❌ Effect to compute data already available → just compute it (no state, no effect)
+```
+
+If nothing external is involved, the effect is probably wrong.
+
+### Prefer `Set` for repeated membership checks
+
+`Array.includes` in a loop is O(n·m). Build a `Set` once for O(1) lookups.
+
+```typescript
+// ❌ O(n·m)                              // ✅ O(n)
+rows.filter((r) => selectedIds.includes(r.id));
+const selected = new Set(selectedIds);
+rows.filter((r) => selected.has(r.id));
+```
+
+### No component definitions inside render
+
+Defining a component inside another component's body gives it a new identity
+every render, so React unmounts/remounts its subtree (state loss, flicker).
+Hoist it to module scope. The same applies to render props passed to framework
+components (`PageTable` cell renderers, `PageForm` inputs) — keep the function
+reference stable (module scope or `useCallback`), never an inline arrow that
+closes over changing values it does not need.
+
+### CSS Modules over inline style objects
+
+An inline `style={{ ... }}` object is a new object every render (breaks
+memoization and PatternFly's own bailouts) and cannot be cached by the browser.
+Prefer a CSS Module class; when a dynamic inline style is unavoidable, memoize
+the object with `useMemo`.
+
+### Never `eslint-disable` in new or modified code
+
+Disabling a rule ships the problem plus a suppression to maintain. Fix the
+cause. (This repo forbids it outright — see the overlay skill.)
+
+### Build `ReactNode` lists, not joined strings
+
+To render multiple lines/items, return an array of nodes or a fragment — do not
+`join('\n')` a string (it renders as one text node with literal newlines and
+loses per-item keys/markup).
+
+```tsx
+// ❌ one text blob                        // ✅ real nodes
+<div>{messages.join('\n')}</div>;
+<List>
+  {messages.map((m) => (
+    <ListItem key={m.id}>{m.text}</ListItem>
+  ))}
+</List>;
+```
+
+### Derive named booleans
+
+Extract complex conditions into named `const`s. The name documents intent and
+the condition stays readable at the call site.
+
+```tsx
+// ❌                                      // ✅
+{
+  !isLoading && !error && items.length > 0 && <Table />;
+}
+const hasResults = !isLoading && !error && items.length > 0;
+{
+  hasResults && <Table />;
+}
+```
+
+### Prefer native/browser APIs
+
+Reach for the platform before writing (or importing) custom code — see
+`pr_review.md` for the review grep. Deep copy → `structuredClone(obj)`; query
+strings → `URLSearchParams`; request cancellation → `AbortController`; URL
+parsing → `new URL(...)`.
+

--- a/.claude/skills/coding_standards.md
+++ b/.claude/skills/coding_standards.md
@@ -600,13 +600,19 @@ adds an extra render, is easy to desync, and hides the data flow. Five common
 misuses:
 
 ```typescript
-// ❌ Syncing derived state          // ✅ Derive during render
+// ❌ Syncing derived state
 const [full, setFull] = useState('');
 useEffect(() => {
   setFull(`${first} ${last}`);
 }, [first, last]);
-const full = `${first} ${last}`;
+```
 
+```typescript
+// ✅ Derive during render
+const full = `${first} ${last}`;
+```
+
+```typescript
 // ❌ Effect to transform props for rendering → compute inline (memoize only if expensive)
 const visible = useMemo(() => rows.filter((r) => r.active), [rows]);
 
@@ -694,4 +700,3 @@ Reach for the platform before writing (or importing) custom code — see
 `pr_review.md` for the review grep. Deep copy → `structuredClone(obj)`; query
 strings → `URLSearchParams`; request cancellation → `AbortController`; URL
 parsing → `new URL(...)`.
-

--- a/.claude/skills/frontend-playwright-e2e/SKILL.md
+++ b/.claude/skills/frontend-playwright-e2e/SKILL.md
@@ -65,12 +65,12 @@ test.describe('Feature Name - Description', () => {
 
 ### Test type guidelines
 
-| Type | Meaning |
-| --- | --- |
-| **Unit** | Pure logic/functions, no DOM, mock dependencies, milliseconds (Vitest) |
-| **Component** | Units together, mocked APIs, Vitest, UI/form behavior; don't mock unless necessary |
-| **Integration** | Live API, no mocking; API interaction (RBAC, job execution, DB) |
-| **User acceptance** | Full user flows spanning resources (create template → run job → verify output) |
+| Type                | Meaning                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| **Unit**            | Pure logic/functions, no DOM, mock dependencies, milliseconds (Vitest)             |
+| **Component**       | Units together, mocked APIs, Vitest, UI/form behavior; don't mock unless necessary |
+| **Integration**     | Live API, no mocking; API interaction (RBAC, job execution, DB)                    |
+| **User acceptance** | Full user flows spanning resources (create template → run job → verify output)     |
 
 ### Critical Playwright rules
 

--- a/.claude/skills/frontend-playwright-e2e/SKILL.md
+++ b/.claude/skills/frontend-playwright-e2e/SKILL.md
@@ -143,6 +143,38 @@ Never conclude test work until all tests pass and lint/TypeScript issues are res
 Do not start a second UI if port 4100 is already bound. To launch a run without
 dumping secrets, use the **Running tests** wizard below.
 
+#### 6. Web-first assertions & auto-waiting
+
+`expect(locator)` assertions auto-retry until they pass or time out, and
+locator actions auto-wait for the element to be actionable. Rely on that — never
+add manual sleeps.
+
+```typescript
+// GOOD — retries until the element appears / has the text
+await expect(page.getByRole('heading', { name: 'Details' })).toBeVisible();
+await expect(page.getByTestId('status')).toHaveText('Successful');
+
+// AVOID — arbitrary sleep, flaky and slow
+await page.waitForTimeout(3000);
+expect(await page.getByTestId('status').textContent()).toBe('Successful');
+```
+
+Prefer `waitForResponse` (see rule #4) over `waitForTimeout` when you need to
+wait for data.
+
+#### Common anti-patterns
+
+- **Hard sleeps** — `waitForTimeout()` to "let things settle". Use a web-first
+  assertion or `waitForResponse` instead.
+- **Manual retry/poll loops** — re-implementing what `expect(locator)` already
+  does. Assert on the locator.
+- **Reading then asserting** — `expect(await locator.textContent())` does not
+  retry. Use `await expect(locator).toHaveText(...)`.
+- **Asserting on detached elements** — after a navigation or re-render, re-query
+  the locator; do not hold a stale handle.
+- **Acting after navigation with no wait** — follow a navigation with a
+  web-first assertion on the new page before interacting.
+
 ### Test development methodology
 
 Validate workflows manually with browser automation (Playwright MCP) before writing tests:

--- a/.claude/skills/testing_guidelines.md
+++ b/.claude/skills/testing_guidelines.md
@@ -346,47 +346,39 @@ it('should increment counter when button clicked', async () => {
 
 ---
 
-## Accessibility Testing (vitest-axe)
+## Accessibility Testing
 
-Accessibility is part of every UI change, so it belongs in the unit test. Test
-it at three levels, cheapest first.
+Accessibility is part of every UI change, so assert it in the unit test using
+the tools already in the stack — no extra dependency required.
 
-**1. Automated smoke check** — run `axe` over the rendered container and assert
-no violations:
-
-```typescript
-import { axe } from 'vitest-axe';
-
-it('has no accessibility violations', async () => {
-  const { container } = render(<CredentialForm />);
-  expect(await axe(container)).toHaveNoViolations();
-});
-```
-
-**2. Role/name queries as the default** — writing assertions with `getByRole`
+**1. Role/name queries as the default** — writing assertions with `getByRole`
 
 - accessible name (see **Query Priority**) proves elements are reachable by
   assistive tech. If a query needs `getByTestId`, that is usually a missing
   label, not a test problem — fix the component.
 
-**3. Keyboard and focus** — for interactive flows, assert with the keyboard,
+**2. Keyboard and focus** — for interactive flows, assert with the keyboard,
 not just the mouse (reuse `userEvent.setup()` from **User Interaction**):
 
 ```typescript
 const user = userEvent.setup();
-render(<ConfirmDialog />);
+render(<CredentialForm />);
 
 await user.tab();
 expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
 await user.keyboard('{Enter}');
 ```
 
-> **Caveat — `happy-dom` limits `axe`.** The default test environment is
-> `happy-dom` (see **Test Stack** / **Vitest Configuration**), which does not
+**Automated axe scan (optional).** An `axe`/`toHaveNoViolations` smoke check is
+useful but `vitest-axe` is **not** currently a dependency in this repo — adding
+it is a prerequisite, not something to assume. Even then, note the caveat below.
+
+> **Caveat — `happy-dom` limits axe-style checks.** The default test environment
+> is `happy-dom` (see **Test Stack** / **Vitest Configuration**), which does not
 > compute layout or styles. Checks that depend on rendering — color-contrast,
 > visibility/overlap, computed geometry — are unreliable or silent no-ops here.
-> Treat the `axe` smoke check as catching structural issues (missing labels,
-> roles, `alt`, ARIA misuse). Contrast and visual-focus checks belong in
+> An automated scan under happy-dom only catches structural issues (missing
+> labels, roles, `alt`, ARIA misuse). Contrast and visual-focus checks belong in
 > Playwright against a real browser, not Vitest.
 
 ---

--- a/.claude/skills/testing_guidelines.md
+++ b/.claude/skills/testing_guidelines.md
@@ -362,7 +362,7 @@ not just the mouse (reuse `userEvent.setup()` from **User Interaction**):
 
 ```typescript
 const user = userEvent.setup();
-render(<CredentialForm />);
+render(<MyForm />);
 
 await user.tab();
 expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();

--- a/.claude/skills/testing_guidelines.md
+++ b/.claude/skills/testing_guidelines.md
@@ -346,6 +346,51 @@ it('should increment counter when button clicked', async () => {
 
 ---
 
+## Accessibility Testing (vitest-axe)
+
+Accessibility is part of every UI change, so it belongs in the unit test. Test
+it at three levels, cheapest first.
+
+**1. Automated smoke check** — run `axe` over the rendered container and assert
+no violations:
+
+```typescript
+import { axe } from 'vitest-axe';
+
+it('has no accessibility violations', async () => {
+  const { container } = render(<CredentialForm />);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+**2. Role/name queries as the default** — writing assertions with `getByRole`
+
+- accessible name (see **Query Priority**) proves elements are reachable by
+  assistive tech. If a query needs `getByTestId`, that is usually a missing
+  label, not a test problem — fix the component.
+
+**3. Keyboard and focus** — for interactive flows, assert with the keyboard,
+not just the mouse (reuse `userEvent.setup()` from **User Interaction**):
+
+```typescript
+const user = userEvent.setup();
+render(<ConfirmDialog />);
+
+await user.tab();
+expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+await user.keyboard('{Enter}');
+```
+
+> **Caveat — `happy-dom` limits `axe`.** The default test environment is
+> `happy-dom` (see **Test Stack** / **Vitest Configuration**), which does not
+> compute layout or styles. Checks that depend on rendering — color-contrast,
+> visibility/overlap, computed geometry — are unreliable or silent no-ops here.
+> Treat the `axe` smoke check as catching structural issues (missing labels,
+> roles, `alt`, ARIA misuse). Contrast and visual-focus checks belong in
+> Playwright against a real browser, not Vitest.
+
+---
+
 ## Skipping Tests
 
 Use `test.skip()` for tests that depend on data not always available:

--- a/.claude/skills/testing_guidelines.md
+++ b/.claude/skills/testing_guidelines.md
@@ -26,7 +26,7 @@ Each workspace has a `vitest.setup.ts` that calls:
 ```typescript
 import '@testing-library/jest-dom/vitest';
 import { mockI18n, enablePreview } from './vitest.common';
-mockI18n();     // Mocks react-i18next globally — t() returns the key string
+mockI18n(); // Mocks react-i18next globally — t() returns the key string
 enablePreview(); // Captures DOM snapshot on test failure via vitest-preview
 ```
 
@@ -56,9 +56,7 @@ const server = setupServer(
   ),
 
   // GET — return single item
-  http.get(awxAPI`/feature_flags_state/`, () =>
-    HttpResponse.json({ MY_FLAG: true })
-  ),
+  http.get(awxAPI`/feature_flags_state/`, () => HttpResponse.json({ MY_FLAG: true })),
 
   // POST — create
   http.post(awxAPI`/users/`, async ({ request }) => {
@@ -79,19 +77,17 @@ afterAll(() => server.close());
 
 ### `onUnhandledRequest` options
 
-| Value     | Use when                                                |
-| --------- | ------------------------------------------------------- |
-| `'warn'`  | Default — logs unhandled requests but doesn't fail      |
-| `'error'` | Strict — fails test on any unmocked API call            |
-| `'bypass'`| Permissive — silently passes through unhandled requests |
+| Value      | Use when                                                |
+| ---------- | ------------------------------------------------------- |
+| `'warn'`   | Default — logs unhandled requests but doesn't fail      |
+| `'error'`  | Strict — fails test on any unmocked API call            |
+| `'bypass'` | Permissive — silently passes through unhandled requests |
 
 ### Override handlers in individual tests
 
 ```typescript
 it('should show error on API failure', async () => {
-  server.use(
-    http.get(awxAPI`/users/`, () => HttpResponse.json({}, { status: 500 }))
-  );
+  server.use(http.get(awxAPI`/users/`, () => HttpResponse.json({}, { status: 500 })));
   // ... render and assert error state
 });
 ```
@@ -178,9 +174,12 @@ it('should return feature flags from API', async () => {
 ### Hook test with timeout (for slow or complex hooks)
 
 ```typescript
-await waitFor(() => {
-  expect(result.current).toBeDefined();
-}, { timeout: 10000 });
+await waitFor(
+  () => {
+    expect(result.current).toBeDefined();
+  },
+  { timeout: 10000 }
+);
 ```
 
 ### Hooks that read OPTIONS response
@@ -189,16 +188,19 @@ await waitFor(() => {
 const server = setupServer(
   http.options(awxAPI`/credentials/`, () =>
     HttpResponse.json({
-      actions: { GET: { credential_type: { filterable: true, type: 'field' } } }
+      actions: { GET: { credential_type: { filterable: true, type: 'field' } } },
     })
   )
 );
 
 it('should generate filters from OPTIONS', async () => {
   const { result } = renderHook(() => useCredentialTypesFilters());
-  await waitFor(() => {
-    expect(result.current.length).toBeGreaterThan(0);
-  }, { timeout: 10000 });
+  await waitFor(
+    () => {
+      expect(result.current.length).toBeGreaterThan(0);
+    },
+    { timeout: 10000 }
+  );
 });
 ```
 
@@ -319,9 +321,12 @@ await waitFor(() => {
 });
 
 // With custom timeout for slow operations
-await waitFor(() => {
-  expect(result.current.data).toBeDefined();
-}, { timeout: 15000 });
+await waitFor(
+  () => {
+    expect(result.current.data).toBeDefined();
+  },
+  { timeout: 15000 }
+);
 ```
 
 ---
@@ -369,18 +374,6 @@ expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
 await user.keyboard('{Enter}');
 ```
 
-**Automated axe scan (optional).** An `axe`/`toHaveNoViolations` smoke check is
-useful but `vitest-axe` is **not** currently a dependency in this repo — adding
-it is a prerequisite, not something to assume. Even then, note the caveat below.
-
-> **Caveat — `happy-dom` limits axe-style checks.** The default test environment
-> is `happy-dom` (see **Test Stack** / **Vitest Configuration**), which does not
-> compute layout or styles. Checks that depend on rendering — color-contrast,
-> visibility/overlap, computed geometry — are unreliable or silent no-ops here.
-> An automated scan under happy-dom only catches structural issues (missing
-> labels, roles, `alt`, ARIA misuse). Contrast and visual-focus checks belong in
-> Playwright against a real browser, not Vitest.
-
 ---
 
 ## Skipping Tests
@@ -399,8 +392,8 @@ Never commit `test.only()` — ESLint rule `no-only-tests` will catch it.
 
 ## What to Test
 
-| Type          | Focus on                                            |
-| ------------- | --------------------------------------------------- |
+| Type          | Focus on                                             |
+| ------------- | ---------------------------------------------------- |
 | **Component** | User interactions, conditional rendering, edge cases |
 | **Hook**      | Return values, state transitions, error handling     |
 | **Utility**   | Input/output transformations, boundary conditions    |


### PR DESCRIPTION
## Summary

Additive guidance for the on-demand skills, covering conventions the current
ESLint configuration does not enforce — each with the **reason** and the **fix**.
Skill markdown only; no runtime code changes. Additions-only diff (182 insertions,
0 deletions).

**`coding_standards.md`** — new `## 19. React & TypeScript Patterns`:
- "You might not need an Effect" — the 5 common misuses + the non-effect fix.
- `Set` for repeated membership checks (O(1) vs `Array.includes` in a loop).
- No component definitions inside render; keep framework render props stable.
- CSS Modules over inline style objects (memoization/caching).
- Never `eslint-disable` in new/modified code.
- Build `ReactNode` lists, not `join('\\n')` strings.
- Derive named booleans for complex conditions.
- Prefer native APIs (`structuredClone` / `URLSearchParams` / `AbortController` / `URL`).

**`testing_guidelines.md`** — new `## Accessibility Testing`:
role/name queries + keyboard/focus using the tools already in the stack.

**`frontend-playwright-e2e/SKILL.md`** — web-first assertions & auto-waiting
rule + a common-anti-patterns list (no hard sleeps, poll loops, read-then-
assert, detached elements, act-after-nav).

Scoped to React 18 (no React 19 APIs); i18n intentionally skipped (already
covered in `coding_standards.md` §16).

## Type of Change

- [x] Documentation

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (documentation / skill markdown only; no runtime code touched).

## Testing

### Manual Testing

Additions-only diff verified (`git diff --stat`: 182 insertions, 0 deletions).
All code examples use framework-generic or ansible-ui-real names.
