### PR TITLE
fix(notifications): allow org auditors to access notification tab

### DIFF
--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.test.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.test.tsx
@@ -2,7 +2,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { ReactNode } from 'react';
 import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { AwxActiveUserProvider } from '../../../common/useAwxActiveUser';
 import { ManagementJobPage } from './ManagementJobPage';
@@ -62,23 +64,29 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('ManagementJobPage', () => {
-  test('should render page with system job template name as title', async () => {
-    render(
+function renderManagementJobPage(children?: ReactNode) {
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
       <MemoryRouter initialEntries={['/administration/management_jobs/1/schedules']}>
         <AwxActiveUserProvider>
           <Routes>
             <Route path="/administration/management_jobs/:id" element={<ManagementJobPage />}>
               <Route
                 path="schedules"
-                element={<div data-testid="schedules-tab">Schedules Tab</div>}
+                element={children ?? <div data-testid="schedules-tab">Schedules Tab</div>}
               />
               <Route path="" element={<Navigate to="schedules" replace />} />
             </Route>
           </Routes>
         </AwxActiveUserProvider>
       </MemoryRouter>
-    );
+    </SWRConfig>
+  );
+}
+
+describe('ManagementJobPage', () => {
+  test('should render page with system job template name as title', async () => {
+    renderManagementJobPage();
 
     await waitFor(
       () => {
@@ -89,5 +97,61 @@ describe('ManagementJobPage', () => {
     );
 
     expect(screen.getByTestId('schedules-tab')).toBeInTheDocument();
+  });
+
+  test('should show notifications tab when user has notification access', async () => {
+    server.use(
+      http.get(
+        ({ request }) =>
+          request.url.includes('/organizations/') && request.url.includes('role_level'),
+        () =>
+          HttpResponse.json({
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ id: 1, name: 'Default' }],
+          })
+      )
+    );
+
+    renderManagementJobPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toBeInTheDocument();
+    });
+  });
+
+  test('should show system job template errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) =>
+          request.url.includes('/system_job_templates/1/') && !request.url.includes('/schedules'),
+        () => HttpResponse.json({ detail: 'Failed to load system job template' }, { status: 500 })
+      )
+    );
+
+    renderManagementJobPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+  });
+
+  test('should show notification access errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) =>
+          request.url.includes('/organizations/') && request.url.includes('role_level'),
+        () => HttpResponse.json({ detail: 'Failed to load organizations' }, { status: 500 })
+      )
+    );
+
+    renderManagementJobPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 });

--- a/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.tsx
+++ b/frontend/awx/administration/management-jobs/ManagementJobPage/ManagementJobPage.tsx
@@ -2,16 +2,14 @@
 import { PageHeader, PageLayout, useGetPageUrl } from '@ansible/ansible-ui-framework';
 import { LoadingPage } from '@ansible/ansible-ui-framework/components/LoadingPage';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
-import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
+import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { AwxError } from '../../../common/AwxError';
-import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
-import { Organization } from '../../../interfaces/Organization';
 import { SystemJobTemplate } from '../../../interfaces/SystemJobTemplate';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useCanViewNotificationsTab } from '../../../resources/notifications/hooks/useCanViewNotificationsTab';
 
 export function ManagementJobPage() {
   const { t } = useTranslation();
@@ -23,25 +21,22 @@ export function ManagementJobPage() {
   } = useGetItem<SystemJobTemplate>(awxAPI`/system_job_templates`, params.id);
 
   const getPageUrl = useGetPageUrl();
-  const { activeAwxUser } = useAwxActiveUser();
-
   const {
-    data: isNotifAdmin,
-    error: isNotifAdminError,
-    refresh: refreshNotifAdmin,
-  } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
-  );
+    canViewNotificationsTab,
+    error: notificationsTabError,
+    refresh: refreshNotificationsTab,
+    isLoading: isNotificationsTabLoading,
+  } = useCanViewNotificationsTab();
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
-  if (isNotifAdminError)
-    return <AwxError error={isNotifAdminError} handleRefresh={refreshNotifAdmin} />;
+  if (notificationsTabError)
+    return <AwxError error={notificationsTabError} handleRefresh={refreshNotificationsTab} />;
 
-  if (!(systemJobTemplate && isNotifAdmin)) return <LoadingPage breadcrumbs tabs />;
+  if (!systemJobTemplate || isNotificationsTabLoading) return <LoadingPage breadcrumbs tabs />;
 
   const tabs = [{ label: t('Schedules'), page: AwxRoute.ManagementJobSchedules }];
 
