### PR TITLE
Show authenticator options on detail page

### DIFF
--- a/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorDetails.test.tsx
+++ b/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorDetails.test.tsx
@@ -1,10 +1,83 @@
 /* eslint-disable i18next/no-literal-string */
-import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { Authenticator } from '../../../interfaces/Authenticator';
+import type { AuthenticatorPlugins } from '../../../interfaces/AuthenticatorPlugin';
+import { gatewayAPI } from '../../../utils/gateway-api-utils';
+import authenticator_plugins from '../components/authenticatorPlugins.fixture.json';
+import authenticators from '../components/authenticators.fixture.json';
 import { PlatformAuthenticatorDetails } from './PlatformAuthenticatorDetails';
 
+const localAuthenticator = {
+  ...authenticators.results[0],
+  enabled: true,
+  create_objects: true,
+  remove_users: false,
+} as unknown as Authenticator;
+
+const server = setupServer(
+  http.get(gatewayAPI`/authenticators/1/`, () => {
+    return HttpResponse.json(localAuthenticator);
+  }),
+  http.get(gatewayAPI`/authenticators/`, () => {
+    return HttpResponse.json({ count: 0, results: [] });
+  }),
+  http.get(gatewayAPI`/authenticator_plugins/`, () => {
+    return HttpResponse.json(authenticator_plugins as AuthenticatorPlugins);
+  })
+);
+
 describe('PlatformAuthenticatorDetails', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const renderComponent = () =>
+    render(
+      <MemoryRouter initialEntries={['/access/authenticators/1/details']}>
+        <Routes>
+          <Route
+            path="/access/authenticators/:id/details"
+            element={<PlatformAuthenticatorDetails />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
   it('exports the PlatformAuthenticatorDetails component', () => {
     expect(PlatformAuthenticatorDetails).toBeDefined();
     expect(typeof PlatformAuthenticatorDetails).toBe('function');
+  });
+
+  it('displays authenticator option fields on the details page', async () => {
+    renderComponent();
+
+    expect(await screen.findByText('Enabled')).toBeInTheDocument();
+    expect(screen.getByText('Create objects')).toBeInTheDocument();
+    expect(screen.getByText('Remove users')).toBeInTheDocument();
+    expect(screen.getAllByText('On')).toHaveLength(2);
+    expect(screen.getByText('Off')).toBeInTheDocument();
+  });
+
+  it('displays Off when all authenticator options are disabled', async () => {
+    server.use(
+      http.get(gatewayAPI`/authenticators/1/`, () => {
+        return HttpResponse.json({
+          ...localAuthenticator,
+          enabled: false,
+          create_objects: false,
+          remove_users: false,
+        });
+      })
+    );
+
+    renderComponent();
+
+    expect(await screen.findByText('Enabled')).toBeInTheDocument();
+    expect(screen.getAllByText('Off')).toHaveLength(3);
   });
 });

--- a/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorDetails.tsx
+++ b/platform/access/authenticators/AuthenticatorPage/PlatformAuthenticatorDetails.tsx
@@ -64,6 +64,7 @@ export function PlatformAuthenticatorDetails() {
   });
   const isLegacyAuthenticator = authenticator?.type.includes('legacy') ?? false;
   const type = getAuthenticatorTypeLabel(authenticator.type, t);
+  const formatBoolean = (value: boolean) => (value ? t('On') : t('Off'));
   return (
     <Scrollable>
       <PageDetails disableScroll>
@@ -77,6 +78,13 @@ export function PlatformAuthenticatorDetails() {
           }
           isLegacy={isLegacyAuthenticator}
         />
+        <PageDetail label={t('Enabled')}>{formatBoolean(authenticator.enabled)}</PageDetail>
+        <PageDetail label={t('Create objects')}>
+          {formatBoolean(authenticator.create_objects)}
+        </PageDetail>
+        <PageDetail label={t('Remove users')}>
+          {formatBoolean(authenticator.remove_users)}
+        </PageDetail>
         {fields.map((field) => (
           <PageDetail label={field.label} key={field.label}>
             {field.value}


### PR DESCRIPTION
## Summary

Show **Enabled**, **Create objects**, and **Remove users** on the authenticator detail (view) page.

Fixes the UI portion of [AAP-59823](https://redhat.atlassian.net/browse/AAP-59823). These fields were only visible in edit mode; the gateway API already returns them.

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (single page fix + unit test). Minimal risk of unintended side effects.

## Testing

### Manual Testing

- Tested locally against containerized AAP 2.6.1 gateway (`PLATFORM_SERVER` + `npm start`)
- Verified displayed values match `/api/gateway/v1/authenticators/<id>/`

### Screenshots
**Before** — authenticator detail page without Enabled / Create objects / Remove users:
<img width="2220" height="484" alt="before" src="https://github.com/user-attachments/assets/aa7ae05a-c951-4344-a87f-387e3d574874" />

**After** — same page with the three options visible:
<img width="1899" height="546" alt="after" src="https://github.com/user-attachments/assets/df21cfef-ac05-4007-9caf-5d693570b71c" />


- Assisted by Cursor 