### PR TITLE
Remove redundant SWRConfig wrappers from tests

### DIFF
--- a/frontend/awx/access/credentials/CredentialPlugins/CredentialPlugins.test.tsx
+++ b/frontend/awx/access/credentials/CredentialPlugins/CredentialPlugins.test.tsx
@@ -3,17 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { CredentialPlugins, CredentialPluginsForm } from './CredentialPlugins';
 
 function TestWrapper({ children }: Readonly<{ children: React.ReactNode }>) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 const mockCredentialOptions = {

--- a/frontend/awx/access/credentials/CredentialPlugins/hooks/useCredentialPluginsDialog.test.tsx
+++ b/frontend/awx/access/credentials/CredentialPlugins/hooks/useCredentialPluginsDialog.test.tsx
@@ -5,18 +5,13 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { CredentialTestResponse } from '../../../../interfaces/CredentialTestResponse';
 import { CredentialPluginsModal, CredentialPluginsModalProps } from './useCredentialPluginsDialog';
 
 function TestWrapper({ children }: Readonly<{ children: React.ReactNode }>) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 const mockCredential = {

--- a/frontend/awx/access/credentials/Credentials.test.tsx
+++ b/frontend/awx/access/credentials/Credentials.test.tsx
@@ -2,17 +2,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { Credentials } from './Credentials';
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 const mockCredentialTypes = {

--- a/frontend/awx/administration/activity-stream/ActivityStream.test.tsx
+++ b/frontend/awx/administration/activity-stream/ActivityStream.test.tsx
@@ -3,10 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { ActivityStreams } from './ActivityStream';
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
 
 const emptyListFixture = {
   count: 0,
@@ -80,14 +83,6 @@ const activityStreamFixture = {
     },
   ],
 };
-
-function TestWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
-}
 
 const server = setupServer(
   http.options(awxAPI`/activity_stream/`, () => HttpResponse.json(mockActivityStreamOptions)),

--- a/frontend/awx/administration/deprecations/DeprecationAffectedJobs.test.tsx
+++ b/frontend/awx/administration/deprecations/DeprecationAffectedJobs.test.tsx
@@ -3,24 +3,19 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { DeprecationAffectedJobs } from './DeprecationAffectedJobs';
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter
-        initialEntries={[
-          `/deprecations/${encodeURIComponent('with_items on module')}/affected-jobs`,
-        ]}
-      >
-        <Routes>
-          <Route path="/deprecations/:deprecationType/affected-jobs" element={children} />
-        </Routes>
-      </MemoryRouter>
-    </SWRConfig>
+    <MemoryRouter
+      initialEntries={[`/deprecations/${encodeURIComponent('with_items on module')}/affected-jobs`]}
+    >
+      <Routes>
+        <Route path="/deprecations/:deprecationType/affected-jobs" element={children} />
+      </Routes>
+    </MemoryRouter>
   );
 }
 
