### PR TITLE
Show empty-string extra vars on job Details (AAP-85950)

### DIFF
--- a/frontend/awx/views/jobs/JobDetails.test.tsx
+++ b/frontend/awx/views/jobs/JobDetails.test.tsx
@@ -169,8 +169,9 @@ describe('JobDetails Component', () => {
       </MemoryRouter>
     );
     expect(screen.queryByText('Extra variables')).toBeInTheDocument();
-    expect(screen.queryByText('var1: answer1')).toBeInTheDocument();
-    expect(screen.queryByText('var2: ')).not.toBeInTheDocument();
+    const extraVars = screen.getAllByTestId('code-block-value')[0];
+    expect(extraVars).toHaveTextContent('var1: answer1');
+    expect(extraVars).toHaveTextContent(/var2:/);
   });
   it('conditionally renders source control branch field', () => {
     mockJob.scm_branch = 'foo';

--- a/frontend/awx/views/jobs/jobUtils.test.tsx
+++ b/frontend/awx/views/jobs/jobUtils.test.tsx
@@ -136,11 +136,11 @@ describe('jobUtils', () => {
       expect(getFilteredExtraVars('')).toBe('');
     });
 
-    it('should filter out empty string values', () => {
+    it('should preserve empty string values', () => {
       const input = JSON.stringify({ name: 'test', empty: '', value: 123 });
       const result = getFilteredExtraVars(input);
       const parsed = JSON.parse(result!) as Record<string, unknown>;
-      expect(parsed).toEqual({ name: 'test', value: 123 });
+      expect(parsed).toEqual({ name: 'test', empty: '', value: 123 });
     });
 
     it('should preserve non-empty values', () => {

--- a/frontend/awx/views/jobs/jobUtils.tsx
+++ b/frontend/awx/views/jobs/jobUtils.tsx
@@ -178,10 +178,10 @@ export function useGetLaunchedByDetails() {
 }
 
 /**
- * Filter out empty string values from extra_vars while preserving large integer precision.
+ * Normalize extra_vars for Job Details while preserving large integer precision.
  *
- * Uses precision-preserving JSON utilities to prevent large integers (>16 digits)
- * from being converted to scientific notation.
+ * Empty string values are kept so Details matches the job API and playbook extra vars.
+ * Large integers (>16 digits) must not be converted to scientific notation.
  */
 export const getFilteredExtraVars = (
   extraVars: string | null | undefined
@@ -190,8 +190,7 @@ export const getFilteredExtraVars = (
 
   try {
     const parsed = parseJSONPreservingLargeInts(extraVars) as Record<string, unknown>;
-    const filtered = Object.fromEntries(Object.entries(parsed).filter(([, value]) => value !== ''));
-    return stringifyPreservingLargeInts(filtered);
+    return stringifyPreservingLargeInts(parsed);
   } catch (error) {
     return extraVars;
   }


### PR DESCRIPTION
## Summary
Job Details hid extra vars whose value is an empty string (`""`). The job API and playbook still received those keys, which made troubleshooting look like the variable was never set.
This removes the `value !== ''` filter in `getFilteredExtraVars()` so Details matches Review and `GET /api/controller/v2/jobs/<id>/`.
Fixes [AAP-85950](https://redhat.atlassian.net/browse/AAP-85950).
This is the inverse of the AAP-49448 Details display filter. Explicit empty extra vars (Prompt on Launch) are valid Ansible extra vars and must remain visible.
## Type of Change
- [x] Bug fix
## Risk Analysis - REQUIRED
- [x] **Low** — Narrowly scoped (Job Details extra vars display + unit tests). Does not change launch or extra-vars injection.
## Testing
### Automated
- `npx vitest run frontend/awx/views/jobs/jobUtils.test.tsx frontend/awx/views/jobs/JobDetails.test.tsx`
### Manual
- Local Platform UI (`PLATFORM_SERVER` + `npm start`) against RPM AAP 2.6
- Launch JT with Prompt on Launch extra vars `{"x": "", "y": "value"}`
- Review showed `x`; Details previously showed only `y`; after this change Details shows `x` (empty) and `y`
- Playbook: `x is defined, value: ''`
## Screenshots
Launch extra vars: `{"x": "", "y": "value"}`
### Before
Job Details Extra variables showed only `y` (`x` was hidden).
<img width="1894" height="952" alt="before" src="https://github.com/user-attachments/assets/6358960f-de2f-4582-93b3-3b82fcc201ea" />

### After
Job Details Extra variables shows both `x` (empty string) and `y`.
<img width="1894" height="952" alt="after" src="https://github.com/user-attachments/assets/6df17d41-46ca-4972-ba47-834905a392a3" />AAP-85950

- Assisted by Cursor Grok 4.6
