### PR TITLE
fix(platform): delete legacy tokens via controller API (AAP-74711)

### DIFF
--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -1,7 +1,8 @@
 import { FrameworkTranslationsProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
 import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { Token } from '@ansible/awx-ui/interfaces/Token';
-import { act, fireEvent, renderHook, screen, waitFor } from '@testing-library/react';
+import { act, renderHook, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { BrowserRouter } from 'react-router-dom';
@@ -45,7 +46,7 @@ function createToken(overrides: Partial<Token> & Pick<Token, 'id' | 'type' | 'ur
 const legacyToken = createToken({
   id: 1,
   type: 'o_auth2_access_token',
-  url: '/api/v2/tokens/1/',
+  url: '/api/controller/v2/tokens/1/',
   description: 'Legacy token',
   scope: 'write',
 });
@@ -65,11 +66,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   </BrowserRouter>
 );
 
-async function confirmTokenDeletion() {
-  fireEvent.click(screen.getByRole('checkbox'));
-  await act(() => {
-    fireEvent.click(screen.getByRole('button', { name: /Delete token/i }));
-  });
+async function confirmTokenDeletion(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('checkbox'));
+  await user.click(screen.getByRole('button', { name: /Delete token/i }));
 }
 
 describe('getTokenDeleteUrl', () => {
@@ -81,44 +80,24 @@ describe('getTokenDeleteUrl', () => {
     expect(getTokenDeleteUrl(gatewayToken)).toBe(gatewayAPI`/tokens/2/`);
   });
 
-  it('prefers the gateway URL when the token URL points at the gateway', () => {
+  it('routes legacy tokens to the controller API based on type, regardless of URL', () => {
     const token = createToken({
       id: 3,
       type: 'o_auth2_access_token',
       url: '/api/gateway/v1/tokens/3/',
     });
 
-    expect(getTokenDeleteUrl(token)).toBe(gatewayAPI`/tokens/3/`);
+    expect(getTokenDeleteUrl(token)).toBe(awxAPI`/tokens/3/`);
   });
 
-  it('prefers the controller URL when the token URL points at controller', () => {
+  it('routes regular access tokens to the gateway API based on type, regardless of URL', () => {
     const token = createToken({
       id: 4,
       type: 'Access Token',
-      url: '/api/v2/tokens/4/',
+      url: '/api/controller/v2/tokens/4/',
     });
 
-    expect(getTokenDeleteUrl(token)).toBe(awxAPI`/tokens/4/`);
-  });
-
-  it('falls back to the legacy token type when the URL is ambiguous', () => {
-    const token = createToken({
-      id: 5,
-      type: 'o_auth2_access_token',
-      url: '/tokens/5/',
-    });
-
-    expect(getTokenDeleteUrl(token)).toBe(awxAPI`/tokens/5/`);
-  });
-
-  it('defaults to the gateway API for non-legacy access tokens with ambiguous URLs', () => {
-    const token = createToken({
-      id: 6,
-      type: 'Access Token',
-      url: '/tokens/6/',
-    });
-
-    expect(getTokenDeleteUrl(token)).toBe(gatewayAPI`/tokens/6/`);
+    expect(getTokenDeleteUrl(token)).toBe(gatewayAPI`/tokens/4/`);
   });
 });
 
@@ -131,6 +110,7 @@ describe('useDeleteAAPUserTokens', () => {
   const onComplete = vi.fn();
 
   it('deletes the legacy token through the AWX controller API, not the gateway API', async () => {
+    const user = userEvent.setup();
     let awxCalled = false;
     let gatewayCalled = false;
     server.use(
@@ -149,7 +129,7 @@ describe('useDeleteAAPUserTokens', () => {
       result.current([legacyToken]);
     });
 
-    await confirmTokenDeletion();
+    await confirmTokenDeletion(user);
 
     await waitFor(() => {
       expect(awxCalled).toBe(true);
@@ -159,6 +139,7 @@ describe('useDeleteAAPUserTokens', () => {
   });
 
   it('deletes gateway tokens through the gateway API, not the AWX controller API', async () => {
+    const user = userEvent.setup();
     let awxCalled = false;
     let gatewayCalled = false;
     server.use(
@@ -177,7 +158,7 @@ describe('useDeleteAAPUserTokens', () => {
       result.current([gatewayToken]);
     });
 
-    await confirmTokenDeletion();
+    await confirmTokenDeletion(user);
 
     await waitFor(() => {
       expect(awxCalled).toBe(false);
@@ -187,6 +168,7 @@ describe('useDeleteAAPUserTokens', () => {
   });
 
   it('deletes mixed legacy and gateway tokens through their respective APIs', async () => {
+    const user = userEvent.setup();
     let awxCalled = false;
     let gatewayCalled = false;
     server.use(
@@ -205,7 +187,7 @@ describe('useDeleteAAPUserTokens', () => {
       result.current([legacyToken, gatewayToken]);
     });
 
-    await confirmTokenDeletion();
+    await confirmTokenDeletion(user);
 
     await waitFor(() => {
       expect(awxCalled).toBe(true);

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -5,7 +5,7 @@ import { act, renderHook, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 import { getTokenDeleteUrl, useDeleteUserTokens } from './useDeleteAAPUserTokens';
@@ -59,11 +59,11 @@ const gatewayToken = createToken({
 });
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <BrowserRouter>
+  <MemoryRouter>
     <PageDialogProvider>
       <FrameworkTranslationsProvider>{children}</FrameworkTranslationsProvider>
     </PageDialogProvider>
-  </BrowserRouter>
+  </MemoryRouter>
 );
 
 async function confirmTokenDeletion(user: ReturnType<typeof userEvent.setup>) {

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -5,7 +5,7 @@ import { act, fireEvent, renderHook, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { BrowserRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 import { useDeleteUserTokens } from './useDeleteAAPUserTokens';
 
@@ -26,11 +26,12 @@ const server = setupServer();
 
 describe('useDeleteAAPUserTokens', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  beforeEach(() => vi.clearAllMocks());
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
   const onComplete = vi.fn();
-  const token: Token = {
+  const legacyToken: Token = {
     id: 1,
     type: 'o_auth2_access_token',
     url: '/api/v2/tokens/1/',
@@ -40,6 +41,24 @@ describe('useDeleteAAPUserTokens', () => {
     user: 1,
     application: 1,
     scope: 'write',
+    expires: '2024-12-31T00:00:00Z',
+    last_used: null,
+    summary_fields: {
+      user: { id: 1, username: 'testuser', first_name: 'Test', last_name: 'User' },
+      application: { id: 1, name: 'Test Application' },
+    },
+  };
+
+  const gatewayToken: Token = {
+    id: 2,
+    type: 'Access Token',
+    url: '/api/gateway/v1/tokens/2/',
+    description: 'Gateway token',
+    created: '2024-01-01T00:00:00Z',
+    modified: '2024-01-01T00:00:00Z',
+    user: 1,
+    application: 1,
+    scope: 'read',
     expires: '2024-12-31T00:00:00Z',
     last_used: null,
     summary_fields: {
@@ -72,7 +91,7 @@ describe('useDeleteAAPUserTokens', () => {
 
     const { result } = renderHook(() => useDeleteUserTokens(onComplete), { wrapper });
     act(() => {
-      result.current([token]);
+      result.current([legacyToken]);
     });
 
     const checkbox = screen.getByRole('checkbox');
@@ -92,6 +111,45 @@ describe('useDeleteAAPUserTokens', () => {
 
     expect(awxCalled).toBe(true);
     expect(gatewayCalled).toBe(false);
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('deletes gateway tokens through the gateway API, not the AWX controller API', async () => {
+    let awxCalled = false;
+    let gatewayCalled = false;
+    server.use(
+      http.delete(awxAPI`/tokens/2/`, () => {
+        awxCalled = true;
+        return HttpResponse.json({});
+      }),
+      http.delete(gatewayAPI`/tokens/2/`, () => {
+        gatewayCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    const { result } = renderHook(() => useDeleteUserTokens(onComplete), { wrapper });
+    act(() => {
+      result.current([gatewayToken]);
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    act(() => {
+      fireEvent.click(checkbox);
+    });
+
+    const submitButton = screen.getByRole('button', { name: /Delete token/i });
+    await act(async () => {
+      fireEvent.click(submitButton);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    });
+
+    expect(awxCalled).toBe(false);
+    expect(gatewayCalled).toBe(true);
     expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -1,0 +1,97 @@
+import { FrameworkTranslationsProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
+import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
+import { Token } from '@ansible/awx-ui/interfaces/Token';
+import { act, fireEvent, renderHook, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { BrowserRouter } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { gatewayAPI } from '../../../utils/gateway-api-utils';
+import { useDeleteUserTokens } from './useDeleteAAPUserTokens';
+
+vi.mock('@patternfly/react-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@patternfly/react-core')>();
+  return {
+    ...actual,
+    Modal: ({ children, title }: { children: React.ReactNode; title: string }) => (
+      <div data-testid="modal">
+        <h1>{title}</h1>
+        {children}
+      </div>
+    ),
+  };
+});
+
+const server = setupServer();
+
+describe('useDeleteAAPUserTokens', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const onComplete = vi.fn();
+  const token: Token = {
+    id: 1,
+    type: 'o_auth2_access_token',
+    url: '/api/v2/tokens/1/',
+    description: 'Legacy token',
+    created: '2024-01-01T00:00:00Z',
+    modified: '2024-01-01T00:00:00Z',
+    user: 1,
+    application: 1,
+    scope: 'write',
+    expires: '2024-12-31T00:00:00Z',
+    last_used: null,
+    summary_fields: {
+      user: { id: 1, username: 'testuser', first_name: 'Test', last_name: 'User' },
+      application: { id: 1, name: 'Test Application' },
+    },
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <BrowserRouter>
+      <PageDialogProvider>
+        <FrameworkTranslationsProvider>{children}</FrameworkTranslationsProvider>
+      </PageDialogProvider>
+    </BrowserRouter>
+  );
+
+  it('deletes the legacy token through the AWX controller API, not the gateway API', async () => {
+    let awxCalled = false;
+    let gatewayCalled = false;
+    server.use(
+      http.delete(awxAPI`/tokens/1/`, () => {
+        awxCalled = true;
+        return HttpResponse.json({});
+      }),
+      http.delete(gatewayAPI`/tokens/1/`, () => {
+        gatewayCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    const { result } = renderHook(() => useDeleteUserTokens(onComplete), { wrapper });
+    act(() => {
+      result.current([token]);
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    act(() => {
+      fireEvent.click(checkbox);
+    });
+
+    const submitButton = screen.getByRole('button', { name: /Delete token/i });
+    await act(async () => {
+      fireEvent.click(submitButton);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    });
+
+    expect(awxCalled).toBe(true);
+    expect(gatewayCalled).toBe(false);
+    expect(onComplete).toHaveBeenCalled();
+  });
+});

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -1,13 +1,13 @@
 import { FrameworkTranslationsProvider, PageDialogProvider } from '@ansible/ansible-ui-framework';
 import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { Token } from '@ansible/awx-ui/interfaces/Token';
-import { act, fireEvent, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, renderHook, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { BrowserRouter } from 'react-router-dom';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
-import { useDeleteUserTokens } from './useDeleteAAPUserTokens';
+import { getTokenDeleteUrl, useDeleteUserTokens } from './useDeleteAAPUserTokens';
 
 vi.mock('@patternfly/react-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@patternfly/react-core')>();
@@ -24,36 +24,9 @@ vi.mock('@patternfly/react-core', async (importOriginal) => {
 
 const server = setupServer();
 
-describe('useDeleteAAPUserTokens', () => {
-  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-  beforeEach(() => vi.clearAllMocks());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
-
-  const onComplete = vi.fn();
-  const legacyToken: Token = {
-    id: 1,
-    type: 'o_auth2_access_token',
-    url: '/api/v2/tokens/1/',
-    description: 'Legacy token',
-    created: '2024-01-01T00:00:00Z',
-    modified: '2024-01-01T00:00:00Z',
-    user: 1,
-    application: 1,
-    scope: 'write',
-    expires: '2024-12-31T00:00:00Z',
-    last_used: null,
-    summary_fields: {
-      user: { id: 1, username: 'testuser', first_name: 'Test', last_name: 'User' },
-      application: { id: 1, name: 'Test Application' },
-    },
-  };
-
-  const gatewayToken: Token = {
-    id: 2,
-    type: 'Access Token',
-    url: '/api/gateway/v1/tokens/2/',
-    description: 'Gateway token',
+function createToken(overrides: Partial<Token> & Pick<Token, 'id' | 'type' | 'url'>): Token {
+  return {
+    description: 'Test token',
     created: '2024-01-01T00:00:00Z',
     modified: '2024-01-01T00:00:00Z',
     user: 1,
@@ -65,15 +38,97 @@ describe('useDeleteAAPUserTokens', () => {
       user: { id: 1, username: 'testuser', first_name: 'Test', last_name: 'User' },
       application: { id: 1, name: 'Test Application' },
     },
+    ...overrides,
   };
+}
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <BrowserRouter>
-      <PageDialogProvider>
-        <FrameworkTranslationsProvider>{children}</FrameworkTranslationsProvider>
-      </PageDialogProvider>
-    </BrowserRouter>
-  );
+const legacyToken = createToken({
+  id: 1,
+  type: 'o_auth2_access_token',
+  url: '/api/v2/tokens/1/',
+  description: 'Legacy token',
+  scope: 'write',
+});
+
+const gatewayToken = createToken({
+  id: 2,
+  type: 'Access Token',
+  url: '/api/gateway/v1/tokens/2/',
+  description: 'Gateway token',
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <BrowserRouter>
+    <PageDialogProvider>
+      <FrameworkTranslationsProvider>{children}</FrameworkTranslationsProvider>
+    </PageDialogProvider>
+  </BrowserRouter>
+);
+
+async function confirmTokenDeletion() {
+  fireEvent.click(screen.getByRole('checkbox'));
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Delete token/i }));
+  });
+}
+
+describe('getTokenDeleteUrl', () => {
+  it('routes legacy controller tokens to the AWX API', () => {
+    expect(getTokenDeleteUrl(legacyToken)).toBe(awxAPI`/tokens/1/`);
+  });
+
+  it('routes gateway tokens to the gateway API', () => {
+    expect(getTokenDeleteUrl(gatewayToken)).toBe(gatewayAPI`/tokens/2/`);
+  });
+
+  it('prefers the gateway URL when the token URL points at the gateway', () => {
+    const token = createToken({
+      id: 3,
+      type: 'o_auth2_access_token',
+      url: '/api/gateway/v1/tokens/3/',
+    });
+
+    expect(getTokenDeleteUrl(token)).toBe(gatewayAPI`/tokens/3/`);
+  });
+
+  it('prefers the controller URL when the token URL points at controller', () => {
+    const token = createToken({
+      id: 4,
+      type: 'Access Token',
+      url: '/api/v2/tokens/4/',
+    });
+
+    expect(getTokenDeleteUrl(token)).toBe(awxAPI`/tokens/4/`);
+  });
+
+  it('falls back to the legacy token type when the URL is ambiguous', () => {
+    const token = createToken({
+      id: 5,
+      type: 'o_auth2_access_token',
+      url: '/tokens/5/',
+    });
+
+    expect(getTokenDeleteUrl(token)).toBe(awxAPI`/tokens/5/`);
+  });
+
+  it('defaults to the gateway API for non-legacy access tokens with ambiguous URLs', () => {
+    const token = createToken({
+      id: 6,
+      type: 'Access Token',
+      url: '/tokens/6/',
+    });
+
+    expect(getTokenDeleteUrl(token)).toBe(gatewayAPI`/tokens/6/`);
+  });
+});
+
+describe('useDeleteAAPUserTokens', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const onComplete = vi.fn();
 
   it('deletes the legacy token through the AWX controller API, not the gateway API', async () => {
     let awxCalled = false;
@@ -94,24 +149,13 @@ describe('useDeleteAAPUserTokens', () => {
       result.current([legacyToken]);
     });
 
-    const checkbox = screen.getByRole('checkbox');
-    act(() => {
-      fireEvent.click(checkbox);
-    });
+    await confirmTokenDeletion();
 
-    const submitButton = screen.getByRole('button', { name: /Delete token/i });
-    await act(async () => {
-      fireEvent.click(submitButton);
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(awxCalled).toBe(true);
+      expect(gatewayCalled).toBe(false);
+      expect(onComplete).toHaveBeenCalled();
     });
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-    });
-
-    expect(awxCalled).toBe(true);
-    expect(gatewayCalled).toBe(false);
-    expect(onComplete).toHaveBeenCalled();
   });
 
   it('deletes gateway tokens through the gateway API, not the AWX controller API', async () => {
@@ -133,23 +177,40 @@ describe('useDeleteAAPUserTokens', () => {
       result.current([gatewayToken]);
     });
 
-    const checkbox = screen.getByRole('checkbox');
+    await confirmTokenDeletion();
+
+    await waitFor(() => {
+      expect(awxCalled).toBe(false);
+      expect(gatewayCalled).toBe(true);
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('deletes mixed legacy and gateway tokens through their respective APIs', async () => {
+    let awxCalled = false;
+    let gatewayCalled = false;
+    server.use(
+      http.delete(awxAPI`/tokens/1/`, () => {
+        awxCalled = true;
+        return HttpResponse.json({});
+      }),
+      http.delete(gatewayAPI`/tokens/2/`, () => {
+        gatewayCalled = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    const { result } = renderHook(() => useDeleteUserTokens(onComplete), { wrapper });
     act(() => {
-      fireEvent.click(checkbox);
+      result.current([legacyToken, gatewayToken]);
     });
 
-    const submitButton = screen.getByRole('button', { name: /Delete token/i });
-    await act(async () => {
-      fireEvent.click(submitButton);
-      await Promise.resolve();
-    });
+    await confirmTokenDeletion();
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+    await waitFor(() => {
+      expect(awxCalled).toBe(true);
+      expect(gatewayCalled).toBe(true);
+      expect(onComplete).toHaveBeenCalled();
     });
-
-    expect(awxCalled).toBe(false);
-    expect(gatewayCalled).toBe(true);
-    expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.test.tsx
@@ -67,7 +67,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 async function confirmTokenDeletion() {
   fireEvent.click(screen.getByRole('checkbox'));
-  await act(async () => {
+  await act(() => {
     fireEvent.click(screen.getByRole('button', { name: /Delete token/i }));
   });
 }

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
@@ -6,10 +6,14 @@ import { getItemKey, requestDelete } from '@ansible/common-ui/crud/Data';
 import { useTranslation } from 'react-i18next';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 
-function getTokenDeleteUrl(token: Token) {
-  return token.type === 'o_auth2_access_token'
-    ? awxAPI`/tokens/${token.id.toString()}/`
-    : gatewayAPI`/tokens/${token.id.toString()}/`;
+export function getTokenDeleteUrl(token: Token) {
+  if (token.url.includes('/api/gateway/')) {
+    return gatewayAPI`/tokens/${token.id.toString()}/`;
+  }
+  if (token.url.includes('/api/v2/') || token.type === 'o_auth2_access_token') {
+    return awxAPI`/tokens/${token.id.toString()}/`;
+  }
+  return gatewayAPI`/tokens/${token.id.toString()}/`;
 }
 
 export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
@@ -7,13 +7,10 @@ import { useTranslation } from 'react-i18next';
 import { gatewayAPI } from '../../../utils/gateway-api-utils';
 
 export function getTokenDeleteUrl(token: Token) {
-  if (token.url.includes('/api/gateway/')) {
-    return gatewayAPI`/tokens/${token.id.toString()}/`;
-  }
-  if (token.url.includes('/api/v2/') || token.type === 'o_auth2_access_token') {
-    return awxAPI`/tokens/${token.id.toString()}/`;
-  }
-  return gatewayAPI`/tokens/${token.id.toString()}/`;
+  const tokenId = token.id.toString();
+  return token.type === 'o_auth2_access_token'
+    ? awxAPI`/tokens/${tokenId}/`
+    : gatewayAPI`/tokens/${tokenId}/`;
 }
 
 export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
@@ -1,9 +1,9 @@
 import { compareStrings, useBulkConfirmation } from '@ansible/ansible-ui-framework';
 import { useUserTokensColumns } from '@ansible/awx-ui/access/users/hooks/useUserTokensColumns';
+import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { Token } from '@ansible/awx-ui/interfaces/Token';
 import { getItemKey, requestDelete } from '@ansible/common-ui/crud/Data';
 import { useTranslation } from 'react-i18next';
-import { gatewayAPI } from '../../../utils/gateway-api-utils';
 
 export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {
   const { t } = useTranslation();
@@ -28,7 +28,7 @@ export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {
       actionColumns: userTokensColumns,
       onComplete,
       actionFn: (token: Token, signal) =>
-        requestDelete(gatewayAPI`/tokens/${token.id.toString()}/`, signal),
+        requestDelete(awxAPI`/tokens/${token.id.toString()}/`, signal),
     });
   };
   return deleteTokens;

--- a/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
+++ b/platform/access/users/hooks/useDeleteAAPUserTokens.tsx
@@ -4,6 +4,13 @@ import { awxAPI } from '@ansible/awx-ui/common/api/awx-utils';
 import { Token } from '@ansible/awx-ui/interfaces/Token';
 import { getItemKey, requestDelete } from '@ansible/common-ui/crud/Data';
 import { useTranslation } from 'react-i18next';
+import { gatewayAPI } from '../../../utils/gateway-api-utils';
+
+function getTokenDeleteUrl(token: Token) {
+  return token.type === 'o_auth2_access_token'
+    ? awxAPI`/tokens/${token.id.toString()}/`
+    : gatewayAPI`/tokens/${token.id.toString()}/`;
+}
 
 export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {
   const { t } = useTranslation();
@@ -27,8 +34,7 @@ export function useDeleteUserTokens(onComplete: (items: Token[]) => void) {
       confirmationColumns: userTokensColumns,
       actionColumns: userTokensColumns,
       onComplete,
-      actionFn: (token: Token, signal) =>
-        requestDelete(awxAPI`/tokens/${token.id.toString()}/`, signal),
+      actionFn: (token: Token, signal) => requestDelete(getTokenDeleteUrl(token), signal),
     });
   };
   return deleteTokens;


### PR DESCRIPTION
## Summary

Fixes legacy OAuth2 token deletion in the platform UI. `useDeleteAAPUserTokens` was sending all DELETE requests through `gatewayAPI` (`/api/gateway/v1/tokens/<id>/`), which does not own legacy `OAuth2AccessToken` resources, causing "No OAuth2AccessToken matches the given query."

Deletion is now routed by `token.type`:

- **Legacy tokens** (`o_auth2_access_token`) → `awxAPI` (uses the configured controller prefix, e.g. `/api/controller/v2/tokens/<id>/`)
- **Regular tokens** (`Access Token`) → `gatewayAPI` (unchanged)

Adds regression tests for legacy deletion, gateway deletion, mixed bulk deletion, and type-based routing precedence.

Cherry-picked from ansible-automation-platform/aap-ui (`lgalis/AAP-74711/fix-legacy-token-deletion`).

## Type of Change

- [x] Bug fix
- [x] Tests

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

- Delete a legacy OAuth2 token (`o_auth2_access_token`) and confirm it succeeds without the "No OAuth2AccessToken matches the given query" error
- Delete a gateway-managed `Access Token` and confirm it still deletes via the gateway API
- Bulk-delete a selection containing both legacy and gateway tokens