@@ -211,15 +206,13 @@ describe('DeprecationAffectedJobs', () => {
 
   it('should display empty state for unrecognized deprecation type', async () => {
     const UnknownWrapper = ({ children }: { children: ReactNode }) => (
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter
-          initialEntries={[`/deprecations/${encodeURIComponent('nonexistent_type')}/affected-jobs`]}
-        >
-          <Routes>
-            <Route path="/deprecations/:deprecationType/affected-jobs" element={children} />
-          </Routes>
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter
+        initialEntries={[`/deprecations/${encodeURIComponent('nonexistent_type')}/affected-jobs`]}
+      >
+        <Routes>
+          <Route path="/deprecations/:deprecationType/affected-jobs" element={children} />
+        </Routes>
+      </MemoryRouter>
     );
 
     server.use(

--- a/frontend/awx/administration/deprecations/DeprecationsDashboard.test.tsx
+++ b/frontend/awx/administration/deprecations/DeprecationsDashboard.test.tsx
@@ -1,19 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { DeprecationsDashboard } from './DeprecationsDashboard';
 
-function Wrapper({ children }: { children: ReactNode }) {
-  return (
-    <MemoryRouter>
-      <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
-    </MemoryRouter>
-  );
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 const mockJobsResponse = {

--- a/frontend/awx/administration/deprecations/hooks/useDeprecationData.test.tsx
+++ b/frontend/awx/administration/deprecations/hooks/useDeprecationData.test.tsx
@@ -1,16 +1,9 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { ReactNode } from 'react';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useDeprecationData } from './useDeprecationData';
-
-/** Wrap each hook render in a fresh SWR cache to prevent cross-test cache sharing. */
-function swrWrapper({ children }: { children: ReactNode }) {
-  return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
-}
 
 const mockJobsResponse = {
   results: [
@@ -104,7 +97,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => new Promise(() => {}))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.data).toBeUndefined();
@@ -120,7 +113,7 @@ describe('useDeprecationData', () => {
       })
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -148,7 +141,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(emptyEventsResponse))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -171,7 +164,7 @@ describe('useDeprecationData', () => {
       })
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -184,7 +177,7 @@ describe('useDeprecationData', () => {
   it('should surface an error when the initial jobs fetch fails', async () => {
     server.use(http.get(awxAPI`/jobs/`, () => new HttpResponse(null, { status: 500 })));
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -222,7 +215,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockWithDictEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -260,7 +253,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockBareVarEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -297,7 +290,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockIncludeEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -334,7 +327,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockSquashEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -371,7 +364,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockHashEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -408,7 +401,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockUnknownEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -445,7 +438,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockTaskNameEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -482,7 +475,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockTaskEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -519,7 +512,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockTaskEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -553,7 +546,7 @@ describe('useDeprecationData', () => {
       )
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -587,7 +580,7 @@ describe('useDeprecationData', () => {
       )
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -621,7 +614,7 @@ describe('useDeprecationData', () => {
       )
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -658,7 +651,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockBareEvents))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -678,7 +671,7 @@ describe('useDeprecationData', () => {
       http.get(awxAPI`/jobs/:jobId/job_events/`, () => HttpResponse.json(mockEventsWithItems))
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -698,7 +691,7 @@ describe('useDeprecationData', () => {
       })
     );
 
-    const { result } = renderHook(() => useDeprecationData(), { wrapper: swrWrapper });
+    const { result } = renderHook(() => useDeprecationData());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -2,7 +2,6 @@ import { vi, test, afterEach, describe, expect } from 'vitest';
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import {
   IToolbarFilter,
   PageAlertToasterProvider,
@@ -215,13 +214,9 @@ const mockView: IAutomationDashboardView = {
 function testWrapper() {
   return (
     <MemoryRouter>
-      <SWRConfig
-        value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}
-      >
-        <PageAlertToasterProvider>
-          <AutomationDashboard />
-        </PageAlertToasterProvider>
-      </SWRConfig>
+      <PageAlertToasterProvider>
+        <AutomationDashboard />
+      </PageAlertToasterProvider>
     </MemoryRouter>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardBaseView.test.ts
+++ b/frontend/awx/analytics/automation-dashboard/common/useAutomationDashboardBaseView.test.ts
@@ -1,15 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
-import {
-  act,
-  renderHook as rtlRenderHook,
-  waitFor,
-  type RenderHookOptions,
-  type RenderHookResult,
-} from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { createElement, type ReactNode } from 'react';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import {
   IToolbarDateRangeFilter,
@@ -19,20 +11,6 @@ import {
 import { metricsAPI } from '../../../common/api/metrics-utils';
 import { useAutomationDashboardBaseView } from './useAutomationDashboardBaseView';
 
-function SwrWrapper({ children }: Readonly<{ children: ReactNode }>) {
-  return createElement(
-    SWRConfig,
-    { value: { provider: () => new Map(), shouldRetryOnError: false } },
-    children
-  );
-}
-
-function renderHook<Result, Props>(
-  render: (initialProps: Props) => Result,
-  options?: RenderHookOptions<Props>
-): RenderHookResult<Result, Props> {
-  return rtlRenderHook(render, { ...options, wrapper: SwrWrapper });
-}
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 
 // ─── Test Data ────────────────────────────────────────────────────────────────

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
@@ -144,11 +143,7 @@ function buildProps(overrides: Partial<IAutomationDashboardView> = {}): IAutomat
 function Wrapper({ children }: { children: ReactNode }) {
   return (
     <MemoryRouter>
-      <SWRConfig
-        value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}
-      >
-        <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
-      </SWRConfig>
+      <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
     </MemoryRouter>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardTableToolbarRow.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { ReactNode } from 'react';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { PageAlertToasterProvider } from '@ansible/ansible-ui-framework';
@@ -57,11 +56,7 @@ function buildProps(
 function Wrapper({ children }: { children: ReactNode }) {
   return (
     <MemoryRouter>
-      <SWRConfig
-        value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}
-      >
-        <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
-      </SWRConfig>
+      <PageAlertToasterProvider>{children}</PageAlertToasterProvider>
     </MemoryRouter>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/views/useGetReportDetails.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useGetReportDetails.test.tsx
@@ -2,8 +2,6 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, test, expect } from 'vitest';
-import { SWRConfig } from 'swr';
-import { ReactNode } from 'react';
 import { ToolbarFilterType } from '../../../../../framework';
 import { useGetReportDetails } from './useGetReportDetails';
 import type { IDashboardDetails } from '../types';
@@ -27,12 +25,6 @@ const dashboardDetailsFixture: IDashboardDetails = {
   host_chart: { kind: 'day', items: [{ label: 'Mon', value: 2 }] },
 };
 
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}>
-    {children}
-  </SWRConfig>
-);
-
 const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -49,7 +41,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       expect(result.current.isLoading).toBe(true);
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -64,7 +56,7 @@ describe('useGetReportDetails', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
 
@@ -82,7 +74,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
 
@@ -102,7 +94,7 @@ describe('useGetReportDetails', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       await waitFor(() => expect(result.current.error).toBeDefined());
 
@@ -117,7 +109,7 @@ describe('useGetReportDetails', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       await waitFor(() => expect(result.current.error).toBeDefined());
 
@@ -136,7 +128,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}), { wrapper });
+      const { result } = renderHook(() => useGetReportDetails([], {}));
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
 
@@ -153,9 +145,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([], {}, { tz: 'Europe/Ljubljana' }), {
-        wrapper,
-      });
+      const { result } = renderHook(() => useGetReportDetails([], {}, { tz: 'Europe/Ljubljana' }));
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
 
@@ -182,9 +172,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([nameFilter], filterState), {
-        wrapper,
-      });
+      const { result } = renderHook(() => useGetReportDetails([nameFilter], filterState));
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
 
@@ -211,9 +199,8 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(
-        () => useGetReportDetails([nameFilter], filterState, { tz: 'UTC' }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useGetReportDetails([nameFilter], filterState, { tz: 'UTC' })
       );
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
@@ -247,9 +234,7 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportDetails([requiredDateRangeFilter], {}), {
-        wrapper,
-      });
+      const { result } = renderHook(() => useGetReportDetails([requiredDateRangeFilter], {}));
 
       await new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -266,9 +251,8 @@ describe('useGetReportDetails', () => {
         })
       );
 
-      const { result } = renderHook(
-        () => useGetReportDetails([requiredDateRangeFilter], { period: ['custom', '01/01/2024'] }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useGetReportDetails([requiredDateRangeFilter], { period: ['custom', '01/01/2024'] })
       );
 
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -284,9 +268,8 @@ describe('useGetReportDetails', () => {
         )
       );
 
-      const { result } = renderHook(
-        () => useGetReportDetails([requiredDateRangeFilter], { period: ['custom', '2024-01-01'] }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useGetReportDetails([requiredDateRangeFilter], { period: ['custom', '2024-01-01'] })
       );
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());
@@ -299,12 +282,10 @@ describe('useGetReportDetails', () => {
         )
       );
 
-      const { result } = renderHook(
-        () =>
-          useGetReportDetails([requiredDateRangeFilter], {
-            period: ['custom', '2024-01-01', '2024-01-31'],
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useGetReportDetails([requiredDateRangeFilter], {
+          period: ['custom', '2024-01-01', '2024-01-31'],
+        })
       );
 
       await waitFor(() => expect(result.current.reportDetails).toBeDefined());

--- a/frontend/awx/analytics/automation-dashboard/views/useGetReportSubscriptionCosts.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useGetReportSubscriptionCosts.test.tsx
@@ -2,8 +2,6 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { SWRConfig } from 'swr';
-import { ReactNode } from 'react';
 import { useGetReportSubscriptionCosts } from './useGetReportSubscriptionCosts';
 import type { ISubscriptionCosts } from '../types';
 import { metricsAPI } from '../../../common/api/metrics-utils';
@@ -20,12 +18,6 @@ const subscriptionCostsFixture: ISubscriptionCosts[] = [
 ];
 
 // ─── Wrapper ──────────────────────────────────────────────────────────────────
-
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}>
-    {children}
-  </SWRConfig>
-);
 
 // ─── MSW server ───────────────────────────────────────────────────────────────
 
@@ -47,7 +39,7 @@ describe('useGetReportSubscriptionCosts', () => {
         })
       );
 
-      const { result } = renderHook(() => useGetReportSubscriptionCosts(), { wrapper });
+      const { result } = renderHook(() => useGetReportSubscriptionCosts());
 
       expect(result.current.isLoading).toBe(true);
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -62,7 +54,7 @@ describe('useGetReportSubscriptionCosts', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportSubscriptionCosts(), { wrapper });
+      const { result } = renderHook(() => useGetReportSubscriptionCosts());
 
       await waitFor(() => expect(result.current.subscriptionCosts).toBeDefined());
 
@@ -78,7 +70,7 @@ describe('useGetReportSubscriptionCosts', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportSubscriptionCosts(), { wrapper });
+      const { result } = renderHook(() => useGetReportSubscriptionCosts());
 
       await waitFor(() => expect(result.current.subscriptionCosts).toBeDefined());
 
@@ -94,7 +86,7 @@ describe('useGetReportSubscriptionCosts', () => {
         )
       );
 
-      const { result } = renderHook(() => useGetReportSubscriptionCosts(), { wrapper });
+      const { result } = renderHook(() => useGetReportSubscriptionCosts());
 
       await waitFor(() => expect(result.current.error).toBeDefined());
 

--- a/frontend/awx/common/useAwxConfig.test.tsx
+++ b/frontend/awx/common/useAwxConfig.test.tsx
@@ -1,9 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { SWRConfig } from 'swr';
 import { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { awxAPI } from './api/awx-utils';
 import { AwxConfigProviderInternal, useAwxConfigState } from './useAwxConfig';
 
@@ -16,15 +15,7 @@ const mockConfig = {
 };
 
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig
-    value={{
-      dedupingInterval: 0,
-      provider: () => new Map(),
-      shouldRetryOnError: false,
-    }}
-  >
-    <AwxConfigProviderInternal>{children}</AwxConfigProviderInternal>
-  </SWRConfig>
+  <AwxConfigProviderInternal>{children}</AwxConfigProviderInternal>
 );
 
 const server = setupServer();

--- a/frontend/awx/common/useAwxView.test.tsx
+++ b/frontend/awx/common/useAwxView.test.tsx
@@ -2,11 +2,9 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
-import { SWRConfig } from 'swr';
 import { awxAPI } from './api/awx-utils';
 import { useAwxView, compareByField } from './useAwxView';
 import { AwxHost } from '../interfaces/AwxHost';
-import { ReactNode } from 'react';
 import { ToolbarFilterType } from '@ansible/ansible-ui-framework';
 
 vi.mock('./useAwxConfig', () => ({
@@ -58,18 +56,6 @@ const createMockResponse = (page: number, count = 40) => ({
   previous: page === 2 ? '/api/v2/hosts/?page=1' : null,
   results: mockHosts,
 });
-
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig
-    value={{
-      dedupingInterval: 0,
-      provider: () => new Map(),
-      shouldRetryOnError: false,
-    }}
-  >
-    {children}
-  </SWRConfig>
-);
 
 let page2ErrorTriggered = false;
 
@@ -123,13 +109,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -154,13 +138,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -182,13 +164,11 @@ describe('useAwxView', () => {
 
   describe('upsertItem', () => {
     test('should update an existing item in the list', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -206,13 +186,11 @@ describe('useAwxView', () => {
     });
 
     test('should prepend a new item to the list', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -257,21 +235,19 @@ describe('useAwxView', () => {
           })
         );
 
-        const { result } = renderHook(
-          () =>
-            useAwxView<AwxHost>({
-              url: '/api/v2/hosts/',
-              disableQueryString: true,
-              toolbarFilters: [
-                {
-                  key: 'name',
-                  label: 'Name',
-                  type: ToolbarFilterType.Search,
-                  query: 'name__icontains',
-                },
-              ],
-            }),
-          { wrapper }
+        const { result } = renderHook(() =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+            toolbarFilters: [
+              {
+                key: 'name',
+                label: 'Name',
+                type: ToolbarFilterType.Search,
+                query: 'name__icontains',
+              },
+            ],
+          })
         );
 
         await waitFor(() => {
@@ -317,21 +293,19 @@ describe('useAwxView', () => {
           })
         );
 
-        const { result } = renderHook(
-          () =>
-            useAwxView<AwxHost>({
-              url: '/api/v2/hosts/',
-              disableQueryString: true,
-              toolbarFilters: [
-                {
-                  key: 'name',
-                  label: 'Name',
-                  type: ToolbarFilterType.Search,
-                  query: 'name__icontains',
-                },
-              ],
-            }),
-          { wrapper }
+        const { result } = renderHook(() =>
+          useAwxView<AwxHost>({
+            url: '/api/v2/hosts/',
+            disableQueryString: true,
+            toolbarFilters: [
+              {
+                key: 'name',
+                label: 'Name',
+                type: ToolbarFilterType.Search,
+                query: 'name__icontains',
+              },
+            ],
+          })
         );
 
         await waitFor(() => {
@@ -370,13 +344,11 @@ describe('useAwxView', () => {
         serviceDownStatusCode: 503,
       });
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       expect(result.current.error).toBeDefined();
@@ -393,13 +365,11 @@ describe('useAwxView', () => {
         serviceDownStatusCode: 503,
       });
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       expect(result.current.error).toBeDefined();
@@ -415,13 +385,11 @@ describe('useAwxView', () => {
         serviceDownStatusCode: 502,
       });
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       expect((result.current.error as Error).message).toBe(
@@ -435,13 +403,11 @@ describe('useAwxView', () => {
         serviceDownStatusCode: undefined,
       });
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       expect(result.current.error).toBeDefined();
@@ -454,13 +420,11 @@ describe('useAwxView', () => {
         serviceDownStatusCode: 503,
       });
 
-      const { result, rerender } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result, rerender } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       expect(result.current.error).toBeDefined();
@@ -488,13 +452,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -514,13 +476,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -534,17 +494,15 @@ describe('useAwxView', () => {
 
   describe('Table columns default sort', () => {
     test('should use defaultSort column when provided', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-            tableColumns: [
-              { header: 'Name', cell: () => '', sort: 'name' },
-              { header: 'Created', cell: () => '', sort: 'created', defaultSort: true },
-            ],
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+          tableColumns: [
+            { header: 'Name', cell: () => '', sort: 'name' },
+            { header: 'Created', cell: () => '', sort: 'created', defaultSort: true },
+          ],
+        })
       );
 
       await waitFor(() => {
@@ -555,17 +513,15 @@ describe('useAwxView', () => {
     });
 
     test('should use first column for sort when no defaultSort specified', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-            tableColumns: [
-              { header: 'Name', cell: () => '', sort: 'name' },
-              { header: 'Created', cell: () => '', sort: 'created' },
-            ],
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+          tableColumns: [
+            { header: 'Name', cell: () => '', sort: 'name' },
+            { header: 'Created', cell: () => '', sort: 'created' },
+          ],
+        })
       );
 
       await waitFor(() => {
@@ -578,13 +534,11 @@ describe('useAwxView', () => {
 
   describe('Item management', () => {
     test('should update item in the list', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -607,13 +561,11 @@ describe('useAwxView', () => {
     });
 
     test('should not update item if items list is undefined', () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       // Call updateItem before items are loaded
@@ -626,13 +578,11 @@ describe('useAwxView', () => {
     });
 
     test('should not update item if item not found in list', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -651,13 +601,11 @@ describe('useAwxView', () => {
 
   describe('Selection with refresh', () => {
     test('should select items and refresh', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -675,13 +623,11 @@ describe('useAwxView', () => {
     });
 
     test('should unselect items and refresh', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -720,13 +666,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -750,13 +694,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -776,13 +718,11 @@ describe('useAwxView', () => {
         })
       );
 
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+        })
       );
 
       await waitFor(() => {
@@ -804,14 +744,12 @@ describe('useAwxView', () => {
     });
 
     test('should handle default selection when provided', async () => {
-      const { result } = renderHook(
-        () =>
-          useAwxView<AwxHost>({
-            url: '/api/v2/hosts/',
-            disableQueryString: true,
-            defaultSelection: [mockHosts[0], mockHosts[1]],
-          }),
-        { wrapper }
+      const { result } = renderHook(() =>
+        useAwxView<AwxHost>({
+          url: '/api/v2/hosts/',
+          disableQueryString: true,
+          defaultSelection: [mockHosts[0], mockHosts[1]],
+        })
       );
 
       await waitFor(() => {

--- a/frontend/awx/resources/groups/hooks/useGroupSelectDialog.test.tsx
+++ b/frontend/awx/resources/groups/hooks/useGroupSelectDialog.test.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { ReactNode } from 'react';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useAwxView } from '../../../common/useAwxView';
@@ -11,12 +9,6 @@ import { InventoryGroup } from '../../../interfaces/InventoryGroup';
 vi.mock('../../../common/useAwxConfig', () => ({
   useAwxConfigState: vi.fn(() => ({ serviceDown: false, serviceDownStatusCode: undefined })),
 }));
-
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}>
-    {children}
-  </SWRConfig>
-);
 
 const server = setupServer();
 
@@ -40,16 +32,14 @@ describe('GroupSelectDialog view URL construction (#3252)', () => {
       })
     );
 
-    const { result } = renderHook(
-      () =>
-        useAwxView<InventoryGroup>({
-          url: awxAPI`/groups/${groupId}/potential_children/`,
-          queryParams: {
-            not__id: groupId,
-            not__parents: groupId,
-          },
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useAwxView<InventoryGroup>({
+        url: awxAPI`/groups/${groupId}/potential_children/`,
+        queryParams: {
+          not__id: groupId,
+          not__parents: groupId,
+        },
+      })
     );
 
     await waitFor(() => {
@@ -75,16 +65,14 @@ describe('GroupSelectDialog view URL construction (#3252)', () => {
       })
     );
 
-    const { result } = renderHook(
-      () =>
-        useAwxView<InventoryGroup>({
-          url: awxAPI`/groups/${groupId}/potential_children/`,
-          queryParams: {
-            not__id: groupId,
-            not__parents: groupId,
-          },
-        }),
-      { wrapper }
+    const { result } = renderHook(() =>
+      useAwxView<InventoryGroup>({
+        url: awxAPI`/groups/${groupId}/potential_children/`,
+        queryParams: {
+          not__id: groupId,
+          not__parents: groupId,
+        },
+      })
     );
 
     await waitFor(() => {

--- a/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.test.tsx
+++ b/frontend/awx/resources/inventories/inventorySources/InventorySourceDetails.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { InventorySourceDetails, LastJobTooltip } from './InventorySourceDetails';
 
@@ -90,16 +89,14 @@ afterAll(() => server.close());
 
 function renderInventorySourceDetails(inventorySourceId?: string) {
   return render(
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter initialEntries={['/inventories/inventory/1/sources/1/details']}>
-        <Routes>
-          <Route
-            path="/inventories/:inventory_type/:id/sources/:source_id/details"
-            element={<InventorySourceDetails inventorySourceId={inventorySourceId} />}
-          />
-        </Routes>
-      </MemoryRouter>
-    </SWRConfig>
+    <MemoryRouter initialEntries={['/inventories/inventory/1/sources/1/details']}>
+      <Routes>
+        <Route
+          path="/inventories/:inventory_type/:id/sources/:source_id/details"
+          element={<InventorySourceDetails inventorySourceId={inventorySourceId} />}
+        />
+      </Routes>
+    </MemoryRouter>
   );
 }
 

--- a/frontend/awx/resources/sources/InventorySourceForm.test.tsx
+++ b/frontend/awx/resources/sources/InventorySourceForm.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { awxAPI } from '../../common/api/awx-utils';
 import { InventorySource } from '../../interfaces/InventorySource';
@@ -506,11 +505,9 @@ describe('EditInventorySource', () => {
 
     const user = userEvent.setup();
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter>
-          <EditInventorySource />
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter>
+        <EditInventorySource />
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -546,16 +543,14 @@ describe('EditInventorySource', () => {
 
       const user = userEvent.setup();
       render(
-        <SWRConfig value={{ provider: () => new Map() }}>
-          <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
-            <Routes>
-              <Route
-                path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
-                element={<EditInventorySource />}
-              />
-            </Routes>
-          </MemoryRouter>
-        </SWRConfig>
+        <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
+          <Routes>
+            <Route
+              path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
+              element={<EditInventorySource />}
+            />
+          </Routes>
+        </MemoryRouter>
       );
 
       await waitFor(() => {
@@ -596,16 +591,14 @@ describe('EditInventorySource', () => {
 
       const user = userEvent.setup();
       render(
-        <SWRConfig value={{ provider: () => new Map() }}>
-          <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
-            <Routes>
-              <Route
-                path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
-                element={<EditInventorySource />}
-              />
-            </Routes>
-          </MemoryRouter>
-        </SWRConfig>
+        <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
+          <Routes>
+            <Route
+              path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
+              element={<EditInventorySource />}
+            />
+          </Routes>
+        </MemoryRouter>
       );
 
       await waitFor(() => {
@@ -649,16 +642,14 @@ describe('EditInventorySource', () => {
       // Use a fresh SWR cache so this test's GET override is not shadowed by cached data
       // from prior tests that already fetched /inventory_sources/1/.
       render(
-        <SWRConfig value={{ provider: () => new Map() }}>
-          <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
-            <Routes>
-              <Route
-                path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
-                element={<EditInventorySource />}
-              />
-            </Routes>
-          </MemoryRouter>
-        </SWRConfig>
+        <MemoryRouter initialEntries={['/infrastructure/inventories/inventory/2/sources/1/edit']}>
+          <Routes>
+            <Route
+              path="/infrastructure/inventories/inventory/:id/sources/:source_id/edit"
+              element={<EditInventorySource />}
+            />
+          </Routes>
+        </MemoryRouter>
       );
 
       await waitFor(() => {

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import {
@@ -536,16 +535,14 @@ describe('TemplateLaunchWizard', () => {
 
         const user = userEvent.setup();
         render(
-          <SWRConfig value={{ provider: () => new Map() }}>
-            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
-              <Routes>
-                <Route
-                  path="/job-templates/:id/launch"
-                  element={<LaunchTemplate jobType="job_templates" />}
-                />
-              </Routes>
-            </MemoryRouter>
-          </SWRConfig>
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
         );
 
         await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
@@ -577,16 +574,14 @@ describe('TemplateLaunchWizard', () => {
 
         const user = userEvent.setup();
         render(
-          <SWRConfig value={{ provider: () => new Map() }}>
-            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
-              <Routes>
-                <Route
-                  path="/job-templates/:id/launch"
-                  element={<LaunchTemplate jobType="job_templates" />}
-                />
-              </Routes>
-            </MemoryRouter>
-          </SWRConfig>
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
         );
 
         await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());
@@ -623,16 +618,14 @@ describe('TemplateLaunchWizard', () => {
 
         const user = userEvent.setup();
         render(
-          <SWRConfig value={{ provider: () => new Map() }}>
-            <MemoryRouter initialEntries={['/job-templates/1/launch']}>
-              <Routes>
-                <Route
-                  path="/job-templates/:id/launch"
-                  element={<LaunchTemplate jobType="job_templates" />}
-                />
-              </Routes>
-            </MemoryRouter>
-          </SWRConfig>
+          <MemoryRouter initialEntries={['/job-templates/1/launch']}>
+            <Routes>
+              <Route
+                path="/job-templates/:id/launch"
+                element={<LaunchTemplate jobType="job_templates" />}
+              />
+            </Routes>
+          </MemoryRouter>
         );
 
         await waitFor(() => expect(screen.getByText('Prompt on Launch')).toBeInTheDocument());

--- a/frontend/awx/views/jobs/JobOutput/JobOutputEvents.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutputEvents.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { JobEvent } from '../../../interfaces/JobEvent';
 import { testFixture as jobFixture } from '../jobDetails.fixture';
@@ -42,16 +41,14 @@ afterAll(() => server.close());
 
 function renderJobOutput(job: typeof jobFixture) {
   return render(
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <JobOutputEvents
-        job={job}
-        reloadJob={vi.fn()}
-        toolbarFilters={[]}
-        filterState={{}}
-        isFollowModeEnabled={false}
-        setIsFollowModeEnabled={vi.fn()}
-      />
-    </SWRConfig>
+    <JobOutputEvents
+      job={job}
+      reloadJob={vi.fn()}
+      toolbarFilters={[]}
+      filterState={{}}
+      isFollowModeEnabled={false}
+      setIsFollowModeEnabled={vi.fn()}
+    />
   );
 }
 
@@ -82,16 +79,14 @@ describe('JobOutputEvents', () => {
 
     const completedJob = { ...jobFixture, status: 'successful' as const };
     rerender(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <JobOutputEvents
-          job={completedJob}
-          reloadJob={vi.fn()}
-          toolbarFilters={[]}
-          filterState={{}}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={vi.fn()}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={completedJob}
+        reloadJob={vi.fn()}
+        toolbarFilters={[]}
+        filterState={{}}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={vi.fn()}
+      />
     );
 
     expect(
@@ -127,8 +122,6 @@ describe('JobOutputEvents', () => {
     const stableReloadJob = vi.fn();
     const stableSetFollow = vi.fn();
     const stableFilterState = {};
-    const swrConfig = { provider: () => new Map() };
-
     vi.mocked(useJobOutput).mockReturnValue({
       jobEventCount: 1,
       getJobOutputEvent: vi.fn(),
@@ -137,16 +130,14 @@ describe('JobOutputEvents', () => {
     });
 
     const { rerender } = render(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={stableFilterState}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={stableFilterState}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
 
     const firstCallCount = jobEventToRowsSpy.mock.calls.length;
@@ -160,16 +151,14 @@ describe('JobOutputEvents', () => {
     });
 
     rerender(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={stableFilterState}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={stableFilterState}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
 
     expect(jobEventToRowsSpy.mock.calls.length).toBe(firstCallCount);
@@ -204,8 +193,6 @@ describe('JobOutputEvents', () => {
     const stableFilterState = {};
     const stableReloadJob = vi.fn();
     const stableSetFollow = vi.fn();
-    const swrConfig = { provider: () => new Map() };
-
     vi.mocked(useJobOutput).mockReturnValue({
       jobEventCount: 1,
       getJobOutputEvent: vi.fn(),
@@ -214,16 +201,14 @@ describe('JobOutputEvents', () => {
     });
 
     const { rerender } = render(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={stableFilterState}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={stableFilterState}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
     const callsAfterFirstRender = jobEventToRowsSpy.mock.calls.length;
     expect(callsAfterFirstRender).toBeGreaterThanOrEqual(1);
@@ -238,16 +223,14 @@ describe('JobOutputEvents', () => {
     });
 
     rerender(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={stableFilterState}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={stableFilterState}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
 
     const callsForNewEvent = jobEventToRowsSpy.mock.calls.filter((args) => args[0]?.counter === 2);
@@ -277,8 +260,6 @@ describe('JobOutputEvents', () => {
 
     const stableReloadJob = vi.fn();
     const stableSetFollow = vi.fn();
-    const swrConfig = { provider: () => new Map() };
-
     vi.mocked(useJobOutput).mockReturnValue({
       jobEventCount: 1,
       getJobOutputEvent: vi.fn(),
@@ -287,16 +268,14 @@ describe('JobOutputEvents', () => {
     });
 
     const { rerender } = render(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={{}}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={{}}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
 
     expect(jobEventToRowsSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
@@ -312,16 +291,14 @@ describe('JobOutputEvents', () => {
     });
 
     rerender(
-      <SWRConfig value={swrConfig}>
-        <JobOutputEvents
-          job={jobFixture}
-          reloadJob={stableReloadJob}
-          toolbarFilters={[]}
-          filterState={newFilterState}
-          isFollowModeEnabled={false}
-          setIsFollowModeEnabled={stableSetFollow}
-        />
-      </SWRConfig>
+      <JobOutputEvents
+        job={jobFixture}
+        reloadJob={stableReloadJob}
+        toolbarFilters={[]}
+        filterState={newFilterState}
+        isFollowModeEnabled={false}
+        setIsFollowModeEnabled={stableSetFollow}
+      />
     );
 
     const callsForEvent1 = jobEventToRowsSpy.mock.calls.filter((args) => args[0]?.counter === 1);

--- a/frontend/awx/views/jobs/hooks/useJobsView.test.tsx
+++ b/frontend/awx/views/jobs/hooks/useJobsView.test.tsx
@@ -1,8 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { ReactNode } from 'react';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { useJobsView } from './useJobsView';
@@ -32,21 +30,9 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <SWRConfig
-    value={{
-      dedupingInterval: 0,
-      provider: () => new Map(),
-      shouldRetryOnError: false,
-    }}
-  >
-    {children}
-  </SWRConfig>
-);
-
 describe('useJobsView', () => {
   it('should fetch unified jobs excluding sync launch type', async () => {
-    const { result } = renderHook(() => useJobsView(), { wrapper });
+    const { result } = renderHook(() => useJobsView());
 
     await waitFor(() => {
       expect(result.current.pageItems).toBeDefined();
@@ -58,7 +44,7 @@ describe('useJobsView', () => {
   });
 
   it('should return itemCount from the API response', async () => {
-    const { result } = renderHook(() => useJobsView(), { wrapper });
+    const { result } = renderHook(() => useJobsView());
 
     await waitFor(() => {
       expect(result.current.itemCount).toBe(2);
@@ -72,7 +58,7 @@ describe('useJobsView', () => {
       )
     );
 
-    const { result } = renderHook(() => useJobsView(), { wrapper });
+    const { result } = renderHook(() => useJobsView());
 
     await waitFor(() => {
       expect(result.current.itemCount).toBe(0);

--- a/frontend/eda/overview/EdaOverview.test.tsx
+++ b/frontend/eda/overview/EdaOverview.test.tsx
@@ -3,17 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { edaAPI, setEdaApiPath } from '../common/eda-utils';
 import { EdaOverview } from './EdaOverview';
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 describe('EdaOverview', () => {

--- a/frontend/eda/projects/ProjectsList.test.tsx
+++ b/frontend/eda/projects/ProjectsList.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { edaAPI } from '../common/eda-utils';
 import { Projects } from './Projects';
@@ -10,11 +9,7 @@ import mockProjects from './fixtures/edaProjects.fixture.json';
 import mockProjectsOptions from './fixtures/edaProjectsOptions.fixture.json';
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </SWRConfig>
-  );
+  return <MemoryRouter>{children}</MemoryRouter>;
 }
 
 describe('Projects List Component', () => {

--- a/frontend/hub/administration/signature-keys/SignatureKeys.test.tsx
+++ b/frontend/hub/administration/signature-keys/SignatureKeys.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { pulpAPI } from '../../common/api/formatPath';
 import { SignatureKeys } from './SignatureKeys';
@@ -34,11 +33,9 @@ const mockEmptyResponse = {
 
 function renderSignatureKeys() {
   return render(
-    <SWRConfig value={{ provider: () => new Map() }}>
-      <MemoryRouter>
-        <SignatureKeys />
-      </MemoryRouter>
-    </SWRConfig>
+    <MemoryRouter>
+      <SignatureKeys />
+    </MemoryRouter>
   );
 }
 

--- a/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
+++ b/frontend/hub/collections/CollectionPage/CollectionDocumentation.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { CollectionDocumentation, CollectionVersionsContent } from './CollectionDocumentation';
 
@@ -579,11 +578,9 @@ describe('CollectionDocumentation', () => {
     );
 
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <TestWrapper initialPath="/collections/validated/testnamespace/testcollection/documentation/changelog">
-          <CollectionDocumentation />
-        </TestWrapper>
-      </SWRConfig>
+      <TestWrapper initialPath="/collections/validated/testnamespace/testcollection/documentation/changelog">
+        <CollectionDocumentation />
+      </TestWrapper>
     );
 
     await waitFor(() => {
@@ -617,11 +614,9 @@ describe('CollectionDocumentation', () => {
     );
 
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <TestWrapper>
-          <CollectionDocumentation />
-        </TestWrapper>
-      </SWRConfig>
+      <TestWrapper>
+        <CollectionDocumentation />
+      </TestWrapper>
     );
 
     await waitFor(() => {
@@ -647,11 +642,9 @@ describe('CollectionDocumentation', () => {
     );
 
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <TestWrapper>
-          <CollectionDocumentation />
-        </TestWrapper>
-      </SWRConfig>
+      <TestWrapper>
+        <CollectionDocumentation />
+      </TestWrapper>
     );
 
     await waitFor(() => {

--- a/frontend/hub/common/components/InsightsSelectGroup.test.tsx
+++ b/frontend/hub/common/components/InsightsSelectGroup.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InsightsSelectGroup } from './InsightsSelectGroup';
 
@@ -53,12 +52,9 @@ describe('InsightsSelectGroup', () => {
 
   const renderComponent = (props = {}) => {
     return render(
-      // Fresh SWRConfig per test prevents cache from previous tests polluting responses
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter>
-          <InsightsSelectGroup {...defaultProps} {...props} />
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter>
+        <InsightsSelectGroup {...defaultProps} {...props} />
+      </MemoryRouter>
     );
   };
 

--- a/frontend/hub/common/components/InsightsSelectUser.test.tsx
+++ b/frontend/hub/common/components/InsightsSelectUser.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InsightsSelectUser } from './InsightsSelectUser';
 
@@ -50,11 +49,9 @@ describe('InsightsSelectUser', () => {
   const renderComponent = (props = {}) => {
     return render(
       // Fresh SWR cache per render avoids stale /users data from earlier tests in this file
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter>
-          <InsightsSelectUser {...defaultProps} {...props} />
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter>
+        <InsightsSelectUser {...defaultProps} {...props} />
+      </MemoryRouter>
     );
   };
 

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentActivity.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentActivity.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { ExecutionEnvironmentActivity } from './ExecutionEnvironmentActivity';
 
 const mockEmptyActivityResponse = {
@@ -40,16 +39,14 @@ describe('ExecutionEnvironmentActivity', () => {
 
   test('should display empty state when no activities exist', async () => {
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter initialEntries={['/execution-environments/test-ee/activity']}>
-          <Routes>
-            <Route
-              path="/execution-environments/:id/activity"
-              element={<ExecutionEnvironmentActivity />}
-            />
-          </Routes>
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter initialEntries={['/execution-environments/test-ee/activity']}>
+        <Routes>
+          <Route
+            path="/execution-environments/:id/activity"
+            element={<ExecutionEnvironmentActivity />}
+          />
+        </Routes>
+      </MemoryRouter>
     );
 
     await waitFor(() => {

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentDetails.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { ExecutionEnvironmentDetails } from './ExecutionEnvironmentDetails';
 
 interface ReadmeType {
@@ -61,16 +60,14 @@ describe('ExecutionEnvironmentDetails', () => {
 
   const renderWithFreshCache = () => {
     return render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter initialEntries={['/execution-environments/test-ee/details']}>
-          <Routes>
-            <Route
-              path="/execution-environments/:id/details"
-              element={<ExecutionEnvironmentDetails />}
-            />
-          </Routes>
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter initialEntries={['/execution-environments/test-ee/details']}>
+        <Routes>
+          <Route
+            path="/execution-environments/:id/details"
+            element={<ExecutionEnvironmentDetails />}
+          />
+        </Routes>
+      </MemoryRouter>
     );
   };
 

--- a/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.test.tsx
+++ b/frontend/hub/execution-environments/ExecutionEnvironmentPage/ExecutionEnvironmentPage.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { ExecutionEnvironment } from '../ExecutionEnvironment';
 import { ExecutionEnvironmentPage } from './ExecutionEnvironmentPage';
 
@@ -76,15 +75,11 @@ describe('ExecutionEnvironmentPage', () => {
 
   test('should render all tabs correctly', async () => {
     render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter
-          initialEntries={['/execution-environments/test-execution-environment/details']}
-        >
-          <Routes>
-            <Route path="/execution-environments/:id/*" element={<ExecutionEnvironmentPage />} />
-          </Routes>
-        </MemoryRouter>
-      </SWRConfig>
+      <MemoryRouter initialEntries={['/execution-environments/test-execution-environment/details']}>
+        <Routes>
+          <Route path="/execution-environments/:id/*" element={<ExecutionEnvironmentPage />} />
+        </Routes>
+      </MemoryRouter>
     );
 
     await waitFor(

--- a/platform/main/PlatformAbout.test.tsx
+++ b/platform/main/PlatformAbout.test.tsx
@@ -13,7 +13,6 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import type { ComponentProps } from 'react';
 import { useEffect } from 'react';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import platformLogo from '../assets/platform-logo.svg?url';
 import platformLogoWhite from '../assets/platform-logo-white.svg?url';
@@ -40,13 +39,11 @@ function OpenPlatformAboutDialog() {
 
 function mountAbout(settings: IPageSettings) {
   return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      <PageSettingsContext.Provider value={[settings, vi.fn()]}>
-        <PageDialogProvider>
-          <OpenPlatformAboutDialog />
-        </PageDialogProvider>
-      </PageSettingsContext.Provider>
-    </SWRConfig>
+    <PageSettingsContext.Provider value={[settings, vi.fn()]}>
+      <PageDialogProvider>
+        <OpenPlatformAboutDialog />
+      </PageDialogProvider>
+    </PageSettingsContext.Provider>
   );
 }
 

--- a/platform/main/PlatformApp.test.tsx
+++ b/platform/main/PlatformApp.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import * as GatewayUIAuth from './GatewayUIAuth';
 import * as PlatformActiveUserModule from './PlatformActiveUserProvider';
@@ -30,9 +29,7 @@ vi.mock('./usePlatformNavigation', () => ({
 const mountPlatformApp = (component: React.ReactNode) => {
   return render(
     <MemoryRouter>
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <AwxConfigProvider>{component}</AwxConfigProvider>
-      </SWRConfig>
+      <AwxConfigProvider>{component}</AwxConfigProvider>
     </MemoryRouter>
   );
 };

--- a/platform/main/PlatformMasthead.test.tsx
+++ b/platform/main/PlatformMasthead.test.tsx
@@ -9,7 +9,6 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { QuickStart } from '@patternfly/quickstarts';
 import { MemoryRouter } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlatformMasthead } from './PlatformMasthead';
 import { PlatformRoute } from './PlatformRoutes';
@@ -86,15 +85,13 @@ function mountMasthead(settings?: IPageSettings) {
   const pageSettings: IPageSettings = settings ?? { activeTheme: 'light', theme: 'light' };
   return render(
     <MemoryRouter>
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <PageSettingsContext.Provider value={[pageSettings, vi.fn()]}>
-          <PageNavSideBarProvider>
-            <PageDialogProvider>
-              <PlatformMasthead />
-            </PageDialogProvider>
-          </PageNavSideBarProvider>
-        </PageSettingsContext.Provider>
-      </SWRConfig>
+      <PageSettingsContext.Provider value={[pageSettings, vi.fn()]}>
+        <PageNavSideBarProvider>
+          <PageDialogProvider>
+            <PlatformMasthead />
+          </PageDialogProvider>
+        </PageNavSideBarProvider>
+      </PageSettingsContext.Provider>
     </MemoryRouter>
   );
 }

--- a/platform/resource/PlatformAwxUser.test.tsx
+++ b/platform/resource/PlatformAwxUser.test.tsx
@@ -3,7 +3,6 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { PlatformAwxUser } from './PlatformAwxUser';
@@ -24,16 +23,12 @@ afterAll(() => server.close());
 
 function wrapper({ children }: { children: ReactNode }) {
   return (
-    <SWRConfig
-      value={{ dedupingInterval: 0, provider: () => new Map(), shouldRetryOnError: false }}
-    >
-      <MemoryRouter initialEntries={['/users/1']}>
-        <Routes>
-          <Route path="/users/:id" element={children} />
-          <Route path="/mock-resource-route" element={<div>Navigated</div>} />
-        </Routes>
-      </MemoryRouter>
-    </SWRConfig>
+    <MemoryRouter initialEntries={['/users/1']}>
+      <Routes>
+        <Route path="/users/:id" element={children} />
+        <Route path="/mock-resource-route" element={<div>Navigated</div>} />
+      </Routes>
+    </MemoryRouter>
   );
 }
 

--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlags.test.tsx
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlags.test.tsx
@@ -2,7 +2,6 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { SWRConfig } from 'swr';
 import { useRuntimeFeatureFlags } from './useRuntimeFeatureFlags';
 import { IFeatureFlag } from './IFeatureFlag';
 
@@ -11,12 +10,6 @@ const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
-
-function wrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>{children}</SWRConfig>
-  );
-}
 
 function createFlag(overrides: Partial<IFeatureFlag> = {}): IFeatureFlag {
   return {
@@ -73,7 +66,7 @@ describe('useRuntimeFeatureFlags', () => {
     ];
     mockFeatureFlagsAPI(flags);
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -89,7 +82,7 @@ describe('useRuntimeFeatureFlags', () => {
     ];
     mockFeatureFlagsAPI(flags);
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -104,7 +97,7 @@ describe('useRuntimeFeatureFlags', () => {
     ];
     mockFeatureFlagsAPI(flags);
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -119,7 +112,7 @@ describe('useRuntimeFeatureFlags', () => {
     ];
     mockFeatureFlagsAPI(flags);
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -131,7 +124,7 @@ describe('useRuntimeFeatureFlags', () => {
   it('should return error on API failure', async () => {
     server.use(http.get('/api/gateway/v1/feature_flags/', () => HttpResponse.error()));
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -150,7 +143,7 @@ describe('useRuntimeFeatureFlags', () => {
       )
     );
 
-    const { result } = renderHook(() => useRuntimeFeatureFlags(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlags());
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.flags).toEqual([]);

--- a/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
+++ b/platform/settings/runtime-feature-flags/useRuntimeFeatureFlagsEnabled.test.tsx
@@ -2,7 +2,6 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { SWRConfig } from 'swr';
 import { useRuntimeFeatureFlagsEnabled } from './useRuntimeFeatureFlagsEnabled';
 
 const server = setupServer();
@@ -10,12 +9,6 @@ const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
-
-function wrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>{children}</SWRConfig>
-  );
-}
 
 describe('useRuntimeFeatureFlagsEnabled', () => {
   it('should return true when RUNTIME_FEATURE_FLAGS is true', async () => {
@@ -27,7 +20,7 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
       )
     );
 
-    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -44,7 +37,7 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
       )
     );
 
-    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -55,7 +48,7 @@ describe('useRuntimeFeatureFlagsEnabled', () => {
   it('should return true on API error', async () => {
     server.use(http.get('/api/gateway/v1/settings/feature_flags/', () => HttpResponse.error()));
 
-    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled(), { wrapper });
+    const { result } = renderHook(() => useRuntimeFeatureFlagsEnabled());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);


### PR DESCRIPTION
## Summary

Removes redundant SWRConfig wrappers from multiple tests.

SWR cache is now reset universally before all Vitest tests (see https://github.com/ansible/ansible-ui/blob/devel/frontend/awx/vitest.setup.ts). It is no longer necessary to include it before each individual test.

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.
