### PR TITLE
Fix subscription config refresh race

### DIFF
--- a/frontend/awx/common/useAwxConfig.test.tsx
+++ b/frontend/awx/common/useAwxConfig.test.tsx
@@ -176,4 +176,35 @@ describe('useAwxConfig', () => {
       expect(result.current.serviceDownStatusCode).toBe(504);
     });
   });
+
+  test('refreshAwxConfig resolves after loading the latest config', async () => {
+    let requestCount = 0;
+    const refreshedConfig = {
+      ...mockConfig,
+      license_info: {
+        ...mockConfig.license_info,
+        time_remaining: 2000000,
+      },
+    };
+
+    server.use(
+      http.get(awxAPI`/config/`, () => {
+        requestCount += 1;
+        return HttpResponse.json(requestCount === 1 ? mockConfig : refreshedConfig);
+      })
+    );
+
+    const { result } = renderHook(() => useAwxConfigState(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.awxConfig?.license_info.time_remaining).toBe(1000000);
+    });
+
+    await result.current.refreshAwxConfig?.();
+
+    await waitFor(() => {
+      expect(result.current.awxConfig?.license_info.time_remaining).toBe(2000000);
+    });
+    expect(requestCount).toBe(2);
+  });
 });

--- a/frontend/awx/common/useAwxConfig.tsx
+++ b/frontend/awx/common/useAwxConfig.tsx
@@ -10,7 +10,7 @@ const AwxConfigContext = createContext<{
   awxConfigError?: Error;
   serviceDown?: boolean;
   serviceDownStatusCode?: number;
-  refreshAwxConfig?: () => void;
+  refreshAwxConfig?: () => Promise<Config | undefined>;
 }>({});
 
 export function useAwxConfig() {

--- a/platform/main/PlatformSubscription.test.tsx
+++ b/platform/main/PlatformSubscription.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlatformSubscription } from './PlatformSubscription';
+
+const mockRefreshAwxConfig = vi.hoisted(() => vi.fn());
+const mockUseAwxConfigState = vi.hoisted(() => vi.fn());
+const mockUseHasAwxService = vi.hoisted(() => vi.fn());
+
+vi.mock('@ansible/awx-ui/common/useAwxConfig', () => ({
+  useAwxConfigState: mockUseAwxConfigState,
+}));
+
+vi.mock('./GatewayServices', () => ({
+  useHasAwxService: mockUseHasAwxService,
+}));
+
+vi.mock('@ansible/awx-ui/common/AwxError', () => ({
+  AwxError: (props: Readonly<{ handleRefresh: () => void }>) => (
+    <button type="button" onClick={props.handleRefresh}>
+      Refresh
+    </button>
+  ),
+}));
+
+vi.mock('@ansible/ansible-ui-framework/components/LoadingState', () => ({
+  LoadingState: () => <div>Loading</div>,
+}));
+
+vi.mock('../settings/SubscriptionWizard', () => ({
+  SubscriptionWizard: (props: Readonly<{ onSuccess: () => void }>) => (
+    <button type="button" onClick={props.onSuccess}>
+      Complete subscription
+    </button>
+  ),
+}));
+
+describe('PlatformSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefreshAwxConfig.mockResolvedValue(undefined);
+    mockUseHasAwxService.mockReturnValue(true);
+    mockUseAwxConfigState.mockReturnValue({
+      awxConfig: { license_info: { compliant: true } },
+      awxConfigError: undefined,
+      serviceDown: false,
+      refreshAwxConfig: mockRefreshAwxConfig,
+    });
+  });
+
+  it('refreshes the config when the AWX error retry action is used', async () => {
+    const user = userEvent.setup();
+    const error = new Error('Config request failed');
+    mockUseAwxConfigState.mockReturnValue({
+      awxConfig: undefined,
+      awxConfigError: error,
+      serviceDown: false,
+      refreshAwxConfig: mockRefreshAwxConfig,
+    });
+
+    render(<PlatformSubscription>Content</PlatformSubscription>);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(mockRefreshAwxConfig).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes the config after the subscription wizard succeeds', async () => {
+    const user = userEvent.setup();
+    mockUseAwxConfigState.mockReturnValue({
+      awxConfig: { license_info: {} },
+      awxConfigError: undefined,
+      serviceDown: false,
+      refreshAwxConfig: mockRefreshAwxConfig,
+    });
+
+    render(<PlatformSubscription>Content</PlatformSubscription>);
+
+    await user.click(screen.getByRole('button', { name: 'Complete subscription' }));
+
+    expect(mockRefreshAwxConfig).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes the config when the subscription cannot be found', async () => {
+    const user = userEvent.setup();
+    mockUseAwxConfigState.mockReturnValue({
+      awxConfig: null,
+      awxConfigError: undefined,
+      serviceDown: false,
+      refreshAwxConfig: mockRefreshAwxConfig,
+    });
+
+    render(<PlatformSubscription>Content</PlatformSubscription>);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(mockRefreshAwxConfig).toHaveBeenCalledOnce();
+  });
+
+  it('renders children when the subscription is already configured', () => {
+    render(<PlatformSubscription>Content</PlatformSubscription>);
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});

