### PR TITLE
fix(inventories): support labels on constructed inventories

### DIFF
--- a/frontend/awx/resources/inventories/InventoryForm.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.test.tsx
@@ -435,7 +435,7 @@ describe('InventoryForm', () => {
       expect(postSpy).not.toHaveBeenCalled();
     });
 
-    it('should render create constructed inventory form with correct title', async () => {
+    it('should render create constructed inventory form with labels field', async () => {
       render(
         <MemoryRouter initialEntries={['/inventories/constructed_inventory/create']}>
           <Routes>
@@ -452,6 +452,7 @@ describe('InventoryForm', () => {
       });
 
       expect(screen.getByTestId('source_vars')).toBeInTheDocument();
+      expect(screen.getByTestId('label-select')).toBeInTheDocument();
     });
 
     it('should navigate away when cancel is clicked on constructed inventory form', async () => {
@@ -486,6 +487,7 @@ describe('InventoryForm', () => {
       async () => {
         const postInventorySpy = vi.fn();
         const postInputInventorySpy = vi.fn();
+        const labelPostSpy = vi.fn();
         server.use(
           http.post(
             ({ request }) =>
@@ -520,6 +522,13 @@ describe('InventoryForm', () => {
               postInputInventorySpy(await request.json());
               return HttpResponse.json({});
             }
+          ),
+          http.post(
+            ({ request }) => request.url.includes('/inventories/100/labels/'),
+            async ({ request }) => {
+              labelPostSpy(await request.json());
+              return HttpResponse.json({});
+            }
           )
         );
 
@@ -550,6 +559,7 @@ describe('InventoryForm', () => {
         await user.type(screen.getByTestId('source_vars'), 'plugin: constructed.dynamic');
 
         await user.click(screen.getByTestId('inventories'));
+        await user.click(screen.getByTestId('label-select'));
 
         await user.click(screen.getByRole('button', { name: /create inventory/i }));
 
@@ -560,6 +570,9 @@ describe('InventoryForm', () => {
         });
         await waitFor(() => {
           expect(postInputInventorySpy).toHaveBeenCalledWith({ id: 10 });
+        });
+        await waitFor(() => {
+          expect(labelPostSpy).toHaveBeenCalledWith({ name: 'new-label' });
         });
       }
     );
@@ -1866,7 +1879,7 @@ describe('InventoryForm', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should not render labels select or prevent_instance_group_fallback checkbox for constructed inventory', async () => {
+    it('should render labels select but not prevent_instance_group_fallback for constructed inventory', async () => {
       render(
         <MemoryRouter initialEntries={['/inventories/constructed_inventory/create']}>
           <Routes>
@@ -1882,7 +1895,7 @@ describe('InventoryForm', () => {
         expect(screen.getByRole('button', { name: /create inventory/i })).toBeInTheDocument()
       );
 
-      expect(screen.queryByTestId('label-select')).not.toBeInTheDocument();
+      expect(screen.getByTestId('label-select')).toBeInTheDocument();
       expect(
         screen.queryByRole('checkbox', { name: /prevent instance group fallback/i })
       ).not.toBeInTheDocument();
@@ -3022,7 +3035,7 @@ describe('InventoryForm', () => {
     );
 
     it(
-      'should not call labels endpoint when editing a constructed inventory',
+      'should update labels when editing a constructed inventory',
       { timeout: 15000 },
       async () => {
         const patchSpy = vi.fn();
@@ -3075,12 +3088,13 @@ describe('InventoryForm', () => {
           expect(screen.getByDisplayValue('constructed test')).toBeInTheDocument();
         });
 
+        await user.click(screen.getByTestId('label-select'));
         await user.click(screen.getByRole('button', { name: /save inventory/i }));
 
         await waitFor(() => {
           expect(patchSpy).toHaveBeenCalled();
+          expect(labelPostSpy).toHaveBeenCalledWith({ name: 'new-label', organization: 1 });
         });
-        expect(labelPostSpy).not.toHaveBeenCalled();
       }
     );
   });

--- a/frontend/awx/resources/inventories/InventoryForm.tsx
+++ b/frontend/awx/resources/inventories/InventoryForm.tsx
@@ -87,7 +87,7 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
     }
 
     // Update new inventory with selected labels
-    if (newInventory.kind === '' && data.labels.length > 0)
+    if (newInventory.kind !== 'smart' && data.labels.length > 0)
       promises.push(submitLabels(newInventory, data.labels));
 
     await Promise.all(promises);
@@ -125,6 +125,7 @@ export function CreateInventory(props: { inventoryKind: '' | 'constructed' | 'sm
             update_cache_timeout: 0,
             limit: '',
             source_vars: '',
+            labels: [],
           }
         : {
             kind: inventoryKind,
@@ -207,7 +208,10 @@ export function EditInventory() {
       submitInstanceGroups(updatedInventory, instanceGroups ?? [], originalInstanceGroups ?? [])
     );
 
-    if (params.inventory_type === 'inventory') {
+    if (
+      params.inventory_type === 'inventory' ||
+      params.inventory_type === 'constructed_inventory'
+    ) {
       promises.push(submitLabels(inventory as Inventory, labels || []));
     }
 
@@ -262,6 +266,7 @@ export function EditInventory() {
             ...inventory,
             instanceGroups: originalInstanceGroups,
             inventories: (inputInventoriesResults ?? []) as Inventory[],
+            labels: inventory.summary_fields?.labels?.results ?? [],
           }
         : {
             ...inventory,
@@ -427,7 +432,7 @@ function InventoryInputs(props: { inventoryKind: string }) {
           />
         </>
       )}
-      {inventoryKind === '' && (
+      {inventoryKind !== 'smart' && (
         <PageFormLabelSelect<InventoryCreate>
           labelHelpTitle={t('Labels')}
           labelHelp={inventoryFormDetailLabels.labels}

--- a/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.test.tsx
+++ b/frontend/awx/resources/inventories/InventoryPage/InventoryDetails.test.tsx
@@ -136,6 +136,37 @@ describe('InventoryDetails', () => {
     expect(screen.getByText(/0 \(Normal\)/)).toBeInTheDocument();
   });
 
+  it('should render labels for constructed inventory', async () => {
+    const constructedInventory: Inventory = {
+      ...baseInventory,
+      id: 42,
+      kind: 'constructed',
+      summary_fields: {
+        ...baseInventory.summary_fields,
+        labels: {
+          count: 1,
+          results: [
+            { ...baseInventory.summary_fields.labels.results[0], id: 7, name: 'constructed label' },
+          ],
+        },
+      },
+      hosts_with_active_failures: 0,
+      total_groups: 0,
+      total_inventory_sources: 0,
+      inventory_sources_with_failures: 0,
+      update_cache_timeout: 0,
+      verbosity: 0,
+      source_vars: '',
+      limit: '',
+    };
+
+    renderInventoryDetails(constructedInventory);
+
+    await waitFor(() => {
+      expect(screen.getByText('constructed label')).toBeInTheDocument();
+    });
+  });
+
   it('should render input inventory labels for constructed inventory', async () => {
     // Use id: 99 so the SWR cache from the previous constructed-inventory test (id: 9)
     // does not bleed into this one. The page-aware handler ensures that only page=1


### PR DESCRIPTION
## Summary

Adds label support for constructed inventories. Labels can now be selected when creating or editing a constructed inventory, are synchronized with the labels API, and are displayed in the inventory details view.

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [ ] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [x] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

> Tests run against a fresh AAP instance (version based on branch).

### External Server E2E Runs

Not applicable.

### Manual Testing

1. Open the create form for a constructed inventory.
2. Verify the Labels field is available and select a label.
3. Create the inventory and verify the label is saved.
4. Open an existing constructed inventory, change its labels, save, and verify the update persists.
5. Open the constructed inventory details page and verify its labels are displayed.

### Screenshots

**Before**
<img width="1251" height="489" alt="image" src="https://github.com/user-attachments/assets/4ba3ee6e-f024-4528-9aa0-ac2c4cc87c77" />

**After**
<img width="1251" height="489" alt="image" src="https://github.com/user-attachments/assets/e555db9e-fb24-463a-ba67-69c7232ff30e" />
