### PR TITLE
fix(e2e): select Default org without depending on its description

### DIFF
--- a/playwright/tests/integration/automation-decisions/credentials/credentials.spec.ts
+++ b/playwright/tests/integration/automation-decisions/credentials/credentials.spec.ts
@@ -2,6 +2,7 @@ import { isSaaS } from '@ansible/playwright/commands/getTopologyType';
 import { createE2EName } from '@ansible/playwright/commands/createE2EName';
 import { navigateTo } from '@ansible/playwright/commands/navigateTo';
 import { setupAfter, setupBefore } from '@ansible/playwright/commands/setup';
+import { singleSelectByLabel } from '@ansible/playwright/commands/singleSelectByLabel';
 import { EdaCredential, EdaCredentialType } from '@ansible/playwright/utils';
 import { expect, test } from '@playwright/test';
 
@@ -110,8 +111,7 @@ test.describe('EDA Credentials', () => {
       }
       await page.getByRole('textbox', { name: 'Name' }).click();
       await page.getByRole('textbox', { name: 'Name' }).fill(credentialName);
-      await page.getByRole('button', { name: 'Organization' }).click();
-      await page.getByRole('option', { name: 'Default The default' }).click();
+      await singleSelectByLabel('Organization', 'Default', page);
       await page.getByRole('button', { name: 'Credential type' }).click();
       await page.getByRole('textbox', { name: 'Search input' }).fill('Basic Analytics');
       await page.getByRole('option', { name: 'Basic Analytics' }).click();

--- a/playwright/tests/integration/automation-decisions/credentials/credentials.spec.ts
+++ b/playwright/tests/integration/automation-decisions/credentials/credentials.spec.ts
@@ -39,8 +39,10 @@ test.describe('EDA Credentials', () => {
       await page.getByRole('textbox', { name: 'Type to filter' }).click();
       await page.getByRole('textbox', { name: 'Type to filter' }).fill('Basic Analytics');
       await page.getByRole('button', { name: 'apply filter' }).click();
-      await page.waitForTimeout(2000);
-      if (await page.getByRole('heading', { name: 'No results found' }).isVisible()) {
+      const noResults = page.getByRole('heading', { name: 'No results found' });
+      const basicAnalyticsLink = page.getByRole('link', { name: 'Basic Analytics' });
+      await expect(noResults.or(basicAnalyticsLink)).toBeVisible();
+      if (await noResults.isVisible()) {
         await page.getByRole('button', { name: 'Clear all filters' }).nth(1).click();
         await EdaCredentialType.ui.create(page, {
           credentialTypeName: 'Basic Analytics',
@@ -94,10 +96,12 @@ test.describe('EDA Credentials', () => {
       await page.getByRole('button', { name: 'apply filter' }).click();
       await page.getByRole('link', { name: 'Basic Analytics' }).click();
       await page.getByRole('tab', { name: 'Credentials' }).click();
-      await page.waitForTimeout(2000);
-      if (
-        await page.getByRole('heading', { name: 'There are currently no credentials' }).isVisible()
-      ) {
+      const emptyCredentials = page.getByRole('heading', {
+        name: 'There are currently no credentials',
+      });
+      const selectAll = page.getByRole('checkbox', { name: 'Select all' });
+      await expect(emptyCredentials.or(selectAll)).toBeVisible();
+      if (await emptyCredentials.isVisible()) {
         await page.getByRole('link', { name: 'Create credential' }).click();
       } else {
         await page.getByRole('checkbox', { name: 'Select all' }).check();
@@ -112,9 +116,7 @@ test.describe('EDA Credentials', () => {
       await page.getByRole('textbox', { name: 'Name' }).click();
       await page.getByRole('textbox', { name: 'Name' }).fill(credentialName);
       await singleSelectByLabel('Organization', 'Default', page);
-      await page.getByRole('button', { name: 'Credential type' }).click();
-      await page.getByRole('textbox', { name: 'Search input' }).fill('Basic Analytics');
-      await page.getByRole('option', { name: 'Basic Analytics' }).click();
+      await singleSelectByLabel('Credential type', 'Basic Analytics', page);
       await page.getByRole('textbox', { name: 'Username' }).click();
       await page.getByRole('textbox', { name: 'Username' }).fill('test');
       await page.getByRole('textbox', { name: 'Password' }).click();


### PR DESCRIPTION
## Summary

The EDA credential duplication test (`credentials.spec.ts`) timed out waiting for Organization option `Default The default`. The live accessible name is now `Default Specifies the default organization` (name + description).

Select the Default organization with `singleSelectByLabel` so the test searches by org name and does not depend on description text.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

Re-run `playwright/tests/integration/automation-decisions/credentials/credentials.spec.ts` against a live AAP instance, specifically:

`EDA Credentials > eda credentials - create a credential of type Basic Anlytics and get the right error message on duplication`

### Manual Testing

Not applicable — test-only change.

### Screenshots

Not applicable.