### PR TITLE
[AAP-90411] fix(e2e): assert inventory-path after source edit

### DIFF
--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-sources.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/tabs/inventory-sources.spec.ts
@@ -72,7 +72,7 @@ test.describe('Inventory Source List', () => {
       ).toBeVisible();
 
       await expect(page.getByTestId('description')).toContainText('mock description');
-      await expect(page.getByTestId('inventory-file')).toContainText('hello_world.yml');
+      await expect(page.getByTestId('inventory-path')).toContainText('hello_world.yml');
       await expect(page.getByTestId('enabled-options')).toContainText('Overwrite');
 
       await Inventory.ui.delete(page, inventoryName);


### PR DESCRIPTION
## Summary

- Fixes the failing live test `Inventory Source List > should edit source from the list view and update info`.
- After [#3251](https://github.com/ansible/ansible-ui/pull/3251), the details field label is **Inventory path**, so `PageDetail` renders `data-testid="inventory-path"` instead of `inventory-file`.
- The edit still saved correctly (`hello_world.yml` was on the page); the spec was asserting the old testid.

Jira: [AAP-90411](https://issues.redhat.com/browse/AAP-90411)

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

Failed Currents run that this addresses: test `should edit source from the list view and update info` consistently timed out on `getByTestId('inventory-file')` while the accessibility snapshot showed **Inventory path** = `hello_world.yml`.

### Manual Testing

Not run locally (no UI on port 4100). Verification is the one-line testid update matching the details page contract.

### Screenshots

N/A — test-only change.

Assisted-by: Cursor Grok 4.6 (SpaceXAI)

Made with [Cursor](https://cursor.com)