### PR TITLE
fix(AAP-90404): paste into Monaco via clipboard to avoid JSON corruption

### DIFF
--- a/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleEditWizard.test.tsx
@@ -74,21 +74,35 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
+async function renderEditWizard() {
+  const user = userEvent.setup();
+  render(
+    <TestWrapper>
+      <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
+    </TestWrapper>
+  );
+  await waitFor(() => {
+    expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
+  });
+  // PageWizard sets activeStep in an effect, so the Next footer is not on first paint.
+  await screen.findByRole('button', { name: /^Next$/ });
+  return user;
+}
+
+async function goToRulesStep(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole('button', { name: /^Next$/ }));
+  await waitFor(() => {
+    expect(screen.getByText('Schedule Rules')).toBeInTheDocument();
+  });
+}
+
 describe('ScheduleEditWizard', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
   it('should render wizard with correct steps on initial load', async () => {
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
+    await renderEditWizard();
 
     const nav = screen.getByTestId('wizard-nav');
     expect(nav).toBeInTheDocument();
@@ -99,76 +113,29 @@ describe('ScheduleEditWizard', () => {
   });
 
   it('should render schedule name in title', async () => {
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
+    await renderEditWizard();
 
     expect(screen.getByTestId('page-title')).toBeInTheDocument();
   });
 
   it('should display rules when navigating to Rules step', async () => {
-    const user = userEvent.setup();
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
-
-    const nextButton = screen.getByRole('button', { name: /^Next$/ });
-    await user.click(nextButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('Schedule Rules')).toBeInTheDocument();
-    });
+    const user = await renderEditWizard();
+    await goToRulesStep(user);
 
     expect(screen.getByTestId('row-id-1')).toBeInTheDocument();
     expect(screen.getByTestId('row-id-2')).toBeInTheDocument();
   });
 
   it('should show Add rule button on Rules step', async () => {
-    const user = userEvent.setup();
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
-
-    await user.click(screen.getByRole('button', { name: /^Next$/ }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Schedule Rules')).toBeInTheDocument();
-    });
+    const user = await renderEditWizard();
+    await goToRulesStep(user);
 
     expect(screen.getByRole('button', { name: /add rule/i })).toBeInTheDocument();
   });
 
   it('should have actions column with edit and delete for each rule row', async () => {
-    const user = userEvent.setup();
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
-
-    await user.click(screen.getByRole('button', { name: /^Next$/ }));
+    const user = await renderEditWizard();
+    await goToRulesStep(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('row-id-1')).toBeInTheDocument();
@@ -182,22 +149,8 @@ describe('ScheduleEditWizard', () => {
   });
 
   it('should render rule rows with RRule column', async () => {
-    const user = userEvent.setup();
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
-
-    await user.click(screen.getByRole('button', { name: /^Next$/ }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Schedule Rules')).toBeInTheDocument();
-    });
+    const user = await renderEditWizard();
+    await goToRulesStep(user);
 
     expect(screen.getByText('RRule')).toBeInTheDocument();
     expect(screen.getByTestId('row-id-1')).toBeInTheDocument();
@@ -205,18 +158,8 @@ describe('ScheduleEditWizard', () => {
   });
 
   it('should add new rule when clicking Add rule and Save rule', async () => {
-    const user = userEvent.setup();
-    render(
-      <TestWrapper>
-        <ScheduleEditWizard resourceEndPoint={awxAPI`/job_templates/`} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('page-title')).toHaveTextContent('Edit Test Schedule');
-    });
-
-    await user.click(screen.getByRole('button', { name: /^Next$/ }));
+    const user = await renderEditWizard();
+    await goToRulesStep(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('row-id-1')).toBeInTheDocument();

--- a/playwright/commands/fillMonacoEditor.ts
+++ b/playwright/commands/fillMonacoEditor.ts
@@ -8,8 +8,8 @@ import { Locator, Page } from '@playwright/test';
  * `<input>`, `<textarea>`, or `[contenteditable]` elements.
  *
  * Strategy varies by browser:
- * - Chromium/Firefox: Clipboard paste (Ctrl+V) bypasses auto-closing brackets
- *   and reliably triggers Monaco's content-change handlers.
+ * - Chromium/Firefox: Clipboard paste (ControlOrMeta+V) bypasses auto-closing
+ *   brackets and reliably triggers Monaco's content-change handlers.
  * - WebKit: Pastes via a temporary textarea (clipboard API is unavailable due
  *   to permission restrictions on non-Chromium browsers). The textarea is
  *   created, filled, copied to clipboard via JS, then pasted into Monaco.
@@ -28,7 +28,7 @@ import { Locator, Page } from '@playwright/test';
 export async function fillMonacoEditor(page: Page, text: string, editorLocator?: Locator) {
   const editor = editorLocator ?? page.getByRole('textbox', { name: 'Editor content' });
   await editor.click({ force: true });
-  await page.keyboard.press('Control+a');
+  await page.keyboard.press('ControlOrMeta+a');
   if (text === '') {
     await page.keyboard.press('Backspace');
     return;
@@ -49,13 +49,13 @@ export async function fillMonacoEditor(page: Page, text: string, editorLocator?:
     }, text);
     // textarea.select() steals focus; restore Monaco focus and selection before paste.
     await editor.click({ force: true });
-    await page.keyboard.press('Control+a');
-    await page.keyboard.press('Control+v');
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('ControlOrMeta+v');
   } else {
     // Chromium/Firefox: Use navigator.clipboard to paste without per-keystroke events.
     await page.evaluate(async (value: string) => {
       await navigator.clipboard.writeText(value);
     }, text);
-    await page.keyboard.press('Control+v');
+    await page.keyboard.press('ControlOrMeta+v');
   }
 }

--- a/playwright/commands/fillMonacoEditor.ts
+++ b/playwright/commands/fillMonacoEditor.ts
@@ -5,8 +5,19 @@ import { Locator, Page } from '@playwright/test';
  *
  * Monaco 0.56+ uses a `native-edit-context` element that is NOT a standard
  * `<textarea>` or `[contenteditable]`. Playwright's `.fill()` only works on
- * `<input>`, `<textarea>`, or `[contenteditable]` elements, so we use the
- * keyboard to select-all and type instead.
+ * `<input>`, `<textarea>`, or `[contenteditable]` elements.
+ *
+ * Clipboard paste (Ctrl+V) is used instead of `keyboard.type()` or
+ * `keyboard.insertText()`:
+ * - `type()` sends per-keystroke events and triggers Monaco auto-closing
+ *   brackets/quotes, which corrupts structured JSON/YAML.
+ * - `insertText()` dispatches only an `input` event and may not update the
+ *   Monaco model / form value when native-edit-context is enabled.
+ * Paste inserts the whole string, bypasses auto-closing, and fires Monaco's
+ * content-change handlers so React Hook Form stays in sync.
+ *
+ * Empty string: select-all + Backspace. Pasting or inserting `''` does not
+ * reliably clear the current selection.
  *
  * @param page  - The Playwright Page object
  * @param text  - The text to enter into the editor
@@ -17,5 +28,12 @@ export async function fillMonacoEditor(page: Page, text: string, editorLocator?:
   const editor = editorLocator ?? page.getByRole('textbox', { name: 'Editor content' });
   await editor.click({ force: true });
   await page.keyboard.press('Control+a');
-  await page.keyboard.type(text);
+  if (text === '') {
+    await page.keyboard.press('Backspace');
+    return;
+  }
+  await page.evaluate(async (value: string) => {
+    await navigator.clipboard.writeText(value);
+  }, text);
+  await page.keyboard.press('Control+v');
 }

--- a/playwright/commands/fillMonacoEditor.ts
+++ b/playwright/commands/fillMonacoEditor.ts
@@ -7,17 +7,18 @@ import { Locator, Page } from '@playwright/test';
  * `<textarea>` or `[contenteditable]`. Playwright's `.fill()` only works on
  * `<input>`, `<textarea>`, or `[contenteditable]` elements.
  *
- * Clipboard paste (Ctrl+V) is used instead of `keyboard.type()` or
- * `keyboard.insertText()`:
- * - `type()` sends per-keystroke events and triggers Monaco auto-closing
- *   brackets/quotes, which corrupts structured JSON/YAML.
- * - `insertText()` dispatches only an `input` event and may not update the
- *   Monaco model / form value when native-edit-context is enabled.
- * Paste inserts the whole string, bypasses auto-closing, and fires Monaco's
- * content-change handlers so React Hook Form stays in sync.
+ * Strategy varies by browser:
+ * - Chromium/Firefox: Clipboard paste (Ctrl+V) bypasses auto-closing brackets
+ *   and reliably triggers Monaco's content-change handlers.
+ * - WebKit: Pastes via a temporary textarea (clipboard API is unavailable due
+ *   to permission restrictions on non-Chromium browsers). The textarea is
+ *   created, filled, copied to clipboard via JS, then pasted into Monaco.
  *
- * Empty string: select-all + Backspace. Pasting or inserting `''` does not
- * reliably clear the current selection.
+ * Why not keyboard.type() everywhere?
+ * - Sends per-keystroke events and triggers Monaco auto-closing brackets/quotes,
+ *   corrupting structured JSON/YAML.
+ *
+ * Empty string: select-all + Backspace (works reliably across all browsers).
  *
  * @param page  - The Playwright Page object
  * @param text  - The text to enter into the editor
@@ -32,8 +33,29 @@ export async function fillMonacoEditor(page: Page, text: string, editorLocator?:
     await page.keyboard.press('Backspace');
     return;
   }
-  await page.evaluate(async (value: string) => {
-    await navigator.clipboard.writeText(value);
-  }, text);
-  await page.keyboard.press('Control+v');
+
+  const browserName = page.context().browser()?.browserType().name() || 'chromium';
+
+  if (browserName === 'webkit') {
+    // WebKit: navigator.clipboard is unavailable (permissions ignored on non-Chromium).
+    // Workaround: copy via a temporary textarea + execCommand, then paste into Monaco.
+    await page.evaluate((value: string) => {
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }, text);
+    // textarea.select() steals focus; restore Monaco focus and selection before paste.
+    await editor.click({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.press('Control+v');
+  } else {
+    // Chromium/Firefox: Use navigator.clipboard to paste without per-keystroke events.
+    await page.evaluate(async (value: string) => {
+      await navigator.clipboard.writeText(value);
+    }, text);
+    await page.keyboard.press('Control+v');
+  }
 }

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -63,16 +63,20 @@ const config: PlaywrightTestConfig = {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    // fillMonacoEditor pastes via the clipboard (Ctrl+V). Chromium honors these
-    // permissions; other browsers ignore unknown entries.
-    permissions: ['clipboard-read', 'clipboard-write'],
+    // fillMonacoEditor only needs clipboard-write. Chromium honors this grant;
+    // other browsers ignore unknown permission entries.
+    permissions: ['clipboard-write'],
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: 'live chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        // Hub copy-CLI specs call navigator.clipboard.readText().
+        permissions: ['clipboard-read', 'clipboard-write'],
+      },
       dependencies: ['coverage setup'],
 
       // Commenting this out for now to see if it is really needed

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -63,13 +63,16 @@ const config: PlaywrightTestConfig = {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    // fillMonacoEditor pastes via the clipboard (Ctrl+V). Chromium honors these
+    // permissions; other browsers ignore unknown entries.
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: 'live chromium',
-      use: { ...devices['Desktop Chrome'], permissions: ['clipboard-read', 'clipboard-write'] },
+      use: { ...devices['Desktop Chrome'] },
       dependencies: ['coverage setup'],
 
       // Commenting this out for now to see if it is really needed

--- a/playwright/tests/integration/automation-content/namespaces/namespaces.spec.ts
+++ b/playwright/tests/integration/automation-content/namespaces/namespaces.spec.ts
@@ -1,10 +1,11 @@
-import { expect, test } from '@playwright/test';
+import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
+import { createE2EName } from '@ansible/playwright/commands/createE2EName';
+import { fillMonacoEditor } from '@ansible/playwright/commands/fillMonacoEditor';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
+import { selectTableRow } from '@ansible/playwright/commands/selectTableRow';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
 import { Namespace } from '@ansible/playwright/utils';
-import { createE2EName } from '@ansible/playwright/commands/createE2EName';
-import { clickTableRow } from '@ansible/playwright/commands/clickTableRow';
-import { selectTableRow } from '@ansible/playwright/commands/selectTableRow';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(setupBefore());
 test.afterEach(setupAfter);
@@ -23,8 +24,7 @@ test.describe('Hub - Namespaces', () => {
       await expect(page).toHaveURL(/\/namespaces\/create/);
       await page.getByTestId('name').fill(namespaceName);
       await page.getByTestId('company').fill('test company');
-      await page.locator('.view-lines').click();
-      await page.keyboard.type('name: example_namespace');
+      await fillMonacoEditor(page, 'name: example_namespace');
       await page.getByText('Preview', { exact: true }).click();
       await expect(page.getByTestId('resources-form-group')).toContainText(
         'name: example_namespace'

--- a/playwright/tests/integration/automation-decisions/credential-types/credential-types-crud.spec.ts
+++ b/playwright/tests/integration/automation-decisions/credential-types/credential-types-crud.spec.ts
@@ -57,6 +57,9 @@ test.describe('EDA Credential Types - CRUD Operations', () => {
       });
 
       await test.step('Generate extra vars and verify injectors', async () => {
+        await expect(page.getByRole('button', { name: 'Generate extra vars' })).toBeVisible({
+          timeout: 15000,
+        });
         await page.getByRole('button', { name: 'Generate extra vars' }).click();
         await expect(
           page.locator('#injectors').getByRole('textbox', { name: 'Editor content' })

--- a/playwright/tests/integration/automation-execution/infrastructure/inventories/constructed/constructed-inventory-crud.spec.ts
+++ b/playwright/tests/integration/automation-execution/infrastructure/inventories/constructed/constructed-inventory-crud.spec.ts
@@ -176,25 +176,16 @@ test.describe('Constructed Inventory', () => {
         await clickPageAction('Edit inventory', page);
         await expect(page.getByRole('heading', { name: 'Edit' })).toBeVisible();
 
-        // Update source vars to add strict mode and bad variables
-        await page.locator('.view-line').click();
-        await page.keyboard.press('Control+a');
-
-        // Type YAML line by line with actual Enter key presses
-        const yamlLines = [
-          `plugin: constructed`,
-          `strict: true`,
-          `groups:`,
-          `  is_shutdown: "state | default('running') == 'shutdown'"`,
-          `  product_dev: "account_alias == 'product_dev'"`,
-        ];
-
-        for (let i = 0; i < yamlLines.length; i++) {
-          await page.keyboard.type(yamlLines[i]);
-          if (i < yamlLines.length - 1) {
-            await page.keyboard.press('Enter');
-          }
-        }
+        await fillMonacoEditor(
+          page,
+          [
+            'plugin: constructed',
+            'strict: true',
+            'groups:',
+            `  is_shutdown: "state | default('running') == 'shutdown'"`,
+            `  product_dev: "account_alias == 'product_dev'"`,
+          ].join('\n')
+        );
 
         // Save and wait for navigation
         await page.getByRole('button', { name: 'Save inventory' }).click();

--- a/playwright/utils/namespace.ts
+++ b/playwright/utils/namespace.ts
@@ -1,10 +1,11 @@
+import { HubNamespace } from '@ansible/hub-ui/namespaces/HubNamespace';
 import { Page, expect } from '@playwright/test';
 import { hubAPI } from '../commands/apiClient';
-import { createE2EName } from '../commands/createE2EName';
-import { navigateTo } from '../commands/navigateTo';
 import { clickTableRow } from '../commands/clickTableRow';
+import { createE2EName } from '../commands/createE2EName';
 import { deleteResourceFromDetailsPage } from '../commands/deleteResourceFromDetailsPage';
-import { HubNamespace } from '@ansible/hub-ui/namespaces/HubNamespace';
+import { fillMonacoEditor } from '../commands/fillMonacoEditor';
+import { navigateTo } from '../commands/navigateTo';
 
 export interface CreateNamespaceOptions {
   name?: string;
@@ -76,8 +77,7 @@ export const Namespace = {
       }
 
       if (options.resources) {
-        await page.locator('.view-lines').click();
-        await page.keyboard.type(options.resources);
+        await fillMonacoEditor(page, options.resources);
       }
 
       if (options.linkText && options.linkUrl) {


### PR DESCRIPTION
## Summary

`credential-types-crud.spec.ts` ("should create and edit a credential type") timed out waiting for **Generate extra vars**. That button only renders when React Hook Form `inputs` is a parsed object with `fields.length > 0`. The form gets that value from Monaco's `onDidChangeContent` handler.

`fillMonacoEditor` used `page.keyboard.type()`, which sends one keydown per character. Monaco's JSON language auto-closes `{`, `[`, and `"`, so the typed JSON was corrupted, the schema never parsed, the button never appeared, and the click hung until the 60s timeout.

The required fix is to fill Monaco without per-keystroke auto-closing, in a way that still updates the model / RHF.

## What is required for that failure

- **`fillMonacoEditor`**: clipboard paste (`Ctrl+V`) instead of `keyboard.type()`. Paste inserts the whole string, skips auto-closing, and fires content-change handlers so the form stays in sync.
- `keyboard.insertText()` is not used: it dispatches only an `input` event and may not update the Monaco 0.56 native-edit-context model / RHF (see #3468).

Clipboard permissions: this spec is `@not_mock` and runs on `live chromium`, which already had `clipboard-read` / `clipboard-write`. The global config grant is not what unblocks this test; it only matters if other projects call the same helper.

## What is not required for that failure

| Change | Why it is in this PR |
| --- | --- |
| 15s wait for "Generate extra vars" | Fail faster if fill is still wrong. Does not fix the timeout by itself. |
| Empty-string → Backspace | `remotes.spec.ts` calls `fillMonacoEditor(page, '')`. The credential type test never clears the editor that way. |
| Namespace + constructed-inventory `keyboard.type()` → helper | Same auto-pair class of bug on other specs. |
| `ScheduleEditWizard.test.tsx` | Unrelated Vitest flake that failed the `Vitest (awx) / views` CI gate. |
| Clipboard perms on all Playwright projects | Needed for paste on mock/other browsers; `live chromium` already had them. |

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once preliminary checks pass, comment `/run-playwright` on this PR.

### Manual Testing

- [ ] `cd playwright && npx playwright test tests/integration/automation-decisions/credential-types/credential-types-crud.spec.ts --project 'live chromium' --retries=0`
- [ ] Spot-check another `fillMonacoEditor` caller (e.g. `regular-inventory-crud.spec.ts` or `workflow-visualizer.spec.ts`)

### Why clipboard paste (and what we ruled out)

- `keyboard.type()` — auto-closes `{}` / `[]` / `""` and corrupts JSON/YAML.
- `locator.fill()` — fails on Monaco 0.56 `native-edit-context`.
- `keyboard.insertText()` — bulk insert, but may not update the model / RHF (#3468).
- Clipboard paste — bulk insert that still fires Monaco content-change handlers.
