### PR TITLE
[AAP-92380] Stabilize workflow visualizer save assertion

### DIFF
--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
@@ -62,8 +62,9 @@ async function saveAndDismissToast(page: import('@playwright/test').Page) {
   // found" and hides the server error that explains it. Keep the budget under
   // the per-test timeout: this helper runs several times per test, so a larger
   // value would just trade the reported error for a generic test timeout.
-  const toast = page.getByText('Successfully saved workflow visualizer');
-  const errorAlert = page.getByText('Failed to save workflow job template');
+  const toaster = page.getByTestId('alert-toaster');
+  const toast = toaster.getByText('Successfully saved workflow visualizer');
+  const errorAlert = toaster.getByText('Failed to save workflow job template');
   await expect(toast.or(errorAlert).first()).toBeVisible({ timeout: 60000 });
 
   if (
@@ -72,13 +73,13 @@ async function saveAndDismissToast(page: import('@playwright/test').Page) {
       .isVisible()
       .catch(() => false)
   ) {
-    const alertText = await page.getByTestId('alert-toaster').innerText();
+    const alertText = await toaster.innerText();
     throw new Error(`Workflow visualizer save failed: ${alertText.trim()}`);
   }
 
   // The success toast self-dismisses after 5s, so closing it is best effort —
   // requiring the close button would just move the race rather than remove it.
-  const closeBtn = page.getByRole('button', { name: /Close.*alert/ });
+  const closeBtn = toaster.getByRole('button', { name: /Close.*alert/ });
   if (await closeBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await closeBtn.click();
   }

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
@@ -59,13 +59,20 @@ async function saveAndDismissToast(page: import('@playwright/test').Page) {
   // backend the outcome regularly takes longer than the old 30s budget. Assert
   // on the success toast or the failure alert, whichever lands first: waiting
   // only on the toast reports a failed save as an opaque "element(s) not
-  // found" and hides the server error that explains it.
+  // found" and hides the server error that explains it. Keep the budget under
+  // the per-test timeout: this helper runs several times per test, so a larger
+  // value would just trade the reported error for a generic test timeout.
   const toast = page.getByText('Successfully saved workflow visualizer');
   const errorAlert = page.getByText('Failed to save workflow job template');
-  await expect(toast.or(errorAlert).first()).toBeVisible({ timeout: 120000 });
+  await expect(toast.or(errorAlert).first()).toBeVisible({ timeout: 60000 });
 
-  if (await errorAlert.isVisible().catch(() => false)) {
-    const alertText = await page.locator('.pf-v6-c-alert.pf-m-danger').innerText();
+  if (
+    await errorAlert
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    const alertText = await page.getByTestId('alert-toaster').innerText();
     throw new Error(`Workflow visualizer save failed: ${alertText.trim()}`);
   }
 

--- a/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
+++ b/playwright/tests/integration/automation-execution/workflow-visualizer/workflow-visualizer-template-switch.spec.ts
@@ -48,9 +48,29 @@ async function getNodeCredentials(page: import('@playwright/test').Page, nodeId:
 
 async function saveAndDismissToast(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: 'Fit to Screen' }).click();
-  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  // The toolbar Save is disabled until the visualizer registers the pending
+  // edit, so wait for it to become enabled instead of clicking a dead button.
+  const saveButton = page.getByTestId('workflow-visualizer-toolbar-save');
+  await expect(saveButton).toBeEnabled({ timeout: 30000 });
+  await saveButton.click();
+
+  // Saving issues a sequence of node and credential requests, so on a live
+  // backend the outcome regularly takes longer than the old 30s budget. Assert
+  // on the success toast or the failure alert, whichever lands first: waiting
+  // only on the toast reports a failed save as an opaque "element(s) not
+  // found" and hides the server error that explains it.
   const toast = page.getByText('Successfully saved workflow visualizer');
-  await expect(toast).toBeVisible({ timeout: 30000 });
+  const errorAlert = page.getByText('Failed to save workflow job template');
+  await expect(toast.or(errorAlert).first()).toBeVisible({ timeout: 120000 });
+
+  if (await errorAlert.isVisible().catch(() => false)) {
+    const alertText = await page.locator('.pf-v6-c-alert.pf-m-danger').innerText();
+    throw new Error(`Workflow visualizer save failed: ${alertText.trim()}`);
+  }
+
+  // The success toast self-dismisses after 5s, so closing it is best effort —
+  // requiring the close button would just move the race rather than remove it.
   const closeBtn = page.getByRole('button', { name: /Close.*alert/ });
   if (await closeBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await closeBtn.click();


### PR DESCRIPTION
## Summary

`saveAndDismissToast` in the workflow visualizer template-switch spec waited only on the success toast. The toolbar creates that toast with a 5s auto-dismiss timeout, while saving issues a long sequence of node and credential requests, so on a live backend the outcome regularly landed outside the old 30s budget and the transient toast could come and go unobserved.

The helper also clicked Save by role. The toolbar renders two save controls ("Save" and "Save and exit"), and the toolbar button is disabled until the visualizer registers the pending edit, so the click could land on a dead button.

This change:

- targets the toolbar button by test id instead of by accessible name
- waits for it to become enabled rather than clicking a disabled control
- races the success toast against the failure alert, and surfaces the alert text

That last point matters for diagnosis: waiting only on the toast reported a failed save as an opaque `element(s) not found`, hiding the server error that explained it.

Test-only change; no product code is touched.

## Type of Change

- [x] Tests

## Risk Analysis - REQUIRED

- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Testing

### Manual Testing

Ran the full spec against a live AAP backend. 10 of 12 scenarios pass, including every scenario that exercises the save helper.

The two remaining failures (Scenarios 11 and 12) are unrelated to this change and do not reach the save path — both fail in `beforeEach`, in the shared `login()` command, on its 5s wait for the toolbar user button after 11+ consecutive logins in a serial run. That is a separate pre-existing issue in a shared command and is out of scope here.
