### PR TITLE
fix: project status link missing and inventory source last job status link malformed

### DIFF
--- a/frontend/awx/resources/inventories/hooks/useInventorySourceColumns.tsx
+++ b/frontend/awx/resources/inventories/hooks/useInventorySourceColumns.tsx
@@ -59,26 +59,33 @@ export function useInventorySourceColumns(options?: {
     () => ({
       header: t('Last job status'),
       cell: (inventorySource: InventorySource) => {
-        return (
-          <Link
-            to={getPageUrl(AwxRoute.JobOutput, {
-              params: {
-                id: inventorySource?.summary_fields?.last_job?.id,
-                job_type: 'inventory',
-              },
-            })}
-          >
-            <StatusCell
-              tooltip={
-                inventorySource.summary_fields.last_job ? (
-                  <LastJobTooltip job={inventorySource?.summary_fields?.last_job} />
-                ) : undefined
-              }
-              tooltipId={inventorySource.summary_fields.last_job?.id}
-              status={inventorySource.status}
-            />
-          </Link>
+        const lastJob = inventorySource?.summary_fields?.last_job;
+        const statusCell = (
+          <StatusCell
+            tooltip={
+              lastJob ? <LastJobTooltip job={lastJob} /> : undefined
+            }
+            tooltipId={lastJob?.id}
+            status={inventorySource.status}
+          />
         );
+
+        if (lastJob?.id) {
+          return (
+            <Link
+              to={getPageUrl(AwxRoute.JobOutput, {
+                params: {
+                  id: lastJob.id,
+                  job_type: 'inventory',
+                },
+              })}
+            >
+              {statusCell}
+            </Link>
+          );
+        }
+
+        return statusCell;
       },
     }),
     [t, getPageUrl]

--- a/frontend/awx/resources/projects/hooks/useProjectStatusColumn.tsx
+++ b/frontend/awx/resources/projects/hooks/useProjectStatusColumn.tsx
@@ -27,15 +27,16 @@ export function useProjectStatusColumn(options?: {
   }> = useMemo(
     () => ({
       header: t('Status'),
-      cell: (item) =>
-        item.summary_fields?.current_job || item.summary_fields?.last_job ? (
+      cell: (item) => {
+        const jobId = item.summary_fields?.current_job?.id ?? item.summary_fields?.last_job?.id;
+        return (item.summary_fields?.current_job || item.summary_fields?.last_job) && jobId ? (
           <Tooltip content={options?.tooltip ?? ''} position="top">
             <StatusCell
               status={item.status}
               to={getPageUrl(AwxRoute.JobOutput, {
                 params: {
                   job_type: item.type,
-                  id: item.summary_fields?.current_job?.id ?? item.summary_fields?.last_job?.id,
+                  id: jobId,
                 },
               })}
               disableLinks={options?.disableLinks}
@@ -45,7 +46,8 @@ export function useProjectStatusColumn(options?: {
           <Tooltip content={options?.tooltipAlt ?? ''} position="top">
             <StatusCell status={item.status} />
           </Tooltip>
-        ),
+        );
+      },
       sort: options?.disableSort ? undefined : 'status',
     }),
     [


### PR DESCRIPTION
## Summary

Fixes — Two related bugs in the AAP UI where status links in list views are broken:

1. **Inventory Source "Last Job Status" link is malformed with literal `:id`**: The `<Link>` wrapper in `useInventorySourceColumns.tsx` was unconditionally rendered regardless of whether `last_job` existed in `summary_fields`. When `last_job` is undefined (e.g., inventory source has never been synced), `summary_fields?.last_job?.id` evaluates to `undefined`, leaving the `:id` route parameter unsubstituted. This produced URLs like `/execution/jobs/inventory/:id/output`.

   **Fix**: Only render the `<Link>` when `lastJob?.id` is available. When no last job exists, render a plain `StatusCell` without a link wrapper.

2. **Project status link is missing**: The `useProjectStatusColumn.tsx` could render a link with an invalid URL when `summary_fields.current_job` or `last_job` existed as objects but contained no valid `id`. This caused the `getPageUrl` call to produce a URL with literal `:id`, which rendered as a non-functional or missing link.

   **Fix**: Added a guard to verify the job `id` is present before rendering the status as a clickable link. When no valid job id is available, the status is shown without a link.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

1. Navigate to **Infrastructure → Inventories → [Inventory] → Sources**
2. Verify that synced inventory sources show a clickable status link pointing to `/execution/jobs/inventory/<actual_id>/output`
3. Verify that inventory sources that have never been synced show a status badge without a link (no broken `:id` URL)
4. Navigate to **Resources → Projects**
5. Verify that synced projects show a clickable status link pointing to the correct job output page
6. Verify that projects with no sync history show a status badge without a link

---

> Made with [Cursor](https://cursor.com)
