### PR TITLE
Clear Monaco content before entering replacement text

### DIFF
--- a/playwright/commands/fillMonacoEditor.ts
+++ b/playwright/commands/fillMonacoEditor.ts
@@ -17,5 +17,6 @@ export async function fillMonacoEditor(page: Page, text: string, editorLocator?:
   const editor = editorLocator ?? page.getByRole('textbox', { name: 'Editor content' });
   await editor.click({ force: true });
   await page.keyboard.press('Control+a');
+  await page.keyboard.press('Backspace');
   await page.keyboard.type(text);
 }


### PR DESCRIPTION
## Summary

Ensure `fillMonacoEditor` clears the selected editor contents before typing replacement text. Monaco 0.56 native edit context can otherwise append or concatenate the new value.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [x] **Medium** — Scoped but cross-cutting
- [ ] **Low** — Narrowly scoped

The code change is one line, but the shared helper has 25 callers across 15 files.

## Testing

- Prettier
- `git diff --check`
- Full CI
- Live Playwright via `/run-playwright`