-  if (activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
+  if (canViewNotificationsTab) {
     tabs.push({ label: t('Notifications'), page: AwxRoute.ManagementJobNotifications });
   }
 

--- a/frontend/awx/resources/notifications/hooks/useCanViewNotificationsTab.test.tsx
+++ b/frontend/awx/resources/notifications/hooks/useCanViewNotificationsTab.test.tsx
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { ReactNode } from 'react';
+import { SWRConfig } from 'swr';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { AwxUser } from '../../../interfaces/User';
+import { useCanViewNotificationsTab } from './useCanViewNotificationsTab';
+
+vi.mock('../../../common/useAwxActiveUser', () => ({
+  useAwxActiveUser: vi.fn(),
+}));
+
+const organization = { id: 1, name: 'Default' };
+
+const activeUser: AwxUser = {
+  id: 1,
+  username: 'org_auditor_test',
+  is_system_auditor: false,
+  summary_fields: {
+    resource: { ansible_id: '1', resource_type: 'shared.user' },
+    organization: { id: 1, name: 'Default', description: '' },
+    user_capabilities: { edit: false, delete: false },
+  },
+  auth: [],
+};
+
+let notificationAdminResults: (typeof organization)[] = [];
+let auditorResults: (typeof organization)[] = [];
+let failingRoleLevels = new Set<string>();
+let organizationRequestCount = 0;
+
+const server = setupServer(
+  http.get(
+    ({ request }) => request.url.includes('/organizations/'),
+    ({ request }) => {
+      organizationRequestCount++;
+      const roleLevel = new URL(request.url).searchParams.get('role_level');
+      if (roleLevel && failingRoleLevels.has(roleLevel)) {
+        return HttpResponse.json({ detail: 'Failed to load organizations' }, { status: 500 });
+      }
+      const results =
+        roleLevel === 'notification_admin_role' ? notificationAdminResults : auditorResults;
+      return HttpResponse.json({ count: results.length, next: null, previous: null, results });
+    }
+  )
+);
+
+function wrapper({ children }: Readonly<{ children: ReactNode }>) {
+  return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeEach(() => {
+  vi.mocked(useAwxActiveUser).mockReturnValue({ activeAwxUser: activeUser });
+  notificationAdminResults = [];
+  auditorResults = [];
+  failingRoleLevels = new Set();
+  organizationRequestCount = 0;
+});
+afterEach(() => {
+  vi.mocked(useAwxActiveUser).mockReset();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+describe('useCanViewNotificationsTab', () => {
+  it('allows system auditors without loading organization roles', () => {
+    vi.mocked(useAwxActiveUser).mockReturnValue({
+      activeAwxUser: { ...activeUser, is_system_auditor: true },
+    });
+
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    expect(result.current.canViewNotificationsTab).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(organizationRequestCount).toBe(0);
+  });
+
+  it('allows notification admins to view notification tabs', async () => {
+    notificationAdminResults = [organization];
+
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    await waitFor(() => expect(result.current.canViewNotificationsTab).toBe(true));
+  });
+
+  it('allows organization auditors to view notification tabs', async () => {
+    auditorResults = [organization];
+
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    await waitFor(() => expect(result.current.canViewNotificationsTab).toBe(true));
+  });
+
+  it('does not allow users without notification admin or auditor roles', async () => {
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.canViewNotificationsTab).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('does not return errors after any role grants notification tab access', async () => {
+    notificationAdminResults = [organization];
+    failingRoleLevels.add('auditor_role');
+
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    await waitFor(() => expect(result.current.canViewNotificationsTab).toBe(true));
+
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('returns errors when notification tab access cannot be determined', async () => {
+    failingRoleLevels.add('notification_admin_role');
+
+    const { result } = renderHook(() => useCanViewNotificationsTab(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+
+    expect(result.current.canViewNotificationsTab).toBe(false);
+    result.current.refresh();
+    await waitFor(() => expect(organizationRequestCount).toBeGreaterThan(2));
+  });
+});

--- a/frontend/awx/resources/notifications/hooks/useCanViewNotificationsTab.ts
+++ b/frontend/awx/resources/notifications/hooks/useCanViewNotificationsTab.ts
@@ -1,0 +1,37 @@
+import { useGet } from '@ansible/common-ui/crud/useGet';
+import { useCallback } from 'react';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
+import { Organization } from '../../../interfaces/Organization';
+
+function hasOrganizations(response?: AwxItemsResponse<Organization>) {
+  return (response?.results.length ?? 0) > 0;
+}
+
+export function useCanViewNotificationsTab() {
+  const { activeAwxUser } = useAwxActiveUser();
+  const isSystemAuditor = activeAwxUser?.is_system_auditor === true;
+  const organizationsUrl = isSystemAuditor ? undefined : awxAPI`/organizations/`;
+  const notificationAdmin = useGet<AwxItemsResponse<Organization>>(organizationsUrl, {
+    role_level: 'notification_admin_role',
+    count_disabled: 1,
+  });
+  const auditor = useGet<AwxItemsResponse<Organization>>(organizationsUrl, {
+    role_level: 'auditor_role',
+    count_disabled: 1,
+  });
+  const canViewNotificationsTab =
+    isSystemAuditor || hasOrganizations(notificationAdmin.data) || hasOrganizations(auditor.data);
+  const refresh = useCallback(() => {
+    notificationAdmin.refresh();
+    auditor.refresh();
+  }, [notificationAdmin, auditor]);
+
+  return {
+    canViewNotificationsTab,
+    error: canViewNotificationsTab ? undefined : notificationAdmin.error || auditor.error,
+    isLoading: canViewNotificationsTab ? false : notificationAdmin.isLoading || auditor.isLoading,
+    refresh,
+  };
+}

--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.test.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { AwxActiveUserProvider } from '../../../common/useAwxActiveUser';
 import { ProjectPage } from './ProjectPage';
@@ -18,9 +19,7 @@ const server = setupServer(
     () => HttpResponse.json(mockProject)
   ),
   http.get(
-    ({ request }) =>
-      request.url.includes('/organizations/') &&
-      request.url.includes('role_level=notification_admin_role'),
+    ({ request }) => request.url.includes('/organizations/') && request.url.includes('role_level'),
     () => HttpResponse.json({ count: 0, results: [], next: null, previous: null })
   )
 );
@@ -29,9 +28,9 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('ProjectPage', () => {
-  it('should display project name in page header', async () => {
-    render(
+function renderProjectPage() {
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
       <MemoryRouter initialEntries={['/projects/1']}>
         <AwxActiveUserProvider disabled>
           <Routes>
@@ -39,10 +38,71 @@ describe('ProjectPage', () => {
           </Routes>
         </AwxActiveUserProvider>
       </MemoryRouter>
-    );
+    </SWRConfig>
+  );
+}
+
+describe('ProjectPage', () => {
+  it('should display project name in page header', async () => {
+    renderProjectPage();
 
     await waitFor(() => {
       expect(screen.getByTestId('page-title')).toHaveTextContent('Test Project');
     });
+  });
+
+  it('should show notifications tab when user has notification access', async () => {
+    server.use(
+      http.get(
+        ({ request }) =>
+          request.url.includes('/organizations/') && request.url.includes('role_level'),
+        () =>
+          HttpResponse.json({
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ id: 1, name: 'Default' }],
+          })
+      )
+    );
+
+    renderProjectPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toBeInTheDocument();
+    });
+  });
+
+  it('should show project errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('/projects/') && request.url.includes('/1'),
+        () => HttpResponse.json({ detail: 'Failed to load project' }, { status: 500 })
+      )
+    );
+
+    renderProjectPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+  });
+
+  it('should show notification access errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) =>
+          request.url.includes('/organizations/') && request.url.includes('role_level'),
+        () => HttpResponse.json({ detail: 'Failed to load organizations' }, { status: 500 })
+      )
+    );
+
+    renderProjectPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 });

--- a/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
+++ b/frontend/awx/resources/projects/ProjectPage/ProjectPage.tsx
@@ -15,12 +15,10 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useViewActivityStream } from '../../../access/common/useViewActivityStream';
 import { AwxError } from '../../../common/AwxError';
-import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
-import { Organization } from '../../../interfaces/Organization';
 import { Project } from '../../../interfaces/Project';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useCanViewNotificationsTab } from '../../notifications/hooks/useCanViewNotificationsTab';
 import { useProjectActions } from '../hooks/useProjectActions';
 
 export function ProjectPage() {
@@ -35,17 +33,12 @@ export function ProjectPage() {
   } = useGet<Project>(awxAPI`/projects/${params.id ?? ''}/`);
   const pageNavigate = usePageNavigate();
   const itemActions = useProjectActions(() => pageNavigate(AwxRoute.Projects));
-  const { activeAwxUser } = useAwxActiveUser();
   const {
-    data: isNotifAdmin,
-    error: isNotifAdminError,
-    refresh: refreshNotifAdmin,
-    isLoading: isNotifAdminLoading,
-  } = useGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`, {
-    role_level: 'notification_admin_role',
-    count_disabled: 1,
-  });
-  const error = isNotifAdminError || projectError;
+    canViewNotificationsTab,
+    error: notificationsTabError,
+    refresh: refreshNotificationsTab,
+    isLoading: isNotificationsTabLoading,
+  } = useCanViewNotificationsTab();
   const getPageUrl = useGetPageUrl();
   const tabs: { label: string; page: string }[] = useMemo(() => {
     const tabs = [
@@ -55,13 +48,16 @@ export function ProjectPage() {
       { label: t('User Access'), page: AwxRoute.ProjectUsers },
       { label: t('Team Access'), page: AwxRoute.ProjectTeams },
     ];
-    if (activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
+    if (canViewNotificationsTab) {
       tabs.push({ label: t('Notifications'), page: AwxRoute.ProjectNotifications });
     }
     return tabs;
-  }, [t, activeAwxUser, isNotifAdmin]);
-  if (error) return <AwxError error={error} handleRefresh={projectRefresh || refreshNotifAdmin} />;
-  if (!project || isProjectLoading || isNotifAdminLoading) return <LoadingPage breadcrumbs tabs />;
+  }, [t, canViewNotificationsTab]);
+  if (projectError) return <AwxError error={projectError} handleRefresh={projectRefresh} />;
+  if (notificationsTabError)
+    return <AwxError error={notificationsTabError} handleRefresh={refreshNotificationsTab} />;
+  if (!project || isProjectLoading || isNotificationsTabLoading)
+    return <LoadingPage breadcrumbs tabs />;
 
   return (
     <PageLayout>

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.test.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { TemplatePage } from './TemplatePage';
 
@@ -39,18 +40,61 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('TemplatePage', () => {
-  it('should render template page with template name', async () => {
-    render(
+function renderTemplatePage() {
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
       <MemoryRouter initialEntries={['/templates/job-template/1']}>
         <Routes>
           <Route path="/templates/job-template/:id" element={<TemplatePage />} />
         </Routes>
       </MemoryRouter>
-    );
+    </SWRConfig>
+  );
+}
+
+describe('TemplatePage', () => {
+  it('should render template page with template name', async () => {
+    renderTemplatePage();
 
     await waitFor(() => {
       expect(screen.getByTestId('Test Job Template')).toBeInTheDocument();
     });
+  });
+
+  it('should show notifications tab when user has notification access', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('organizations'),
+        () =>
+          HttpResponse.json({
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ id: 1, name: 'Default' }],
+          })
+      )
+    );
+
+    renderTemplatePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toBeInTheDocument();
+    });
+  });
+
+  it('should show notification access errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('organizations'),
+        () => HttpResponse.json({ detail: 'Failed to load organizations' }, { status: 500 })
+      )
+    );
+
+    renderTemplatePage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 });

--- a/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplatePage.tsx
@@ -9,18 +9,16 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { LoadingPage } from '@ansible/ansible-ui-framework/components/LoadingPage';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
-import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
+import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useViewActivityStream } from '../../../access/common/useViewActivityStream';
 import { AwxError } from '../../../common/AwxError';
-import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
-import { Organization } from '../../../interfaces/Organization';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useCanViewNotificationsTab } from '../../notifications/hooks/useCanViewNotificationsTab';
 import { useTemplateActions } from '../hooks/useTemplateActions';
 
 export function TemplatePage() {
@@ -29,7 +27,6 @@ export function TemplatePage() {
     'job_template+workflow_job_template+workflow_job_template_node'
   );
 
-  const { activeAwxUser } = useAwxActiveUser();
   const params = useParams<{ id: string }>();
   const {
     error: templateError,
@@ -38,13 +35,11 @@ export function TemplatePage() {
     refresh,
   } = useGetItem<JobTemplate>(awxAPI`/job_templates`, params.id);
   const {
-    data: isNotifAdmin,
-    error: isNotifAdminError,
-    refresh: refreshNotifAdmin,
-    isLoading: isNotifAdminLoading,
-  } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
-  );
+    canViewNotificationsTab,
+    error: notificationsTabError,
+    refresh: refreshNotificationsTab,
+    isLoading: isNotificationsTabLoading,
+  } = useCanViewNotificationsTab();
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const itemActions = useTemplateActions({
@@ -52,7 +47,6 @@ export function TemplatePage() {
     isJobTemplate: template?.type === 'job_template' ? true : false,
   });
 
-  const error = isNotifAdminError || templateError;
   const tabs: { label: string; page: string }[] = useMemo(() => {
     const tabs = [
       { label: t('Details'), page: AwxRoute.JobTemplateDetails },
@@ -62,13 +56,15 @@ export function TemplatePage() {
       { label: t('Jobs'), page: AwxRoute.JobTemplateJobs },
       { label: t('Survey'), page: AwxRoute.JobTemplateSurvey },
     ];
-    if (activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)) {
+    if (canViewNotificationsTab) {
       tabs.push({ label: t('Notifications'), page: AwxRoute.JobTemplateNotifications });
     }
     return tabs;
-  }, [t, activeAwxUser, isNotifAdmin]);
-  if (error) return <AwxError error={error} handleRefresh={refresh || refreshNotifAdmin} />;
-  if (isTemplateLoading || isNotifAdminLoading) return <LoadingPage breadcrumbs tabs />;
+  }, [t, canViewNotificationsTab]);
+  if (templateError) return <AwxError error={templateError} handleRefresh={refresh} />;
+  if (notificationsTabError)
+    return <AwxError error={notificationsTabError} handleRefresh={refreshNotificationsTab} />;
+  if (isTemplateLoading || isNotificationsTabLoading) return <LoadingPage breadcrumbs tabs />;
 
   return (
     <PageLayout>

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { testWorkflowJobTemplateFixture } from './workflowJobTemplateDetails.fixture';
 import { WorkflowJobTemplatePage } from './WorkflowJobTemplatePage';
@@ -21,9 +22,9 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('WorkflowJobTemplatePage', () => {
-  it('should render template page with template name', async () => {
-    render(
+function renderWorkflowJobTemplatePage() {
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
       <MemoryRouter initialEntries={['/templates/workflow-job-template/1']}>
         <Routes>
           <Route
@@ -32,10 +33,53 @@ describe('WorkflowJobTemplatePage', () => {
           />
         </Routes>
       </MemoryRouter>
-    );
+    </SWRConfig>
+  );
+}
+
+describe('WorkflowJobTemplatePage', () => {
+  it('should render template page with template name', async () => {
+    renderWorkflowJobTemplatePage();
 
     await waitFor(() => {
       expect(screen.getByTestId('Test Workflow Job Template')).toBeInTheDocument();
     });
+  });
+
+  it('should show notifications tab when user has notification access', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('organizations'),
+        () =>
+          HttpResponse.json({
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ id: 1, name: 'Default' }],
+          })
+      )
+    );
+
+    renderWorkflowJobTemplatePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toBeInTheDocument();
+    });
+  });
+
+  it('should show notification access errors', async () => {
+    server.use(
+      http.get(
+        ({ request }) => request.url.includes('organizations'),
+        () => HttpResponse.json({ detail: 'Failed to load organizations' }, { status: 500 })
+      )
+    );
+
+    renderWorkflowJobTemplatePage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 });

--- a/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
+++ b/frontend/awx/resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.tsx
@@ -9,18 +9,16 @@ import {
 } from '@ansible/ansible-ui-framework';
 import { LoadingPage } from '@ansible/ansible-ui-framework/components/LoadingPage';
 import { PageRoutedTabs } from '@ansible/common-ui/PageRoutedTabs';
-import { useGet, useGetItem } from '@ansible/common-ui/crud/useGet';
+import { useGetItem } from '@ansible/common-ui/crud/useGet';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useViewActivityStream } from '../../../access/common/useViewActivityStream';
 import { AwxError } from '../../../common/AwxError';
-import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { useAwxActiveUser } from '../../../common/useAwxActiveUser';
-import { Organization } from '../../../interfaces/Organization';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { AwxRoute } from '../../../main/AwxRoutes';
+import { useCanViewNotificationsTab } from '../../notifications/hooks/useCanViewNotificationsTab';
 import { useTemplateActions } from '../hooks/useTemplateActions';
 
 export function WorkflowJobTemplatePage() {
@@ -29,7 +27,6 @@ export function WorkflowJobTemplatePage() {
     'job_template+workflow_job_template+workflow_job_template_node'
   );
   const params = useParams<{ id: string }>();
-  const { activeAwxUser } = useAwxActiveUser();
   const {
     error: templateError,
     data: template,
@@ -38,19 +35,16 @@ export function WorkflowJobTemplatePage() {
   } = useGetItem<WorkflowJobTemplate>(awxAPI`/workflow_job_templates`, params.id);
 
   const {
-    data: isNotifAdmin,
-    error: isNotifAdminError,
-    refresh: refreshNotifAdmin,
-    isLoading: isNotifAdminLoading,
-  } = useGet<AwxItemsResponse<Organization>>(
-    awxAPI`/organizations/?role_level=notification_admin_role&count_disabled=1`
-  );
+    canViewNotificationsTab,
+    error: notificationsTabError,
+    refresh: refreshNotificationsTab,
+    isLoading: isNotificationsTabLoading,
+  } = useCanViewNotificationsTab();
   const getPageUrl = useGetPageUrl();
   const pageNavigate = usePageNavigate();
   const itemActions = useTemplateActions({
     onTemplatesDeleted: () => pageNavigate(AwxRoute.Templates),
   });
-  const error = isNotifAdminError || templateError;
 
   const tabs: ({ label: string; page: string } | false)[] = useMemo(
     () => [
@@ -60,16 +54,18 @@ export function WorkflowJobTemplatePage() {
       { label: t('Schedules'), page: AwxRoute.WorkflowJobTemplateSchedules },
       { label: t('Jobs'), page: AwxRoute.WorkflowJobTemplateJobs },
       { label: t('Survey'), page: AwxRoute.WorkflowJobTemplateSurvey },
-      activeAwxUser?.is_system_auditor || (isNotifAdmin && isNotifAdmin.results.length > 0)
+      canViewNotificationsTab
         ? { label: t('Notifications'), page: AwxRoute.WorkflowJobTemplateNotifications }
         : false,
     ],
 
-    [t, activeAwxUser, isNotifAdmin]
+    [t, canViewNotificationsTab]
   );
 
-  if (error) return <AwxError error={error} handleRefresh={refresh || refreshNotifAdmin} />;
-  if (!template || isTemplateLoading || isNotifAdminLoading)
+  if (templateError) return <AwxError error={templateError} handleRefresh={refresh} />;
+  if (notificationsTabError)
+    return <AwxError error={notificationsTabError} handleRefresh={refreshNotificationsTab} />;
+  if (!template || isTemplateLoading || isNotificationsTabLoading)
     return <LoadingPage breadcrumbs tabs />;
 
   return (


### PR DESCRIPTION
## Summary

Fixes notification tab visibility so organization auditors can access notification tabs consistently across AWX resource pages.

This adds a shared useCanViewNotificationsTab hook that grants notification tab access to:

- system auditors
- notification admins
- organization auditors

Updated pages:

- Management Jobs
- Projects
- Job Templates
- Workflow Job Templates

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->
N/A

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment /run-playwright on this PR.

│ Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

N/A

### Manual Testing

Suggested verification:

1. Log in as an organization auditor.
2. Navigate to:
    - a Project page
    - a Job Template page
    - a Workflow Job Template page
    - a Management Job page
3. Confirm the Notifications tab is visible.
4. Log in as a user without system auditor, organization auditor, or notification admin access.
5. Confirm the Notifications tab is not visible.
6. Log in as a system auditor or notification admin.
7. Confirm the Notifications tab remains visible.

Automated tests run:

```bash
  npm --prefix frontend/awx run vitest -- resources/notifications/hooks/useCanViewNotificationsTab.test.tsx
administration/management-jobs/ManagementJobPage/ManagementJobPage.test.tsx resources/projects/ProjectPage/ProjectPage.test.tsx
resources/templates/TemplatePage/TemplatePage.test.tsx resources/templates/WorkflowJobTemplatePage/WorkflowJobTemplatePage.test.tsx
```

Result:

```text
  Test Files  5 passed (5)
  Tests       20 passed (20)
```

### Screenshots

N/A — no styling or layout changes; this only updates role-based visibility for an existing tab.