--- a/platform/main/PlatformSubscription.test.tsx
+++ b/platform/main/PlatformSubscription.test.tsx
@@ -65,7 +65,7 @@ describe('PlatformSubscription', () => {
     expect(mockRefreshAwxConfig).toHaveBeenCalledOnce();
   });
 
-  it('refreshes the config after the subscription wizard succeeds', async () => {
+  it('does not refresh the config after the subscription wizard succeeds', async () => {
     const user = userEvent.setup();
     mockUseAwxConfigState.mockReturnValue({
       awxConfig: { license_info: {} },
@@ -78,7 +78,7 @@ describe('PlatformSubscription', () => {
 
     await user.click(screen.getByRole('button', { name: 'Complete subscription' }));
 
-    expect(mockRefreshAwxConfig).toHaveBeenCalledOnce();
+    expect(mockRefreshAwxConfig).not.toHaveBeenCalled();
   });
 
   it('refreshes the config when the subscription cannot be found', async () => {

--- a/platform/main/PlatformSubscription.tsx
+++ b/platform/main/PlatformSubscription.tsx
@@ -42,7 +42,7 @@ export function PlatformSubscription(props: Readonly<{ children: ReactNode }>) {
     if (!awxConfig.license_info || !Object.keys(awxConfig.license_info).length) {
       return (
         <Page>
-          <SubscriptionWizard onSuccess={() => void refreshAwxConfig?.()} />
+          <SubscriptionWizard onSuccess={() => undefined} />
         </Page>
       );
     }

--- a/platform/main/PlatformSubscription.tsx
+++ b/platform/main/PlatformSubscription.tsx
@@ -25,21 +25,24 @@ export function PlatformSubscription(props: Readonly<{ children: ReactNode }>) {
     if (awxConfigError) {
       return (
         <Page>
-          <AwxError error={awxConfigError} handleRefresh={refreshAwxConfig} />
+          <AwxError error={awxConfigError} handleRefresh={() => void refreshAwxConfig?.()} />
         </Page>
       );
     }
 
     if (!awxConfig) {
       return (
-        <AwxError error={new Error(t`Subscription not found`)} handleRefresh={refreshAwxConfig} />
+        <AwxError
+          error={new Error(t`Subscription not found`)}
+          handleRefresh={() => void refreshAwxConfig?.()}
+        />
       );
     }
 
     if (!awxConfig.license_info || !Object.keys(awxConfig.license_info).length) {
       return (
         <Page>
-          <SubscriptionWizard onSuccess={() => refreshAwxConfig?.()} />
+          <SubscriptionWizard onSuccess={() => void refreshAwxConfig?.()} />
         </Page>
       );
     }

--- a/platform/settings/SubscriptionWizard.test.tsx
+++ b/platform/settings/SubscriptionWizard.test.tsx
@@ -395,5 +395,44 @@ describe('SubscriptionWizard Component', () => {
 
       expect(patchCalled).toBe(false);
     }, 30000);
+
+    it('should explain when the manifest upload succeeds but refresh fails', async () => {
+      mockRefreshAwxConfig.mockRejectedValue(new Error('Refresh failed'));
+
+      server.use(http.post('*/config/', () => HttpResponse.json({})));
+
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      await user.click(screen.getByRole('button', { name: 'Subscription manifest' }));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const file = new File(['mock manifest content'], 'manifest.zip', {
+        type: 'application/zip',
+      });
+      await user.upload(fileInput, file);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+      await user.click(
+        screen.getByRole('checkbox', { name: /I agree to the terms of the license agreement/i })
+      );
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Finish' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Subscription uploaded, but the subscription status could not be refreshed. Please try again.'
+          )
+        ).toBeInTheDocument();
+      });
+
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+    }, 30000);
   });
 });

--- a/platform/settings/SubscriptionWizard.test.tsx
+++ b/platform/settings/SubscriptionWizard.test.tsx
@@ -7,9 +7,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SubscriptionWizard } from './SubscriptionWizard';
 
+const mockRefreshAwxConfig = vi.hoisted(() => vi.fn());
+
 vi.mock('@ansible/awx-ui/common/useAwxConfig', () => ({
   useAwxConfig: () => ({ eula: 'End User License Agreement text for testing.' }),
-  useAwxConfigState: () => ({ refreshAwxConfig: vi.fn() }),
+  useAwxConfigState: () => ({ refreshAwxConfig: mockRefreshAwxConfig }),
 }));
 
 const server = setupServer();
@@ -35,6 +37,7 @@ const renderWithRouter = (props = defaultProps) => {
 describe('SubscriptionWizard Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRefreshAwxConfig.mockResolvedValue(undefined);
   });
 
   describe('Wizard Structure', () => {
@@ -331,6 +334,14 @@ describe('SubscriptionWizard Component', () => {
 
     it('should not enable INSIGHTS_TRACKING_STATE when submitting manifest subscription', async () => {
       let patchCalled = false;
+      const events: string[] = [];
+
+      mockRefreshAwxConfig.mockImplementation(async () => {
+        events.push('refresh-start');
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        events.push('refresh-complete');
+      });
+      mockOnSuccess.mockImplementation(() => events.push('success'));
 
       server.use(
         http.post('*/config/', () => HttpResponse.json({})),
@@ -371,7 +382,7 @@ describe('SubscriptionWizard Component', () => {
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
       await waitFor(() => {
-        expect(mockOnSuccess).toHaveBeenCalled();
+        expect(events).toEqual(['refresh-start', 'refresh-complete', 'success']);
       });
 
       expect(patchCalled).toBe(false);

--- a/platform/settings/SubscriptionWizard.test.tsx
+++ b/platform/settings/SubscriptionWizard.test.tsx
@@ -263,6 +263,14 @@ describe('SubscriptionWizard Component', () => {
   describe('Auto-enabling Insights Tracking', () => {
     it('should enable INSIGHTS_TRACKING_STATE when submitting service account subscription', async () => {
       let patchedSettings: Record<string, unknown> | undefined;
+      const events: string[] = [];
+
+      mockRefreshAwxConfig.mockImplementation(async () => {
+        events.push('refresh-start');
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        events.push('refresh-complete');
+      });
+      mockOnSuccess.mockImplementation(() => events.push('success'));
 
       server.use(
         http.post('*/config/subscriptions/', () =>
@@ -326,7 +334,7 @@ describe('SubscriptionWizard Component', () => {
       await user.click(screen.getByRole('button', { name: 'Finish' }));
 
       await waitFor(() => {
-        expect(mockOnSuccess).toHaveBeenCalled();
+        expect(events).toEqual(['refresh-start', 'refresh-complete', 'success']);
       });
 
       expect(patchedSettings).toEqual({ INSIGHTS_TRACKING_STATE: true });

--- a/platform/settings/SubscriptionWizard.tsx
+++ b/platform/settings/SubscriptionWizard.tsx
@@ -91,7 +91,7 @@ export function SubscriptionWizard(props: Readonly<{ onSuccess: () => void }>) {
           });
           break;
       }
-      refreshAwxConfig?.();
+      await refreshAwxConfig?.();
       props.onSuccess();
     },
     [props, refreshAwxConfig]

--- a/platform/settings/SubscriptionWizard.tsx
+++ b/platform/settings/SubscriptionWizard.tsx
@@ -91,10 +91,16 @@ export function SubscriptionWizard(props: Readonly<{ onSuccess: () => void }>) {
           });
           break;
       }
-      await refreshAwxConfig?.();
+      try {
+        await refreshAwxConfig?.();
+      } catch {
+        throw new Error(
+          t`Subscription uploaded, but the subscription status could not be refreshed. Please try again.`
+        );
+      }
       props.onSuccess();
     },
-    [props, refreshAwxConfig]
+    [props, refreshAwxConfig, t]
   );
 
   return (


### PR DESCRIPTION
## Summary
- wait for subscription config revalidation before completing a manifest upload
- expose the SWR refresh promise from the config context
- add regression coverage for refresh ordering

## Testing
- targeted Vitest tests
- ESLint
- Prettier
- AWX package TypeScript check

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact
- [ ] **Medium** — Scoped but cross-cutting
- [x] **Low** — Narrowly scoped subscription refresh fix

## Dependencies

None.

This change contains no customer, manifest, credential, escalation, or internal-ticket details.