### PR TITLE
fix(awx): show workflow approval description on details page (AAP-87838)

### DIFF
--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.test.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.test.tsx
@@ -27,6 +27,9 @@ describe('WorkflowApprovalDetails', () => {
       expect(screen.getByTestId('label-name')).toHaveTextContent('Name');
       expect(screen.getByTestId('name')).toHaveTextContent('Test Workflow Approval');
 
+      expect(screen.getByTestId('label-description')).toHaveTextContent('Description');
+      expect(screen.getByTestId('description')).toHaveTextContent('Test approval description');
+
       expect(screen.getByTestId('label-status')).toHaveTextContent('Status');
       expect(screen.getByTestId('status')).toHaveTextContent('Timed out');
 

--- a/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.tsx
+++ b/frontend/awx/administration/workflow-approvals/WorkflowApprovalPage/WorkflowApprovalDetails.tsx
@@ -11,7 +11,7 @@ export function WorkflowApprovalDetails() {
     awxAPI`/workflow_approvals`,
     params.id
   );
-  const columns = useWorkflowApprovalsColumns();
+  const columns = useWorkflowApprovalsColumns({ includeDescription: true });
   return workflowApproval ? (
     <PageDetails>
       <PageDetailsFromColumns item={workflowApproval} columns={columns} />

--- a/frontend/awx/administration/workflow-approvals/hooks/useWorkflowApprovalsColumns.tsx
+++ b/frontend/awx/administration/workflow-approvals/hooks/useWorkflowApprovalsColumns.tsx
@@ -14,6 +14,7 @@ import { WorkflowApprovalStatusCell } from '../components/WorkflowApprovalStatus
 export function useWorkflowApprovalsColumns(options?: {
   disableSort?: boolean;
   disableLinks?: boolean;
+  includeDescription?: boolean;
 }) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -27,10 +28,20 @@ export function useWorkflowApprovalsColumns(options?: {
     ...options,
     to: nameTo,
   });
+  const descriptionColumn = useMemo<ITableColumn<WorkflowApproval>>(
+    () => ({
+      id: 'description',
+      header: t('Description'),
+      type: 'description',
+      value: (workflow_approval) => workflow_approval.description,
+    }),
+    [t]
+  );
   const tableColumns = useMemo<ITableColumn<WorkflowApproval>[]>(
     () => [
       idColumn,
       nameColumn,
+      ...(options?.includeDescription ? [descriptionColumn] : []),
       {
         header: t('Started'),
         cell: (workflow_approval: WorkflowApproval) =>
@@ -49,7 +60,7 @@ export function useWorkflowApprovalsColumns(options?: {
         defaultSortDirection: 'desc',
       },
     ],
-    [idColumn, nameColumn, t]
+    [descriptionColumn, idColumn, nameColumn, options?.includeDescription, t]
   );
   return tableColumns;
 }


### PR DESCRIPTION
## Summary

- Display the workflow approval `description` field on the Workflow Approval **Details** page, matching data already returned by the Controller API.
- Add an `includeDescription` option to `useWorkflowApprovalsColumns` so the list table and approve/deny confirmation modals remain unchanged.
- Description renders in the standard multi-column details grid (not full-width), consistent with the Workflow Job Details tab layout.

Fixes [AAP-87838](https://redhat.atlassian.net/browse/AAP-87838).

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

1. Launch a workflow with an approval node that has a non-empty description.
2. Navigate to **Workflow Approvals** and open the pending approval.
3. Confirm **Description** appears on the Details tab in the grid layout alongside ID, Name, Started, and Status.
4. Confirm the Workflow Approvals list table does not show a Description column.
5. Confirm approve/deny confirmation modals do not show Description.

### Unit tests

- `WorkflowApprovalDetails.test.tsx` — asserts description renders on the details page.


Before
<img width="1875" height="654" alt="image" src="https://github.com/user-attachments/assets/ef0fac44-5894-40de-ae89-a42f02b45d5d" />

After
<img width="1875" height="654" alt="image" src="https://github.com/user-attachments/assets/a7a61c64-7e95-4334-92e8-1efd931db0c7" />


Made with [Cursor](https://cursor.com)