### PR TITLE
fix(job-output): show status counts in legends

### DIFF
--- a/frontend/awx/views/jobs/JobOutput/JobOutput.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobOutput.test.tsx
@@ -99,7 +99,8 @@ describe('JobOutput', () => {
     render(<HostStatusBar counts={jobFixture.host_status_counts || {}} />);
 
     expect(screen.getByTestId('status-bar')).toBeInTheDocument();
-    expect(screen.getByText('Success 100%')).toBeInTheDocument();
+    expect(screen.getByText('Success 1')).toBeInTheDocument();
+    expect(screen.queryByText('Success 100%')).not.toBeInTheDocument();
   });
 
   it('should render JobOutputToolbar with filter options', () => {

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.test.tsx
@@ -1,11 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { SWRConfiguration } from 'swr';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { Job } from '../../../interfaces/Job';
 import { JobEvent } from '../../../interfaces/JobEvent';
+import { AwxRoute } from '../../../main/AwxRoutes';
 import { JobStatusBar } from './JobStatusBar';
+
+const mockPageNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('@ansible/ansible-ui-framework', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ansible/ansible-ui-framework')>();
+  return {
+    ...actual,
+    usePageNavigate: () => mockPageNavigate,
+  };
+});
 
 const mockUseGet = vi.fn(
   (
@@ -52,7 +64,13 @@ const baseJob = {
 
 describe('JobStatusBar polling', () => {
   beforeEach(() => {
+    mockPageNavigate.mockClear();
     mockUseGet.mockClear();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should pass undefined URL when job is finished', () => {
@@ -144,6 +162,116 @@ describe('JobStatusBar polling', () => {
 
     renderJobStatusBar(runningJob);
 
-    expect(screen.getByTestId('waiting-label')).toBeInTheDocument();
+    expect(
+      screen.getByText('Running initial setup. Waiting to execute playbook')
+    ).toBeInTheDocument();
+  });
+
+  it('should show the host total without status-specific host counts', () => {
+    const finishedJob = {
+      ...baseJob,
+      status: 'successful',
+      started: '2023-06-06T18:22:42Z',
+      finished: '2023-06-06T18:23:02Z',
+      host_status_counts: {
+        ok: 999,
+        dark: 1,
+        failures: 2,
+      },
+    } as unknown as Job;
+
+    renderJobStatusBar(finishedJob);
+
+    expect(screen.getByText('Hosts')).toBeInTheDocument();
+    expect(screen.getByText('1002')).toBeInTheDocument();
+    expect(screen.queryByText('Unreachable')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
+  });
+
+  it('should count undefined host status values as zero', () => {
+    const finishedJob = {
+      ...baseJob,
+      status: 'successful',
+      started: '2023-06-06T18:22:42Z',
+      finished: '2023-06-06T18:23:02Z',
+      playbook_counts: { play_count: 1, task_count: 9 },
+      host_status_counts: {
+        ok: undefined,
+        failures: 2,
+      },
+    } as unknown as Job;
+
+    renderJobStatusBar(finishedJob);
+
+    expect(screen.getByText('Hosts')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('should not show a host count when host status counts are unavailable', () => {
+    const finishedJob = {
+      ...baseJob,
+      status: 'successful',
+      started: '2023-06-06T18:22:42Z',
+      finished: '2023-06-06T18:23:02Z',
+      host_status_counts: undefined,
+    } as unknown as Job;
+
+    renderJobStatusBar(finishedJob);
+
+    expect(screen.queryByText('Hosts')).not.toBeInTheDocument();
+  });
+
+  it('should update elapsed time every second for running jobs', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-06-06T18:22:47Z'));
+    const runningJob = {
+      ...baseJob,
+      status: 'running',
+      started: '2023-06-06T18:22:42Z',
+    } as unknown as Job;
+
+    renderJobStatusBar(runningJob);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('00:00:06')).toBeInTheDocument();
+  });
+
+  it('should clear elapsed time for running jobs without a start time', () => {
+    vi.useFakeTimers();
+    const runningJob = {
+      ...baseJob,
+      status: 'running',
+      started: undefined,
+    } as unknown as Job;
+
+    renderJobStatusBar(runningJob);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('00:00:00')).not.toBeInTheDocument();
+  });
+
+  it('should navigate to the workflow visualizer from workflow jobs', async () => {
+    const user = userEvent.setup();
+    const workflowJob = {
+      ...baseJob,
+      type: 'workflow_job',
+      status: 'successful',
+      finished: '2023-06-06T18:23:02Z',
+      unified_job_template: 42,
+    } as unknown as Job;
+
+    renderJobStatusBar(workflowJob);
+
+    await user.click(screen.getByRole('button', { name: 'View workflow visualizer' }));
+
+    expect(mockPageNavigate).toHaveBeenCalledWith(AwxRoute.WorkflowVisualizer, {
+      params: { id: 42 },
+    });
   });
 });

--- a/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/JobStatusBar.tsx
@@ -92,11 +92,9 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
 
   const playCount = job.playbook_counts?.play_count;
   const taskCount = job.playbook_counts?.task_count;
-  const darkCount = job.host_status_counts?.dark;
-  const failureCount = job.host_status_counts?.failures;
-  const totalHostCount = job.host_status_counts
-    ? Object.keys(job.host_status_counts || {}).reduce(
-        (sum, key) => sum + (job.host_status_counts[key as 'ok' | 'failures' | 'dark'] as number),
+  const totalHostCount: number = job.host_status_counts
+    ? (Object.values(job.host_status_counts) as (number | undefined)[]).reduce<number>(
+        (sum, count) => sum + (count ?? 0),
         0
       )
     : 0;
@@ -154,8 +152,6 @@ export function JobStatusBar(props: Readonly<{ job: Job }>) {
           <Count label={t('Plays')} count={playCount} />
           <Count label={t('Tasks')} count={taskCount} />
           <Count label={t('Hosts')} count={totalHostCount} />
-          <Count label={t('Unreachable')} count={darkCount} />
-          <Count label={t('Failed')} count={failureCount} />
           <FlexItem>
             {t('Elapsed')} <Badge isRead>{elapsed}</Badge>
           </FlexItem>

--- a/frontend/awx/views/jobs/JobOutput/StatusBar.test.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.test.tsx
@@ -6,7 +6,7 @@ import { HostStatusBar, WorkflowNodesStatusBar } from './StatusBar';
 
 describe('StatusBar', () => {
   describe('HostStatusBar', () => {
-    it('should display host status percentages', () => {
+    it('should display host status counts', () => {
       const counts: HostStatusCounts = {
         ok: 10,
         skipped: 0,
@@ -15,7 +15,8 @@ describe('StatusBar', () => {
         dark: 0,
       };
       render(<HostStatusBar counts={counts} />);
-      expect(screen.getByText('Success 100%')).toBeInTheDocument();
+      expect(screen.getByText('Success 10')).toBeInTheDocument();
+      expect(screen.queryByText('Success 100%')).not.toBeInTheDocument();
     });
 
     it('should display multiple status types', () => {
@@ -27,10 +28,10 @@ describe('StatusBar', () => {
         dark: 0,
       };
       render(<HostStatusBar counts={counts} />);
-      expect(screen.getByText('Success 50%')).toBeInTheDocument();
-      expect(screen.getByText('Skipped 20%')).toBeInTheDocument();
-      expect(screen.getByText('Changed 20%')).toBeInTheDocument();
-      expect(screen.getByText('Failed 10%')).toBeInTheDocument();
+      expect(screen.getByText('Success 5')).toBeInTheDocument();
+      expect(screen.getByText('Skipped 2')).toBeInTheDocument();
+      expect(screen.getByText('Changed 2')).toBeInTheDocument();
+      expect(screen.getByText('Failed 1')).toBeInTheDocument();
     });
 
     it('should render status bar element', () => {
@@ -45,6 +46,18 @@ describe('StatusBar', () => {
       expect(screen.getByTestId('status-bar')).toBeInTheDocument();
     });
 
+    it('should display exact counts for large inventories with minority statuses', () => {
+      const counts: HostStatusCounts = {
+        ok: 999,
+        dark: 1,
+      };
+      render(<HostStatusBar counts={counts} />);
+      expect(screen.getByText('Success 999')).toBeInTheDocument();
+      expect(screen.getByText('Unreachable 1')).toBeInTheDocument();
+      expect(screen.queryByText('Success 100%')).not.toBeInTheDocument();
+      expect(screen.queryByText('Unreachable 0%')).not.toBeInTheDocument();
+    });
+
     it('should show unavailable message when no counts', () => {
       const counts = {} as HostStatusCounts;
       render(<HostStatusBar counts={counts} />);
@@ -53,7 +66,7 @@ describe('StatusBar', () => {
   });
 
   describe('WorkflowNodesStatusBar', () => {
-    it('should display workflow node status percentages', () => {
+    it('should display workflow node status counts', () => {
       const nodes: WorkflowNode[] = [
         { summary_fields: { job: { status: 'successful' } } } as WorkflowNode,
         { summary_fields: { job: { status: 'successful' } } } as WorkflowNode,
@@ -61,7 +74,8 @@ describe('StatusBar', () => {
         { summary_fields: { job: { status: 'successful' } } } as WorkflowNode,
       ];
       render(<WorkflowNodesStatusBar nodes={nodes} />);
-      expect(screen.getByText('Success 100%')).toBeInTheDocument();
+      expect(screen.getByText('Success 4')).toBeInTheDocument();
+      expect(screen.queryByText('Success 100%')).not.toBeInTheDocument();
     });
 
     it('should display mixed workflow status', () => {
@@ -72,9 +86,9 @@ describe('StatusBar', () => {
         { summary_fields: { job: { status: 'error' } } } as WorkflowNode,
       ];
       render(<WorkflowNodesStatusBar nodes={nodes} />);
-      expect(screen.getByText('Success 25%')).toBeInTheDocument();
-      expect(screen.getByText('Canceled 25%')).toBeInTheDocument();
-      expect(screen.getByText('Error 50%')).toBeInTheDocument();
+      expect(screen.getByText('Success 1')).toBeInTheDocument();
+      expect(screen.getByText('Canceled 1')).toBeInTheDocument();
+      expect(screen.getByText('Error 2')).toBeInTheDocument();
     });
 
     it('should handle nodes without job status', () => {
@@ -83,7 +97,7 @@ describe('StatusBar', () => {
         { summary_fields: { job: { status: 'successful' } } } as WorkflowNode,
       ];
       render(<WorkflowNodesStatusBar nodes={nodes} />);
-      expect(screen.getByText('Success 100%')).toBeInTheDocument();
+      expect(screen.getByText('Success 1')).toBeInTheDocument();
     });
 
     it('should render status bar element', () => {

--- a/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
+++ b/frontend/awx/views/jobs/JobOutput/StatusBar.tsx
@@ -154,15 +154,9 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
   const { t } = useTranslation();
   const { counts, status } = props;
   const noData = Object.keys(counts).length === 0;
-  const totalCounts = Object.values(counts).reduce(
-    (sum: number, count: number) => sum + count,
-    0
-  ) as number;
-
-  const barSegments = Object.keys(status).map((key) => {
+  const barSegments = Object.entries(status).map(([key, statusProps]) => {
     const count = (counts[key as keyof T] as number) || 0;
-    const jobStatus =
-      (status[key as keyof K] as StatusProps) ?? (status as CommonStatusType)['dark'];
+    const jobStatus = statusProps as StatusProps;
     return (
       <Tooltip
         key={key}
@@ -205,7 +199,7 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
               (status[key as keyof K] as StatusProps)?.label ??
               (status as CommonStatusType)['dark'].label
             }
-            percent={(((counts[key as keyof T] as number) ?? 0) / totalCounts) * 100}
+            count={(counts[key as keyof T] as number) ?? 0}
           />
         ))}
       </Legend>
@@ -213,13 +207,13 @@ function StatusBar<T extends object, K extends object>(props: StatusBarProps<T, 
   );
 }
 
-function LegendItem(props: { color: string; label: string; percent: number }) {
-  const { color, label, percent } = props;
+function LegendItem(props: Readonly<{ color: string; label: string; count: number }>) {
+  const { color, label, count } = props;
 
   return (
     <div>
       <LegendBox color={color} />
-      {label} {Math.round(percent)}%
+      {label} {count}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Show exact status counts in job output legends instead of rounded percentages.
- Update the job header status bar to show a single total Hosts count, removing separate Unreachable and Failed badges there.
- Add regression coverage for host/workflow status legends, large inventories with minority statuses, missing host counts, elapsed time behavior, and workflow visualizer navigation.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by
posting a comment `/run-playwright` on this PR.

│ Tests run against a fresh AAP instance (version based on
│ branch).

### External Server E2E Runs

Not applicable.

### Manual Testing

- Open a job output page with host status counts.
- Verify the status legend displays exact counts, not percentages.
- Verify large inventories with small failure/unreachable counts still show those exact minority counts.
- Verify the job header shows the total Hosts count and no longer duplicates Unreachable / Failed counts next to it.
- Open a workflow job output page and verify the workflow visualizer action still navigates correctly.

### Screenshots

Not applicable.