### PR TITLE
Feature/conditional survey

### DIFF
--- a/frontend/awx/common/SurveyStep.tsx
+++ b/frontend/awx/common/SurveyStep.tsx
@@ -5,11 +5,13 @@ import { PageSelectOption } from '@ansible/ansible-ui-framework/PageInputs/PageS
 import { usePageWizard } from '@ansible/ansible-ui-framework/PageWizard/PageWizardProvider';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { useEffect } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 import { Spec, Survey } from '../interfaces/Survey';
 import { WizardFormValues } from '../resources/templates/WorkflowVisualizer/types';
 import { awxAPI } from './api/awx-utils';
+import { evaluateConditions } from './useSurveyConditions';
 
 function getJobType(resource: WizardFormValues['resource']) {
   if (!resource) return;
@@ -35,10 +37,14 @@ export function SurveyStep({
   templateId,
   jobType,
   singleColumn,
+  pageNumber,
+  surveySpecData,
 }: {
   templateId?: string;
   jobType?: string;
   singleColumn?: boolean;
+  pageNumber?: number;
+  surveySpecData?: Survey;
 }) {
   const { t } = useTranslation();
   const { wizardData, stepData } = usePageWizard();
@@ -52,31 +58,34 @@ export function SurveyStep({
 
   jobType = jobType ?? getJobType(resource);
 
-  const { data: survey_spec } = useGet<Survey>(
-    awxAPI`/${jobType ?? 'job_templates'}/${id}/survey_spec/`
+  const { data: fetchedSpec } = useGet<Survey>(
+    !surveySpecData ? awxAPI`/${jobType ?? 'job_templates'}/${id}/survey_spec/` : ''
   );
+  const survey_spec = surveySpecData ?? fetchedSpec;
 
   useEffect(() => {
+    if (!survey_spec?.spec) return;
     const survey: { [key: string]: string | string[] | number } = {};
-    const surveyStep = stepData.survey as {
-      survey: {
-        [key: string]: string | number | string[];
-      };
-    };
+    // Collect previous values from all survey-related wizard steps
+    let previousValues: Record<string, string | number | string[]> | undefined;
+    for (const key of Object.keys(stepData)) {
+      if (key === 'survey' || key.startsWith('survey_page_')) {
+        const step = stepData[key] as { survey?: Record<string, string | number | string[]> } | undefined;
+        if (step?.survey) {
+          previousValues = { ...(previousValues ?? {}), ...step.survey };
+        }
+      }
+    }
 
-    survey_spec?.spec?.forEach((obj: Spec) => {
-      const surveyVariable = surveyStep?.survey?.[obj?.variable];
-
-      if (surveyVariable) {
-        survey[obj.variable] = surveyVariable;
+    survey_spec.spec.forEach((obj: Spec) => {
+      const prev = previousValues?.[obj.variable];
+      if (prev !== undefined) {
+        survey[obj.variable] = prev;
         return;
       }
-      if (obj.default === '') {
-        return;
-      }
+      if (obj.default === '' || obj.default === undefined || obj.default === null) return;
       if (obj.type === 'multiselect') {
-        const specDefault = obj.default as string;
-        survey[obj.variable] = specDefault.split('\n');
+        survey[obj.variable] = String(obj.default).split('\n');
         return;
       }
       survey[obj.variable] = obj.default;
@@ -84,6 +93,36 @@ export function SurveyStep({
 
     reset({ survey });
   }, [survey_spec, reset, stepData]);
+
+  // Watch current form values for condition evaluation
+  const surveyValues = useWatch({ name: 'survey' }) as Record<string, unknown> | undefined;
+
+  // Build condition data from all sources
+  const conditionData: Record<string, unknown> = {};
+  const wizardSurvey = (wizardData as Record<string, unknown>)?.survey;
+  if (wizardSurvey && typeof wizardSurvey === 'object') {
+    Object.assign(conditionData, wizardSurvey as Record<string, unknown>);
+  }
+  for (const key of Object.keys(stepData)) {
+    if (key === 'survey' || key.startsWith('survey_page_')) {
+      const step = stepData[key] as { survey?: Record<string, unknown> } | undefined;
+      if (step?.survey) {
+        Object.assign(conditionData, step.survey);
+      }
+    }
+  }
+  if (survey_spec?.spec) {
+    for (const item of survey_spec.spec) {
+      if (conditionData[item.variable] === undefined) {
+        if (item.default !== undefined && item.default !== null && item.default !== '') {
+          conditionData[item.variable] = item.default;
+        }
+      }
+    }
+  }
+  if (surveyValues && typeof surveyValues === 'object') {
+    Object.assign(conditionData, surveyValues as Record<string, unknown>);
+  }
 
   const getChoices = (name: string): PageSelectOption<string>[] => {
     const choices: PageSelectOption<string>[] = [];
@@ -107,92 +146,91 @@ export function SurveyStep({
     return choices;
   };
 
+  // Filter to this page's elements (or all if no pageNumber)
+  const pageElements = survey_spec?.spec
+    ? (pageNumber === undefined ? survey_spec.spec : survey_spec.spec.filter((el) => (el.page ?? 1) === pageNumber))
+    : [];
+
+  // Apply conditions
+  const visibleElements = pageElements.filter((el) => evaluateConditions(el, conditionData));
+
+  // Group by category
+  const categories: string[] = [];
+  const seen = new Set<string>();
+  for (const el of visibleElements) {
+    const cat = el.category ?? '';
+    if (!seen.has(cat)) { seen.add(cat); categories.push(cat); }
+  }
+
+  const renderField = (element: Spec) => {
+    if (element.type === 'text') return (
+      <PageFormTextInput key={element.variable} name={`survey.${element.variable}`} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" isRequired={element.required} type="text" maxLength={element.max} minLength={element.min} />
+    );
+    if (element.type === 'integer' || element.type === 'float') return (
+      <PageFormTextInput key={element.variable} name={`survey.${element.variable}`} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" isRequired={element.required} type="number" max={element.max} min={element.min} />
+    );
+    if (element.type === 'password') return (
+      <PageFormTextInput key={element.variable} name={`survey.${element.variable}`} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" isRequired={element.required} type="password" maxLength={element.max} minLength={element.min} />
+    );
+    if (element.type === 'textarea') return (
+      <PageFormTextArea key={element.variable} name={`survey.${element.variable}`} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" isRequired={element.required} maxLength={element.max} minLength={element.min} />
+    );
+    if (element.type === 'multiplechoice') return (
+      <PageFormSelect key={element.variable} name={`survey.${element.variable}`} placeholderText={t('Select option')} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" options={getChoices(element.question_name)} isRequired={element.required} />
+    );
+    if (element.type === 'multiselect') return (
+      <PageFormMultiSelect key={element.variable} name={`survey.${element.variable}`} placeholder={t('Select option(s)')} label={t(element.question_name)} labelHelp={element.question_description} labelHelpTitle="" options={getChoices(element.question_name)} isRequired={element.required} />
+    );
+    return null;
+  };
+
   return (
-    <PageFormSection singleColumn={singleColumn}>
-      {survey_spec?.spec.map((element, index) =>
-        element.type === 'text' ? (
-          <PageFormTextInput
-            key={index}
-            name={`survey.${element.variable}`}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            isRequired={element.required}
-            type="text"
-            maxLength={element.max}
-            minLength={element.min}
-          />
-        ) : element.type === 'integer' ? (
-          <PageFormTextInput
-            key={index}
-            name={`survey.${element.variable}`}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            isRequired={element.required}
-            type="number"
-            max={element.max}
-            min={element.min}
-          />
-        ) : element.type === 'float' ? (
-          <PageFormTextInput
-            key={index}
-            name={`survey.${element.variable}`}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            isRequired={element.required}
-            type="number"
-            max={element.max}
-            min={element.min}
-          />
-        ) : element.type === 'password' ? (
-          <PageFormTextInput
-            key={index}
-            name={`survey.${element.variable}`}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            isRequired={element.required}
-            type="password"
-            maxLength={element.max}
-            minLength={element.min}
-          />
-        ) : element.type === 'textarea' ? (
-          <PageFormTextArea
-            key={index}
-            name={`survey.${element.variable}`}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            isRequired={element.required}
-            maxLength={element.max}
-            minLength={element.min}
-          ></PageFormTextArea>
-        ) : element.type === 'multiplechoice' ? (
-          <PageFormSelect
-            key={index}
-            name={`survey.${element.variable}`}
-            placeholderText={t('Select option')}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            options={getChoices(element.question_name)}
-            isRequired={element.required}
-          ></PageFormSelect>
-        ) : element.type === 'multiselect' ? (
-          <PageFormMultiSelect
-            key={index}
-            name={`survey.${element.variable}`}
-            placeholder={t('Select option(s)')}
-            label={t(element.question_name)}
-            labelHelp={element.question_description}
-            labelHelpTitle=""
-            options={getChoices(element.question_name)}
-            isRequired={element.required}
-          />
-        ) : undefined
-      )}
-    </PageFormSection>
+    <div style={{ gridColumn: '1 / -1' }}>
+      {categories.map((category) => {
+        const categoryElements = visibleElements.filter((el) => (el.category ?? '') === category);
+        if (categoryElements.length === 0) return null;
+
+        if (!category) {
+          return (
+            <PageFormSection key="__uncategorized" singleColumn={singleColumn}>
+              {categoryElements.map(renderField)}
+            </PageFormSection>
+          );
+        }
+
+        return (
+          <Card key={category} isFlat style={{ marginBottom: '16px' }}>
+            <CardTitle>{category}</CardTitle>
+            <CardBody>
+              <PageFormSection singleColumn={singleColumn}>
+                {categoryElements.map(renderField)}
+              </PageFormSection>
+            </CardBody>
+          </Card>
+        );
+      })}
+    </div>
   );
+}
+
+/** Extract unique page numbers from a survey spec. */
+export function getSurveyPages(spec: Spec[]): number[] {
+  const pageSet = new Set<number>();
+  for (const element of spec) {
+    pageSet.add(element.page ?? 1);
+  }
+  return Array.from(pageSet).sort((a, b) => a - b);
+}
+
+/** Build a label for a survey page based on its categories. */
+export function getSurveyPageLabel(spec: Spec[], pageNum: number): string {
+  const pageElements = spec.filter((el) => (el.page ?? 1) === pageNum);
+  const categories = new Set<string>();
+  for (const el of pageElements) {
+    if (el.category) categories.add(el.category);
+  }
+  if (categories.size > 0) {
+    return Array.from(categories).join(', ');
+  }
+  return `Survey (${pageNum})`;
 }

--- a/frontend/awx/common/SurveyStep.tsx
+++ b/frontend/awx/common/SurveyStep.tsx
@@ -13,6 +13,27 @@ import { WizardFormValues } from '../resources/templates/WorkflowVisualizer/type
 import { awxAPI } from './api/awx-utils';
 import { evaluateConditions } from './useSurveyConditions';
 
+/**
+ * Read a survey variable's value from the wizard step that owns it. Each survey
+ * page is a separate wizard step (`survey_page_<n>`, or `survey` for a single
+ * page), so a variable defined on page N is authoritative only in that step's
+ * snapshot. Reading from the owning step avoids stale duplicates that other
+ * pages' snapshots may still hold after the value changed.
+ */
+function getOwnedSurveyValue(
+  variable: string,
+  page: number,
+  stepData: Record<string, unknown>
+): unknown {
+  const ownerStep = (stepData[`survey_page_${page}`] ?? stepData['survey']) as
+    | { survey?: Record<string, unknown> }
+    | undefined;
+  if (ownerStep?.survey && variable in ownerStep.survey) {
+    return ownerStep.survey[variable];
+  }
+  return undefined;
+}
+
 function getJobType(resource: WizardFormValues['resource']) {
   if (!resource) return;
 
@@ -49,6 +70,7 @@ export function SurveyStep({
   const { t } = useTranslation();
   const { wizardData, stepData } = usePageWizard();
   const { reset } = useFormContext();
+  const stepDataRecord = stepData as Record<string, unknown>;
 
   let { resource } = wizardData as WizardFormValues;
   if (!resource && stepData?.nodePromptsStep) {
@@ -66,21 +88,13 @@ export function SurveyStep({
   useEffect(() => {
     if (!survey_spec?.spec) return;
     const survey: { [key: string]: string | string[] | number } = {};
-    // Collect previous values from all survey-related wizard steps
-    let previousValues: Record<string, string | number | string[]> | undefined;
-    for (const key of Object.keys(stepData)) {
-      if (key === 'survey' || key.startsWith('survey_page_')) {
-        const step = stepData[key] as { survey?: Record<string, string | number | string[]> } | undefined;
-        if (step?.survey) {
-          previousValues = { ...(previousValues ?? {}), ...step.survey };
-        }
-      }
-    }
 
     survey_spec.spec.forEach((obj: Spec) => {
-      const prev = previousValues?.[obj.variable];
+      // Read the prior value from the step that owns this variable (by page),
+      // not from a stale duplicate copied into another page's step snapshot.
+      const prev = getOwnedSurveyValue(obj.variable, obj.page ?? 1, stepDataRecord);
       if (prev !== undefined) {
-        survey[obj.variable] = prev;
+        survey[obj.variable] = prev as string | string[] | number;
         return;
       }
       if (obj.default === '' || obj.default === undefined || obj.default === null) return;
@@ -92,36 +106,48 @@ export function SurveyStep({
     });
 
     reset({ survey });
-  }, [survey_spec, reset, stepData]);
+  }, [survey_spec, reset, stepDataRecord]);
 
   // Watch current form values for condition evaluation
   const surveyValues = useWatch({ name: 'survey' }) as Record<string, unknown> | undefined;
 
-  // Build condition data from all sources
+  // Build condition data: resolve each variable from a single source of truth.
+  // Live form values win for the current page; every other variable is read from
+  // the step that owns it (by page), so a stale copy lingering in another page's
+  // snapshot can no longer override an updated value.
+  const wizardSurvey = (wizardData as Record<string, unknown>)?.survey as
+    | Record<string, unknown>
+    | undefined;
   const conditionData: Record<string, unknown> = {};
-  const wizardSurvey = (wizardData as Record<string, unknown>)?.survey;
-  if (wizardSurvey && typeof wizardSurvey === 'object') {
-    Object.assign(conditionData, wizardSurvey as Record<string, unknown>);
-  }
-  for (const key of Object.keys(stepData)) {
-    if (key === 'survey' || key.startsWith('survey_page_')) {
-      const step = stepData[key] as { survey?: Record<string, unknown> } | undefined;
-      if (step?.survey) {
-        Object.assign(conditionData, step.survey);
-      }
-    }
-  }
   if (survey_spec?.spec) {
     for (const item of survey_spec.spec) {
-      if (conditionData[item.variable] === undefined) {
-        if (item.default !== undefined && item.default !== null && item.default !== '') {
-          conditionData[item.variable] = item.default;
+      const itemPage = item.page ?? 1;
+      const isCurrentPage = pageNumber === undefined || itemPage === pageNumber;
+
+      let value: unknown;
+      let found = false;
+      if (isCurrentPage && surveyValues && item.variable in surveyValues) {
+        value = surveyValues[item.variable];
+        found = true;
+      } else {
+        const owned = getOwnedSurveyValue(item.variable, itemPage, stepDataRecord);
+        if (owned !== undefined) {
+          value = owned;
+          found = true;
         }
       }
+      if (!found && wizardSurvey && item.variable in wizardSurvey) {
+        value = wizardSurvey[item.variable];
+        found = true;
+      }
+      if (!found && item.default !== undefined && item.default !== null && item.default !== '') {
+        value = item.default;
+        found = true;
+      }
+      if (found) {
+        conditionData[item.variable] = value;
+      }
     }
-  }
-  if (surveyValues && typeof surveyValues === 'object') {
-    Object.assign(conditionData, surveyValues as Record<string, unknown>);
   }
 
   const getChoices = (name: string): PageSelectOption<string>[] => {

--- a/frontend/awx/common/useSurveyConditions.ts
+++ b/frontend/awx/common/useSurveyConditions.ts
@@ -1,0 +1,61 @@
+import type { Spec, SurveyCondition } from '../interfaces/Survey';
+
+function evaluateSingleCondition(
+  condition: SurveyCondition,
+  data: Record<string, unknown>
+): boolean {
+  const variable = condition.variable;
+  const operator = condition.operator;
+  const expected = condition.value;
+  const actual = data[variable];
+  const isPresent =
+    variable in data && actual !== undefined && actual !== null && actual !== '';
+
+  if (operator === 'is_set') return isPresent;
+  if (operator === 'is_not_set') return !isPresent;
+  if (!isPresent) return false;
+
+  const actualStr = String(actual);
+
+  switch (operator) {
+    case 'eq':
+      return actualStr === String(expected);
+    case 'neq':
+      return actualStr !== String(expected);
+    case 'in': {
+      const list = Array.isArray(expected) ? expected : [expected];
+      return list.map(String).includes(actualStr);
+    }
+    case 'notin': {
+      const list = Array.isArray(expected) ? expected : [expected];
+      return !list.map(String).includes(actualStr);
+    }
+    case 'gt':
+    case 'lt':
+    case 'gte':
+    case 'lte': {
+      const a = parseFloat(actualStr);
+      const b = parseFloat(String(expected));
+      if (isNaN(a) || isNaN(b)) return false;
+      if (operator === 'gt') return a > b;
+      if (operator === 'lt') return a < b;
+      if (operator === 'gte') return a >= b;
+      return a <= b;
+    }
+    default:
+      return false;
+  }
+}
+
+export function evaluateConditions(
+  element: Spec,
+  data: Record<string, unknown>
+): boolean {
+  const conditions = element.conditions;
+  if (!conditions || conditions.length === 0) return true;
+
+  const logic = element.condition_logic ?? 'and';
+  const results = conditions.map((c) => evaluateSingleCondition(c, data));
+
+  return logic === 'or' ? results.some(Boolean) : results.every(Boolean);
+}

--- a/frontend/awx/common/useSurveyConditions.ts
+++ b/frontend/awx/common/useSurveyConditions.ts
@@ -8,8 +8,7 @@ function evaluateSingleCondition(
   const operator = condition.operator;
   const expected = condition.value;
   const actual = data[variable];
-  const isPresent =
-    variable in data && actual !== undefined && actual !== null && actual !== '';
+  const isPresent = variable in data && actual !== undefined && actual !== null && actual !== '';
 
   if (operator === 'is_set') return isPresent;
   if (operator === 'is_not_set') return !isPresent;
@@ -47,10 +46,7 @@ function evaluateSingleCondition(
   }
 }
 
-export function evaluateConditions(
-  element: Spec,
-  data: Record<string, unknown>
-): boolean {
+export function evaluateConditions(element: Spec, data: Record<string, unknown>): boolean {
   const conditions = element.conditions;
   if (!conditions || conditions.length === 0) return true;
 
@@ -58,4 +54,36 @@ export function evaluateConditions(
   const results = conditions.map((c) => evaluateSingleCondition(c, data));
 
   return logic === 'or' ? results.some(Boolean) : results.every(Boolean);
+}
+
+/**
+ * Remove survey answers whose spec conditions are not met.
+ *
+ * The survey form seeds a default value for every spec field regardless of its
+ * conditions, so conditionally-hidden fields still carry their default in the
+ * form data. Before that data is shown in the review step or submitted, drop the
+ * entries for fields whose conditions evaluate to false, so only the fields the
+ * user actually saw are included.
+ *
+ * Conditions are evaluated against the full answer set (the survey values merged
+ * over any additional context such as extra vars), matching the visibility logic
+ * used while rendering the survey.
+ */
+export function pruneSurveyByConditions<T = unknown>(
+  survey: Record<string, T>,
+  spec: Spec[] | undefined,
+  context: object = {}
+): Record<string, T> {
+  if (!spec || spec.length === 0) return { ...survey };
+
+  const data: Record<string, unknown> = { ...(context as Record<string, unknown>), ...survey };
+  const result: Record<string, T> = { ...survey };
+
+  for (const element of spec) {
+    if (element.variable in result && !evaluateConditions(element, data)) {
+      delete result[element.variable];
+    }
+  }
+
+  return result;
 }

--- a/frontend/awx/interfaces/Survey.ts
+++ b/frontend/awx/interfaces/Survey.ts
@@ -4,6 +4,12 @@ export interface Survey {
   spec: Spec[];
 }
 
+export interface SurveyCondition {
+  variable: string;
+  operator: 'eq' | 'neq' | 'in' | 'notin' | 'gt' | 'lt' | 'gte' | 'lte' | 'is_set' | 'is_not_set';
+  value?: string | number | string[];
+}
+
 export interface Spec {
   question_name: string;
   question_description: string;
@@ -15,4 +21,8 @@ export interface Spec {
   default: string | number;
   choices: string[] | string;
   new_question: boolean;
+  category?: string;
+  page?: number;
+  conditions?: SurveyCondition[];
+  condition_logic?: 'and' | 'or';
 }

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -10,15 +10,17 @@ import {
 import { yamlToJson } from '@ansible/ansible-ui-framework/utils/codeEditorUtils';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AwxError } from '../../../common/AwxError';
-import { SurveyStep } from '../../../common/SurveyStep';
+import { SurveyStep, getSurveyPages, getSurveyPageLabel } from '../../../common/SurveyStep';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Credential } from '../../../interfaces/Credential';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { LaunchConfiguration } from '../../../interfaces/LaunchConfiguration';
+import { Survey } from '../../../interfaces/Survey';
 import { UnifiedJob } from '../../../interfaces/UnifiedJob';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
 import { AwxRoute } from '../../../main/AwxRoutes';
@@ -98,12 +100,16 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
     error: getLaunchError,
     refresh: getLaunchRefresh,
   } = useGet<LaunchConfiguration>(awxAPI`/${jobType}/${resourceId}/launch/`);
+  const { data: surveySpec } = useGet<Survey>(
+    awxAPI`/${jobType}/${resourceId}/survey_spec/`
+  );
   const error = getTemplateError || getLaunchError;
   const refresh = getTemplateRefresh || getLaunchRefresh;
   const getJobOutputUrl = useGetJobOutputUrl();
 
   if (error) return <AwxError error={error} handleRefresh={refresh} />;
   if (!config || !template) return <LoadingPage breadcrumbs tabs />;
+  if (config.survey_enabled && !surveySpec) return <LoadingPage breadcrumbs tabs />;
   const handleSubmit = async (formValues: TemplateLaunch) => {
     if (formValues) {
       const { credential_passwords = {}, prompt = undefined, survey } = formValues;
@@ -205,6 +211,7 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
       config={config}
       handleSubmit={handleSubmit}
       jobType={jobType}
+      surveySpec={surveySpec}
     />
   );
 }
@@ -214,11 +221,13 @@ export function LaunchWizard({
   config,
   handleSubmit,
   jobType,
+  surveySpec,
 }: Readonly<{
   template: JobTemplate | WorkflowJobTemplate;
   config: LaunchConfiguration;
   handleSubmit: (values: TemplateLaunch) => Promise<void>;
   jobType: string;
+  surveySpec?: Survey;
 }>) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
@@ -227,6 +236,24 @@ export function LaunchWizard({
     ...label,
     isReadOnly: true,
   }));
+
+  // Build dynamic survey wizard steps
+  const surveySteps: PageWizardStep[] = useMemo(() => {
+    if (!config?.survey_enabled || !surveySpec?.spec || surveySpec.spec.length === 0) return [];
+    const pages = getSurveyPages(surveySpec.spec);
+    if (pages.length <= 1) {
+      return [{
+        id: 'survey',
+        label: getSurveyPageLabel(surveySpec.spec, pages[0] ?? 1),
+        inputs: <SurveyStep jobType={jobType} templateId={template.id.toString()} surveySpecData={surveySpec} />,
+      }];
+    }
+    return pages.map((pageNum) => ({
+      id: `survey_page_${pageNum}`,
+      label: getSurveyPageLabel(surveySpec.spec, pageNum),
+      inputs: <SurveyStep jobType={jobType} templateId={template.id.toString()} pageNumber={pageNum} surveySpecData={surveySpec} />,
+    }));
+  }, [config?.survey_enabled, surveySpec, jobType, template, t]);
 
   const initialValues: { [stepId: string]: Partial<TemplateLaunch> } = {
     nodePromptsStep: {
@@ -252,7 +279,7 @@ export function LaunchWizard({
       launch_config: config,
     },
     credential_passwords: {},
-    survey: {},
+    ...Object.fromEntries(surveySteps.map((step) => [step.id, {}])),
   };
 
   const steps: PageWizardStep[] = [
@@ -301,12 +328,7 @@ export function LaunchWizard({
       },
       inputs: <CredentialPasswordsStep<LaunchConfiguration> config={config} />,
     },
-    {
-      id: 'survey',
-      label: t('Survey'),
-      hidden: () => !config?.survey_enabled,
-      inputs: <SurveyStep jobType={jobType} templateId={template.id.toString()} />,
-    },
+    ...surveySteps,
     {
       id: 'review',
       label: t('Review'),

--- a/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AwxError } from '../../../common/AwxError';
 import { SurveyStep, getSurveyPages, getSurveyPageLabel } from '../../../common/SurveyStep';
+import { pruneSurveyByConditions } from '../../../common/useSurveyConditions';
 import { awxErrorAdapter } from '../../../common/adapters/awxErrorAdapter';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { Credential } from '../../../interfaces/Credential';
@@ -100,9 +101,7 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
     error: getLaunchError,
     refresh: getLaunchRefresh,
   } = useGet<LaunchConfiguration>(awxAPI`/${jobType}/${resourceId}/launch/`);
-  const { data: surveySpec } = useGet<Survey>(
-    awxAPI`/${jobType}/${resourceId}/survey_spec/`
-  );
+  const { data: surveySpec } = useGet<Survey>(awxAPI`/${jobType}/${resourceId}/survey_spec/`);
   const error = getTemplateError || getLaunchError;
   const refresh = getTemplateRefresh || getLaunchRefresh;
   const getJobOutputUrl = useGetJobOutputUrl();
@@ -168,9 +167,10 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
           const extraVarsObj = prompt?.extra_vars
             ? (JSON.parse(yamlToJson(prompt?.extra_vars)) as object)
             : {};
+          const visibleSurvey = pruneSurveyByConditions(survey, surveySpec?.spec, extraVarsObj);
           setValue('extra_vars', {
             ...extraVarsObj,
-            ...survey,
+            ...visibleSurvey,
           });
         }
 
@@ -178,10 +178,11 @@ export function LaunchTemplate({ jobType }: { jobType: string }) {
           const extraVarsObj = prompt?.extra_vars
             ? (JSON.parse(yamlToJson(prompt?.extra_vars)) as object)
             : {};
+          const visibleSurvey = pruneSurveyByConditions(survey, surveySpec?.spec, extraVarsObj);
 
           payload = {
             ...payload,
-            extra_vars: { ...extraVarsObj, ...survey },
+            extra_vars: { ...extraVarsObj, ...visibleSurvey },
           };
         }
 
@@ -242,16 +243,31 @@ export function LaunchWizard({
     if (!config?.survey_enabled || !surveySpec?.spec || surveySpec.spec.length === 0) return [];
     const pages = getSurveyPages(surveySpec.spec);
     if (pages.length <= 1) {
-      return [{
-        id: 'survey',
-        label: getSurveyPageLabel(surveySpec.spec, pages[0] ?? 1),
-        inputs: <SurveyStep jobType={jobType} templateId={template.id.toString()} surveySpecData={surveySpec} />,
-      }];
+      return [
+        {
+          id: 'survey',
+          label: getSurveyPageLabel(surveySpec.spec, pages[0] ?? 1),
+          inputs: (
+            <SurveyStep
+              jobType={jobType}
+              templateId={template.id.toString()}
+              surveySpecData={surveySpec}
+            />
+          ),
+        },
+      ];
     }
     return pages.map((pageNum) => ({
       id: `survey_page_${pageNum}`,
       label: getSurveyPageLabel(surveySpec.spec, pageNum),
-      inputs: <SurveyStep jobType={jobType} templateId={template.id.toString()} pageNumber={pageNum} surveySpecData={surveySpec} />,
+      inputs: (
+        <SurveyStep
+          jobType={jobType}
+          templateId={template.id.toString()}
+          pageNumber={pageNum}
+          surveySpecData={surveySpec}
+        />
+      ),
     }));
   }, [config?.survey_enabled, surveySpec, jobType, template, t]);
 

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
@@ -24,7 +24,7 @@ import {
   MultipleChoiceFieldType,
 } from '../../../common/MultipleChoiceField';
 import { awxAPI } from '../../../common/api/awx-utils';
-import { Spec, Survey } from '../../../interfaces/Survey';
+import { Spec, Survey, SurveyCondition } from '../../../interfaces/Survey';
 import { AwxRoute } from '../../../main/AwxRoutes';
 
 type ResourceType = 'job_templates' | 'workflow_job_templates';
@@ -136,6 +136,9 @@ interface IProps {
 
 interface FormSpec extends Spec {
   formattedChoices?: ChoiceOption[];
+  condition_variable?: string;
+  condition_operator?: string;
+  condition_value?: string;
 }
 
 export function TemplateSurveyForm(props: IProps) {
@@ -186,6 +189,7 @@ export function TemplateSurveyForm(props: IProps) {
 
   const formattedChoices = getFormattedChoices(question);
 
+  const firstCondition = question?.conditions?.[0];
   const initialValues: FormSpec = {
     question_name: question?.question_name || '',
     question_description: question?.question_description || '',
@@ -198,6 +202,11 @@ export function TemplateSurveyForm(props: IProps) {
     choices: question?.choices ?? [],
     formattedChoices,
     new_question: !question,
+    category: question?.category ?? '',
+    page: question?.page ?? 1,
+    condition_variable: firstCondition?.variable ?? '',
+    condition_operator: firstCondition?.operator ?? '',
+    condition_value: firstCondition?.value !== undefined ? String(firstCondition.value) : '',
   };
 
   const onSubmit: PageFormSubmitHandler<FormSpec & { 'add-choice'?: string }> = async (
@@ -240,7 +249,17 @@ export function TemplateSurveyForm(props: IProps) {
       question_name: newQuestion.question_name,
       question_description: newQuestion.question_description,
       choices: newQuestion.choices,
+      category: newQuestion.category || undefined,
+      page: newQuestion.page ? Number(newQuestion.page) : undefined,
     };
+
+    if (newQuestion.condition_variable && newQuestion.condition_operator) {
+      question.conditions = [{
+        variable: newQuestion.condition_variable,
+        operator: newQuestion.condition_operator as SurveyCondition['operator'],
+        value: newQuestion.condition_value || undefined,
+      }];
+    }
 
     const isDuplicate = updatedSurvey.spec.some((q) => q.variable === newQuestion.variable);
 
@@ -305,15 +324,19 @@ export function TemplateSurveyForm(props: IProps) {
       defaultValue={initialValues}
       disableSubmitOnEnter
     >
-      <TemplateSurveyInputs />
+      <TemplateSurveyInputs surveyVariables={survey?.spec?.map((s) => s.variable) ?? []} />
     </AwxPageForm>
   );
 }
 
-function TemplateSurveyInputs() {
+function TemplateSurveyInputs({ surveyVariables }: { surveyVariables: string[] }) {
   const { t } = useTranslation();
 
   const answerType = useWatch({ name: 'type' }) as string;
+  const currentVariable = useWatch({ name: 'variable' }) as string;
+  const conditionVariable = useWatch({ name: 'condition_variable' }) as string;
+
+  const otherVariables = surveyVariables.filter((v) => v !== currentVariable);
 
   return (
     <>
@@ -377,6 +400,74 @@ function TemplateSurveyInputs() {
           name="required"
         />
       </PageFormGroup>
+
+      <PageFormTextInput
+        id="question-category"
+        name="category"
+        type="text"
+        label={t`Category`}
+        placeholder={t('Enter category name')}
+        labelHelp={t`Group this question under a category heading.`}
+      />
+
+      <PageFormTextInput
+        id="question-page"
+        name="page"
+        type="number"
+        min={1}
+        label={t`Page`}
+        placeholder="1"
+        labelHelp={t`Which wizard page this question appears on. Questions on different pages become separate wizard steps.`}
+      />
+
+      {otherVariables.length > 0 && (
+        <>
+          <PageFormSelect
+            name="condition_variable"
+            id="condition-variable"
+            label={t('Condition: Variable')}
+            placeholderText={t('No condition')}
+            options={[
+              { value: '', label: t('No condition') },
+              ...otherVariables.map((v) => ({ value: v, label: v })),
+            ]}
+            labelHelp={t`Only show this question when the selected variable matches the condition.`}
+          />
+
+          {conditionVariable && (
+            <>
+              <PageFormSelect
+                name="condition_operator"
+                id="condition-operator"
+                label={t('Condition: Operator')}
+                placeholderText={t('Select operator')}
+                options={[
+                  { value: 'eq', label: t('Equals (eq)') },
+                  { value: 'neq', label: t('Not equals (neq)') },
+                  { value: 'in', label: t('In list (in)') },
+                  { value: 'notin', label: t('Not in list (notin)') },
+                  { value: 'gt', label: t('Greater than (gt)') },
+                  { value: 'lt', label: t('Less than (lt)') },
+                  { value: 'gte', label: t('Greater or equal (gte)') },
+                  { value: 'lte', label: t('Less or equal (lte)') },
+                  { value: 'is_set', label: t('Is set') },
+                  { value: 'is_not_set', label: t('Is not set') },
+                ]}
+                isRequired
+              />
+
+              <PageFormTextInput
+                id="condition-value"
+                name="condition_value"
+                type="text"
+                label={t`Condition: Value`}
+                placeholder={t('Enter expected value')}
+                labelHelp={t`The value to compare against. Leave empty for is_set/is_not_set operators.`}
+              />
+            </>
+          )}
+        </>
+      )}
 
       {answerType && <SelectedAnswerType answer={answerType} />}
     </>

--- a/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx
@@ -12,8 +12,10 @@ import { PageFormSection } from '@ansible/ansible-ui-framework/PageForm/Utils/Pa
 import { useURLSearchParams } from '@ansible/ansible-ui-framework/components/useURLSearchParams';
 import { useGet } from '@ansible/common-ui/crud/useGet';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { AddCircleOIcon, TrashIcon } from '@patternfly/react-icons';
 import { useEffect } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { AwxError } from '../../../common/AwxError';
@@ -33,6 +35,20 @@ const minDefault = 0;
 const maxDefault = 1024;
 
 const isMultiSelect = (type: string) => type === 'multiselect' || type === 'multiplechoice';
+
+/** Operator options for survey question conditions. Labels are translated at render. */
+const CONDITION_OPERATOR_OPTIONS: { value: SurveyCondition['operator']; label: string }[] = [
+  { value: 'eq', label: 'Equals (eq)' },
+  { value: 'neq', label: 'Not equals (neq)' },
+  { value: 'in', label: 'In list (in)' },
+  { value: 'notin', label: 'Not in list (notin)' },
+  { value: 'gt', label: 'Greater than (gt)' },
+  { value: 'lt', label: 'Less than (lt)' },
+  { value: 'gte', label: 'Greater or equal (gte)' },
+  { value: 'lte', label: 'Less or equal (lte)' },
+  { value: 'is_set', label: 'Is set' },
+  { value: 'is_not_set', label: 'Is not set' },
+];
 
 function getFormattedChoices(question: Spec | undefined): ChoiceOption[] | undefined {
   if (!question || !isMultiSelect(question.type)) return undefined;
@@ -136,9 +152,6 @@ interface IProps {
 
 interface FormSpec extends Spec {
   formattedChoices?: ChoiceOption[];
-  condition_variable?: string;
-  condition_operator?: string;
-  condition_value?: string;
 }
 
 export function TemplateSurveyForm(props: IProps) {
@@ -189,7 +202,6 @@ export function TemplateSurveyForm(props: IProps) {
 
   const formattedChoices = getFormattedChoices(question);
 
-  const firstCondition = question?.conditions?.[0];
   const initialValues: FormSpec = {
     question_name: question?.question_name || '',
     question_description: question?.question_description || '',
@@ -204,9 +216,12 @@ export function TemplateSurveyForm(props: IProps) {
     new_question: !question,
     category: question?.category ?? '',
     page: question?.page ?? 1,
-    condition_variable: firstCondition?.variable ?? '',
-    condition_operator: firstCondition?.operator ?? '',
-    condition_value: firstCondition?.value !== undefined ? String(firstCondition.value) : '',
+    conditions: (question?.conditions ?? []).map((c) => ({
+      variable: c.variable,
+      operator: c.operator,
+      value: c.value !== undefined ? String(c.value) : '',
+    })),
+    condition_logic: question?.condition_logic ?? 'and',
   };
 
   const onSubmit: PageFormSubmitHandler<FormSpec & { 'add-choice'?: string }> = async (
@@ -253,12 +268,16 @@ export function TemplateSurveyForm(props: IProps) {
       page: newQuestion.page ? Number(newQuestion.page) : undefined,
     };
 
-    if (newQuestion.condition_variable && newQuestion.condition_operator) {
-      question.conditions = [{
-        variable: newQuestion.condition_variable,
-        operator: newQuestion.condition_operator as SurveyCondition['operator'],
-        value: newQuestion.condition_value || undefined,
-      }];
+    const validConditions = (newQuestion.conditions ?? [])
+      .filter((c) => c.variable && c.operator)
+      .map((c) => ({
+        variable: c.variable,
+        operator: c.operator,
+        value: c.value === '' || c.value === undefined ? undefined : c.value,
+      }));
+    if (validConditions.length > 0) {
+      question.conditions = validConditions;
+      question.condition_logic = newQuestion.condition_logic ?? 'and';
     }
 
     const isDuplicate = updatedSurvey.spec.some((q) => q.variable === newQuestion.variable);
@@ -334,7 +353,6 @@ function TemplateSurveyInputs({ surveyVariables }: { surveyVariables: string[] }
 
   const answerType = useWatch({ name: 'type' }) as string;
   const currentVariable = useWatch({ name: 'variable' }) as string;
-  const conditionVariable = useWatch({ name: 'condition_variable' }) as string;
 
   const otherVariables = surveyVariables.filter((v) => v !== currentVariable);
 
@@ -420,57 +438,105 @@ function TemplateSurveyInputs({ surveyVariables }: { surveyVariables: string[] }
         labelHelp={t`Which wizard page this question appears on. Questions on different pages become separate wizard steps.`}
       />
 
-      {otherVariables.length > 0 && (
-        <>
-          <PageFormSelect
-            name="condition_variable"
-            id="condition-variable"
-            label={t('Condition: Variable')}
-            placeholderText={t('No condition')}
-            options={[
-              { value: '', label: t('No condition') },
-              ...otherVariables.map((v) => ({ value: v, label: v })),
-            ]}
-            labelHelp={t`Only show this question when the selected variable matches the condition.`}
-          />
-
-          {conditionVariable && (
-            <>
-              <PageFormSelect
-                name="condition_operator"
-                id="condition-operator"
-                label={t('Condition: Operator')}
-                placeholderText={t('Select operator')}
-                options={[
-                  { value: 'eq', label: t('Equals (eq)') },
-                  { value: 'neq', label: t('Not equals (neq)') },
-                  { value: 'in', label: t('In list (in)') },
-                  { value: 'notin', label: t('Not in list (notin)') },
-                  { value: 'gt', label: t('Greater than (gt)') },
-                  { value: 'lt', label: t('Less than (lt)') },
-                  { value: 'gte', label: t('Greater or equal (gte)') },
-                  { value: 'lte', label: t('Less or equal (lte)') },
-                  { value: 'is_set', label: t('Is set') },
-                  { value: 'is_not_set', label: t('Is not set') },
-                ]}
-                isRequired
-              />
-
-              <PageFormTextInput
-                id="condition-value"
-                name="condition_value"
-                type="text"
-                label={t`Condition: Value`}
-                placeholder={t('Enter expected value')}
-                labelHelp={t`The value to compare against. Leave empty for is_set/is_not_set operators.`}
-              />
-            </>
-          )}
-        </>
-      )}
+      {otherVariables.length > 0 && <SurveyConditions otherVariables={otherVariables} />}
 
       {answerType && <SelectedAnswerType answer={answerType} />}
     </>
+  );
+}
+
+function SurveyConditions({ otherVariables }: Readonly<{ otherVariables: string[] }>) {
+  const { t } = useTranslation();
+  const { fields, append, remove } = useFieldArray({ name: 'conditions' });
+
+  return (
+    <PageFormSection title={t('Conditions')} singleColumn>
+      {fields.length > 1 && (
+        <PageFormSelect
+          name="condition_logic"
+          id="condition-logic"
+          label={t('Match conditions')}
+          options={[
+            { value: 'and', label: t('All conditions must match (AND)') },
+            { value: 'or', label: t('Any condition can match (OR)') },
+          ]}
+          labelHelp={t`Whether all or any of the conditions must be met for this question to be shown.`}
+        />
+      )}
+
+      {fields.map((field, index) => (
+        <SurveyConditionRow
+          key={field.id}
+          index={index}
+          otherVariables={otherVariables}
+          onRemove={() => remove(index)}
+        />
+      ))}
+
+      <Button
+        type="button"
+        variant="link"
+        icon={<AddCircleOIcon />}
+        onClick={() => append({ variable: '', operator: 'eq', value: '' })}
+      >
+        {t('Add condition')}
+      </Button>
+    </PageFormSection>
+  );
+}
+
+function SurveyConditionRow(
+  props: Readonly<{ index: number; otherVariables: string[]; onRemove: () => void }>
+) {
+  const { index, otherVariables, onRemove } = props;
+  const { t } = useTranslation();
+  const operator = useWatch({ name: `conditions.${index}.operator` }) as string;
+  const needsValue = operator !== 'is_set' && operator !== 'is_not_set';
+
+  return (
+    <PageFormGroup label={t('Only show when')}>
+      <Flex alignItems={{ default: 'alignItemsFlexEnd' }} spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem grow={{ default: 'grow' }}>
+          <PageFormSelect
+            name={`conditions.${index}.variable`}
+            id={`condition-variable-${index}`}
+            label={t('Variable')}
+            placeholderText={t('Select variable')}
+            options={otherVariables.map((v) => ({ value: v, label: v }))}
+            isRequired
+          />
+        </FlexItem>
+        <FlexItem grow={{ default: 'grow' }}>
+          <PageFormSelect
+            name={`conditions.${index}.operator`}
+            id={`condition-operator-${index}`}
+            label={t('Operator')}
+            placeholderText={t('Select operator')}
+            options={CONDITION_OPERATOR_OPTIONS.map((o) => ({ value: o.value, label: t(o.label) }))}
+            isRequired
+          />
+        </FlexItem>
+        {needsValue && (
+          <FlexItem grow={{ default: 'grow' }}>
+            <PageFormTextInput
+              id={`condition-value-${index}`}
+              name={`conditions.${index}.value`}
+              type="text"
+              label={t`Value`}
+              placeholder={t('Enter expected value')}
+            />
+          </FlexItem>
+        )}
+        <FlexItem>
+          <Button
+            icon={<TrashIcon />}
+            variant="plain"
+            aria-label={t('Remove condition')}
+            onClick={onRemove}
+          />
+        </FlexItem>
+      </Flex>
+    </PageFormGroup>
   );
 }
 

--- a/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
+++ b/frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { awxAPI } from '../../../../common/api/awx-utils';
 import { CredentialLabel } from '../../../../common/CredentialLabel';
+import { pruneSurveyByConditions } from '../../../../common/useSurveyConditions';
 import { useVerbosityString } from '../../../../common/useVerbosityString';
 import type { Credential } from '../../../../interfaces/Credential';
 import { ExecutionEnvironment } from '../../../../interfaces/ExecutionEnvironment';
@@ -48,14 +49,18 @@ function processSurvey(
   surveyConfig: Survey | null
 ): string {
   const extraVarsObj = extra_vars ? (JSON.parse(yamlToJson(extra_vars)) as object) : {};
-  const updatedSurvey: { [key: string]: string | string[] } = { ...survey };
+
+  // Drop answers for fields whose conditions are not met, so conditionally-hidden
+  // fields (which still carry their seeded default) don't appear in the review.
+  const visibleSurvey = pruneSurveyByConditions(survey, surveyConfig?.spec, extraVarsObj);
+  const updatedSurvey: { [key: string]: string | string[] } = { ...visibleSurvey };
 
   if (surveyConfig?.spec) {
     const passwordFields = surveyConfig.spec
       .filter((q) => q.type === 'password')
       .map((q) => q.variable);
 
-    const maskedSurveyPasswords = maskPasswords(survey, passwordFields);
+    const maskedSurveyPasswords = maskPasswords(visibleSurvey, passwordFields);
     Object.keys(maskedSurveyPasswords).forEach((passwordKey) => {
       updatedSurvey[passwordKey] = maskedSurveyPasswords[passwordKey];
     });


### PR DESCRIPTION
# feat(ui): conditional surveys with categories, multi-page wizard, and a condition editor

## Summary

This PR adds **conditional (dynamic) surveys** to AWX Job Template and Workflow Job
Template launch flows. Survey questions can now be shown or hidden based on the
answers to *other* questions, grouped into **categories**, and split across
**multiple wizard pages**. The survey editor gets a UI to author these conditions
without touching raw JSON.

It is a direct, concrete take on the long-standing request in
[ansible/awx#20 — Programmable Surveys](https://github.com/ansible/awx/issues/20),
which explicitly asks for *conditional survey questions that depend on previous
answers*.

> **Transparency / provenance:** This feature was designed and implemented with the
> help of AI (Claude Code). It was built as a **self-contained, standalone
> solution** on top of the existing survey code. I'm opening it as a genuine
> contribution — but I'm equally happy for it to be treated as a **proof of concept
> or an idea to build on**. Feel free to merge it, cherry-pick parts of it, or use it
> purely as a reference for a "proper" implementation. No hard feelings whichever way
> it goes. I wanted to make the AI involvement explicit rather than hide it.

## Motivation

Today surveys are a flat list: every question is always visible and there's no way
to react to previous answers. In practice, launch forms often need branching
("only ask for the DB password if the user chose *external database*"), logical
grouping, and a less overwhelming layout for large surveys. Issue [#20](https://github.com/ansible/awx/issues/20) has tracked
this need for a long time. This PR is an attempt to cover the "conditional
questions" part of that request end-to-end in the new React/PatternFly UI.

## What it does

**Condition engine**
- New `evaluateConditions()` / `pruneSurveyByConditions()` helpers in
  `frontend/awx/common/useSurveyConditions.ts`.
- Operators: `eq`, `neq`, `in`, `notin`, `gt`, `lt`, `gte`, `lte`, `is_set`,
  `is_not_set`.
- Multiple conditions per question combined with **AND / OR** logic
  (`condition_logic`).
- Conditions are evaluated against the full answer set (survey answers merged over
  extra vars context), so visibility reacts live as the user types.

**Survey editor (`TemplateSurveyForm.tsx`)**
- A **condition editor** UI: add/remove condition rows, pick the driving variable
  (from other survey questions), pick an operator, and enter the expected value.
- Value input is hidden automatically for `is_set` / `is_not_set`.
- AND/OR selector appears once there is more than one condition.
- New per-question fields: **Category** and **Page**.

**Launch wizard (`TemplateLaunchWizard.tsx` / `SurveyStep.tsx`)**
- Questions with a `page` number are rendered as **separate wizard steps**;
  a single-page survey keeps the old single "Survey" step.
- Questions are grouped by **category** into titled PatternFly cards.
- Hidden questions are filtered out of the rendered form in real time.
- Page-aware value resolution: each variable is read from the wizard step that
  "owns" it, avoiding stale duplicate values leaking across pages.

**Review step & submission correctness**
- `pruneSurveyByConditions()` is applied before the **review step** and before the
  **launch payload** is built, so conditionally-hidden fields (which still carry a
  seeded default) are **not** submitted as extra vars and don't show up in review.

**Data model (`interfaces/Survey.ts`)**
- `Spec` extended with optional `category`, `page`, `conditions`, `condition_logic`.
- New `SurveyCondition` interface. All fields are optional, so existing surveys keep
  working unchanged.

## Scope / affected files

- `frontend/awx/common/useSurveyConditions.ts` (new)
- `frontend/awx/common/SurveyStep.tsx`
- `frontend/awx/interfaces/Survey.ts`
- `frontend/awx/resources/templates/TemplatePage/TemplateLaunchWizard.tsx`
- `frontend/awx/resources/templates/TemplatePage/TemplateSurveyForm.tsx`
- `frontend/awx/resources/templates/TemplatePage/steps/TemplateLaunchReviewStep.tsx`

## What it does NOT do (limitations / out of scope)

- **Frontend only, by design.** This PR ships only the UI. The condition metadata is
  stored inside the existing `survey_spec` structure, so on its own there is **no
  server-side enforcement** — a caller hitting the launch API directly could still
  submit a hidden field's value. This is UI-level branching, not a security boundary.
  - **Note:** I have also prototyped a **matching backend validator in AWX** that
    enforces these conditions server-side, but I deliberately left it out of this PR
    to keep the change small and self-contained and to get a read on the frontend
    direction first. If there's interest, I'm happy to open a **separate follow-up PR
    against `ansible/awx`** with the backend piece so the two sides line up.
- **No automated tests included yet.** No new Vitest/Playwright coverage was added
  for the condition engine, the editor UI, or the multi-page wizard. This is the
  biggest gap before a real merge.
- **No dynamic / API-populated fields.** Issue [#20](https://github.com/ansible/awx/issues/20) also asks for questions whose
  choices are fetched at runtime (e.g. reading options from an API / external data
  source, or populating a dropdown from live inventory, projects, credentials, etc.).
  This PR only branches on **statically authored** answers — it does not pull choice
  lists from any endpoint.
- **No computed / derived fields.** There's no way to auto-fill or calculate a
  question's value from other answers or from an external lookup — the user still
  enters every visible field manually.
- **No custom validation rules** beyond the existing survey field types (no
  regex/range/cross-field validation driven by the survey spec).


## Backwards compatibility

Surveys without the new fields behave exactly as before: no categories → no cards,
single page → single survey step, no conditions → always visible. The new `Spec`
fields are all optional.

## How to test manually

1. Open a Job Template with surveys enabled → **Survey** tab → add/edit a question.
2. Set a **Category** and a **Page**, then add one or more **Conditions** referencing
   another question (try AND vs OR, and `is_set` / `eq` / `in`).
3. Launch the template: verify questions appear/disappear as you change answers,
   that pages become separate wizard steps, and that categories render as cards.
4. On the **Review** step and in the launched job's **extra vars**, confirm that
   hidden questions are absent.

## Notes for reviewers

I'd especially appreciate feedback on: whether this belongs in the frontend at all
vs. a backend-backed survey spec, the shape of the `SurveyCondition` schema, and how
you'd want the multi-page/category concepts modeled if this were to be done
"officially". Again — happy for this to be merged, adapted, or just used as input for
[issue #20.](https://github.com/ansible/awx/issues/20)
