### PR TITLE
fix: exclude large fields from jobs list request

### DIFF
--- a/frontend/awx/views/jobs/JobsList.test.tsx
+++ b/frontend/awx/views/jobs/JobsList.test.tsx
@@ -305,6 +305,31 @@ describe('JobsList Component Tests', () => {
       { timeout: 10000 }
     );
   }, 15000);
+
+  test('excludes large fields (artifacts, extra_vars) from the jobs list request', async () => {
+    let fetchedExclude: string | null = null;
+    server.events.on('request:match', ({ request }) => {
+      const url = new URL(request.url);
+      if (url.pathname.includes('/unified_jobs/') && !url.searchParams.get('id__in')) {
+        fetchedExclude = url.searchParams.get('exclude');
+      }
+    });
+
+    render(
+      <MemoryRouter>
+        <Jobs />
+      </MemoryRouter>
+    );
+
+    await waitFor(
+      () => {
+        expect(fetchedExclude).toBe('artifacts,extra_vars');
+      },
+      { timeout: 10000 }
+    );
+
+    server.events.removeAllListeners();
+  }, 15000);
 });
 
 describe('getWsAction', () => {

--- a/frontend/awx/views/jobs/JobsList.tsx
+++ b/frontend/awx/views/jobs/JobsList.tsx
@@ -87,7 +87,11 @@ export function JobsList(props: {
     url: awxAPI`/unified_jobs/`,
     toolbarFilters,
     tableColumns,
-    queryParams: { ...props?.queryParams, or__labels__name: focusLabels },
+    queryParams: {
+      ...props?.queryParams,
+      or__labels__name: focusLabels,
+      exclude: 'artifacts,extra_vars',
+    },
   });
   const rowActions = useJobRowActions(view.unselectItemsAndRefresh);
   const toolbarActions = useJobToolbarActions(view.unselectItemsAndRefresh);


### PR DESCRIPTION
## Summary

The jobs list page (`/jobs`) fetches `GET /api/controller/v2/unified_jobs/` for every row, but the response included large fields (`artifacts`, `extra_vars`) that are not used anywhere in the list view. This bloats every list load, poll, and refresh. The controller API already supports an `exclude=field1,field2` query parameter to omit fields from list responses; the frontend just wasn't using it for this request.

## Root Cause Analysis

`JobsList.tsx` builds its `useAwxView` call without an `exclude` param:

- Affected file: `frontend/awx/views/jobs/JobsList.tsx:86-91`
- `queryParams` passed to `useAwxView` only set `or__labels__name`; no `exclude` was ever added, so the backend defaults to returning every field, including `artifacts` and `extra_vars`.
- Confirmed via `useJobsColumns.tsx` that neither field is rendered by any list/card/expanded column. The only consumers of `job.artifacts` / `job.extra_vars` are in `JobDetails.tsx`, which is populated by a separate per-job fetch, not the list query — so excluding them from the list request has no effect on the details page.

**Fix:** added `exclude: 'artifacts,extra_vars'` to the `queryParams` object passed into `useAwxView` in `JobsList.tsx`.

## Type of Change

- [x] Bug fix

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped: a single additive query parameter on one list view's request. No changes to table columns, row actions, or the job details page.

## Testing

### Regression Test

Added `excludes large fields (artifacts, extra_vars) from the jobs list request` in `frontend/awx/views/jobs/JobsList.test.tsx`, which asserts the initial `unified_jobs` list request includes `exclude=artifacts,extra_vars`.

### Mutation Testing

```
[PASS] Regression test correctly fails without fix — test is strong
```

### Similar Bug Detection

Pattern: a list view fetches a "large" field (JSON/YAML blob or long text) that's only rendered on a details page, without an `exclude` param to omit it from the list request. Candidates found for follow-up (not fixed in this PR, out of scope):

1. `frontend/awx/resources/hosts/Hosts.tsx:28` — Hosts list fetches `variables` (host YAML/JSON vars), unused in `useHostsColumns`.
2. `frontend/awx/resources/inventories/Inventories.tsx:44-49` — Inventories list fetches `variables`, unused in `useInventoriesColumns`.
3. `frontend/awx/resources/templates/TemplatesList.tsx:74-88` — Job/Workflow Job Templates list fetches `extra_vars`, unused in `useTemplateColumns`. Same field name as this bug; highest-traffic list after Jobs.
4. `frontend/awx/administration/notifiers/Notifiers.tsx:29-33` — Notifiers list fetches `notification_configuration`/`messages`, unused in `useNotifiersColumns`.

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### Manual Testing

- Open the Jobs list page and inspect the network request to `/api/controller/v2/unified_jobs/` — confirm `exclude=artifacts,extra_vars` is present as a query parameter and those fields are absent from the response.
- Open a job's details page and confirm `extra_vars`/`artifacts` still render correctly (unaffected, since details use a separate fetch).

### Screenshots

N/A — no visual/UI change.

Assisted-by: Claude Code / Sonnet 5 (Anthropic)