### PR TITLE
AAP-91595 XLAB Implementing subsequent design changes

### DIFF
--- a/framework/PageDashboard/PageDashboardCard.tsx
+++ b/framework/PageDashboard/PageDashboardCard.tsx
@@ -19,6 +19,17 @@ import { PageDashboardContext } from './PageDashboard';
 export type PageDashboardCardWidth = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 export type PageDashboardCardHeight = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
+/** The number of grid columns (out of the dashboard's 24-column grid) each card width spans. */
+export const PAGE_DASHBOARD_CARD_WIDTH_COL_SPAN: Record<PageDashboardCardWidth, number> = {
+  xxs: 3,
+  xs: 4,
+  sm: 6,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  xxl: 24,
+};
+
 const heightUnit = 90;
 
 export function PageDashboardCard(props: {
@@ -71,15 +82,7 @@ export function PageDashboardCard(props: {
 
   const dashboardContext = useContext(PageDashboardContext);
 
-  let colSpan = {
-    xxs: 3,
-    xs: 4,
-    sm: 6,
-    md: 8,
-    lg: 12,
-    xl: 16,
-    xxl: 24,
-  }[props.width || 'md'];
+  let colSpan = PAGE_DASHBOARD_CARD_WIDTH_COL_SPAN[props.width || 'md'];
   if (colSpan > dashboardContext.columns) {
     colSpan = dashboardContext.columns;
   }

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.css
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.css
@@ -63,12 +63,6 @@
   padding-bottom: 2px;
 }
 
-.automation-dashboard-at-a-glance-streak {
-  border-top: 1px solid var(--pf-t--global--border--color--default);
-  margin-top: var(--pf-t--global--spacer--md);
-  padding-top: var(--pf-t--global--spacer--md);
-}
-
 .automation-dashboard-at-a-glance-streak-cells {
   width: 100%;
   margin-top: var(--pf-t--global--spacer--sm);
@@ -78,11 +72,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   width: 80px;
   height: 80px;
   cursor: default;
-  padding: 6px 4px 4px;
+  padding: 4px;
   border: 0;
   background: none;
   font: inherit;
@@ -144,7 +138,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   width: 100%;
   min-height: 22px;
   margin-top: 2px;
@@ -192,23 +186,6 @@
 .pf-v6-theme-dark .pf-v6-c-label__icon .automation-dashboard-leaderboard-rank-crown--3,
 .pf-v6-theme-dark .automation-dashboard-leaderboard-rank-crown--3 {
   color: var(--pf-t--global--color--nonstatus--orange--default);
-}
-
-/* "At a Glance" KPI columns: the Flex stacks vertically below PatternFly's xl breakpoint
-   (1200px) and switches to a row at xl+. Divide the columns with a bottom border while
-   stacked and a right border once they sit side by side. */
-.automation-at-a-glance-kpi-divider {
-  border-bottom: 1px solid var(--pf-t--global--border--color--default);
-  padding-bottom: var(--pf-t--global--spacer--md);
-}
-
-@media screen and (min-width: 1200px) {
-  .automation-at-a-glance-kpi-divider {
-    border-bottom: none;
-    padding-bottom: 0;
-    border-right: 1px solid var(--pf-t--global--border--color--default);
-    padding-right: var(--pf-t--global--spacer--md);
-  }
 }
 
 /* Automation levels — SimpleListItem's default padding is tight; give the row content
@@ -259,10 +236,6 @@
 
 .automation-dashboard-highlights-split-kpi__metric-content {
   align-items: flex-start;
-}
-
-.automation-dashboard-highlights-split-kpi__label-row {
-  white-space: nowrap;
 }
 
 .automation-dashboard-accent-icon {

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.css
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.css
@@ -211,25 +211,68 @@
   }
 }
 
-/* Automation dimensions — SimpleListItem's default padding is tight; give the row content
+/* Automation levels — SimpleListItem's default padding is tight; give the row content
    more breathing room since each item holds an icon + two-line title/value cluster. */
-.automation-dashboard-dimension-row .pf-v6-c-simple-list__item-link {
+.automation-dashboard-level-row .pf-v6-c-simple-list__item-link {
   padding-block: 10px;
 }
 
 /* A little extra breathing room between the 3 rows so they don't feel cramped, without
    force-stretching them to match the (unrelated) height of the leaderboard list beside them. */
-.automation-dashboard-dimension-list .pf-v6-c-simple-list__item + .pf-v6-c-simple-list__item {
+.automation-dashboard-level-list .pf-v6-c-simple-list__item + .pf-v6-c-simple-list__item {
   margin-top: 12px;
 }
 
-/* Tint the leaderboard bars with the same info accent as the dimension icons, and
+/* Tint the leaderboard bars with the same subtle accent as the dimension icons, and
    animate them as they grow/shrink when switching dimensions — PF's Progress indicator
    uses the brand color and has no width transition of its own. */
 .automation-dashboard-dimension-bars .pf-v6-c-progress {
-  --pf-v6-c-progress__indicator--BackgroundColor: var(--pf-t--global--color--status--info--default);
+  --pf-v6-c-progress__indicator--BackgroundColor: var(--pf-t--global--icon--color--subtle);
 }
 
 .automation-dashboard-dimension-bars .pf-v6-c-progress__indicator {
   transition: width 0.3s ease;
+}
+
+.automation-dashboard-highlights-split-kpi {
+  width: 100%;
+  min-height: 100%;
+}
+
+.automation-dashboard-highlights-split-kpi__dimension {
+  flex: 3 1 0;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 var(--pf-t--global--spacer--sm);
+}
+
+.automation-dashboard-highlights-split-kpi__metric {
+  flex: 7 1 0;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 var(--pf-t--global--spacer--sm);
+}
+
+.automation-dashboard-highlights-split-kpi__metric-content {
+  align-items: flex-start;
+}
+
+.automation-dashboard-highlights-split-kpi__label-row {
+  white-space: nowrap;
+}
+
+.automation-dashboard-accent-icon {
+  --pf-v6-c-icon__content--m-custom--Color: var(--pf-t--global--icon--color--subtle);
+}
+
+.automation-dashboard-featured-template-star {
+  --pf-v6-c-icon__content--m-custom--Color: var(--pf-t--global--color--nonstatus--yellow--300);
+}
+
+.pf-v6-theme-dark .automation-dashboard-featured-template-star {
+  --pf-v6-c-icon__content--m-custom--Color: var(--pf-t--global--color--nonstatus--yellow--default);
 }

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx
@@ -101,8 +101,6 @@ const mockDetails: IDashboardDetails = {
   total_time_saving: 50,
   total_number_of_host_job_runs: 20,
   total_number_of_job_runs: 30,
-  top_projects: [{ id: 1, name: 'Project Alpha', execution_count: 10 }],
-  top_users: [{ id: 1, name: 'Alice', execution_count: 5 }],
   job_chart: { kind: 'day', items: [{ label: '2024-01-01', value: 3 }] },
   host_chart: { kind: 'day', items: [{ label: '2024-01-01', value: 2 }] },
 };

--- a/frontend/awx/analytics/automation-dashboard/AutomationDashboardMainPage.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationDashboardMainPage.tsx
@@ -15,7 +15,7 @@ export function AutomationDashboardMainPage() {
   const { ref: gridProbeRef, gridColumns } = useDashboardGridColumns();
   const dashboardContextValue = useMemo(() => ({ columns: gridColumns }), [gridColumns]);
   const description = t(
-    'Discover the significant cost and time savings achieved by automating Ansible jobs with the Ansible Automation Platform. Explore how automation reduces manual effort, enhances efficiency, and optimizes IT operations across your organization.'
+    'View automation performance, goals, and cost savings for your organization.'
   );
   const tabs = [
     {

--- a/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { PageDashboardContext } from '@ansible/ansible-ui-framework';
-import { AutomationLeaderboards, getLeaderboardCardWidths } from './AutomationLeaderboards';
+import {
+  PageDashboardCard,
+  PageDashboardCardWidth,
+  PageDashboardContext,
+} from '@ansible/ansible-ui-framework';
+import {
+  AutomationLeaderboards,
+  CARD_WIDTH_COL_SPAN,
+  getLeaderboardCardWidths,
+} from './AutomationLeaderboards';
 import type { AutomationLeaderboardsView } from './views/useAutomationLeaderboardsView';
 import { useAutomationLeaderboardsView } from './views/useAutomationLeaderboardsView';
 
@@ -46,6 +54,23 @@ function renderLeaderboards(view: Partial<AutomationLeaderboardsView>) {
   );
 }
 
+describe('CARD_WIDTH_COL_SPAN', () => {
+  test('should match the column span PageDashboardCard itself derives from each width tier', () => {
+    (Object.keys(CARD_WIDTH_COL_SPAN) as PageDashboardCardWidth[]).forEach((width) => {
+      const { container, unmount } = render(
+        <PageDashboardContext.Provider value={{ columns: 24 }}>
+          <PageDashboardCard width={width}>content</PageDashboardCard>
+        </PageDashboardContext.Provider>
+      );
+
+      const card = container.querySelector('.page-dashboard-card') as HTMLElement;
+      expect(card.style.gridColumn).toBe(`span ${CARD_WIDTH_COL_SPAN[width]}`);
+
+      unmount();
+    });
+  });
+});
+
 describe('getLeaderboardCardWidths', () => {
   test('should keep both card rows at the default widths on a narrow grid', () => {
     expect(getLeaderboardCardWidths(12)).toEqual({ topCardsWidth: 'lg', bottomCardsWidth: 'lg' });
@@ -65,6 +90,19 @@ describe('getLeaderboardCardWidths', () => {
 describe('AutomationLeaderboards', () => {
   afterEach(() => vi.clearAllMocks());
 
+  // Renders the full card tree (unlike the other tests below, which all short-circuit before
+  // it) — that's ~4-5s under load, so it needs a longer timeout than the 5s default.
+  test('should render the sync timestamp and every leaderboard section on the happy path', () => {
+    renderLeaderboards({});
+
+    expect(screen.getByText(/Updated: .+/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'At a glance' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Streak' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Activity levels' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Top 10 organizations' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '30-day achievements' })).toBeInTheDocument();
+  }, 15000);
+
   test('should show only a loading spinner while the view is loading', () => {
     renderLeaderboards({ isLoading: true });
 
@@ -72,7 +110,7 @@ describe('AutomationLeaderboards', () => {
     expect(
       screen.queryByRole('heading', { name: 'No leaderboard data yet' })
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/last sync on .+ UTC/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Updated: .+/)).not.toBeInTheDocument();
   });
 
   test('should show the empty state when the report has never been synced', () => {
@@ -94,7 +132,7 @@ describe('AutomationLeaderboards', () => {
     expect(screen.getByText('Metrics service unavailable')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    expect(screen.queryByText(/last sync on .+ UTC/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Updated: .+/)).not.toBeInTheDocument();
   });
 
   test('should prefer the error state over the never-synced empty state', () => {

--- a/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.test.tsx
@@ -72,18 +72,18 @@ describe('CARD_WIDTH_COL_SPAN', () => {
 });
 
 describe('getLeaderboardCardWidths', () => {
-  test('should keep both card rows at the default widths on a narrow grid', () => {
+  test('should keep both card rows at the default widths below 18 columns', () => {
     expect(getLeaderboardCardWidths(12)).toEqual({ topCardsWidth: 'lg', bottomCardsWidth: 'lg' });
-    expect(getLeaderboardCardWidths(15)).toEqual({ topCardsWidth: 'lg', bottomCardsWidth: 'lg' });
+    expect(getLeaderboardCardWidths(17)).toEqual({ topCardsWidth: 'lg', bottomCardsWidth: 'lg' });
   });
 
-  test('should widen the top row and narrow the bottom row on a medium grid', () => {
-    expect(getLeaderboardCardWidths(16)).toEqual({ topCardsWidth: 'xl', bottomCardsWidth: 'md' });
-    expect(getLeaderboardCardWidths(23)).toEqual({ topCardsWidth: 'xl', bottomCardsWidth: 'md' });
+  test('should widen the top row and narrow the bottom row from 18 to 24 columns', () => {
+    expect(getLeaderboardCardWidths(18)).toEqual({ topCardsWidth: 'xxl', bottomCardsWidth: 'md' });
+    expect(getLeaderboardCardWidths(24)).toEqual({ topCardsWidth: 'xxl', bottomCardsWidth: 'md' });
   });
 
-  test('should use the widest top cards and revert the bottom row on a wide grid', () => {
-    expect(getLeaderboardCardWidths(24)).toEqual({ topCardsWidth: 'xxl', bottomCardsWidth: 'lg' });
+  test('should keep the widest top cards and revert the bottom row past 24 columns', () => {
+    expect(getLeaderboardCardWidths(25)).toEqual({ topCardsWidth: 'xxl', bottomCardsWidth: 'lg' });
   });
 });
 

--- a/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx
@@ -10,18 +10,42 @@ import { useAutomationLeaderboardsView } from './views/useAutomationLeaderboards
 import { EmptyStateNoData } from '@ansible/ansible-ui-framework/components/EmptyStateNoData';
 import { useTranslation } from 'react-i18next';
 import { EmptyStateError } from '@ansible/ansible-ui-framework/components/EmptyStateError';
+import { AutomationStreak } from './components/leaderboards/AutomationStreak';
 
 /** Breakpoint (in grid columns) where the top cards widen from 'lg' to 'xl'/'xxl'. */
 const WIDE_LAYOUT_MIN_COLUMNS = 16;
 /** Breakpoint range (in grid columns) where the top cards use 'xl' (and the bottom cards narrow to 'md') before both revert. */
 const NARROW_BOTTOM_CARDS_MAX_COLUMNS = 23;
 
+/**
+ * Mirrors `PageDashboardCard`'s own width → column-span mapping
+ * (framework/PageDashboard/PageDashboardCard.tsx) since that map isn't exported. Exported so
+ * `AutomationLeaderboards.test.tsx` can assert it stays in sync with the real component instead
+ * of silently drifting.
+ */
+export const CARD_WIDTH_COL_SPAN: Record<PageDashboardCardWidth, number> = {
+  xxs: 3,
+  xs: 4,
+  sm: 6,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  xxl: 24,
+};
+
 export interface LeaderboardCardWidths {
   topCardsWidth: PageDashboardCardWidth;
   bottomCardsWidth: PageDashboardCardWidth;
 }
 
-/** Maps the measured dashboard grid width (in columns) to the card widths used by each leaderboard row. */
+/**
+ * Maps the measured dashboard grid width (in columns) to the card widths used by each
+ * leaderboard row. This sizes a single full-width card row (Streak, Activity levels) — it's a
+ * deliberately separate scale from `getAtAGlanceKpiCardWidth` in
+ * `components/leaderboards/AutomationAtAGlance.tsx`, which sizes the 3 KPI cards sharing a row.
+ * The two need not change tier at the same column count; don't "align" the numbers without
+ * checking both still look right at every breakpoint.
+ */
 export function getLeaderboardCardWidths(gridColumns: number): LeaderboardCardWidths {
   let topCardsWidth: PageDashboardCardWidth;
   if (gridColumns < WIDE_LAYOUT_MIN_COLUMNS) {
@@ -39,12 +63,12 @@ export function getLeaderboardCardWidths(gridColumns: number): LeaderboardCardWi
 }
 
 /** Shown until the analytics backend has recorded at least one sync (`lastSyncedAt === null`). */
-function LeaderboardsEmptyState() {
+function LeaderboardsEmptyState({ gridColumns }: Readonly<{ gridColumns: number }>) {
   const { t } = useTranslation();
 
   return (
     <DashboardGridRow>
-      <div style={{ gridColumn: 'span 24', maxWidth: '100%' }}>
+      <div style={{ gridColumn: `span ${gridColumns}`, maxWidth: '100%' }}>
         <EmptyStateNoData
           title={t('No leaderboard data yet')}
           description={t(
@@ -58,12 +82,15 @@ function LeaderboardsEmptyState() {
 }
 
 /** Shown when the leaderboards report fails to load. */
-function LeaderboardsErrorState({ error }: Readonly<{ error: Error }>) {
+function LeaderboardsErrorState({
+  error,
+  gridColumns,
+}: Readonly<{ error: Error; gridColumns: number }>) {
   const { t } = useTranslation();
 
   return (
     <DashboardGridRow>
-      <div style={{ gridColumn: 'span 24', maxWidth: '100%' }}>
+      <div style={{ gridColumn: `span ${gridColumns}`, maxWidth: '100%' }}>
         <EmptyStateError titleProp={t('Unable to load leaderboards')} message={error.message} />
       </div>
     </DashboardGridRow>
@@ -81,7 +108,7 @@ function renderLeaderboardsContent(
   if (isLoading) {
     return (
       <DashboardGridRow>
-        <div style={{ gridColumn: 'span 24', maxWidth: '100%' }}>
+        <div style={{ gridColumn: `span ${gridColumns}`, maxWidth: '100%' }}>
           <LoadingState />
         </div>
       </DashboardGridRow>
@@ -89,24 +116,30 @@ function renderLeaderboardsContent(
   }
 
   if (error) {
-    return <LeaderboardsErrorState error={error} />;
+    return <LeaderboardsErrorState error={error} gridColumns={gridColumns} />;
   }
 
   if (!lastSyncedAt) {
-    return <LeaderboardsEmptyState />;
+    return <LeaderboardsEmptyState gridColumns={gridColumns} />;
   }
+
+  // Match the column span PageDashboardCard itself derives from topCardsWidth (clamped to the
+  // measured grid), so the timestamp row lines up with the width of the cards below it instead
+  // of stretching across the full grid.
+  const topCardsColSpan = Math.min(CARD_WIDTH_COL_SPAN[topCardsWidth], gridColumns);
 
   return (
     <>
       <DashboardGridRow>
-        {/* span 24 so the right-aligned timestamp lines up with the widest card below,
-            not the full grid width */}
-        <div style={{ gridColumn: 'span 24', maxWidth: '100%' }}>
+        <div style={{ gridColumn: `span ${topCardsColSpan}`, maxWidth: '100%' }}>
           <HighlightsSyncTimestamp lastSyncedAt={lastSyncedAt} />
         </div>
       </DashboardGridRow>
+
+      <AutomationAtAGlance />
+
       <DashboardGridRow>
-        <AutomationAtAGlance width={topCardsWidth} />
+        <AutomationStreak width={topCardsWidth} />
       </DashboardGridRow>
       <DashboardGridRow>
         <AutomationDimensions width={topCardsWidth} />

--- a/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx
+++ b/frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx
@@ -1,4 +1,3 @@
-import { PageDashboardCardWidth } from '@ansible/ansible-ui-framework';
 import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingState';
 import { DashboardGridRow, DashboardLayout } from './components/DashboardLayout';
 import { AutomationAtAGlance } from './components/leaderboards/AutomationAtAGlance';
@@ -11,56 +10,11 @@ import { EmptyStateNoData } from '@ansible/ansible-ui-framework/components/Empty
 import { useTranslation } from 'react-i18next';
 import { EmptyStateError } from '@ansible/ansible-ui-framework/components/EmptyStateError';
 import { AutomationStreak } from './components/leaderboards/AutomationStreak';
+import { getLeaderboardCardWidths, getTopRowColSpan } from './common/leaderboardCardWidths';
 
-/** Breakpoint (in grid columns) where the top cards widen from 'lg' to 'xl'/'xxl'. */
-const WIDE_LAYOUT_MIN_COLUMNS = 16;
-/** Breakpoint range (in grid columns) where the top cards use 'xl' (and the bottom cards narrow to 'md') before both revert. */
-const NARROW_BOTTOM_CARDS_MAX_COLUMNS = 23;
-
-/**
- * Mirrors `PageDashboardCard`'s own width → column-span mapping
- * (framework/PageDashboard/PageDashboardCard.tsx) since that map isn't exported. Exported so
- * `AutomationLeaderboards.test.tsx` can assert it stays in sync with the real component instead
- * of silently drifting.
- */
-export const CARD_WIDTH_COL_SPAN: Record<PageDashboardCardWidth, number> = {
-  xxs: 3,
-  xs: 4,
-  sm: 6,
-  md: 8,
-  lg: 12,
-  xl: 16,
-  xxl: 24,
-};
-
-export interface LeaderboardCardWidths {
-  topCardsWidth: PageDashboardCardWidth;
-  bottomCardsWidth: PageDashboardCardWidth;
-}
-
-/**
- * Maps the measured dashboard grid width (in columns) to the card widths used by each
- * leaderboard row. This sizes a single full-width card row (Streak, Activity levels) — it's a
- * deliberately separate scale from `getAtAGlanceKpiCardWidth` in
- * `components/leaderboards/AutomationAtAGlance.tsx`, which sizes the 3 KPI cards sharing a row.
- * The two need not change tier at the same column count; don't "align" the numbers without
- * checking both still look right at every breakpoint.
- */
-export function getLeaderboardCardWidths(gridColumns: number): LeaderboardCardWidths {
-  let topCardsWidth: PageDashboardCardWidth;
-  if (gridColumns < WIDE_LAYOUT_MIN_COLUMNS) {
-    topCardsWidth = 'lg';
-  } else if (gridColumns <= NARROW_BOTTOM_CARDS_MAX_COLUMNS) {
-    topCardsWidth = 'xl';
-  } else {
-    topCardsWidth = 'xxl';
-  }
-  const bottomCardsWidth: PageDashboardCardWidth =
-    WIDE_LAYOUT_MIN_COLUMNS <= gridColumns && gridColumns <= NARROW_BOTTOM_CARDS_MAX_COLUMNS
-      ? 'md'
-      : 'lg';
-  return { topCardsWidth, bottomCardsWidth };
-}
+/** Re-exported so `AutomationLeaderboards.test.tsx` doesn't need to import the shared module directly. */
+export { CARD_WIDTH_COL_SPAN, getLeaderboardCardWidths } from './common/leaderboardCardWidths';
+export type { LeaderboardCardWidths } from './common/leaderboardCardWidths';
 
 /** Shown until the analytics backend has recorded at least one sync (`lastSyncedAt === null`). */
 function LeaderboardsEmptyState({ gridColumns }: Readonly<{ gridColumns: number }>) {
@@ -123,10 +77,9 @@ function renderLeaderboardsContent(
     return <LeaderboardsEmptyState gridColumns={gridColumns} />;
   }
 
-  // Match the column span PageDashboardCard itself derives from topCardsWidth (clamped to the
-  // measured grid), so the timestamp row lines up with the width of the cards below it instead
-  // of stretching across the full grid.
-  const topCardsColSpan = Math.min(CARD_WIDTH_COL_SPAN[topCardsWidth], gridColumns);
+  // Lines the timestamp row up with the Streak/Activity-levels cards below instead of
+  // stretching it across the full grid.
+  const topCardsColSpan = getTopRowColSpan(gridColumns);
 
   return (
     <>

--- a/frontend/awx/analytics/automation-dashboard/common/leaderboardCardWidths.ts
+++ b/frontend/awx/analytics/automation-dashboard/common/leaderboardCardWidths.ts
@@ -1,0 +1,45 @@
+import {
+  PageDashboardCardWidth,
+  PAGE_DASHBOARD_CARD_WIDTH_COL_SPAN,
+} from '@ansible/ansible-ui-framework';
+
+/** Breakpoint (in grid columns) where the top-row cards jump from 'lg' to 'xxl'. */
+export const WIDE_LAYOUT_MIN_COLUMNS = 18;
+/** Breakpoint range (in grid columns) where the bottom-row cards narrow to 'md' before reverting to 'lg'. */
+export const NARROW_BOTTOM_CARDS_MAX_COLUMNS = 24;
+
+/** `PageDashboardCard`'s own width → column-span mapping, re-exported so it can't drift out of sync. */
+export const CARD_WIDTH_COL_SPAN = PAGE_DASHBOARD_CARD_WIDTH_COL_SPAN;
+
+export interface LeaderboardCardWidths {
+  topCardsWidth: PageDashboardCardWidth;
+  bottomCardsWidth: PageDashboardCardWidth;
+}
+
+/**
+ * Maps the measured dashboard grid width (in columns) to the card widths used by each
+ * leaderboard row: `topCardsWidth` sizes the sync timestamp, Streak and Activity-levels cards;
+ * `bottomCardsWidth` sizes the bottom row (Top 10 organizations, Achievements).
+ */
+export function getLeaderboardCardWidths(gridColumns: number): LeaderboardCardWidths {
+  let topCardsWidth: PageDashboardCardWidth;
+  if (gridColumns < WIDE_LAYOUT_MIN_COLUMNS) {
+    topCardsWidth = 'lg';
+  } else {
+    topCardsWidth = 'xxl';
+  }
+  const bottomCardsWidth: PageDashboardCardWidth =
+    WIDE_LAYOUT_MIN_COLUMNS <= gridColumns && gridColumns <= NARROW_BOTTOM_CARDS_MAX_COLUMNS
+      ? 'md'
+      : 'lg';
+  return { topCardsWidth, bottomCardsWidth };
+}
+
+/**
+ * `topCardsWidth`'s column span, clamped to the grid — lets the sync-timestamp row (a plain
+ * `<div>`, not a `PageDashboardCard`) line up with the Streak/Activity-levels cards below it.
+ */
+export function getTopRowColSpan(gridColumns: number): number {
+  const { topCardsWidth } = getLeaderboardCardWidths(gridColumns);
+  return Math.min(CARD_WIDTH_COL_SPAN[topCardsWidth], gridColumns);
+}

--- a/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx
@@ -70,8 +70,6 @@ const mockDetails: IDashboardDetails = {
   total_time_saving: 50,
   total_number_of_host_job_runs: 15,
   total_number_of_job_runs: 12,
-  top_projects: [{ id: 1, name: 'Project A', execution_count: 3 }],
-  top_users: [{ id: 1, name: 'User A', execution_count: 2 }],
   job_chart: { kind: 'day', items: [{ label: '2024-01-01', value: 1 }] },
   host_chart: { kind: 'day', items: [{ label: '2024-01-01', value: 1 }] },
 };

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.test.tsx
@@ -15,8 +15,8 @@ describe('AtAGlanceKpiMetric', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Jobs run' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Velocity' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '1,234' })).toBeInTheDocument();
+    expect(screen.getByText('Velocity')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
   });
 
   test('should render a visible description and a caption when provided', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.test.tsx
@@ -4,12 +4,18 @@ import { SyncAltIcon } from '@patternfly/react-icons';
 import { AtAGlanceKpiMetric } from './AtAGlanceKpiMetric';
 
 describe('AtAGlanceKpiMetric', () => {
-  test('should render the title and value', () => {
+  test('should render the title, dimension label and value', () => {
     render(
-      <AtAGlanceKpiMetric title="Jobs run" icon={<SyncAltIcon />} iconStatus="info" value="1,234" />
+      <AtAGlanceKpiMetric
+        title="Jobs run"
+        dimensionIcon={<SyncAltIcon />}
+        dimensionLabel="Velocity"
+        value="1,234"
+      />
     );
 
     expect(screen.getByRole('heading', { name: 'Jobs run' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Velocity' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '1,234' })).toBeInTheDocument();
   });
 
@@ -17,8 +23,8 @@ describe('AtAGlanceKpiMetric', () => {
     render(
       <AtAGlanceKpiMetric
         title="Featured template"
-        icon={<SyncAltIcon />}
-        iconStatus="info"
+        dimensionIcon={<SyncAltIcon />}
+        dimensionLabel="Usage"
         description="Most-used template"
         value="3,558 runs"
         caption={<span>Infrastructure provisioning</span>}
@@ -33,8 +39,8 @@ describe('AtAGlanceKpiMetric', () => {
     render(
       <AtAGlanceKpiMetric
         title="Active organizations"
-        icon={<SyncAltIcon />}
-        iconStatus="info"
+        dimensionIcon={<SyncAltIcon />}
+        dimensionLabel="Reach"
         value="56"
         valueElement={<a href="/organizations">56 orgs</a>}
       />

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.tsx
@@ -1,8 +1,8 @@
-import { Divider, Flex, FlexItem, Icon, Title } from '@patternfly/react-core';
+import { Content, Divider, Flex, FlexItem, Icon } from '@patternfly/react-core';
 import type { ReactNode } from 'react';
+import { PageDashboardCard, PageDashboardCardWidth } from '@ansible/ansible-ui-framework';
 import { DashboardSectionHeading } from './DashboardSectionHeading';
 import { MetricLabel, MetricValue } from './DashboardMetricsText';
-import { PageDashboardCard, PageDashboardCardWidth } from '../../../../../../framework';
 
 export function AtAGlanceKpiMetric(
   props: Readonly<{
@@ -38,6 +38,7 @@ export function AtAGlanceKpiMetric(
       <Flex
         className="automation-dashboard-highlights-split-kpi"
         alignItems={{ default: 'alignItemsStretch' }}
+        style={{ flexFlow: width === 'xs' ? 'column' : 'row' }}
       >
         <FlexItem className="automation-dashboard-highlights-split-kpi__dimension">
           <Flex
@@ -52,17 +53,27 @@ export function AtAGlanceKpiMetric(
               <Icon size="xl" status="custom" className="automation-dashboard-accent-icon">
                 {dimensionIcon}
               </Icon>
-              <Title
-                headingLevel="h4"
-                size="md"
-                style={{ fontWeight: 700, margin: 0, textAlign: 'center' }}
+              <Content
+                component="p"
+                // --pf-t--global--* tokens (defined on :root), not --pf-v6-c-title--*, which
+                // only exists under a .pf-v6-c-title ancestor this <p> doesn't have.
+                style={{
+                  fontSize: 'var(--pf-t--global--font--size--md)',
+                  lineHeight: 'var(--pf-t--global--font--line-height--heading)',
+                  fontWeight: 700,
+                  margin: 0,
+                  textAlign: 'center',
+                }}
               >
                 {dimensionLabel}
-              </Title>
+              </Content>
             </Flex>
           </Flex>
         </FlexItem>
-        <Divider orientation={{ default: 'vertical' }} inset={{ default: 'insetMd' }} />
+        <Divider
+          orientation={{ default: width === 'xs' ? 'horizontal' : 'vertical' }}
+          inset={{ default: 'insetMd' }}
+        />
         <FlexItem className="automation-dashboard-highlights-split-kpi__metric">
           <Flex
             direction={{ default: 'column' }}
@@ -70,7 +81,7 @@ export function AtAGlanceKpiMetric(
             gap={{ default: 'gapSm' }}
             className="automation-dashboard-highlights-split-kpi__metric-content"
           >
-            <div className="automation-dashboard-highlights-split-kpi__label-row">
+            <div>
               <DashboardSectionHeading title={title} help={help} size="md" />
               {description ? <MetricLabel>{description}</MetricLabel> : null}
             </div>

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.tsx
@@ -1,9 +1,8 @@
-import { Flex, Icon } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, Icon, Title } from '@patternfly/react-core';
 import type { ReactNode } from 'react';
 import { DashboardSectionHeading } from './DashboardSectionHeading';
 import { MetricLabel, MetricValue } from './DashboardMetricsText';
-
-type KpiIconStatus = 'info' | 'success' | 'warning' | 'danger' | 'custom';
+import { PageDashboardCard, PageDashboardCardWidth } from '../../../../../../framework';
 
 export function AtAGlanceKpiMetric(
   props: Readonly<{
@@ -15,29 +14,71 @@ export function AtAGlanceKpiMetric(
     value?: string;
     /** Custom element to render instead of the default MetricValue. Use for linked text or smaller values. */
     valueElement?: ReactNode;
-    icon: ReactNode;
-    iconStatus: KpiIconStatus;
+    dimensionIcon: ReactNode;
+    dimensionLabel: string;
     /** Optional small caption rendered under the value, still centered with the rest of the tile. */
     caption?: ReactNode;
+    width?: PageDashboardCardWidth;
   }>
 ) {
-  const { title, help, description, value, valueElement, icon, iconStatus, caption } = props;
+  const {
+    title,
+    help,
+    description,
+    value,
+    valueElement,
+    dimensionIcon,
+    dimensionLabel,
+    caption,
+    width,
+  } = props;
 
   return (
-    <Flex
-      direction={{ default: 'column' }}
-      alignItems={{ default: 'alignItemsCenter' }}
-      gap={{ default: 'gapSm' }}
-    >
-      <Icon size="xl" status={iconStatus}>
-        {icon}
-      </Icon>
-      <div style={{ textAlign: 'center', whiteSpace: 'nowrap' }}>
-        <DashboardSectionHeading title={title} help={help} size="md" />
-      </div>
-      {description ? <MetricLabel>{description}</MetricLabel> : null}
-      {valueElement ?? (value ? <MetricValue>{value}</MetricValue> : null)}
-      {caption}
-    </Flex>
+    <PageDashboardCard width={width ?? 'md'}>
+      <Flex
+        className="automation-dashboard-highlights-split-kpi"
+        alignItems={{ default: 'alignItemsStretch' }}
+      >
+        <FlexItem className="automation-dashboard-highlights-split-kpi__dimension">
+          <Flex
+            justifyContent={{ default: 'justifyContentCenter' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <Flex
+              direction={{ default: 'column' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+              gap={{ default: 'gapSm' }}
+            >
+              <Icon size="xl" status="custom" className="automation-dashboard-accent-icon">
+                {dimensionIcon}
+              </Icon>
+              <Title
+                headingLevel="h4"
+                size="md"
+                style={{ fontWeight: 700, margin: 0, textAlign: 'center' }}
+              >
+                {dimensionLabel}
+              </Title>
+            </Flex>
+          </Flex>
+        </FlexItem>
+        <Divider orientation={{ default: 'vertical' }} inset={{ default: 'insetMd' }} />
+        <FlexItem className="automation-dashboard-highlights-split-kpi__metric">
+          <Flex
+            direction={{ default: 'column' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+            gap={{ default: 'gapSm' }}
+            className="automation-dashboard-highlights-split-kpi__metric-content"
+          >
+            <div className="automation-dashboard-highlights-split-kpi__label-row">
+              <DashboardSectionHeading title={title} help={help} size="md" />
+              {description ? <MetricLabel>{description}</MetricLabel> : null}
+            </div>
+            {valueElement ?? (value ? <MetricValue>{value}</MetricValue> : null)}
+            {caption}
+          </Flex>
+        </FlexItem>
+      </Flex>
+    </PageDashboardCard>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
-import { AutomationAtAGlance } from './AutomationAtAGlance';
+import { AutomationAtAGlance, getAtAGlanceKpiCardWidth } from './AutomationAtAGlance';
 import type {
   AutomationLeaderboardsView,
   StreakDay,
@@ -8,9 +8,8 @@ import type {
 
 vi.mock('@react-hook/resize-observer', () => ({ default: vi.fn() }));
 
-// A 3-day calendar keeps the render cheap — StreakDayStrip's own behaviour is covered in
-// StreakDayStrip.test.tsx; here we only care that AutomationAtAGlance wires the view into
-// the tiles and the two strips.
+// The streak strips moved to AutomationStreak; this calendar only satisfies the view type
+// here — the strips themselves are covered in AutomationStreak.test.tsx.
 const streakCalendar: StreakDay[] = [
   { dateStr: 'Aug 1', state: 'enterpriseAndOrg', enterpriseRuns: 12, orgRuns: 5 },
   { dateStr: 'Aug 2', state: 'enterpriseOnly', enterpriseRuns: 8, orgRuns: 0 },
@@ -45,10 +44,28 @@ vi.mock('../../views/useAutomationLeaderboardsView', () => ({
   useAutomationLeaderboardsView: () => view,
 }));
 
+describe('getAtAGlanceKpiCardWidth', () => {
+  test('should use lg up to 17 columns', () => {
+    expect(getAtAGlanceKpiCardWidth(1)).toBe('lg');
+    expect(getAtAGlanceKpiCardWidth(17)).toBe('lg');
+  });
+
+  test('should use sm from 18 to 23 columns', () => {
+    expect(getAtAGlanceKpiCardWidth(18)).toBe('sm');
+    expect(getAtAGlanceKpiCardWidth(23)).toBe('sm');
+  });
+
+  test('should use md from 24 columns up', () => {
+    expect(getAtAGlanceKpiCardWidth(24)).toBe('md');
+    expect(getAtAGlanceKpiCardWidth(32)).toBe('md');
+  });
+});
+
 describe('AutomationAtAGlance', () => {
   test('should render the KPI tiles with values formatted from the view', () => {
     render(<AutomationAtAGlance />);
 
+    expect(screen.getByRole('heading', { name: 'At a glance' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Jobs run' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '1,234' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '56' })).toBeInTheDocument();
@@ -56,14 +73,18 @@ describe('AutomationAtAGlance', () => {
     expect(screen.getByRole('heading', { name: '3,558 runs' })).toBeInTheDocument();
   });
 
-  test('should render an enterprise and an org streak strip fed by the same calendar', () => {
+  test('should label each KPI tile with its dimension', () => {
+    render(<AutomationAtAGlance />);
+
+    expect(screen.getByRole('heading', { name: 'Velocity' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Reach' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Usage' })).toBeInTheDocument();
+  });
+
+  test('should not render the streak strips (moved to AutomationStreak)', () => {
     const { container } = render(<AutomationAtAGlance />);
 
-    expect(screen.getByRole('heading', { name: 'Enterprise' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Your org' })).toBeInTheDocument();
-    expect(screen.getByText('16-day streak')).toBeInTheDocument();
-    expect(screen.getByText('8-day streak')).toBeInTheDocument();
-    // One cell per calendar day in each of the two strips.
-    expect(container.querySelectorAll('.streak-heat-cell')).toHaveLength(streakCalendar.length * 2);
+    expect(screen.queryByRole('heading', { name: 'Enterprise' })).not.toBeInTheDocument();
+    expect(container.querySelectorAll('.streak-heat-cell')).toHaveLength(0);
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
+import { PageDashboardContext } from '@ansible/ansible-ui-framework';
 import { AutomationAtAGlance, getAtAGlanceKpiCardWidth } from './AutomationAtAGlance';
+import { CARD_WIDTH_COL_SPAN } from '../../common/leaderboardCardWidths';
 import type {
   AutomationLeaderboardsView,
   StreakDay,
@@ -44,10 +46,43 @@ vi.mock('../../views/useAutomationLeaderboardsView', () => ({
   useAutomationLeaderboardsView: () => view,
 }));
 
+describe('AutomationAtAGlance', () => {
+  test('should render the KPI tiles with values formatted from the view', () => {
+    render(<AutomationAtAGlance />);
+
+    expect(screen.getByRole('heading', { name: 'At a glance' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Jobs run' })).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('56')).toBeInTheDocument();
+    expect(screen.getByText('Infrastructure provisioning')).toBeInTheDocument();
+    expect(screen.getByText('3,558 runs')).toBeInTheDocument();
+  });
+
+  test('should label each KPI tile with its dimension', () => {
+    render(<AutomationAtAGlance />);
+
+    expect(screen.getByText('Velocity')).toBeInTheDocument();
+    expect(screen.getByText('Reach')).toBeInTheDocument();
+    expect(screen.getByText('Usage')).toBeInTheDocument();
+  });
+
+  test('should not render the streak strips (moved to AutomationStreak)', () => {
+    const { container } = render(<AutomationAtAGlance />);
+
+    expect(screen.queryByRole('heading', { name: 'Enterprise' })).not.toBeInTheDocument();
+    expect(container.querySelectorAll('.streak-heat-cell')).toHaveLength(0);
+  });
+});
+
 describe('getAtAGlanceKpiCardWidth', () => {
-  test('should use lg up to 17 columns', () => {
-    expect(getAtAGlanceKpiCardWidth(1)).toBe('lg');
-    expect(getAtAGlanceKpiCardWidth(17)).toBe('lg');
+  test('should use xxl (clamps to fill the row) up to 11 columns', () => {
+    expect(getAtAGlanceKpiCardWidth(1)).toBe('xxl');
+    expect(getAtAGlanceKpiCardWidth(11)).toBe('xxl');
+  });
+
+  test('should use xs from 12 to 17 columns', () => {
+    expect(getAtAGlanceKpiCardWidth(12)).toBe('xs');
+    expect(getAtAGlanceKpiCardWidth(17)).toBe('xs');
   });
 
   test('should use sm from 18 to 23 columns', () => {
@@ -59,32 +94,32 @@ describe('getAtAGlanceKpiCardWidth', () => {
     expect(getAtAGlanceKpiCardWidth(24)).toBe('md');
     expect(getAtAGlanceKpiCardWidth(32)).toBe('md');
   });
-});
 
-describe('AutomationAtAGlance', () => {
-  test('should render the KPI tiles with values formatted from the view', () => {
-    render(<AutomationAtAGlance />);
+  test.each([1, 11, 12, 17, 18, 23, 24, 32])(
+    'should render the 3 KPI cards without an uneven wrap at %i grid columns',
+    (gridColumns) => {
+      const { container } = render(
+        <PageDashboardContext.Provider value={{ columns: gridColumns }}>
+          <AutomationAtAGlance />
+        </PageDashboardContext.Provider>
+      );
 
-    expect(screen.getByRole('heading', { name: 'At a glance' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Jobs run' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '1,234' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '56' })).toBeInTheDocument();
-    expect(screen.getByText('Infrastructure provisioning')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '3,558 runs' })).toBeInTheDocument();
-  });
+      const cards = container.querySelectorAll<HTMLElement>('.page-dashboard-card');
+      expect(cards).toHaveLength(3);
 
-  test('should label each KPI tile with its dimension', () => {
-    render(<AutomationAtAGlance />);
+      // Mirrors PageDashboardCard's own clamp (framework/PageDashboard/PageDashboardCard.tsx):
+      // it only shrinks a card's span down to the available column count when the span exceeds
+      // it, so every rendered card must carry this exact value.
+      const rawSpan = CARD_WIDTH_COL_SPAN[getAtAGlanceKpiCardWidth(gridColumns)];
+      const clampedSpan = Math.min(rawSpan, gridColumns);
+      cards.forEach((card) => expect(card.style.gridColumn).toBe(`span ${clampedSpan}`));
 
-    expect(screen.getByRole('heading', { name: 'Velocity' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Reach' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Usage' })).toBeInTheDocument();
-  });
-
-  test('should not render the streak strips (moved to AutomationStreak)', () => {
-    const { container } = render(<AutomationAtAGlance />);
-
-    expect(screen.queryByRole('heading', { name: 'Enterprise' })).not.toBeInTheDocument();
-    expect(container.querySelectorAll('.streak-heat-cell')).toHaveLength(0);
-  });
+      // Either the 3 cards truly sit side by side in one row (their unclamped spans sum to no
+      // more than the grid), or each one is individually clamped to the full row width and so
+      // deliberately stacks into its own row — anything in between is the "uneven wrap" bug.
+      const fitsThreeAcross = rawSpan * 3 <= gridColumns;
+      const stacksFullWidth = clampedSpan === gridColumns;
+      expect(fitsThreeAcross || stacksFullWidth).toBe(true);
+    }
+  );
 });

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.tsx
@@ -11,17 +11,18 @@ import { DashboardGridRow } from '../DashboardLayout';
 
 /**
  * Width of the 3 side-by-side KPI cards, keyed off the measured dashboard grid column count.
+ * Its own breakpoint scale, deliberately separate from `getLeaderboardCardWidths` (that one
+ * sizes a single full-width card, this one sizes 3 sharing a row).
  *
- * This is deliberately its own breakpoint scale, separate from `getLeaderboardCardWidths` in
- * `../../AutomationLeaderboards.tsx`: that one sizes a single full-width card (Streak, Activity
- * levels), this one sizes 3 cards sharing a row, so the two need not — and currently do not —
- * change tier at the same column count. Don't "align" the numbers without checking both still
- * look right at every breakpoint.
+ * Each tier's 3-card total (`'xs'`=4×3=12, `'sm'`=6×3=18, `'md'`=8×3=24) fits within every
+ * column count in that tier's range, so no card ever wraps mid-row. Below 12 columns, `'xxl'`
+ * (span 24) always exceeds the grid and gets clamped to fill it — each card stacks full-width.
  */
 export function getAtAGlanceKpiCardWidth(gridColumns: number): PageDashboardCardWidth {
-  if (gridColumns <= 17) return 'lg';
-  if (gridColumns <= 23) return 'sm';
-  return 'md';
+  if (gridColumns >= 24) return 'md';
+  if (gridColumns >= 18) return 'sm';
+  if (gridColumns >= 12) return 'xs';
+  return 'xxl';
 }
 
 export function AutomationAtAGlance() {
@@ -34,15 +35,18 @@ export function AutomationAtAGlance() {
   return (
     <>
       <DashboardGridRow>
-        <Title
-          data-testid="at-a-glance-card-title"
-          headingLevel="h3"
-          size="xl"
-          style={{ display: 'block', verticalAlign: '-0.15em', lineHeight: '1.2' }}
-        >
-          {title}
-        </Title>
+        <div style={{ gridColumn: `span ${gridColumns}`, maxWidth: '100%' }}>
+          <Title
+            data-testid="at-a-glance-card-title"
+            headingLevel="h3"
+            size="xl"
+            style={{ display: 'block', verticalAlign: '-0.15em', lineHeight: '1.2' }}
+          >
+            {title}
+          </Title>
+        </div>
       </DashboardGridRow>
+
       <DashboardGridRow>
         <AtAGlanceKpiMetric
           width={kpiCardWidth}
@@ -55,7 +59,7 @@ export function AutomationAtAGlance() {
 
         <AtAGlanceKpiMetric
           width={kpiCardWidth}
-          title={t('Active orgs')}
+          title={t('Active organizations')}
           help={t('Organizations with at least one successful job run.')}
           dimensionIcon={<ClusterIcon />}
           dimensionLabel={t('Reach')}

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.tsx
@@ -1,99 +1,99 @@
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PageDashboardCard, PageDashboardCardWidth } from '@ansible/ansible-ui-framework';
-import { Divider, Flex, FlexItem, Truncate } from '@patternfly/react-core';
-import { ClusterIcon, CubesIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { PageDashboardCardWidth, PageDashboardContext } from '@ansible/ansible-ui-framework';
+import { Icon, Title, Truncate } from '@patternfly/react-core';
+import { ClusterIcon, CubesIcon, StarIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { AtAGlanceKpiMetric } from './AtAGlanceKpiMetric';
-import { DashboardSectionHeading } from './DashboardSectionHeading';
-import { StreakDayStrip } from './StreakDayStrip';
 import { DEFAULT_NUMBER_LOCALE } from '../../constants/common';
 import { useAutomationLeaderboardsView } from '../../views/useAutomationLeaderboardsView';
 import '../../AutomationDashboard.css';
+import { DashboardGridRow } from '../DashboardLayout';
 
-export function AutomationAtAGlance(props: Readonly<{ width?: PageDashboardCardWidth }>) {
+/**
+ * Width of the 3 side-by-side KPI cards, keyed off the measured dashboard grid column count.
+ *
+ * This is deliberately its own breakpoint scale, separate from `getLeaderboardCardWidths` in
+ * `../../AutomationLeaderboards.tsx`: that one sizes a single full-width card (Streak, Activity
+ * levels), this one sizes 3 cards sharing a row, so the two need not — and currently do not —
+ * change tier at the same column count. Don't "align" the numbers without checking both still
+ * look right at every breakpoint.
+ */
+export function getAtAGlanceKpiCardWidth(gridColumns: number): PageDashboardCardWidth {
+  if (gridColumns <= 17) return 'lg';
+  if (gridColumns <= 23) return 'sm';
+  return 'md';
+}
+
+export function AutomationAtAGlance() {
   const { t } = useTranslation();
-  const title = t('Automation at a glance');
-  const { atAGlance, streakCalendar } = useAutomationLeaderboardsView();
+  const title = t('At a glance');
+  const { atAGlance } = useAutomationLeaderboardsView();
+  const { columns: gridColumns } = useContext(PageDashboardContext);
+  const kpiCardWidth = getAtAGlanceKpiCardWidth(gridColumns);
 
   return (
-    <PageDashboardCard
-      id={'automation-at-glance'}
-      title={title}
-      helpTitle={title}
-      help={t('Enterprise-wide automation summary for the last 30 days.')}
-      width={props.width ?? 'xxl'}
-    >
-      <Flex
-        style={{ marginTop: '0.5rem' }}
-        alignItems={{ default: 'alignItemsStretch', xl: 'alignItemsFlexStart' }}
-        direction={{ default: 'column', xl: 'row' }}
-        gap={{ default: 'gapLg' }}
-      >
-        <FlexItem className="automation-at-a-glance-kpi-divider" style={{ flex: 1 }}>
-          <AtAGlanceKpiMetric
-            title={t('Jobs run')}
-            help={t('Total successful job runs across the platform in the last 30 days.')}
-            icon={<SyncAltIcon />}
-            iconStatus="info"
-            value={atAGlance.jobsRun.toLocaleString(DEFAULT_NUMBER_LOCALE)}
-          ></AtAGlanceKpiMetric>
-        </FlexItem>
-        <FlexItem className="automation-at-a-glance-kpi-divider" style={{ flex: 1 }}>
-          <AtAGlanceKpiMetric
-            title={t('Active organizations')}
-            help={t('Organizations with at least one successful job run in the last 30 days.')}
-            icon={<ClusterIcon />}
-            iconStatus="info"
-            value={atAGlance.activeOrganizations.toLocaleString(DEFAULT_NUMBER_LOCALE)}
-          ></AtAGlanceKpiMetric>
-        </FlexItem>
-        <FlexItem
-          style={{
-            flex: 1,
-          }}
+    <>
+      <DashboardGridRow>
+        <Title
+          data-testid="at-a-glance-card-title"
+          headingLevel="h3"
+          size="xl"
+          style={{ display: 'block', verticalAlign: '-0.15em', lineHeight: '1.2' }}
         >
-          <AtAGlanceKpiMetric
-            title={t('Featured template')}
-            help={t(
-              'Most-used job template by run count in the last 30 days. Ties are broken alphabetically.'
-            )}
-            icon={<CubesIcon />}
-            iconStatus="info"
-            caption={
+          {title}
+        </Title>
+      </DashboardGridRow>
+      <DashboardGridRow>
+        <AtAGlanceKpiMetric
+          width={kpiCardWidth}
+          title={t('Jobs run')}
+          help={t('Total successful job runs across the platform.')}
+          dimensionIcon={<SyncAltIcon />}
+          dimensionLabel={t('Velocity')}
+          value={atAGlance.jobsRun.toLocaleString(DEFAULT_NUMBER_LOCALE)}
+        ></AtAGlanceKpiMetric>
+
+        <AtAGlanceKpiMetric
+          width={kpiCardWidth}
+          title={t('Active orgs')}
+          help={t('Organizations with at least one successful job run.')}
+          dimensionIcon={<ClusterIcon />}
+          dimensionLabel={t('Reach')}
+          value={atAGlance.activeOrganizations.toLocaleString(DEFAULT_NUMBER_LOCALE)}
+        ></AtAGlanceKpiMetric>
+
+        <AtAGlanceKpiMetric
+          width={kpiCardWidth}
+          title={t('Featured template')}
+          help={t('Most-used job template by run count. Ties are broken alphabetically.')}
+          dimensionIcon={<CubesIcon />}
+          dimensionLabel={t('Usage')}
+          caption={
+            <span
+              style={{
+                fontSize: 'var(--pf-t--global--font--size--sm)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <Icon
+                size="sm"
+                status="custom"
+                className="automation-dashboard-featured-template-star"
+              >
+                <StarIcon />
+              </Icon>
               <Truncate
                 content={atAGlance.featuredTemplate.name}
                 maxCharsDisplayed={40}
                 style={{ fontSize: 'var(--pf-t--global--font--size--sm)', textAlign: 'center' }}
               />
-            }
-            value={`${atAGlance.featuredTemplate.runs.toLocaleString(DEFAULT_NUMBER_LOCALE)} ${t('runs')}`}
-          ></AtAGlanceKpiMetric>
-        </FlexItem>
-      </Flex>
-      <Divider style={{ margin: '1rem 0' }} />
-      <DashboardSectionHeading
-        title={t('Automation streak')}
-        help={t(
-          'Consecutive calendar days (UTC) with at least one successful job run. Enterprise streak counts platform-wide activity; your org streak counts activity in your organization only.'
-        )}
-      />
-      <div style={{ marginTop: '0.5rem' }}>
-        <StreakDayStrip
-          title={t('Enterprise')}
-          streakDays={atAGlance.enterpriseStreakDays}
-          showLegend
-          days={streakCalendar}
-          isSuccess={(day) => day.state !== 'none'}
-          getRuns={(day) => day.enterpriseRuns}
-        />
-        <Divider style={{ margin: '1rem 0' }} />
-        <StreakDayStrip
-          title={t('Your org')}
-          streakDays={atAGlance.orgStreakDays}
-          days={streakCalendar}
-          isSuccess={(day) => day.state === 'enterpriseAndOrg'}
-          getRuns={(day) => day.orgRuns}
-        />
-      </div>
-    </PageDashboardCard>
+            </span>
+          }
+          value={`${atAGlance.featuredTemplate.runs.toLocaleString(DEFAULT_NUMBER_LOCALE)} ${t('runs')}`}
+        ></AtAGlanceKpiMetric>
+      </DashboardGridRow>
+    </>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationDimensions.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationDimensions.test.tsx
@@ -7,7 +7,7 @@ describe('AutomationDimensions', () => {
   test('should render the three dimensions with the current user standing', () => {
     render(<AutomationDimensions />);
 
-    expect(screen.getByRole('heading', { name: 'Automation dimensions' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Activity levels' })).toBeInTheDocument();
     ['Volume', 'Breadth', 'Consistency'].forEach((name) => {
       expect(screen.getByText(name)).toBeInTheDocument();
     });

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationDimensions.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationDimensions.tsx
@@ -25,7 +25,7 @@ import {
 import { DEFAULT_NUMBER_LOCALE } from '../../constants/common';
 import '../../AutomationDashboard.css';
 
-const DIMENSION_ACCENT_COLOR = 'var(--pf-t--global--color--status--info--default)';
+const DIMENSION_ACCENT_COLOR = 'var(--pf-t--global--icon--color--subtle)';
 const DIMENSION_BAR_MAX_WIDTH = 180;
 
 type DimensionMeta = {
@@ -54,7 +54,7 @@ function DimensionRow({
 
   return (
     <SimpleListItem
-      className="automation-dashboard-dimension-row"
+      className="automation-dashboard-level-row"
       isActive={isSelected}
       onClick={onSelect}
     >
@@ -145,11 +145,11 @@ function DimensionBarList({ rows }: Readonly<{ rows: HighlightsDimensionLeaderbo
 
 export function AutomationDimensions(props: Readonly<{ width?: PageDashboardCardWidth }>) {
   const { t } = useTranslation();
-  const title = t('Automation dimensions');
+  const title = t('Activity levels');
   const help = t(
-    'Three scores that capture different aspects of your automation activity in the 30-day window. Rank is among all users on this platform. Ties are broken alphabetically.'
+    'Three scores that capture different aspects of your automation activity. Rank is among all users on this platform. Ties are broken alphabetically.'
   );
-  const subtitle = t('Click a dimension to update the leaderboard.');
+  const subtitle = t('Click a level to update the leaderboard.');
   const { dimensions: dimensionStandings, dimensionLeaderboards } = useAutomationLeaderboardsView();
   const [selectedDimension, setSelectedDimension] = useState<DimensionKey>('volume');
 
@@ -157,21 +157,21 @@ export function AutomationDimensions(props: Readonly<{ width?: PageDashboardCard
     {
       key: 'volume',
       title: t('Volume'),
-      description: t('Total number of successful job runs you triggered in the last 30 days'),
+      description: t('Total number of successful job runs you triggered'),
       icon: <ChartBarIcon style={{ color: DIMENSION_ACCENT_COLOR }} />,
       valueLabel: t('job runs'),
     },
     {
       key: 'breadth',
       title: t('Breadth'),
-      description: t('Number of distinct job templates you executed in the last 30 days'),
+      description: t('Number of distinct job templates you executed'),
       icon: <CubesIcon style={{ color: DIMENSION_ACCENT_COLOR }} />,
       valueLabel: t('distinct templates'),
     },
     {
       key: 'consistency',
       title: t('Consistency'),
-      description: t('Number of days with at least one successful job run in the last 30 days'),
+      description: t('Number of days with at least one successful job run'),
       icon: <CalendarAltIcon style={{ color: DIMENSION_ACCENT_COLOR }} />,
       valueLabel: t('active days'),
     },
@@ -179,7 +179,7 @@ export function AutomationDimensions(props: Readonly<{ width?: PageDashboardCard
   const selectedMeta = dimensions.find((dimension) => dimension.key === selectedDimension);
   return (
     <PageDashboardCard
-      id={'automation-dimensions'}
+      id={'activity-levels'}
       title={title}
       subtitle={subtitle}
       helpTitle={title}
@@ -193,8 +193,8 @@ export function AutomationDimensions(props: Readonly<{ width?: PageDashboardCard
         <FlexItem flex={{ default: 'flex_1' }}>
           <SimpleList
             isControlled={false}
-            aria-label={t('Automation dimensions')}
-            className="automation-dashboard-dimension-list"
+            aria-label={t('Activity levels')}
+            className="automation-dashboard-level-list"
           >
             {dimensions.map((dimension) => (
               <DimensionRow
@@ -216,7 +216,7 @@ export function AutomationDimensions(props: Readonly<{ width?: PageDashboardCard
             <DashboardSectionHeading
               title={t('Top 10 — {{dimension}}', { dimension: selectedMeta?.title })}
               help={t(
-                'Top 10 users ranked by {{label}} in the last 30 days. You are shown in the list if you are in the top 10. Ties are broken alphabetically.',
+                'Top 10 users ranked by {{label}}. You are shown in the list if you are in the top 10. Ties are broken alphabetically.',
                 { label: selectedMeta?.valueLabel }
               )}
             />

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.test.tsx
@@ -50,7 +50,7 @@ describe('AutomationStreak', () => {
     const { container } = render(<AutomationStreak />);
 
     expect(screen.getByRole('heading', { name: 'Enterprise' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Your org' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Your organization' })).toBeInTheDocument();
     expect(screen.getByText('16-day streak')).toBeInTheDocument();
     expect(screen.getByText('8-day streak')).toBeInTheDocument();
     // One cell per calendar day in each of the two strips.

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { AutomationStreak } from './AutomationStreak';
+import type {
+  AutomationLeaderboardsView,
+  StreakDay,
+} from '../../views/useAutomationLeaderboardsView';
+
+vi.mock('@react-hook/resize-observer', () => ({ default: vi.fn() }));
+
+// A 3-day calendar keeps the render cheap — StreakDayStrip's own behaviour is covered in
+// StreakDayStrip.test.tsx; here we only care that AutomationStreak wires the view into
+// the two strips.
+const streakCalendar: StreakDay[] = [
+  { dateStr: 'Aug 1', state: 'enterpriseAndOrg', enterpriseRuns: 12, orgRuns: 5 },
+  { dateStr: 'Aug 2', state: 'enterpriseOnly', enterpriseRuns: 8, orgRuns: 0 },
+  { dateStr: 'Aug 3', state: 'none', enterpriseRuns: 0, orgRuns: 0 },
+];
+
+const view: AutomationLeaderboardsView = {
+  isLoading: false,
+  error: undefined,
+  lastSyncedAt: '2026-09-01T14:00:00.000Z',
+  atAGlance: {
+    jobsRun: 1234,
+    activeOrganizations: 56,
+    featuredTemplate: { name: 'Infrastructure provisioning', runs: 3558 },
+    enterpriseStreakDays: 16,
+    orgStreakDays: 8,
+  },
+  streakCalendar,
+  dimensions: {
+    volume: { score: 0, rank: 0, totalRanked: 0 },
+    breadth: { score: 0, rank: 0, totalRanked: 0 },
+    consistency: { score: 0, rank: 0, totalRanked: 0 },
+  },
+  dimensionLeaderboards: { volume: [], breadth: [], consistency: [] },
+  organizationLeaderboard: [],
+  currentOrgStanding: { rank: 0, totalRuns: 0 },
+  earnedUserAchievements: [],
+  earnedOrgAchievements: [],
+};
+
+vi.mock('../../views/useAutomationLeaderboardsView', () => ({
+  useAutomationLeaderboardsView: () => view,
+}));
+
+describe('AutomationStreak', () => {
+  test('should render an enterprise and an org streak strip fed by the same calendar', () => {
+    const { container } = render(<AutomationStreak />);
+
+    expect(screen.getByRole('heading', { name: 'Enterprise' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Your org' })).toBeInTheDocument();
+    expect(screen.getByText('16-day streak')).toBeInTheDocument();
+    expect(screen.getByText('8-day streak')).toBeInTheDocument();
+    // One cell per calendar day in each of the two strips.
+    expect(container.querySelectorAll('.streak-heat-cell')).toHaveLength(streakCalendar.length * 2);
+  });
+
+  test('should score the enterprise and org strips from different day states', () => {
+    const { container } = render(<AutomationStreak />);
+
+    // Enterprise counts every non-"none" day (2 of 3); the org strip only counts
+    // "enterpriseAndOrg" days (1 of 3).
+    expect(container.querySelectorAll('.streak-heat-cell--success')).toHaveLength(3);
+  });
+});

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { PageDashboardCard, PageDashboardCardWidth } from '@ansible/ansible-ui-framework';
+import { Divider } from '@patternfly/react-core';
+import { StreakDayStrip } from './StreakDayStrip';
+import { useAutomationLeaderboardsView } from '../../views/useAutomationLeaderboardsView';
+import '../../AutomationDashboard.css';
+
+export function AutomationStreak(props: Readonly<{ width?: PageDashboardCardWidth }>) {
+  const { t } = useTranslation();
+  const title = t('Streak');
+  const help = t(
+    'Consecutive calendar days (UTC) with at least one successful job run. Enterprise streak counts platform-wide activity; your org streak counts activity in your organization only.'
+  );
+  const { atAGlance, streakCalendar } = useAutomationLeaderboardsView();
+
+  return (
+    <PageDashboardCard
+      id={'automation-streak'}
+      title={title}
+      helpTitle={title}
+      help={help}
+      width={props.width ?? 'xxl'}
+    >
+      <div style={{ marginTop: '0.5rem' }}>
+        <StreakDayStrip
+          title={t('Enterprise')}
+          streakDays={atAGlance.enterpriseStreakDays}
+          showLegend
+          days={streakCalendar}
+          isSuccess={(day) => day.state !== 'none'}
+          getRuns={(day) => day.enterpriseRuns}
+        />
+        <Divider style={{ margin: '1rem 0' }} />
+        <StreakDayStrip
+          title={t('Your org')}
+          streakDays={atAGlance.orgStreakDays}
+          days={streakCalendar}
+          isSuccess={(day) => day.state === 'enterpriseAndOrg'}
+          getRuns={(day) => day.orgRuns}
+        />
+      </div>
+    </PageDashboardCard>
+  );
+}

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationStreak.tsx
@@ -9,7 +9,7 @@ export function AutomationStreak(props: Readonly<{ width?: PageDashboardCardWidt
   const { t } = useTranslation();
   const title = t('Streak');
   const help = t(
-    'Consecutive calendar days (UTC) with at least one successful job run. Enterprise streak counts platform-wide activity; your org streak counts activity in your organization only.'
+    'Consecutive calendar days (UTC) with at least one successful job run. Enterprise streak counts platform-wide activity; your organization streak counts activity in your organization only.'
   );
   const { atAGlance, streakCalendar } = useAutomationLeaderboardsView();
 
@@ -32,7 +32,7 @@ export function AutomationStreak(props: Readonly<{ width?: PageDashboardCardWidt
         />
         <Divider style={{ margin: '1rem 0' }} />
         <StreakDayStrip
-          title={t('Your org')}
+          title={t('Your organization')}
           streakDays={atAGlance.orgStreakDays}
           days={streakCalendar}
           isSuccess={(day) => day.state === 'enterpriseAndOrg'}

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/DashboardMetricsText.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/DashboardMetricsText.test.tsx
@@ -3,10 +3,11 @@ import { describe, expect, test } from 'vitest';
 import { MetricLabel, MetricValue } from './DashboardMetricsText';
 
 describe('DashboardMetricsText', () => {
-  test('should render the metric value as a heading', () => {
+  test('should render the metric value as text, not a heading', () => {
     render(<MetricValue>1,234</MetricValue>);
 
-    expect(screen.getByRole('heading', { name: '1,234' })).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '1,234' })).not.toBeInTheDocument();
   });
 
   test('should render the metric label text', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/DashboardMetricsText.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/DashboardMetricsText.tsx
@@ -1,11 +1,22 @@
-import { Content, Title } from '@patternfly/react-core';
+import { Content } from '@patternfly/react-core';
 import { ReactNode } from 'react';
 
+/** A `<p>`, not a heading — a data value (e.g. "1,234"), not a section title. */
 export function MetricValue({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <Title headingLevel="h2" size="2xl" style={{ lineHeight: 1.1 }}>
+    <Content
+      component="p"
+      // --pf-t--global--* tokens (defined on :root), not --pf-v6-c-title--*, which only
+      // exists under a .pf-v6-c-title ancestor this <p> doesn't have.
+      style={{
+        fontSize: 'var(--pf-t--global--font--size--2xl)',
+        fontWeight: 'var(--pf-t--global--font--weight--heading--default)',
+        lineHeight: 1.1,
+        margin: 0,
+      }}
+    >
       {children}
-    </Title>
+    </Content>
   );
 }
 

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.test.tsx
@@ -26,7 +26,7 @@ describe('HighlightsLeaderboardPanel', () => {
     renderPanel();
 
     expect(screen.getByText('Your organization')).toBeInTheDocument();
-    expect(screen.getByText("Your org's rank: #1")).toBeInTheDocument();
+    expect(screen.getByText("Your organization's rank: #1")).toBeInTheDocument();
     expect(screen.getByText('2,840 job runs')).toBeInTheDocument();
   });
 });

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.test.tsx
@@ -25,7 +25,7 @@ describe('HighlightsLeaderboardPanel', () => {
   test('should tag the current org and show its standing in the header', () => {
     renderPanel();
 
-    expect(screen.getByText('Your org')).toBeInTheDocument();
+    expect(screen.getByText('Your organization')).toBeInTheDocument();
     expect(screen.getByText("Your org's rank: #1")).toBeInTheDocument();
     expect(screen.getByText('2,840 job runs')).toBeInTheDocument();
   });

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.tsx
@@ -38,9 +38,7 @@ function LeaderboardRankSummary({
 export function HighlightsLeaderboardPanel(props: Readonly<{ width?: PageDashboardCardWidth }>) {
   const { t } = useTranslation();
   const title = t('Top 10 organizations');
-  const help = t(
-    'Top 10 organizations ranked by total successful job runs in the last 30 days. Ties are broken alphabetically.'
-  );
+  const help = t('Ranked by total successful job runs. Ties are broken alphabetically.');
   const { organizationLeaderboard: items, currentOrgStanding } = useAutomationLeaderboardsView();
 
   const rankCell = (item: LeaderboardItem) => <LeaderboardRankCell position={item.rank} />;
@@ -49,7 +47,7 @@ export function HighlightsLeaderboardPanel(props: Readonly<{ width?: PageDashboa
       <Truncate content={item.name} style={item.rank <= 3 ? { fontWeight: 700 } : undefined} />
       {item.isCurrentOrg && (
         <Label isCompact color="purple" style={{ marginLeft: 8 }}>
-          {t('Your org')}
+          {t('Your organization')}
         </Label>
       )}
     </>

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsLeaderboardPanel.tsx
@@ -43,14 +43,22 @@ export function HighlightsLeaderboardPanel(props: Readonly<{ width?: PageDashboa
 
   const rankCell = (item: LeaderboardItem) => <LeaderboardRankCell position={item.rank} />;
   const nameCell = (item: LeaderboardItem) => (
-    <>
-      <Truncate content={item.name} style={item.rank <= 3 ? { fontWeight: 700 } : undefined} />
+    <div style={{ whiteSpace: 'normal' }}>
+      <span
+        style={{
+          display: 'inline-block',
+          verticalAlign: 'middle',
+          marginRight: item.isCurrentOrg ? 8 : 0,
+        }}
+      >
+        <Truncate content={item.name} style={item.rank <= 3 ? { fontWeight: 700 } : undefined} />
+      </span>
       {item.isCurrentOrg && (
-        <Label isCompact color="purple" style={{ marginLeft: 8 }}>
+        <Label isCompact color="purple" style={{ marginRight: 8 }}>
           {t('Your organization')}
         </Label>
       )}
-    </>
+    </div>
   );
   const tableColumns: ITableColumn<LeaderboardItem>[] = [
     {
@@ -80,7 +88,7 @@ export function HighlightsLeaderboardPanel(props: Readonly<{ width?: PageDashboa
       headerControls={
         <LeaderboardRankSummary
           rank={currentOrgStanding.rank}
-          rankText={t("Your org's rank: #{{rank}}", { rank: currentOrgStanding.rank })}
+          rankText={t("Your organization's rank: #{{rank}}", { rank: currentOrgStanding.rank })}
           runsText={t('{{runs}} job runs', {
             runs: currentOrgStanding.totalRuns.toLocaleString(DEFAULT_NUMBER_LOCALE),
           })}

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.test.tsx
@@ -6,8 +6,16 @@ describe('HighlightsSyncTimestamp', () => {
   test('should render the last-sync line with the formatted timestamp', () => {
     render(<HighlightsSyncTimestamp lastSyncedAt="2026-09-01T14:00:00.000Z" />);
 
-    const line = screen.getByText(/last sync on .+ UTC/);
+    const line = screen.getByText(/Updated: .+/);
     expect(line).toHaveTextContent('2026');
+  });
+
+  test('should render the 30-day activity description alongside the timestamp', () => {
+    render(<HighlightsSyncTimestamp lastSyncedAt="2026-09-01T14:00:00.000Z" />);
+
+    expect(
+      screen.getByText('Data shown below is based on the last 30 days of your activity.')
+    ).toBeInTheDocument();
   });
 
   test('should render nothing when there is no sync timestamp yet', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.test.tsx
@@ -10,11 +10,28 @@ describe('HighlightsSyncTimestamp', () => {
     expect(line).toHaveTextContent('2026');
   });
 
+  test('should show the timestamp in UTC, not the local time zone', () => {
+    const lastSyncedAt = '2026-09-01T23:30:00.000Z';
+    render(<HighlightsSyncTimestamp lastSyncedAt={lastSyncedAt} />);
+
+    // Computed the same way as the component, so this doesn't hardcode a locale-specific date
+    // format — it only pins down that `timeZone: 'UTC'` is actually passed through.
+    const expectedUtcStamp = new Date(lastSyncedAt).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+    });
+
+    const line = screen.getByText(/Updated: .+/);
+    expect(line).toHaveTextContent(`UTC`);
+    expect(line).toHaveTextContent(expectedUtcStamp);
+  });
+
   test('should render the 30-day activity description alongside the timestamp', () => {
     render(<HighlightsSyncTimestamp lastSyncedAt="2026-09-01T14:00:00.000Z" />);
 
     expect(
-      screen.getByText('Data shown below is based on the last 30 days of your activity.')
+      screen.getByText('Data shown below is based on the last 30 days of activity.')
     ).toBeInTheDocument();
   });
 

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.tsx
@@ -13,10 +13,12 @@ export function HighlightsSyncTimestamp(props: Readonly<{ lastSyncedAt: string |
     return null;
   }
 
-  // Shown in the viewer's local time zone.
+  // UTC, not the viewer's local time zone — the streak calendar counts by UTC day (see
+  // AutomationStreak's help text), so a local timestamp here could name the wrong day.
   const formatted = syncedAt.toLocaleString(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
+    timeZone: 'UTC',
   });
 
   return (
@@ -29,7 +31,7 @@ export function HighlightsSyncTimestamp(props: Readonly<{ lastSyncedAt: string |
     >
       <FlexItem>
         <Content component="small" style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>
-          {t('Data shown below is based on the last 30 days of your activity.')}
+          {t('Data shown below is based on the last 30 days of activity.')}
         </Content>
       </FlexItem>
       <FlexItem style={{ marginLeft: 'auto' }}>
@@ -46,7 +48,7 @@ export function HighlightsSyncTimestamp(props: Readonly<{ lastSyncedAt: string |
           <Icon size="sm">
             <InfoCircleIcon color="var(--pf-t--global--text--color--subtle)" />
           </Icon>
-          {t('Updated: {{timestamp}}', { timestamp: formatted })}
+          {t('Updated: {{timestamp}} UTC', { timestamp: formatted })}
         </Content>
       </FlexItem>
     </Flex>

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/HighlightsSyncTimestamp.tsx
@@ -1,4 +1,4 @@
-import { Content, Icon } from '@patternfly/react-core';
+import { Content, Flex, FlexItem, Icon } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -13,29 +13,42 @@ export function HighlightsSyncTimestamp(props: Readonly<{ lastSyncedAt: string |
     return null;
   }
 
+  // Shown in the viewer's local time zone.
   const formatted = syncedAt.toLocaleString(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
-    timeZone: 'UTC',
   });
 
   return (
-    <Content
-      component="small"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-        gap: 4,
-        color: 'var(--pf-t--global--text--color--subtle)',
-      }}
+    <Flex
+      justifyContent={{ default: 'justifyContentSpaceBetween' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+      flexWrap={{ default: 'wrap' }}
+      gap={{ default: 'gapSm' }}
+      style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
     >
-      <Icon size="sm">
-        <InfoCircleIcon color="var(--pf-t--global--text--color--subtle)" />
-      </Icon>
-      {t('All data is shown as from the last 30 days with the last sync on {{timestamp}} UTC', {
-        timestamp: formatted,
-      })}
-    </Content>
+      <FlexItem>
+        <Content component="small" style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>
+          {t('Data shown below is based on the last 30 days of your activity.')}
+        </Content>
+      </FlexItem>
+      <FlexItem style={{ marginLeft: 'auto' }}>
+        <Content
+          component="small"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            color: 'var(--pf-t--global--text--color--subtle)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <Icon size="sm">
+            <InfoCircleIcon color="var(--pf-t--global--text--color--subtle)" />
+          </Icon>
+          {t('Updated: {{timestamp}}', { timestamp: formatted })}
+        </Content>
+      </FlexItem>
+    </Flex>
   );
 }

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.test.tsx
@@ -8,7 +8,9 @@ describe('MilestoneBadgesCard', () => {
 
     expect(screen.getByRole('heading', { name: '30-day achievements' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Your achievements' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: "Your org's achievements" })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: "Your organization's achievements" })
+    ).toBeInTheDocument();
   });
 
   test('should render every milestone and org badge', () => {

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.tsx
@@ -105,7 +105,7 @@ function useOrgBadgeConfig(): OrgBadgeConfig[] {
       {
         id: 'sustained' as OrgBadgeId,
         label: t('Sustained'),
-        rule: t('14 or more consecutive org streak days in the current 30-day window.'),
+        rule: t('14 or more consecutive organization streak days in the current 30-day window.'),
         icon: <CalendarWeekIcon />,
       },
       {
@@ -117,7 +117,7 @@ function useOrgBadgeConfig(): OrgBadgeConfig[] {
       {
         id: 'topTier' as OrgBadgeId,
         label: t('Top Tier'),
-        rule: t('Org ranked #1, #2, or #3 at any sync point in the window.'),
+        rule: t('Organization ranked #1, #2, or #3 at any sync point in the window.'),
         icon: <CrownIcon />,
       },
     ],
@@ -233,7 +233,7 @@ export function MilestoneBadgesCard(props: Readonly<{ width?: PageDashboardCardW
         </FlexItem>
         <FlexItem>
           <BadgeShelf
-            title={t("Your org's achievements")}
+            title={t("Your organization's achievements")}
             help={t(
               'Achievements any of the organizations you belong to earned. Visible to all members of your organization.'
             )}

--- a/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.tsx
+++ b/frontend/awx/analytics/automation-dashboard/components/leaderboards/MilestoneBadgesCard.tsx
@@ -188,7 +188,7 @@ function BadgeShelf<T extends Badge>({
   badges,
 }: Readonly<{
   title: string;
-  help: string;
+  help?: string;
   earnedIds: readonly BadgeId[];
   badges: T[];
 }>) {
@@ -204,12 +204,12 @@ export function MilestoneBadgesCard(props: Readonly<{ width?: PageDashboardCardW
   const { t } = useTranslation();
   const title = t('30-day achievements');
   const help = t(
-    'Recognitions earned in the current 30-day window. Achievements reset when the window rolls — re-earn them each period. Earned achievements appear first.'
+    'Recognitions earned during the period. Achievements reset when the window rolls — re-earn them each period. Earned achievements appear first.'
   );
   const badges = useMilestoneBadgeConfig();
   const orgBadges = useOrgBadgeConfig();
   const { earnedUserAchievements, earnedOrgAchievements } = useAutomationLeaderboardsView();
-  const subTitle = t('These achievements reset every 30 days.');
+  const subTitle = t('Achievements reset when the period rolls.');
   return (
     <PageDashboardCard
       id={'milestone-badges-card'}
@@ -227,7 +227,6 @@ export function MilestoneBadgesCard(props: Readonly<{ width?: PageDashboardCardW
         <FlexItem>
           <BadgeShelf
             title={t('Your achievements')}
-            help={t('Achievements you earned in the current 30-day window.')}
             earnedIds={earnedUserAchievements}
             badges={badges}
           />
@@ -236,7 +235,7 @@ export function MilestoneBadgesCard(props: Readonly<{ width?: PageDashboardCardW
           <BadgeShelf
             title={t("Your org's achievements")}
             help={t(
-              'Achievements any of the organizations you belong to earned in the current 30-day window. Visible to all members of your org.'
+              'Achievements any of the organizations you belong to earned. Visible to all members of your organization.'
             )}
             earnedIds={earnedOrgAchievements}
             badges={orgBadges}

--- a/frontend/awx/analytics/automation-dashboard/types/index.ts
+++ b/frontend/awx/analytics/automation-dashboard/types/index.ts
@@ -4,12 +4,6 @@ import { IAutomationDashboardBaseView } from '../common/useAutomationDashboardBa
 
 // ─── Dashboard Data Models (API shapes) ──────────────────────────────────────
 
-export interface IDashboardTableItem {
-  id: number;
-  name: string;
-  execution_count: number;
-}
-
 export interface IDashboardChartItem {
   label: string;
   value: number;
@@ -54,8 +48,6 @@ export interface IDashboardDetails {
   total_time_saving: number | null;
   total_number_of_host_job_runs: number | null;
   total_number_of_job_runs: number | null;
-  top_projects: IDashboardTableItem[];
-  top_users: IDashboardTableItem[];
   job_chart: IDashboardChart;
   host_chart: IDashboardChart;
 }

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
@@ -11,7 +11,9 @@ import { dashboardFilterSetKey } from '../utils/persistedFilterState';
 const USER_ID = 42;
 
 const { mockUseAwxActiveUser } = vi.hoisted(() => ({
-  mockUseAwxActiveUser: vi.fn(() => ({ activeAwxUser: { id: USER_ID } })),
+  mockUseAwxActiveUser: vi.fn<() => { activeAwxUser: { id: number } | undefined }>(() => ({
+    activeAwxUser: { id: USER_ID },
+  })),
 }));
 
 vi.mock('../../../common/useAwxActiveUser', () => ({
@@ -157,6 +159,32 @@ describe('useFilterSetView', () => {
       expect(result.current.value).toBe('2');
       // The first user's cached reports must not leak into the second user's dropdown.
       expect(result.current.filterSets).toEqual([filterSetB]);
+    });
+
+    test('should keep a selection made before the user id resolved', async () => {
+      // Cold load: /me/ not cached yet, so no active user at mount.
+      mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: undefined });
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(pageResponse([filterSetA, filterSetB]))
+        )
+      );
+
+      const { result, rerender } = renderHook(() => useFilterSetView());
+
+      // User picks Report B while /me/ is still loading.
+      await act(async () => {
+        await result.current.queryOptions(queryOpts());
+      });
+      act(() => result.current.setSelectedFilterSet(filterSetB));
+      expect(result.current.selectedFilterSet).toEqual(filterSetB);
+
+      // /me/ resolves — this user has nothing persisted.
+      mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: { id: USER_ID } });
+      rerender();
+
+      expect(result.current.selectedFilterSet).toEqual(filterSetB);
+      expect(result.current.filterSets).toContainEqual(filterSetB);
     });
 
     test('should clear the cache when the new active user has nothing persisted', async () => {

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.test.tsx
@@ -187,6 +187,34 @@ describe('useFilterSetView', () => {
       expect(result.current.filterSets).toContainEqual(filterSetB);
     });
 
+    test('should keep a selection made before the user id resolved even when that user has a persisted value', async () => {
+      // This user has a persisted selection from an earlier session...
+      sessionStorage.setItem(dashboardFilterSetKey(USER_ID), JSON.stringify(filterSetA));
+      // ...but /me/ hasn't resolved yet at mount.
+      mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: undefined });
+      server.use(
+        http.get(metricsAPI`/dashboard_reports/filter_sets/`, () =>
+          HttpResponse.json(pageResponse([filterSetA, filterSetB]))
+        )
+      );
+
+      const { result, rerender } = renderHook(() => useFilterSetView());
+
+      // User picks Report B while /me/ is still loading.
+      await act(async () => {
+        await result.current.queryOptions(queryOpts());
+      });
+      act(() => result.current.setSelectedFilterSet(filterSetB));
+      expect(result.current.selectedFilterSet).toEqual(filterSetB);
+
+      // /me/ resolves to the user with Report A persisted — the fresh selection must survive,
+      // not be silently overwritten by the older persisted value.
+      mockUseAwxActiveUser.mockReturnValue({ activeAwxUser: { id: USER_ID } });
+      rerender();
+
+      expect(result.current.selectedFilterSet).toEqual(filterSetB);
+    });
+
     test('should clear the cache when the new active user has nothing persisted', async () => {
       const OTHER_USER_ID = 7;
       sessionStorage.setItem(dashboardFilterSetKey(USER_ID), JSON.stringify(filterSetA));

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
@@ -41,6 +41,11 @@ export function useFilterSetView() {
     persistedFilterSet
   );
 
+  // Read below without adding `selectedFilterSet` as a dependency (would re-run on every
+  // selection, not just a user switch) or causing stale closures in `queryOptions`.
+  const selectedFilterSetRef = useRef(selectedFilterSet);
+  selectedFilterSetRef.current = selectedFilterSet;
+
   // Which user the selection has been seeded for. Set up front when the id was
   // already known at mount.
   const [seededUserId, setSeededUserId] = useState<number | undefined>(userId);
@@ -49,21 +54,21 @@ export function useFilterSetView() {
   // from that user's persisted value.
   useEffect(() => {
     if (userId === undefined || seededUserId === userId) return;
-    // First seed = the id just resolved after mount (it was unknown, no previous
-    // user). A selection the user made while /me/ was still loading must survive,
-    // so only apply a persisted value here and never clear existing state.
+    // First seed = the id just resolved after mount. A selection made while /me/ was still
+    // loading must survive, so only apply a persisted value if nothing was selected meanwhile.
     const isFirstSeed = seededUserId === undefined;
+    const hasSelectionAlready = isFirstSeed && selectedFilterSetRef.current !== undefined;
     setSeededUserId(userId);
 
     const persisted = readPersistedFilterSet(userId);
-    if (persisted) {
+    if (persisted && !hasSelectionAlready) {
       setValue(String(persisted.id));
       setSelectedFilterSet(persisted);
       setVersion((v) => v + 1);
       // Replace (not merge) the cache: the previous user's fetched report names
       // and filters JSON must not linger in the dropdown after a user switch.
       setFilterSets([persisted]);
-    } else if (!isFirstSeed) {
+    } else if (!isFirstSeed && !persisted) {
       // A different user with nothing saved — reset rather than keep the previous
       // user's selection and fetched options.
       setValue(undefined);
@@ -82,10 +87,6 @@ export function useFilterSetView() {
   const getRequest = useGetRequest<AwxItemsResponse<IDashboardFilterSet>>();
   const getRequestRef = useRef(getRequest);
   getRequestRef.current = getRequest;
-
-  // Read inside the stable `queryOptions` callback without stale closures.
-  const selectedFilterSetRef = useRef(selectedFilterSet);
-  selectedFilterSetRef.current = selectedFilterSet;
 
   const queryOptions = useCallback<PageAsyncSelectOptionsFn<string>>(async ({ next, search }) => {
     const page = next ? Number(next) : 1;

--- a/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useFilterSetView.tsx
@@ -49,14 +49,28 @@ export function useFilterSetView() {
   // from that user's persisted value.
   useEffect(() => {
     if (userId === undefined || seededUserId === userId) return;
+    // First seed = the id just resolved after mount (it was unknown, no previous
+    // user). A selection the user made while /me/ was still loading must survive,
+    // so only apply a persisted value here and never clear existing state.
+    const isFirstSeed = seededUserId === undefined;
     setSeededUserId(userId);
+
     const persisted = readPersistedFilterSet(userId);
-    setValue(persisted ? String(persisted.id) : undefined);
-    setSelectedFilterSet(persisted);
-    setVersion((v) => v + 1);
-    // Replace (not merge) the cache: the previous user's fetched report names and
-    // filters JSON must not linger in the dropdown after a same-tab user switch.
-    setFilterSets(persisted ? [persisted] : []);
+    if (persisted) {
+      setValue(String(persisted.id));
+      setSelectedFilterSet(persisted);
+      setVersion((v) => v + 1);
+      // Replace (not merge) the cache: the previous user's fetched report names
+      // and filters JSON must not linger in the dropdown after a user switch.
+      setFilterSets([persisted]);
+    } else if (!isFirstSeed) {
+      // A different user with nothing saved — reset rather than keep the previous
+      // user's selection and fetched options.
+      setValue(undefined);
+      setSelectedFilterSet(undefined);
+      setVersion((v) => v + 1);
+      setFilterSets([]);
+    }
   }, [userId, seededUserId]);
 
   // Persist the current selection for the active user (or clear it when deselected).

--- a/frontend/awx/analytics/automation-dashboard/views/useGetReportDetails.test.tsx
+++ b/frontend/awx/analytics/automation-dashboard/views/useGetReportDetails.test.tsx
@@ -21,8 +21,6 @@ const dashboardDetailsFixture: IDashboardDetails = {
   total_time_saving: 20,
   total_number_of_host_job_runs: 15,
   total_number_of_job_runs: 12,
-  top_projects: [{ id: 1, name: 'Project 1', execution_count: 5 }],
-  top_users: [{ id: 1, name: 'User 1', execution_count: 3 }],
   job_chart: { kind: 'day', items: [{ label: 'Mon', value: 3 }] },
   host_chart: { kind: 'day', items: [{ label: 'Mon', value: 2 }] },
 };

--- a/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
+++ b/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
@@ -56,30 +56,6 @@ async function mockReportDetailRoute(
         total_saving: 6918332.14,
         total_time_saving: 556.36,
         total_number_of_unique_hosts: 31,
-        top_users: [
-          {
-            id: 1,
-            name: 'Test user',
-            execution_count: 14,
-          },
-        ],
-        top_projects: [
-          {
-            id: 15,
-            name: 'Test Project 1',
-            execution_count: 20,
-          },
-          {
-            id: 9,
-            name: 'Test Project 2',
-            execution_count: 9,
-          },
-          {
-            id: 8,
-            name: 'Test Project 3',
-            execution_count: 2,
-          },
-        ],
         job_chart: {
           kind: 'month',
           items: [

--- a/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
+++ b/playwright/tests/integration/automation-dashboard/automation-dashboard.spec.ts
@@ -128,6 +128,11 @@ test.describe('Automation Dashboard', () => {
     ).toBeVisible();
   });
 
+  test('should show the Dashboard and Leaderboards tabs', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Leaderboards' })).toBeVisible();
+  });
+
   test('Should have correct link in value cards', async ({ page }) => {
     // Wait for dashboard data to load by checking for specific values from our mock
     const successfulJobsCard = page
@@ -149,5 +154,21 @@ test.describe('Automation Dashboard', () => {
 
     await failedJobsCard.getByRole('link', { name: 'See all failed jobs' }).click();
     await expect(page).toHaveURL(new RegExp('/jobs\\?status=failed$'));
+  });
+});
+
+// Leaderboards reads from a local mock (useAutomationLeaderboardsView), not the API, so no
+// extra route mocking is needed here beyond the top-level beforeEach's collection_status mock.
+test.describe('Automation Dashboard - Leaderboards tab', () => {
+  test('should show the leaderboard sections when the Leaderboards tab is selected', async ({
+    page,
+  }) => {
+    await page.getByRole('tab', { name: 'Leaderboards' }).click();
+
+    await expect(page.getByRole('heading', { name: 'At a glance' })).toBeVisible();
+    await expect(page.getByTestId('automation-streak')).toBeVisible();
+    await expect(page.getByTestId('activity-levels')).toBeVisible();
+    await expect(page.getByTestId('highlights-leaderboard-card')).toBeVisible();
+    await expect(page.getByTestId('milestone-badges-card')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
AAP-91595  Implementing subsequent design changes
<!-- What changed and why? -->

This pull request makes several improvements and refactors to the Automation Dashboard's leaderboard and KPI card components, focusing on visual layout, code structure, and test coverage. The most significant changes include a redesign of the "At a Glance" KPI cards to provide clearer dimension labeling and layout, enhanced grid alignment for all leaderboard sections, and updates to related tests and styles.

**Redesign and layout improvements:**

* Refactored the `AtAGlanceKpiMetric` component to split the KPI card into a two-column layout, prominently displaying the dimension icon and label alongside the metric, and updated its API to use `dimensionIcon` and `dimensionLabel` props instead of `icon` and `iconStatus` (`frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.tsx`) [[1]](diffhunk://#diff-3177a0f1621bea1e58d4404eb153dba634610b9f8275b1c0fbae587f3f52a904L1-R5) [[2]](diffhunk://#diff-3177a0f1621bea1e58d4404eb153dba634610b9f8275b1c0fbae587f3f52a904L18-R82).
* Updated the CSS classes and styles to support the new split KPI card layout and improve the appearance of dashboard elements, including subtle accent colors and improved spacing for "levels" rows (`frontend/awx/analytics/automation-dashboard/AutomationDashboard.css`).

**Grid and alignment consistency:**

* Ensured that all leaderboard sections, including loading, error, and empty states, as well as the timestamp row, align their grid column span with the actual card widths, using a new `CARD_WIDTH_COL_SPAN` mapping for consistency (`frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx`) [[1]](diffhunk://#diff-d82de39958238c76a7622bee21545ef701e56319f88a6fb0be06e2bcf64b3a7dR13-R48) [[2]](diffhunk://#diff-d82de39958238c76a7622bee21545ef701e56319f88a6fb0be06e2bcf64b3a7dL42-R71) [[3]](diffhunk://#diff-d82de39958238c76a7622bee21545ef701e56319f88a6fb0be06e2bcf64b3a7dL61-R93) [[4]](diffhunk://#diff-d82de39958238c76a7622bee21545ef701e56319f88a6fb0be06e2bcf64b3a7dL84-R142).

**Test updates and coverage:**

* Updated tests for the redesigned KPI metric API and layout, and added tests to verify that card widths and grid spans stay in sync with the dashboard card component (`frontend/awx/analytics/automation-dashboard/components/leaderboards/AtAGlanceKpiMetric.test.tsx`, `frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.test.tsx`) [[1]](diffhunk://#diff-06f9bc71ffa3039bd5bc5f001e7bdde51292eb7a5c7e8963497e78efee13d866L7-R27) [[2]](diffhunk://#diff-06f9bc71ffa3039bd5bc5f001e7bdde51292eb7a5c7e8963497e78efee13d866L36-R43) [[3]](diffhunk://#diff-a478475877914f5d10d8ca57944c59ab4967522a5bb4873ecdad3ef6ca8c1e41L4-R13) [[4]](diffhunk://#diff-a478475877914f5d10d8ca57944c59ab4967522a5bb4873ecdad3ef6ca8c1e41R57-R73).
* Removed unused mock data properties (`top_projects`, `top_users`) from dashboard test fixtures (`frontend/awx/analytics/automation-dashboard/AutomationDashboard.test.tsx`, `frontend/awx/analytics/automation-dashboard/components/DashboardMainTableCard.test.tsx`) [[1]](diffhunk://#diff-33e16f5f652c6f94d73f671945e00b40fa8c08423615d9699878d8bc976acb81L104-L105) [[2]](diffhunk://#diff-14d4a7fabcd7b2e72cf3d321c9a036169c8c726d3627eda7bdb35551e35c6806L73-L74).

**Copy and content tweaks:**

* Shortened and clarified the dashboard description for better user comprehension (`frontend/awx/analytics/automation-dashboard/AutomationDashboardMainPage.tsx`).

**Component structure:**

* Moved the streak strips out of the "At a Glance" section into a dedicated `AutomationStreak` component, updating both the main leaderboard rendering and related tests (`frontend/awx/analytics/automation-dashboard/AutomationLeaderboards.tsx`, `frontend/awx/analytics/automation-dashboard/components/leaderboards/AutomationAtAGlance.test.tsx`) [[1]](diffhunk://#diff-d82de39958238c76a7622bee21545ef701e56319f88a6fb0be06e2bcf64b3a7dL84-R142) [[2]](diffhunk://#diff-3ea2d8d78cb8e63d944edea302f87c7e32ae105e6ac482de69ec9dc231ad2263L3-R12).
## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

<!-- SELECT ONE. This is required — the PR check will fail if none is selected. -->

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

<!-- List any dependent PRs, required backend changes, or manual setup steps. Remove this section if none. -->

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

<!-- If applicable, attach run(s) from an external server using the GitHub Actions below. Mention the deployment type of the environment used.
- [Run Playwright with Currents](../actions/workflows/run-playwright-currents.yml)
-->

### Manual Testing

<!-- Steps to verify this change, if not obvious from the Jira issue. -->

### Screenshots

<!-- If applicable. Any visual/UI changes MUST include before and after screenshots. -->
<img width="1875" height="1850" alt="image" src="https://github.com/user-attachments/assets/e49f7005-a883-47f9-adf2-cb443d9d8ab5" />
