### PR TITLE
feat(schedules): allow setting, editing and showing labels for schedules via web ui

### DIFF
--- a/frontend/awx/common/PageFormLabelSelect.test.tsx
+++ b/frontend/awx/common/PageFormLabelSelect.test.tsx
@@ -1,55 +1,107 @@
 /* eslint-disable i18next/no-literal-string */
-import { render, screen, waitFor } from '@testing-library/react';
-import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
-import { FormProvider, useForm } from 'react-hook-form';
-import { MemoryRouter } from 'react-router-dom';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAwxGetAllPages } from './useAwxGetAllPages';
 import { PageFormLabelSelect } from './PageFormLabelSelect';
 
-const server = setupServer(
-  http.get(
-    ({ request }) => request.url.includes('/api/v2/labels/'),
-    () =>
-      HttpResponse.json({ count: 2, results: [{ name: 'label1' }, { name: 'label2' }], next: null })
-  )
-);
+vi.mock('@ansible/ansible-ui-framework/PageForm/Inputs/PageFormCreatableSelect', () => ({
+  PageFormCreatableSelect: (props: {
+    additionalControls?: ReactElement;
+    label: string;
+    labelHelp?: string;
+    labelHelpTitle?: string;
+    options: { label: string; value: string }[];
+    placeholderText?: string;
+  }) => (
+    <div>
+      <span>{props.label}</span>
+      <span>{props.placeholderText}</span>
+      <span>{props.labelHelpTitle}</span>
+      <span>{props.labelHelp}</span>
+      {props.additionalControls}
+      <ul>
+        {props.options.map((option) => (
+          <li key={option.value}>{option.label}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+vi.mock('./useAwxGetAllPages', () => ({
+  useAwxGetAllPages: vi.fn(),
+}));
 
-function TestWrapper({ children }: { children: React.ReactNode }) {
-  const methods = useForm();
-  return (
-    <MemoryRouter>
-      <FormProvider {...methods}>{children}</FormProvider>
-    </MemoryRouter>
-  );
+const mockedUseAwxGetAllPages = vi.mocked(useAwxGetAllPages);
+
+function setLabels(
+  results: { name: string; organization?: number }[] | undefined,
+  isLoading = false
+) {
+  mockedUseAwxGetAllPages.mockReturnValue({
+    results,
+    error: undefined,
+    isLoading,
+    refresh: vi.fn(),
+  });
 }
 
 describe('PageFormLabelSelect', () => {
-  beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
-
-  it('should render Labels label', async () => {
-    render(
-      <TestWrapper>
-        <PageFormLabelSelect name="labels" />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('Labels')).toBeInTheDocument();
-    });
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('should render placeholder when loaded', async () => {
+  it('shows a loading option while labels are loading', () => {
+    setLabels(undefined, true);
+
+    render(<PageFormLabelSelect name="labels" />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows all labels and the default placeholder after loading', () => {
+    setLabels([{ name: 'label1' }, { name: 'label2' }]);
+
+    render(<PageFormLabelSelect name="labels" />);
+
+    expect(screen.getByText('Labels')).toBeInTheDocument();
+    expect(screen.getByText('Select or create labels')).toBeInTheDocument();
+    expect(screen.getByText('label1')).toBeInTheDocument();
+    expect(screen.getByText('label2')).toBeInTheDocument();
+  });
+
+  it('filters labels by organization and forwards optional props', () => {
+    setLabels([
+      { name: 'organization label', organization: 7 },
+      { name: 'other organization label', organization: 8 },
+    ]);
+    const additionalControls = <button type="button">Create label</button>;
+
     render(
-      <TestWrapper>
-        <PageFormLabelSelect name="labels" />
-      </TestWrapper>
+      <PageFormLabelSelect
+        name="labels"
+        organizationId={7}
+        placeholderText="Choose labels"
+        labelHelpTitle="Label help"
+        labelHelp="Labels are shared with your organization."
+        additionalControls={additionalControls}
+        shouldUnregister={false}
+      />
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Select or create labels')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Choose labels')).toBeInTheDocument();
+    expect(screen.getByText('Label help')).toBeInTheDocument();
+    expect(screen.getByText('Labels are shared with your organization.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create label' })).toBeInTheDocument();
+    expect(screen.getByText('organization label')).toBeInTheDocument();
+    expect(screen.queryByText('other organization label')).not.toBeInTheDocument();
+  });
+
+  it('shows no options when the loaded response has no results', () => {
+    setLabels(undefined);
+
+    render(<PageFormLabelSelect name="labels" />);
+
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
   });
 });

--- a/frontend/awx/common/PageFormLabelSelect.tsx
+++ b/frontend/awx/common/PageFormLabelSelect.tsx
@@ -19,15 +19,19 @@ export function PageFormLabelSelect<
   placeholderText?: string;
   additionalControls?: ReactElement;
   shouldUnregister?: boolean;
+  organizationId?: number;
 }) {
-  const { labelHelpTitle, labelHelp, name, placeholderText, additionalControls } = props;
+  const { labelHelpTitle, labelHelp, name, placeholderText, additionalControls, organizationId } =
+    props;
   const { t } = useTranslation();
 
   const { results, isLoading } = useAwxGetAllPages<Label>(awxAPI`/labels/`, { order_by: 'name' });
 
   const options = isLoading
     ? [{ label: t('Loading...'), value: '' }]
-    : (results ?? []).map((label) => ({ value: label.name, label: label.name }));
+    : (results ?? [])
+        .filter((label) => organizationId === undefined || label.organization === organizationId)
+        .map((label) => ({ value: label.name, label: label.name }));
 
   return (
     <PageFormCreatableSelect<TFieldValues, TFieldName>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/NodePromptsStep.tsx
@@ -107,6 +107,8 @@ export function NodePromptsStep({
             `Optional labels that describe this job template, such as 'dev' or 'test'. Labels can be used to group and filter job templates and completed jobs.`
           )}
           name="prompt.labels"
+          organizationId={organizationId ?? undefined}
+          shouldUnregister={false}
         />
       </ConditionalField>
       <ConditionalField isHidden={!config.ask_forks_on_launch}>

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.test.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobTemplate } from '../../../../interfaces/JobTemplate';
+import type { WorkflowJobTemplate } from '../../../../interfaces/WorkflowJobTemplate';
+import type { WizardFormValues } from '../types';
+import { PromptReviewDetails } from './PromptReviewDetails';
+
+const mockUsePageWizard = vi.hoisted(() => vi.fn());
+const mockUseGet = vi.hoisted(() => vi.fn(() => ({ data: undefined as unknown })));
+const mockUseGetItem = vi.hoisted(() => vi.fn(() => ({ data: undefined as unknown })));
+
+vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
+  usePageWizard: mockUsePageWizard,
+}));
+
+vi.mock('@ansible/ansible-ui-framework', () => ({
+  PageDetail: ({ label, children }: Readonly<{ label: string; children?: React.ReactNode }>) => (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  ),
+  useGetPageUrl: () => (route: string, options: { params: Record<string, unknown> }) =>
+    `${route}/${JSON.stringify(options.params)}`,
+}));
+
+vi.mock('@ansible/ansible-ui-framework/PageDetails/PageDetailCodeEditor', () => ({
+  PageDetailCodeEditor: ({ value }: Readonly<{ value: string }>) => (
+    <pre data-testid="extra-vars">{value}</pre>
+  ),
+}));
+
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGet: mockUseGet,
+  useGetItem: mockUseGetItem,
+}));
+
+vi.mock('../../../../common/useVerbosityString', () => ({
+  useVerbosityString: (verbosity: number) => `verbosity-${verbosity}`,
+}));
+
+vi.mock('../../../../common/api/awx-utils', () => ({
+  awxAPI: (strings: TemplateStringsArray, ...values: string[]) =>
+    strings.reduce((result, string, index) => result + string + (values[index] ?? ''), ''),
+}));
+
+vi.mock('../../JobTemplateFormHelpers', () => ({
+  parseStringToTagArray: (tags: string) => tags.split(',').map((name) => ({ name })),
+}));
+
+vi.mock('../../TemplatePage/steps/TemplateLaunchReviewStep', () => ({
+  CredentialDetail: ({ credential }: Readonly<{ credential: { name: string } }>) => (
+    <span>{credential.name}</span>
+  ),
+}));
+
+vi.mock('@patternfly/react-core', () => ({
+  Label: ({
+    children,
+    render,
+  }: Readonly<{
+    children: React.ReactNode;
+    render?: (props: { content: React.ReactNode; className: string }) => React.ReactNode;
+  }>) => (render ? render({ content: children, className: 'label' }) : <span>{children}</span>),
+  LabelGroup: ({ children }: Readonly<{ children?: React.ReactNode }>) => <div>{children}</div>,
+}));
+
+function renderReview(
+  template: JobTemplate | WorkflowJobTemplate | null,
+  prompt: Partial<WizardFormValues['prompt']> = {},
+  survey?: WizardFormValues['survey'],
+  labels: { name: string; id?: number }[] = [{ name: 'prop label' }]
+) {
+  mockUsePageWizard.mockReturnValue({ wizardData: { resource: template, prompt, survey } });
+  return render(
+    <MemoryRouter>
+      <PromptReviewDetails labels={labels} />
+    </MemoryRouter>
+  );
+}
+
+const jobTemplate = {
+  id: 42,
+  type: 'job_template',
+  playbook: 'site.yml',
+  summary_fields: {
+    organization: { id: 7, name: 'Org' },
+    inventory: { id: 8, name: 'Template inventory', kind: '' },
+    project: { id: 9, name: 'Project' },
+  },
+} as unknown as JobTemplate;
+
+const workflowTemplate = {
+  id: 43,
+  type: 'workflow_job_template',
+  summary_fields: {},
+} as unknown as WorkflowJobTemplate;
+
+describe('PromptReviewDetails', () => {
+  beforeEach(() => {
+    mockUsePageWizard.mockReset();
+    mockUseGet.mockReturnValue({ data: undefined });
+    mockUseGetItem.mockReturnValue({ data: undefined });
+  });
+
+  it('returns null when the wizard has no template', () => {
+    const { container } = renderReview(null);
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseGet).toHaveBeenCalledWith('');
+  });
+
+  it('renders job template prompt details and processes survey values', () => {
+    mockUseGet.mockReturnValue({ data: { spec: [{ type: 'password', variable: 'secret' }] } });
+    mockUseGetItem
+      .mockReturnValueOnce({ data: { id: 11, name: 'Execution environment' } })
+      .mockReturnValueOnce({ data: { id: 8, name: 'Loaded inventory' } });
+
+    renderReview(
+      jobTemplate,
+      {
+        inventory: { id: 8, kind: 'smart', name: 'Inventory' },
+        credentials: [{ id: 1, name: 'Credential' }] as never,
+        instance_groups: [{ id: 2, name: 'Instance group' }] as never,
+        execution_environment: { id: 11, name: 'EE' },
+        diff_mode: true,
+        scm_branch: 'main',
+        extra_vars: 'existing: value',
+        forks: 3,
+        job_slice_count: 2,
+        job_tags: 'tag-one,tag-two' as never,
+        job_type: 'run',
+        limit: 'web',
+        skip_tags: [{ name: 'skip-me' }],
+        timeout: 60,
+        verbosity: 2,
+      },
+      { secret: 'password' }
+    );
+
+    expect(screen.getByText('site.yml')).toBeInTheDocument();
+    expect(screen.getAllByText('Project').length).toBe(2);
+    expect(screen.getByText('Loaded inventory')).toBeInTheDocument();
+    expect(screen.getByText('Credential')).toBeInTheDocument();
+    expect(screen.getByText('Instance group')).toBeInTheDocument();
+    expect(screen.getByText('tag-one')).toBeInTheDocument();
+    expect(screen.getByText('skip-me')).toBeInTheDocument();
+    expect(screen.getByText('On')).toBeInTheDocument();
+    expect(screen.getByText('verbosity-2')).toBeInTheDocument();
+    expect(screen.getByTestId('extra-vars')).toHaveTextContent('$encrypted$');
+  });
+
+  it('handles an unsupported template type', () => {
+    renderReview({ id: 44, type: 'unsupported', summary_fields: {} } as unknown as JobTemplate);
+    expect(mockUseGet).toHaveBeenCalledWith('');
+  });
+
+  it('renders workflow template details and empty/default prompt values', () => {
+    renderReview(
+      workflowTemplate,
+      {
+        credentials: [],
+        instance_groups: [],
+        execution_environment: {},
+        diff_mode: false,
+        job_tags: [],
+        skip_tags: [],
+        extra_vars: undefined,
+        forks: undefined,
+        timeout: undefined,
+        verbosity: undefined,
+      },
+      undefined,
+      []
+    );
+
+    expect(screen.queryByText('site.yml')).not.toBeInTheDocument();
+    expect(screen.getByText('Off')).toBeInTheDocument();
+    expect(screen.getByText('verbosity-NaN')).toBeInTheDocument();
+    expect(screen.getAllByText('0').length).toBe(2);
+    expect(mockUseGet).toHaveBeenCalledWith('/workflow_job_templates/43/survey_spec/');
+  });
+
+  it('uses prompt labels and the constructed inventory path', () => {
+    renderReview(
+      jobTemplate,
+      {
+        inventory: { id: 8, kind: 'constructed', name: 'Constructed' },
+        execution_environment: undefined,
+        labels: [{ name: 'prompt label', id: 3 }],
+      },
+      undefined,
+      []
+    );
+
+    expect(screen.getByText('prompt label')).toBeInTheDocument();
+  });
+});

--- a/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.tsx
+++ b/frontend/awx/resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails.tsx
@@ -35,7 +35,7 @@ function getSurveySpecUrl(template: JobTemplate | WorkflowJobTemplate) {
   }
 }
 
-export function PromptReviewDetails() {
+export function PromptReviewDetails(props: Readonly<{ labels?: { name: string; id?: number }[] }>) {
   const { t } = useTranslation();
   const getPageUrl = useGetPageUrl();
   const {
@@ -56,7 +56,7 @@ export function PromptReviewDetails() {
     job_slice_count,
     job_tags,
     job_type,
-    labels,
+    labels: promptLabels,
     limit,
     skip_tags,
     timeout,
@@ -185,9 +185,14 @@ export function PromptReviewDetails() {
       <PageDetail label={t('Timeout')}>{timeout ?? 0}</PageDetail>
       <PageDetail label={t('Show changes')}>{diff_mode ? t`On` : t`Off`}</PageDetail>
       <PageDetail label={t('Job slicing')}>{job_slice_count}</PageDetail>
-      <PageDetail label={t('Labels')} isEmpty={isEmpty(labels)}>
+      <PageDetail
+        label={t('Labels')}
+        isEmpty={isEmpty(props.labels?.length ? props.labels : promptLabels)}
+      >
         <LabelGroup>
-          {labels?.map((label) => <Label key={label.id}>{label.name}</Label>)}
+          {(props.labels?.length ? props.labels : promptLabels)?.map((label) => (
+            <Label key={label.id ?? label.name}>{label.name}</Label>
+          ))}
         </LabelGroup>
       </PageDetail>
       <PageDetail label={t('Job tags')} isEmpty={isEmpty(jobTags)}>

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.test.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -105,6 +106,9 @@ describe('ScheduleDetails', () => {
     expect(screen.getByText('Time zone')).toBeInTheDocument();
     expect(screen.getByText('Labels')).toBeInTheDocument();
     expect(screen.getByText('schedule-label')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole('button', { name: 'admin' })[1]);
   });
 
   it('renders an empty labels detail when the schedule has no labels', async () => {
@@ -204,5 +208,109 @@ describe('ScheduleDetails', () => {
     });
 
     expect(screen.getByText('web_servers')).toBeInTheDocument();
+  });
+
+  it('renders optional schedule details and workflow template branch', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/1/`, () =>
+        HttpResponse.json({
+          ...mockSchedule,
+          dtend: '2023-05-17T14:57:05Z',
+          next_run: null,
+          scm_branch: null,
+          diff_mode: false,
+          job_tags: [{ name: 'deploy' }],
+          skip_tags: [{ name: 'debug' }],
+          extra_data: { days: 14 },
+          summary_fields: {
+            ...mockSchedule.summary_fields,
+            unified_job_template: { id: 2, unified_job_type: 'workflow_job' },
+          },
+          rrule:
+            'DTSTART;TZID=America/New_York:20230509T105705 RRULE:FREQ=DAILY;COUNT=1 EXRULE:FREQ=WEEKLY;COUNT=1',
+        })
+      ),
+      http.get(awxAPI`/workflow_job_templates/2/`, () =>
+        HttpResponse.json({ scm_branch: 'workflow-branch' })
+      ),
+      http.get(awxAPI`/schedules/1/credentials/`, () =>
+        HttpResponse.json({
+          count: 1,
+          results: [{ id: 3, name: 'SSH credential', kind: 'ssh' }],
+        })
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/1/schedules/1']}>
+        <Routes>
+          <Route
+            path="/templates/:id/schedules/:schedule_id"
+            element={<ScheduleDetails isSystemJobTemplateSchedule />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Days of data to keep')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('workflow-branch')).toBeInTheDocument();
+    expect(screen.getByText('SSH credential')).toBeInTheDocument();
+    expect(screen.getByText('deploy')).toBeInTheDocument();
+    expect(screen.getByText('debug')).toBeInTheDocument();
+    expect(screen.getByText('Last run')).toBeInTheDocument();
+    expect(screen.getByText('Exrule')).toBeInTheDocument();
+    expect(screen.getByText('Off')).toBeInTheDocument();
+    expect(screen.queryByText('Created')).not.toBeInTheDocument();
+  });
+
+  it('renders string retention data without fetching an unrelated template', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/1/`, () =>
+        HttpResponse.json({
+          ...mockSchedule,
+          extra_data: '{"days": 7}',
+          summary_fields: {
+            ...mockSchedule.summary_fields,
+            unified_job_template: { id: 2, unified_job_type: 'project' },
+          },
+        })
+      )
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/1/schedules/1']}>
+        <Routes>
+          <Route path="/templates/:id/schedules/:schedule_id" element={<ScheduleDetails />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Days of data to keep')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the loading state and API error state', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/1/`, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return HttpResponse.json({}, { status: 500 });
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/1/schedules/1']}>
+        <Routes>
+          <Route path="/templates/:id/schedules/:schedule_id" element={<ScheduleDetails />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.test.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.test.tsx
@@ -58,6 +58,12 @@ const server = setupServer(
       results: [],
     });
   }),
+  http.get(awxAPI`/schedules/1/labels/`, () => {
+    return HttpResponse.json({
+      count: 1,
+      results: [{ id: 1, name: 'schedule-label' }],
+    });
+  }),
   http.get(awxAPI`/job_templates/1/`, () => {
     return HttpResponse.json({
       id: 1,
@@ -90,12 +96,36 @@ describe('ScheduleDetails', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('schedule-label')).toBeInTheDocument();
     });
 
+    expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Test Schedule')).toBeInTheDocument();
     expect(screen.getByText('Description')).toBeInTheDocument();
     expect(screen.getByText('Time zone')).toBeInTheDocument();
+    expect(screen.getByText('Labels')).toBeInTheDocument();
+    expect(screen.getByText('schedule-label')).toBeInTheDocument();
+  });
+
+  it('renders an empty labels detail when the schedule has no labels', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/1/labels/`, () => HttpResponse.json({ count: 0, results: [] }))
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/templates/1/schedules/1']}>
+        <Routes>
+          <Route path="/templates/:id/schedules/:schedule_id" element={<ScheduleDetails />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Name')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
+    expect(screen.queryByText('schedule-label')).not.toBeInTheDocument();
   });
 
   it('renders source control branch when scm_branch is set', async () => {

--- a/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
+++ b/frontend/awx/views/schedules/SchedulePage/ScheduleDetails.tsx
@@ -22,6 +22,7 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { Credential } from '../../../interfaces/Credential';
 import { JobTemplate } from '../../../interfaces/JobTemplate';
 import { WorkflowJobTemplate } from '../../../interfaces/WorkflowJobTemplate';
+import { Label as AwxLabel } from '../../../interfaces/Label';
 import { Schedule } from '../../../interfaces/Schedule';
 import { AwxRoute } from '../../../main/AwxRoutes';
 import { parseStringToTagArray } from '../../../resources/templates/JobTemplateFormHelpers';
@@ -49,6 +50,9 @@ export function ScheduleDetails(props: { isSystemJobTemplateSchedule?: boolean }
   } = useGetItem<Schedule>(awxAPI`/schedules/`, params.schedule_id);
   const { data: credentialResponse } = useGet<AwxItemsResponse<Credential>>(
     awxAPI`/schedules/${params.schedule_id || ''}/credentials/`
+  );
+  const { data: labelResponse } = useGet<AwxItemsResponse<AwxLabel>>(
+    awxAPI`/schedules/${params.schedule_id || ''}/labels/`
   );
 
   // Fetch the unified job template to get scm_branch when it's set on the template
@@ -132,6 +136,11 @@ export function ScheduleDetails(props: { isSystemJobTemplateSchedule?: boolean }
             {credentialResponse?.results?.map((credential: Credential) => (
               <CredentialLabel credential={credential} key={credential.id} />
             ))}
+          </LabelGroup>
+        </PageDetail>
+        <PageDetail label={t('Labels')} isEmpty={!labelResponse?.results?.length}>
+          <LabelGroup>
+            {labelResponse?.results?.map((label) => <Label key={label.id}>{label.name}</Label>)}
           </LabelGroup>
         </PageDetail>
         <PageDetail label={t('Inventory')}>{schedule.summary_fields.inventory?.name}</PageDetail>

--- a/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
+++ b/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { PageWizardContext } from '@ansible/ansible-ui-framework/PageWizard/PageWizardProvider';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,15 +8,33 @@ import { awxAPI } from '../../../common/api/awx-utils';
 import { ScheduleFormWizard } from '../types';
 import { ScheduleResourceInputs } from './ScheduleResourceInputs';
 
-vi.mock('../hooks/useGetTimezones', () => ({
-  useGetTimezones: () => ({
+const mockUseGetTimezones = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      timeZones: { label: string; value: string }[];
+      links?: Record<string, string>;
+    }
+  >(() => ({
     timeZones: [
       { label: 'UTC', value: 'UTC' },
       { label: 'America/New_York', value: 'America/New_York' },
     ],
     links: { 'US/Eastern': 'America/New_York' },
-  }),
+  }))
+);
+
+vi.mock('../hooks/useGetTimezones', () => ({
+  useGetTimezones: mockUseGetTimezones,
 }));
+
+function ScheduleDaysToKeepProbe() {
+  const value = useWatch<ScheduleFormWizard, 'schedule_days_to_keep'>({
+    name: 'schedule_days_to_keep',
+  });
+  return (
+    <span data-testid="schedule-days-state">{value === undefined ? 'removed' : 'present'}</span>
+  );
+}
 
 function TestWrapper({
   children,
@@ -35,7 +54,11 @@ function TestWrapper({
     },
   });
 
-  return <FormProvider {...methods}>{children}</FormProvider>;
+  return (
+    <PageWizardContext.Provider value={{ setWizardData: vi.fn() } as never}>
+      <FormProvider {...methods}>{children}</FormProvider>
+    </PageWizardContext.Provider>
+  );
 }
 
 describe('ScheduleResourceInputs', () => {
@@ -47,6 +70,13 @@ describe('ScheduleResourceInputs', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseGetTimezones.mockImplementation(() => ({
+      timeZones: [
+        { label: 'UTC', value: 'UTC' },
+        { label: 'America/New_York', value: 'America/New_York' },
+      ],
+      links: { 'US/Eastern': 'America/New_York' },
+    }));
   });
 
   it('renders all common fields', () => {
@@ -80,6 +110,50 @@ describe('ScheduleResourceInputs', () => {
     );
 
     expect(screen.queryByText('Labels')).not.toBeInTheDocument();
+  });
+
+  it('updates wizard data and warns when many labels are selected', async () => {
+    render(
+      <TestWrapper
+        defaultValues={{
+          prompt: {
+            labels: Array.from({ length: 81 }, (_, index) => ({
+              id: index,
+              name: `label-${index}`,
+            })),
+          } as never,
+          launch_config: null,
+          resource: {
+            id: 1,
+            ask_labels_on_launch: false,
+            summary_fields: { organization: { id: 42 } },
+          } as never,
+        }}
+      >
+        <ScheduleResourceInputs />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Many labels selected')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/This schedule has 81 labels/)).toBeInTheDocument();
+  });
+
+  it('clears the timezone warning when timezone links are unavailable', () => {
+    mockUseGetTimezones.mockImplementation(() => ({ timeZones: [], links: undefined }));
+
+    render(
+      <TestWrapper defaultValues={{ timezone: 'US/Eastern' }}>
+        <ScheduleResourceInputs />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.queryByText(
+        'Warning: US/Eastern is a link to America/New_York and will be saved as that.'
+      )
+    ).not.toBeInTheDocument();
   });
 
   it('shows a warning when the selected timezone is a link', () => {
@@ -221,17 +295,16 @@ describe('ScheduleResourceInputs', () => {
         defaultValues={{
           schedule_type: 'system_job_template',
           resourceId: 3,
+          schedule_days_to_keep: 10,
         }}
       >
         <ScheduleResourceInputs />
+        <ScheduleDaysToKeepProbe />
       </TestWrapper>
     );
 
-    // Wait for API call to complete
     await waitFor(() => {
-      expect(
-        screen.queryByRole('spinbutton', { name: 'Days of data to keep' })
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('schedule-days-state')).toHaveTextContent('removed');
     });
   });
 

--- a/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
+++ b/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../hooks/useGetTimezones', () => ({
       { label: 'UTC', value: 'UTC' },
       { label: 'America/New_York', value: 'America/New_York' },
     ],
-    links: {},
+    links: { 'US/Eastern': 'America/New_York' },
   }),
 }));
 
@@ -60,6 +60,40 @@ describe('ScheduleResourceInputs', () => {
     expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
     expect(screen.getByTestId('startDateTime-form-group')).toBeInTheDocument();
     expect(screen.getByTestId('timezone')).toBeInTheDocument();
+  });
+
+  it('renders labels when the resource does not prompt for labels', () => {
+    render(
+      <TestWrapper defaultValues={{ launch_config: { ask_labels_on_launch: false } as never }}>
+        <ScheduleResourceInputs />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('Labels')).toBeInTheDocument();
+  });
+
+  it('does not render labels when the resource prompts for labels', () => {
+    render(
+      <TestWrapper defaultValues={{ launch_config: { ask_labels_on_launch: true } as never }}>
+        <ScheduleResourceInputs />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
+  });
+
+  it('shows a warning when the selected timezone is a link', () => {
+    render(
+      <TestWrapper defaultValues={{ timezone: 'US/Eastern' }}>
+        <ScheduleResourceInputs />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.getByText(
+        'Warning: US/Eastern is a link to America/New_York and will be saved as that.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('does not render days_to_keep field by default', () => {

--- a/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
+++ b/frontend/awx/views/schedules/components/ScheduleResourceInputs.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import { useMemo } from 'react';
 import { PageWizardContext } from '@ansible/ansible-ui-framework/PageWizard/PageWizardProvider';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { http, HttpResponse } from 'msw';
@@ -53,9 +54,10 @@ function TestWrapper({
       ...defaultValues,
     },
   });
+  const wizardContextValue = useMemo(() => ({ setWizardData: vi.fn() }), []);
 
   return (
-    <PageWizardContext.Provider value={{ setWizardData: vi.fn() } as never}>
+    <PageWizardContext.Provider value={wizardContextValue as never}>
       <FormProvider {...methods}>{children}</FormProvider>
     </PageWizardContext.Provider>
   );

--- a/frontend/awx/views/schedules/components/ScheduleResourceInputs.tsx
+++ b/frontend/awx/views/schedules/components/ScheduleResourceInputs.tsx
@@ -1,11 +1,14 @@
 import { PageFormTextInput } from '@ansible/ansible-ui-framework';
+import { Alert } from '@patternfly/react-core';
 import { PageFormDateTimePicker } from '@ansible/ansible-ui-framework/PageForm/Inputs/PageFormDateTimePicker';
 import { PageFormSingleSelect } from '@ansible/ansible-ui-framework/PageForm/Inputs/PageFormSingleSelect';
 import { PageFormSection } from '@ansible/ansible-ui-framework/PageForm/Utils/PageFormSection';
+import { usePageWizard } from '@ansible/ansible-ui-framework/PageWizard/PageWizardProvider';
 import { requestGet } from '@ansible/common-ui/crud/Data';
 import { useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { PageFormLabelSelect } from '../../../common/PageFormLabelSelect';
 import { awxAPI } from '../../../common/api/awx-utils';
 import { SystemJobTemplate } from '../../../interfaces/SystemJobTemplate';
 import { useGetTimezones } from '../hooks/useGetTimezones';
@@ -14,6 +17,7 @@ import { ScheduleFormWizard } from '../types';
 export function ScheduleResourceInputs() {
   const { t } = useTranslation();
   const { unregister } = useFormContext<ScheduleFormWizard>();
+  const { setWizardData } = usePageWizard<ScheduleFormWizard>();
   const [timezoneMessage, setTimezoneMessage] = useState('');
   const [hasDaysToKeepField, setHasDaysToKeepField] = useState(false);
   const timeZone = useWatch<ScheduleFormWizard, 'timezone'>({ name: 'timezone' });
@@ -25,6 +29,22 @@ export function ScheduleResourceInputs() {
   const scheduleType = useWatch<ScheduleFormWizard, 'schedule_type'>({
     name: 'schedule_type',
   });
+  const launchConfig = useWatch<ScheduleFormWizard, 'launch_config'>({ name: 'launch_config' });
+  const labels = useWatch<ScheduleFormWizard, 'prompt.labels'>({ name: 'prompt.labels' });
+  useEffect(() => {
+    if (!labels) return;
+    setWizardData((previous) => ({
+      ...previous,
+      prompt: { ...previous.prompt, labels },
+    }));
+  }, [setWizardData, labels]);
+  const asksLabelsOnLaunch =
+    launchConfig?.ask_labels_on_launch ??
+    (resource && 'ask_labels_on_launch' in resource ? resource.ask_labels_on_launch : undefined);
+  const organizationId =
+    resource && 'summary_fields' in resource && 'organization' in resource.summary_fields
+      ? resource.summary_fields.organization?.id
+      : undefined;
   useEffect(() => {
     async function getManagementJob() {
       if (scheduleType === 'system_job_template' && resourceId) {
@@ -88,6 +108,28 @@ export function ScheduleResourceInputs() {
           helperText={timezoneMessage}
           isRequired
         />
+        {asksLabelsOnLaunch !== true ? (
+          <>
+            <PageFormLabelSelect<ScheduleFormWizard>
+              name="prompt.labels"
+              shouldUnregister={false}
+              organizationId={organizationId}
+              labelHelp={t(
+                `Optional labels that describe this schedule, such as 'dev' or 'test'. Labels can be used to group and filter schedules.`
+              )}
+            />
+            {labels && labels.length > 80 ? (
+              <PageFormSection singleColumn>
+                <Alert variant="warning" title={t('Many labels selected')} isInline>
+                  {t(
+                    'This schedule has {{count}} labels. Schedules support up to 100 labels; consider removing unused labels.',
+                    { count: labels.length }
+                  )}
+                </Alert>
+              </PageFormSection>
+            ) : null}
+          </>
+        ) : null}
         {hasDaysToKeepField ? (
           <PageFormTextInput<ScheduleFormWizard>
             name={'schedule_days_to_keep'}

--- a/frontend/awx/views/schedules/hooks/usePostScheduleAccessories.test.tsx
+++ b/frontend/awx/views/schedules/hooks/usePostScheduleAccessories.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { awxAPI } from '../../../common/api/awx-utils';
+import { usePostAccessories } from './usePostScheduleAccessories';
+
+const { processCredentials, processInstanceGroups, processLabels, requestGet } = vi.hoisted(() => ({
+  processCredentials: vi.fn(),
+  processInstanceGroups: vi.fn(),
+  processLabels: vi.fn(),
+  requestGet: vi.fn(),
+}));
+
+vi.mock('@ansible/common-ui/crud/Data', () => ({ requestGet }));
+vi.mock('./useProcessCredentials', () => ({
+  useProcessCredentials: () => processCredentials,
+}));
+vi.mock('./useProcessInstanceGroups', () => ({
+  useProcessInstanceGroups: () => processInstanceGroups,
+}));
+vi.mock('./useProcessLabels', () => ({
+  useProcessLabels: () => processLabels,
+}));
+
+type AccessoriesPayload = Parameters<ReturnType<typeof usePostAccessories>>[1];
+
+const schedule = { id: 42 } as Parameters<ReturnType<typeof usePostAccessories>>[0];
+
+function payload(overrides: Record<string, unknown> = {}): AccessoriesPayload {
+  return {
+    launch_config: null,
+    ...overrides,
+  } as AccessoriesPayload;
+}
+
+describe('usePostAccessories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestGet.mockResolvedValue({ results: [{ id: 7, name: 'Existing label' }] });
+  });
+
+  it('does nothing when no accessories are provided', async () => {
+    const { result } = renderHook(() => usePostAccessories());
+
+    await result.current(schedule, payload());
+
+    expect(processCredentials).not.toHaveBeenCalled();
+    expect(processInstanceGroups).not.toHaveBeenCalled();
+    expect(processLabels).not.toHaveBeenCalled();
+    expect(requestGet).not.toHaveBeenCalled();
+  });
+
+  it('processes credentials, instance groups, and labels', async () => {
+    const launchConfig = { ask_labels_on_launch: false, defaults: { labels: [] } };
+    const credentials = [{ id: 1 }];
+    const instanceGroups = [{ id: 2 }];
+    const labels = [{ id: 3 }];
+    const { result } = renderHook(() => usePostAccessories());
+
+    await result.current(
+      schedule,
+      payload({
+        launch_config: launchConfig,
+        credentials,
+        instance_groups: instanceGroups,
+        labels,
+        organization: 9,
+      })
+    );
+
+    expect(processCredentials).toHaveBeenCalledWith(42, credentials, launchConfig);
+    expect(processInstanceGroups).toHaveBeenCalledWith(42, instanceGroups, launchConfig);
+    expect(requestGet).toHaveBeenCalledWith(awxAPI`/schedules/42/labels/?page_size=200`);
+    expect(processLabels).toHaveBeenCalledWith(
+      42,
+      labels,
+      {
+        ...launchConfig,
+        defaults: {
+          labels: [{ id: 7, name: 'Existing label' }],
+        },
+      },
+      9
+    );
+  });
+
+  it('processes labels without replacing defaults when labels are requested on launch', async () => {
+    const launchConfig = { ask_labels_on_launch: true, defaults: { labels: [] } };
+    const labels = [{ id: 3 }];
+    const { result } = renderHook(() => usePostAccessories());
+
+    await result.current(schedule, payload({ launch_config: launchConfig, labels }));
+
+    expect(requestGet).not.toHaveBeenCalled();
+    expect(processLabels).toHaveBeenCalledWith(42, labels, launchConfig, undefined);
+  });
+});

--- a/frontend/awx/views/schedules/hooks/usePostScheduleAccessories.tsx
+++ b/frontend/awx/views/schedules/hooks/usePostScheduleAccessories.tsx
@@ -1,7 +1,11 @@
+import { requestGet } from '@ansible/common-ui/crud/Data';
 import { useCallback } from 'react';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { awxAPI } from '../../../common/api/awx-utils';
 import { useProcessCredentials } from './useProcessCredentials';
 import { useProcessInstanceGroups } from './useProcessInstanceGroups';
 import { useProcessLabels } from './useProcessLabels';
+import { Label } from '../../../interfaces/Label';
 import { Schedule } from '../../../interfaces/Schedule';
 import { StandardizedFormData } from '../wizard/ScheduleAddWizard';
 
@@ -27,12 +31,17 @@ export function usePostAccessories() {
         await processInstanceGroups(schedule.id, payload.instance_groups, payload.launch_config);
       }
       if (payload.labels) {
-        await processLabels(
-          schedule.id,
-          payload.labels,
-          payload.launch_config,
-          payload.organization
-        );
+        let launchConfig = payload.launch_config;
+        if (launchConfig?.ask_labels_on_launch === false) {
+          const scheduleLabels = await requestGet<AwxItemsResponse<Label>>(
+            awxAPI`/schedules/${schedule.id}/labels/?page_size=200`
+          );
+          launchConfig = {
+            ...launchConfig,
+            defaults: { ...launchConfig.defaults, labels: scheduleLabels.results },
+          };
+        }
+        await processLabels(schedule.id, payload.labels, launchConfig, payload.organization);
       }
     },
     [processCredentials, processInstanceGroups, processLabels]

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
@@ -13,6 +13,10 @@ const server = setupServer(
   http.get(awxAPI`/organizations/`, () =>
     HttpResponse.json({ count: 1, results: [{ id: 1, name: 'Default' }] })
   ),
+  http.get(awxAPI`/labels/`, () => HttpResponse.json({ count: 0, results: [] })),
+  http.get(awxAPI`/schedules/:scheduleId/labels/`, () =>
+    HttpResponse.json({ count: 0, results: [] })
+  ),
   http.post(awxAPI`/schedules/:scheduleId/labels/`, async ({ request }) => {
     const body = await request.json();
     postCalls.push({ url: request.url, body });
@@ -155,6 +159,17 @@ describe('useProcessLabels', () => {
       },
     });
 
+    server.use(
+      http.get(awxAPI`/schedules/:scheduleId/labels/`, () =>
+        HttpResponse.json({
+          count: 2,
+          results: [
+            { id: 1, name: 'label-1' },
+            { id: 2, name: 'label-2' },
+          ],
+        })
+      )
+    );
     const { result } = renderHook(() => useProcessLabels());
 
     await result.current(42, undefined as unknown as Label[], config);
@@ -184,6 +199,11 @@ describe('useProcessLabels', () => {
       defaults: { ...makeLaunchConfig().defaults, labels: [{ id: 2, name: 'schedule-label' }] },
     });
 
+    server.use(
+      http.get(awxAPI`/schedules/:scheduleId/labels/`, () =>
+        HttpResponse.json({ count: 1, results: [{ id: 2, name: 'schedule-label' }] })
+      )
+    );
     const { result } = renderHook(() => useProcessLabels());
 
     await result.current(42, [{ name: 'schedule-label' }] as unknown as Label[], config);

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
@@ -93,11 +93,54 @@ describe('useProcessLabels', () => {
     const disassociateCall = postCalls.find(
       (c) => (c.body as Record<string, unknown>).disassociate === true
     );
-    const associateCall = postCalls.find((c) => (c.body as Record<string, unknown>).id === 2);
+    const associateCall = postCalls.find(
+      (c) => (c.body as Record<string, unknown>).name === 'new-label'
+    );
 
     expect(disassociateCall).toBeDefined();
     expect((disassociateCall?.body as Record<string, unknown>).id).toBe(1);
     expect(associateCall).toBeDefined();
+  });
+
+  it('should disassociate multiple labels without racing requests', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: true,
+      defaults: {
+        ...makeLaunchConfig().defaults,
+        labels: [
+          { id: 1, name: 'label-1' },
+          { id: 2, name: 'label-2' },
+          { id: 3, name: 'label-3' },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [], config);
+
+    expect(postCalls).toHaveLength(3);
+    expect(postCalls.map((call) => (call.body as { id: number }).id)).toEqual([1, 2, 3]);
+  });
+
+  it('should only disassociate each duplicate label once', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: true,
+      defaults: {
+        ...makeLaunchConfig().defaults,
+        labels: [
+          { id: 1, name: 'label-1' },
+          { id: 1, name: 'label-1' },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [], config);
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body).toEqual({ id: 1, disassociate: true });
   });
 
   it('should disassociate existing labels when ask_labels_on_launch is false', async () => {
@@ -120,6 +163,32 @@ describe('useProcessLabels', () => {
     postCalls.forEach((call) => {
       expect((call.body as Record<string, unknown>).disassociate).toBe(true);
     });
+  });
+
+  it('should associate labels when ask_labels_on_launch is false', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: false,
+      defaults: { ...makeLaunchConfig().defaults, labels: [] },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [{ id: 2, name: 'schedule-label' }] as Label[], config, 5);
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body).toEqual({ name: 'schedule-label', organization: 5 });
+  });
+
+  it('should preserve an existing label selected without its id', async () => {
+    const config = makeLaunchConfig({
+      defaults: { ...makeLaunchConfig().defaults, labels: [{ id: 2, name: 'schedule-label' }] },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [{ name: 'schedule-label' }] as unknown as Label[], config);
+
+    expect(postCalls).toHaveLength(0);
   });
 
   it('should fetch default organization when none is provided', async () => {
@@ -156,6 +225,48 @@ describe('useProcessLabels', () => {
     await result.current(42, [] as unknown as Label[], config);
 
     expect(postCalls).toHaveLength(0);
+  });
+
+  it('should use the label organization when provided', async () => {
+    const config = makeLaunchConfig({
+      defaults: {
+        ...makeLaunchConfig().defaults,
+        labels: [],
+      },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(
+      42,
+      [{ name: 'org-label', organization: 99 }] as unknown as Label[],
+      config
+    );
+
+    expect(postCalls[0].body).toEqual({ name: 'org-label', organization: 99 });
+  });
+
+  it('should process labels when launch configuration is null', async () => {
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [{ id: 2, name: 'schedule-label' }] as Label[], null, 5);
+
+    expect(postCalls[0].body).toEqual({ name: 'schedule-label', organization: 5 });
+  });
+
+  it('should fall back to organization 1 when the default organization has no id', async () => {
+    server.use(
+      http.get(awxAPI`/organizations/`, () => HttpResponse.json({ count: 1, results: [{}] }))
+    );
+    const config = makeLaunchConfig({
+      defaults: { ...makeLaunchConfig().defaults, labels: [] },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [{ name: 'fallback-label' }] as unknown as Label[], config);
+
+    expect(postCalls[0].body).toEqual({ name: 'fallback-label', organization: 1 });
   });
 
   it('should use provided organization instead of fetching default', async () => {

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.test.tsx
@@ -308,4 +308,106 @@ describe('useProcessLabels', () => {
     expect(createCall).toBeDefined();
     expect((createCall?.body as Record<string, unknown>).organization).toBe(99);
   });
+
+  it('should resolve a new label from all available labels', async () => {
+    server.use(
+      http.get(awxAPI`/labels/`, () =>
+        HttpResponse.json({
+          count: 1,
+          results: [{ id: 7, name: 'available-label', organization: 5 }],
+        })
+      )
+    );
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: true,
+      defaults: { ...makeLaunchConfig().defaults, labels: [] },
+    });
+
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [{ name: 'available-label' }] as unknown as Label[], config, 5);
+
+    expect(postCalls[0].body).toEqual({ name: 'available-label', organization: 5 });
+  });
+
+  it('should process paginated schedule labels', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/:scheduleId/labels/`, ({ request }) => {
+        if (new URL(request.url).searchParams.has('page')) {
+          return HttpResponse.json({ count: 1, results: [{ id: 2, name: 'second-label' }] });
+        }
+        return HttpResponse.json({
+          count: 1,
+          next: awxAPI`/schedules/42/labels/?page=2`,
+          results: [{ id: 1, name: 'first-label' }],
+        });
+      })
+    );
+    const config = makeLaunchConfig({ ask_labels_on_launch: false });
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(42, [], config);
+
+    expect(postCalls.map((call) => (call.body as { id: number }).id)).toEqual([1, 2]);
+  });
+
+  it('should stop after disassociating labels in disassociate phase', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: false,
+      defaults: { ...makeLaunchConfig().defaults, labels: [] },
+    });
+    server.use(
+      http.get(awxAPI`/schedules/:scheduleId/labels/`, () =>
+        HttpResponse.json({ count: 1, results: [{ id: 1, name: 'existing-label' }] })
+      )
+    );
+    const { result } = renderHook(() => useProcessLabels());
+
+    await result.current(
+      42,
+      [{ id: 2, name: 'new-label' }] as unknown as Label[],
+      config,
+      5,
+      'disassociate'
+    );
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0].body).toEqual({ id: 1, disassociate: true });
+  });
+
+  it('should ignore a missing label during disassociation', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: true,
+      defaults: {
+        ...makeLaunchConfig().defaults,
+        labels: [{ id: 1, name: 'missing-label' }],
+      },
+    });
+    server.use(
+      http.post(awxAPI`/schedules/:scheduleId/labels/`, () =>
+        HttpResponse.json({ detail: 'Label matching query does not exist' }, { status: 404 })
+      )
+    );
+    const { result } = renderHook(() => useProcessLabels());
+
+    await expect(result.current(42, [], config)).resolves.toBeUndefined();
+  });
+
+  it('should rethrow unexpected disassociation errors', async () => {
+    const config = makeLaunchConfig({
+      ask_labels_on_launch: true,
+      defaults: {
+        ...makeLaunchConfig().defaults,
+        labels: [{ id: 1, name: 'label' }],
+      },
+    });
+    server.use(
+      http.post(awxAPI`/schedules/:scheduleId/labels/`, () =>
+        HttpResponse.json({ detail: 'Unexpected failure' }, { status: 500 })
+      )
+    );
+    const { result } = renderHook(() => useProcessLabels());
+
+    await expect(result.current(42, [], config)).rejects.toThrow('Internal Server Error');
+  });
 });

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
@@ -27,6 +27,8 @@ async function getScheduleLabels(scheduleId: number): Promise<Label[]> {
   return labels;
 }
 
+type ProcessLabel = { id: number; name: string; organization?: number };
+
 type PostDisassociate = (
   url: string,
   body: { id: number; disassociate: boolean },
@@ -39,11 +41,11 @@ type PostAssociate = (
 ) => Promise<unknown>;
 
 function resolveSelectedLabels(
-  labels: Label[],
-  existingLabels: Label[],
-  allLabels: Label[],
+  labels: ProcessLabel[],
+  existingLabels: ProcessLabel[],
+  allLabels: ProcessLabel[],
   defaultOrganization: number
-): Label[] {
+): ProcessLabel[] {
   return labels.map((label) => {
     if (label.id) return label;
     return (
@@ -58,7 +60,7 @@ function resolveSelectedLabels(
 }
 
 async function disassociateLabels(
-  labels: Label[],
+  labels: ProcessLabel[],
   scheduleId: number,
   postDisassociate: PostDisassociate,
   signal: AbortSignal
@@ -82,7 +84,7 @@ async function disassociateLabels(
 }
 
 async function associateLabels(
-  labels: Label[],
+  labels: ProcessLabel[],
   scheduleId: number,
   defaultOrganization: number,
   postAssociateLabel: PostAssociate,

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
@@ -1,5 +1,6 @@
 import { useAbortController } from '@ansible/ansible-ui-framework/hooks/useAbortController';
 import { requestGet } from '@ansible/common-ui/crud/Data';
+import { RequestError } from '@ansible/common-ui/crud/RequestError';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
 import { useCallback } from 'react';
 import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
@@ -14,69 +15,95 @@ async function getDefaultOrganization(): Promise<number> {
   const itemsResponse = await requestGet<AwxItemsResponse<Organization>>(awxAPI`/organizations/`);
   return itemsResponse.results[0].id || 1;
 }
+
+async function getScheduleLabels(scheduleId: number): Promise<Label[]> {
+  const labels: Label[] = [];
+  let url: string | undefined = awxAPI`/schedules/${scheduleId}/labels/?page_size=200`;
+  while (url) {
+    const response: AwxItemsResponse<Label> = await requestGet<AwxItemsResponse<Label>>(url);
+    labels.push(...response.results);
+    url = response.next ?? undefined;
+  }
+  return labels;
+}
 export const useProcessLabels = () => {
   const abortController = useAbortController();
   const postDisassociate = usePostRequest<{ id: number; disassociate: boolean }>();
-  const postAssociateLabel = usePostRequest<
-    { name: string; organization: number } | { id: number }
-  >();
+  const postAssociateLabel = usePostRequest<{ name: string; organization: number }>();
 
   return useCallback(
     async (
       scheduleId: number,
       labels: PromptFormValues['labels'],
       launch_config: LaunchConfiguration | null,
-      organization?: number | null
+      organization?: number | null,
+      phase: 'associate' | 'disassociate' = 'associate'
     ) => {
-      const hasLabelsPrompt = launch_config?.ask_labels_on_launch;
-      const existingLabels = launch_config?.defaults?.labels;
-
-      if (hasLabelsPrompt) {
-        const defaultOrganization = organization ?? (await getDefaultOrganization());
-
-        const { added, removed } = getAddedAndRemoved(
-          existingLabels || [],
-          labels ? labels || ([] as Label[]) : []
+      const existingLabels =
+        !launch_config?.ask_labels_on_launch && scheduleId
+          ? await getScheduleLabels(scheduleId)
+          : (launch_config?.defaults?.labels ?? []);
+      const selectedLabelsWithoutIds = (labels ?? []).filter((label) => !label.id);
+      const defaultOrganization =
+        organization ?? (selectedLabelsWithoutIds.length ? await getDefaultOrganization() : 1);
+      const allLabels = selectedLabelsWithoutIds.length
+        ? (await requestGet<AwxItemsResponse<Label>>(awxAPI`/labels/?page_size=200`)).results
+        : [];
+      const selectedLabels = (labels ?? []).map((label) => {
+        if (label.id) return label;
+        return (
+          existingLabels.find((existingLabel) => existingLabel.name === label.name) ??
+          allLabels.find(
+            (availableLabel) =>
+              availableLabel.name === label.name &&
+              availableLabel.organization === defaultOrganization
+          ) ??
+          label
         );
+      });
+      const { added, removed } = getAddedAndRemoved(existingLabels, selectedLabels);
 
-        const disassociationPromises = removed.map((label: { id: number }) =>
-          postDisassociate(
+      const labelsToDisassociate = (
+        phase === 'disassociate' && !launch_config?.ask_labels_on_launch ? existingLabels : removed
+      ).filter(
+        (label, index, labelsToRemove) =>
+          labelsToRemove.findIndex((candidate) => candidate.id === label.id) === index
+      );
+      // The schedule labels endpoint accepts one label per request. Keep removals sequential: AWX
+      // rejects schedule updates while stale non-prompted labels remain associated.
+      for (const label of labelsToDisassociate) {
+        try {
+          await postDisassociate(
             awxAPI`/schedules/${scheduleId.toString()}/labels/`,
-            {
-              id: label.id,
-              disassociate: true,
-            },
+            { id: label.id, disassociate: true },
             abortController.signal
-          )
-        );
+          );
+        } catch (error) {
+          if (
+            !(error instanceof RequestError) ||
+            !error.details?.includes('Label matching query does not exist')
+          ) {
+            throw error;
+          }
+        }
+      }
 
-        const associationPromises = added.map(
-          (label: { name: string; id?: number; organization?: number }) =>
-            postAssociateLabel(
-              awxAPI`/schedules/${scheduleId.toString()}/labels/`,
-              label.id
-                ? { id: label.id }
-                : {
-                    name: label.name,
-                    organization: label?.organization ?? defaultOrganization,
-                  },
-              abortController.signal
-            )
-        );
+      if (phase === 'disassociate') {
+        return;
+      }
 
-        await Promise.all([...disassociationPromises, ...associationPromises]);
-      } else if (existingLabels) {
-        const disassociationPromises = existingLabels.map((label: { id: number }) =>
-          postDisassociate(
-            awxAPI`/schedules/${scheduleId.toString()}/labels/`,
-            {
-              id: label.id,
-              disassociate: true,
-            },
-            abortController.signal
-          )
+      const labelsToAssociate = added;
+      // Keep associations sequential as well; concurrent requests can race AWX's label limit check.
+      for (const label of labelsToAssociate) {
+        const labelOrganization =
+          'organization' in label && typeof label.organization === 'number'
+            ? label.organization
+            : defaultOrganization;
+        await postAssociateLabel(
+          awxAPI`/schedules/${scheduleId.toString()}/labels/`,
+          { name: label.name, organization: labelOrganization },
+          abortController.signal
         );
-        await Promise.all(disassociationPromises);
       }
     },
     [postDisassociate, postAssociateLabel, abortController]

--- a/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessLabels.tsx
@@ -26,6 +26,81 @@ async function getScheduleLabels(scheduleId: number): Promise<Label[]> {
   }
   return labels;
 }
+
+type PostDisassociate = (
+  url: string,
+  body: { id: number; disassociate: boolean },
+  signal?: AbortSignal
+) => Promise<unknown>;
+type PostAssociate = (
+  url: string,
+  body: { name: string; organization: number },
+  signal?: AbortSignal
+) => Promise<unknown>;
+
+function resolveSelectedLabels(
+  labels: Label[],
+  existingLabels: Label[],
+  allLabels: Label[],
+  defaultOrganization: number
+): Label[] {
+  return labels.map((label) => {
+    if (label.id) return label;
+    return (
+      existingLabels.find((existingLabel) => existingLabel.name === label.name) ??
+      allLabels.find(
+        (availableLabel) =>
+          availableLabel.name === label.name && availableLabel.organization === defaultOrganization
+      ) ??
+      label
+    );
+  });
+}
+
+async function disassociateLabels(
+  labels: Label[],
+  scheduleId: number,
+  postDisassociate: PostDisassociate,
+  signal: AbortSignal
+): Promise<void> {
+  for (const label of labels) {
+    try {
+      await postDisassociate(
+        awxAPI`/schedules/${scheduleId.toString()}/labels/`,
+        { id: label.id, disassociate: true },
+        signal
+      );
+    } catch (error) {
+      if (
+        !(error instanceof RequestError) ||
+        !error.details?.includes('Label matching query does not exist')
+      ) {
+        throw error;
+      }
+    }
+  }
+}
+
+async function associateLabels(
+  labels: Label[],
+  scheduleId: number,
+  defaultOrganization: number,
+  postAssociateLabel: PostAssociate,
+  signal: AbortSignal
+): Promise<void> {
+  for (const label of labels) {
+    const labelOrganization =
+      'organization' in label && typeof label.organization === 'number'
+        ? label.organization
+        : defaultOrganization;
+    await postAssociateLabel(
+      awxAPI`/schedules/${scheduleId.toString()}/labels/`,
+      { name: label.name, organization: labelOrganization },
+      signal
+    );
+  }
+}
+
 export const useProcessLabels = () => {
   const abortController = useAbortController();
   const postDisassociate = usePostRequest<{ id: number; disassociate: boolean }>();
@@ -49,18 +124,12 @@ export const useProcessLabels = () => {
       const allLabels = selectedLabelsWithoutIds.length
         ? (await requestGet<AwxItemsResponse<Label>>(awxAPI`/labels/?page_size=200`)).results
         : [];
-      const selectedLabels = (labels ?? []).map((label) => {
-        if (label.id) return label;
-        return (
-          existingLabels.find((existingLabel) => existingLabel.name === label.name) ??
-          allLabels.find(
-            (availableLabel) =>
-              availableLabel.name === label.name &&
-              availableLabel.organization === defaultOrganization
-          ) ??
-          label
-        );
-      });
+      const selectedLabels = resolveSelectedLabels(
+        labels ?? [],
+        existingLabels,
+        allLabels,
+        defaultOrganization
+      );
       const { added, removed } = getAddedAndRemoved(existingLabels, selectedLabels);
 
       const labelsToDisassociate = (
@@ -71,40 +140,25 @@ export const useProcessLabels = () => {
       );
       // The schedule labels endpoint accepts one label per request. Keep removals sequential: AWX
       // rejects schedule updates while stale non-prompted labels remain associated.
-      for (const label of labelsToDisassociate) {
-        try {
-          await postDisassociate(
-            awxAPI`/schedules/${scheduleId.toString()}/labels/`,
-            { id: label.id, disassociate: true },
-            abortController.signal
-          );
-        } catch (error) {
-          if (
-            !(error instanceof RequestError) ||
-            !error.details?.includes('Label matching query does not exist')
-          ) {
-            throw error;
-          }
-        }
-      }
+      await disassociateLabels(
+        labelsToDisassociate,
+        scheduleId,
+        postDisassociate,
+        abortController.signal
+      );
 
       if (phase === 'disassociate') {
         return;
       }
 
-      const labelsToAssociate = added;
       // Keep associations sequential as well; concurrent requests can race AWX's label limit check.
-      for (const label of labelsToAssociate) {
-        const labelOrganization =
-          'organization' in label && typeof label.organization === 'number'
-            ? label.organization
-            : defaultOrganization;
-        await postAssociateLabel(
-          awxAPI`/schedules/${scheduleId.toString()}/labels/`,
-          { name: label.name, organization: labelOrganization },
-          abortController.signal
-        );
-      }
+      await associateLabels(
+        added,
+        scheduleId,
+        defaultOrganization,
+        postAssociateLabel,
+        abortController.signal
+      );
     },
     [postDisassociate, postAssociateLabel, abortController]
   );

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
@@ -39,6 +39,7 @@ const mockScheduleResponse: Schedule = {
 } as Schedule;
 
 const postCalls: { url: string; body: unknown; method: string }[] = [];
+const labelPostCalls: { url: string; body: unknown }[] = [];
 
 const server = setupServer(
   http.post(awxAPI`/job_templates/:id/schedules/`, async ({ request }) => {
@@ -77,13 +78,18 @@ const server = setupServer(
   ),
   http.post(awxAPI`/schedules/:id/credentials/`, () => HttpResponse.json({}, { status: 204 })),
   http.post(awxAPI`/schedules/:id/instance_groups/`, () => HttpResponse.json({}, { status: 204 })),
-  http.post(awxAPI`/schedules/:id/labels/`, () => HttpResponse.json({}, { status: 204 }))
+  http.get(awxAPI`/schedules/:id/labels/`, () => HttpResponse.json({ count: 0, results: [] })),
+  http.post(awxAPI`/schedules/:id/labels/`, async ({ request }) => {
+    labelPostCalls.push({ url: request.url, body: await request.json() });
+    return HttpResponse.json({}, { status: 204 });
+  })
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => {
   server.resetHandlers();
   postCalls.length = 0;
+  labelPostCalls.length = 0;
 });
 afterAll(() => server.close());
 
@@ -194,6 +200,33 @@ describe('useProcessSchedule', () => {
     expect(response.schedule).toBeDefined();
     expect(postCalls[0].method).toBe('PATCH');
     expect(postCalls[0].url).toContain('/schedules/99/');
+  });
+
+  it('should remove existing labels before updating a schedule with prompted labels disabled', async () => {
+    server.use(
+      http.get(awxAPI`/schedules/:id/labels/`, () =>
+        HttpResponse.json({ count: 1, results: [{ id: 7, name: 'old-label' }] })
+      )
+    );
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper(
+        '/templates/:id/schedules/:schedule_id/edit',
+        '/templates/10/schedules/99/edit'
+      ),
+    });
+
+    const payload = makePayload('job_template', {
+      launch_config: {
+        ...makePayload('job_template').launch_config,
+        ask_labels_on_launch: false,
+        defaults: { labels: [] },
+      } as unknown as LaunchConfiguration,
+      prompt: { labels: [] } as unknown as PromptFormValues,
+    });
+
+    await result.current(payload);
+
+    expect(labelPostCalls[0].body).toEqual({ id: 7, disassociate: true });
   });
 
   it('should include prompt data for job_template with launch_config', async () => {

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.test.tsx
@@ -314,4 +314,60 @@ describe('useProcessSchedule', () => {
     expect(response.schedule).toBeDefined();
     expect(postCalls[0].url).toContain('/job_templates/');
   });
+
+  it('should use the resource organization for label associations', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/templates/:id/schedules/create', '/templates/10/schedules/create'),
+    });
+
+    const payload = makePayload('job_template', {
+      resource: {
+        id: 10,
+        type: 'job_template',
+        name: 'Resource',
+        summary_fields: { organization: { id: 12 } },
+      } as unknown as ScheduleFormWizard['resource'],
+      launch_config: {
+        ask_labels_on_launch: true,
+        defaults: { labels: [] },
+      } as unknown as LaunchConfiguration,
+      prompt: { labels: [{ id: 3, name: 'resource-label' }] } as unknown as PromptFormValues,
+    });
+
+    await result.current(payload);
+
+    expect(labelPostCalls[0].body).toEqual({ name: 'resource-label', organization: 12 });
+  });
+
+  it('should POST when only a schedule_id route parameter is present', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper('/schedules/:schedule_id/edit', '/schedules/99/edit'),
+    });
+
+    await result.current(makePayload('job_template'));
+
+    expect(postCalls[0].method).toBe('POST');
+    expect(postCalls[0].url).toContain('/job_templates/');
+  });
+
+  it('should skip label removal when prompt labels are not provided', async () => {
+    const { result } = renderHook(() => useProcessSchedule(), {
+      wrapper: wrapper(
+        '/templates/:id/schedules/:schedule_id/edit',
+        '/templates/10/schedules/99/edit'
+      ),
+    });
+
+    await result.current(
+      makePayload('job_template', {
+        launch_config: {
+          ask_labels_on_launch: false,
+          defaults: { labels: [] },
+        } as unknown as LaunchConfiguration,
+      })
+    );
+
+    expect(postCalls[0].method).toBe('PATCH');
+    expect(labelPostCalls).toHaveLength(0);
+  });
 });

--- a/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
+++ b/frontend/awx/views/schedules/hooks/useProcessSchedules.tsx
@@ -1,17 +1,22 @@
+import { requestGet } from '@ansible/common-ui/crud/Data';
 import { usePatchRequest } from '@ansible/common-ui/crud/usePatchRequest';
 import { usePostRequest } from '@ansible/common-ui/crud/usePostRequest';
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { awxAPI } from '../../../common/api/awx-utils';
+import { AwxItemsResponse } from '../../../common/AwxItemsResponse';
+import { Label } from '../../../interfaces/Label';
 import { Schedule } from '../../../interfaces/Schedule';
 import { BaseSchedulePayload, ScheduleAccessoriesPayload, ScheduleFormWizard } from '../types';
 import { ensureUntilZSuffix, mungePromptData, mungeSurveyAndExtraVarsData } from './ruleHelpers';
 import { usePostAccessories } from './usePostScheduleAccessories';
+import { useProcessLabels } from './useProcessLabels';
 import { useSetRRuleItemToRuleSet } from './useSetRRuleItemToRuleSet';
 
 export const useProcessSchedule = () => {
   const params = useParams<{ id?: string; schedule_id: string }>();
   const postAccessories = usePostAccessories();
+  const processLabels = useProcessLabels();
   const postSchedule = usePostRequest<BaseSchedulePayload | ScheduleAccessoriesPayload, Schedule>();
   const updateSchedule = usePatchRequest<
     BaseSchedulePayload | ScheduleAccessoriesPayload,
@@ -45,6 +50,37 @@ export const useProcessSchedule = () => {
       }
 
       const { type, id } = resource;
+      const resourceOrganization =
+        'summary_fields' in resource && 'organization' in resource.summary_fields
+          ? resource.summary_fields.organization?.id
+          : undefined;
+      const labelOrganization = prompt?.organization ?? resourceOrganization;
+      const removeLabelsBeforeUpdate = async () => {
+        if (
+          !params.schedule_id ||
+          !prompt?.labels ||
+          payloadData.launch_config?.ask_labels_on_launch !== false
+        ) {
+          return;
+        }
+        const scheduleLabels = await requestGet<AwxItemsResponse<Label>>(
+          awxAPI`/schedules/${params.schedule_id}/labels/?page_size=200`
+        );
+        const launchConfig = {
+          ...payloadData.launch_config,
+          defaults: {
+            ...payloadData.launch_config.defaults,
+            labels: scheduleLabels.results,
+          },
+        };
+        await processLabels(
+          Number(params.schedule_id),
+          prompt.labels,
+          launchConfig,
+          labelOrganization,
+          'disassociate'
+        );
+      };
 
       let schedule: Schedule;
       switch (type) {
@@ -79,6 +115,7 @@ export const useProcessSchedule = () => {
             ...promptData,
             extra_data: mungeSurveyAndExtraVarsData(survey ?? {}, prompt?.extra_vars ?? ''),
           };
+          await removeLabelsBeforeUpdate();
           schedule = await request(
             awxAPI`/workflow_job_templates/${id.toString()}/schedules/`,
             requestPayload
@@ -88,7 +125,7 @@ export const useProcessSchedule = () => {
             credentials: prompt?.credentials,
             instance_groups: prompt?.instance_groups,
             labels: prompt?.labels,
-            organization: prompt?.organization,
+            organization: labelOrganization,
           });
           return {
             schedule,
@@ -101,6 +138,7 @@ export const useProcessSchedule = () => {
             ...promptData,
             extra_data: mungeSurveyAndExtraVarsData(survey ?? {}, prompt?.extra_vars ?? ''),
           };
+          await removeLabelsBeforeUpdate();
           schedule = await request(
             awxAPI`/job_templates/${id.toString()}/schedules/`,
             requestPayload
@@ -111,7 +149,7 @@ export const useProcessSchedule = () => {
               credentials: prompt.credentials,
               instance_groups: prompt.instance_groups,
               labels: prompt.labels,
-              organization: prompt.organization,
+              organization: labelOrganization,
             });
           }
 
@@ -121,6 +159,14 @@ export const useProcessSchedule = () => {
         }
       }
     },
-    [params.schedule_id, updateSchedule, postSchedule, getRuleSet, params.id, postAccessories]
+    [
+      params.schedule_id,
+      updateSchedule,
+      postSchedule,
+      getRuleSet,
+      params.id,
+      postAccessories,
+      processLabels,
+    ]
   );
 };

--- a/frontend/awx/views/schedules/wizard/ScheduleReviewStep.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleReviewStep.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScheduleReviewStep } from './ScheduleReviewStep';
+
+const mocks = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  getPageUrl: vi.fn(
+    (route: string, options?: { params: Record<string, unknown> }) =>
+      `${route}/${JSON.stringify(options?.params ?? {})}`
+  ),
+  setWizardData: vi.fn(),
+  useWatch: vi.fn(),
+  wizard: {
+    wizardData: {
+      schedule_type: 'job',
+      resourceId: 42,
+      resource: { id: 42 },
+      schedule_days_to_keep: 7,
+      name: 'Nightly schedule',
+      description: 'Runs at night',
+      startDateTime: { date: '2025-01-01', time: '01:00' },
+      timezone: 'UTC',
+      exceptions: [{ id: 2, rule: 'EXRULE:FREQ=DAILY' }],
+      rules: [{ id: 1, rule: 'RRULE:FREQ=DAILY' }],
+      prompt: { labels: [{ id: 1, name: 'wizard label' }] },
+    },
+    stepData: { details: { prompt: { labels: [{ id: 2, name: 'details label' }] } } },
+    visibleSteps: [],
+    setWizardData: vi.fn(),
+  },
+}));
+
+vi.mock('@ansible/ansible-ui-framework', () => ({
+  PageDetail: ({ label, children }: Readonly<{ label: string; children?: React.ReactNode }>) => (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  ),
+  PageDetails: ({ children }: Readonly<{ children?: React.ReactNode }>) => <div>{children}</div>,
+  useGetPageUrl: () => mocks.getPageUrl,
+}));
+vi.mock('@ansible/ansible-ui-framework/components/LoadingState', () => ({
+  LoadingState: () => <div>Loading</div>,
+}));
+vi.mock('@ansible/ansible-ui-framework/PageForm/Utils/PageFormSection', () => ({
+  PageFormSection: ({
+    title,
+    children,
+  }: Readonly<{ title: string; children?: React.ReactNode }>) => (
+    <section>
+      <h1>{title}</h1>
+      {children}
+    </section>
+  ),
+}));
+vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
+  usePageWizard: () => mocks.wizard,
+}));
+vi.mock('@ansible/common-ui/crud/useGet', () => ({
+  useGetItem: mocks.getItem,
+}));
+vi.mock('@patternfly/react-core', () => ({
+  Label: ({ children }: Readonly<{ children?: React.ReactNode }>) => <span>{children}</span>,
+  LabelGroup: ({ children }: Readonly<{ children?: React.ReactNode }>) => <div>{children}</div>,
+}));
+vi.mock('react-hook-form', () => ({
+  useFormContext: () => ({ control: {} }),
+  useWatch: mocks.useWatch,
+}));
+vi.mock('react-router-dom', () => ({
+  Link: ({ to, children }: Readonly<{ to: string; children?: React.ReactNode }>) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+vi.mock('../../../common/AwxError', () => ({
+  AwxError: ({ error }: Readonly<{ error: unknown }>) => <div>Error: {String(error)}</div>,
+}));
+vi.mock('../../../resources/templates/WorkflowVisualizer/wizard/helpers', () => ({
+  getResourceURL: (type: string) => `/api/${type}`,
+}));
+vi.mock('../../../resources/templates/WorkflowVisualizer/wizard/PromptReviewDetails', () => ({
+  PromptReviewDetails: ({ labels }: Readonly<{ labels?: { name: string }[] }>) => (
+    <div>Prompt details: {labels?.map((label) => label.name).join(',')}</div>
+  ),
+}));
+vi.mock('../components/RulesList', () => ({
+  RulesList: ({ ruleType }: Readonly<{ ruleType: string }>) => <div>{ruleType} list</div>,
+}));
+vi.mock('../SchedulePage/TimezoneToggle', () => ({
+  TimezoneToggle: ({ isLocal }: Readonly<{ isLocal: boolean }>) => (
+    <button>{String(isLocal)}</button>
+  ),
+}));
+
+function setResource(resource: Record<string, unknown>, error?: unknown) {
+  mocks.getItem.mockReturnValue({ data: resource, isLoading: false, error });
+}
+
+describe('ScheduleReviewStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useWatch.mockReturnValue(undefined);
+    mocks.wizard.wizardData = {
+      schedule_type: 'job',
+      resourceId: 42,
+      resource: { id: 42 },
+      schedule_days_to_keep: 7,
+      name: 'Nightly schedule',
+      description: 'Runs at night',
+      startDateTime: { date: '2025-01-01', time: '01:00' },
+      timezone: 'UTC',
+      exceptions: [{ id: 2, rule: 'EXRULE:FREQ=DAILY' }],
+      rules: [{ id: 1, rule: 'RRULE:FREQ=DAILY' }],
+      prompt: { labels: [{ id: 1, name: 'wizard label' }] },
+    } as never;
+    mocks.wizard.stepData = { details: { prompt: { labels: [{ id: 2, name: 'details label' }] } } };
+    mocks.wizard.visibleSteps = [];
+    setResource({ id: 42, name: 'Job template', scm_branch: 'main' });
+    mocks.setWizardData.mockImplementation((update: (previous: object) => object) => update({}));
+    mocks.wizard.setWizardData = mocks.setWizardData;
+  });
+
+  it('renders loading and error states', () => {
+    mocks.getItem.mockReturnValueOnce({ data: undefined, isLoading: true, error: undefined });
+    const { rerender } = render(<ScheduleReviewStep />);
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+
+    setResource({ id: 42 }, 'request failed');
+    rerender(<ScheduleReviewStep />);
+    expect(screen.getByText('Error: request failed')).toBeInTheDocument();
+  });
+
+  it('renders the review without prompt details', () => {
+    mocks.useWatch.mockReturnValue([{ id: 3, name: 'form label' }]);
+    render(<ScheduleReviewStep />);
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Job Template')).toBeInTheDocument();
+    expect(screen.getByText('Job template')).toBeInTheDocument();
+    expect(screen.getByText('2025-01-01, 01:00')).toBeInTheDocument();
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.getByText('wizard label')).toBeInTheDocument();
+    expect(screen.getByText('rules list')).toBeInTheDocument();
+    expect(screen.getByText('exceptions list')).toBeInTheDocument();
+    expect(mocks.setWizardData).toHaveBeenCalled();
+  });
+
+  it('skips label synchronization when no labels are available', () => {
+    mocks.wizard.wizardData = { ...mocks.wizard.wizardData, prompt: {} } as never;
+    mocks.wizard.stepData = { details: {} };
+    render(<ScheduleReviewStep />);
+    expect(screen.getByText('Job template')).toBeInTheDocument();
+  });
+
+  it('handles empty resources and optional review fields', () => {
+    mocks.getItem.mockReturnValue({ data: undefined, isLoading: false, error: undefined });
+    mocks.wizard.wizardData = {
+      ...mocks.wizard.wizardData,
+      schedule_type: 'workflow_job_template',
+      startDateTime: undefined,
+      exceptions: [],
+      prompt: {},
+    } as never;
+    mocks.wizard.visibleSteps = [{ id: 'not-a-prompt-step' }, { id: 'survey' }];
+    render(<ScheduleReviewStep />);
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+  });
+
+  it('renders prompt details and the inventory source link', () => {
+    mocks.wizard.wizardData = {
+      ...mocks.wizard.wizardData,
+      schedule_type: 'inventory_update',
+      prompt: { labels: [] },
+    } as never;
+    mocks.wizard.visibleSteps = [{ id: 'promptStep' }];
+    mocks.wizard.stepData = { details: { prompt: { labels: [{ id: 2, name: 'details label' }] } } };
+    mocks.useWatch.mockReturnValue(null);
+    setResource({
+      id: 8,
+      name: 'Inventory source',
+      type: 'inventory_source',
+      inventory: 9,
+      summary_fields: { inventory: { kind: 'constructed' } },
+    });
+    render(<ScheduleReviewStep />);
+    expect(screen.getByText('Prompt details: details label')).toBeInTheDocument();
+    expect(screen.getByText('Inventory source')).toBeInTheDocument();
+    expect(mocks.getPageUrl).toHaveBeenCalledWith(expect.anything(), {
+      params: { source_id: 8, id: 9, inventory_type: 'constructed' },
+    });
+  });
+});

--- a/frontend/awx/views/schedules/wizard/ScheduleReviewStep.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleReviewStep.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PromptFormValues } from '../../../resources/templates/WorkflowVisualizer/types';
+import type { ScheduleFormWizard } from '../types';
 import { ScheduleReviewStep } from './ScheduleReviewStep';
+
+type WizardDataMock = Partial<Omit<ScheduleFormWizard, 'prompt' | 'resource'>> & {
+  prompt?: Partial<PromptFormValues>;
+  resource?: Record<string, unknown>;
+};
 
 const mocks = vi.hoisted(() => ({
   getItem: vi.fn(),
@@ -25,8 +32,13 @@ const mocks = vi.hoisted(() => ({
       prompt: { labels: [{ id: 1, name: 'wizard label' }] },
     },
     stepData: { details: { prompt: { labels: [{ id: 2, name: 'details label' }] } } },
-    visibleSteps: [],
+    visibleSteps: [] as { id: string }[],
     setWizardData: vi.fn(),
+  } as {
+    wizardData: WizardDataMock;
+    stepData: { details?: { prompt?: Partial<PromptFormValues> } };
+    visibleSteps: { id: string }[];
+    setWizardData: ReturnType<typeof vi.fn>;
   },
 }));
 

--- a/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleReviewStep.tsx
@@ -3,7 +3,9 @@ import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingSt
 import { PageFormSection } from '@ansible/ansible-ui-framework/PageForm/Utils/PageFormSection';
 import { usePageWizard } from '@ansible/ansible-ui-framework/PageWizard/PageWizardProvider';
 import { useGetItem } from '@ansible/common-ui/crud/useGet';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { AwxError } from '../../../common/AwxError';
@@ -13,6 +15,7 @@ import { PromptReviewDetails } from '../../../resources/templates/WorkflowVisual
 import { RulesList } from '../components/RulesList';
 import { TimezoneToggle } from '../SchedulePage/TimezoneToggle';
 import { ScheduleFormWizard, ScheduleResources } from '../types';
+import { PromptFormValues } from '../../../resources/templates/WorkflowVisualizer/types';
 
 const ResourceLink: { [key: string]: string } = {
   inventory_update: AwxRoute.InventorySourceDetail,
@@ -28,7 +31,17 @@ export function ScheduleReviewStep() {
   const getPageUrl = useGetPageUrl();
   const [isLocal, setIsLocal] = useState(true);
 
-  const { wizardData, visibleSteps, setWizardData } = usePageWizard<ScheduleFormWizard>();
+  const { wizardData, stepData, visibleSteps, setWizardData } = usePageWizard<ScheduleFormWizard>();
+  const { control } = useFormContext<ScheduleFormWizard>();
+  const formLabels = useWatch({ control, name: 'prompt.labels' });
+  const promptStepLabels = (
+    wizardData as Partial<ScheduleFormWizard> & {
+      promptStep?: { prompt?: Partial<PromptFormValues> };
+    }
+  ).promptStep?.prompt?.labels;
+  const detailsLabels = stepData.details?.prompt?.labels;
+  const labelsForWizard = formLabels ?? detailsLabels;
+  const reviewLabels = labelsForWizard ?? promptStepLabels ?? wizardData.prompt?.labels;
   const {
     schedule_type,
     resourceId,
@@ -40,6 +53,7 @@ export function ScheduleReviewStep() {
     timezone,
     exceptions,
     rules,
+    prompt,
   } = wizardData;
   const url = getResourceURL(schedule_type);
   const resourceTypeDetail = useGetScheduleTypeDetail(schedule_type);
@@ -53,6 +67,13 @@ export function ScheduleReviewStep() {
     if (!resource) return;
     setWizardData((prev) => ({ ...prev, resource, resourceId: resource.id }));
   }, [setWizardData, resource]);
+  useEffect(() => {
+    if (labelsForWizard === undefined) return;
+    setWizardData((prev) => ({
+      ...prev,
+      prompt: { ...prev.prompt, labels: labelsForWizard },
+    }));
+  }, [labelsForWizard, setWizardData]);
   if (isLoading || !resource) {
     return <LoadingState />;
   }
@@ -99,11 +120,18 @@ export function ScheduleReviewStep() {
           <PageDetail label={t('Local time zone')}>{timezone}</PageDetail>
           <PageDetail label={t('Days of data to keep')}>{schedule_days_to_keep}</PageDetail>
           {!hasPromptDetails && (
-            <PageDetail label={t('Source control branch')}>
-              {resource && 'scm_branch' in resource ? resource.scm_branch : undefined}
-            </PageDetail>
+            <>
+              <PageDetail label={t('Source control branch')}>
+                {resource && 'scm_branch' in resource ? resource.scm_branch : undefined}
+              </PageDetail>
+              <PageDetail label={t('Labels')} isEmpty={!prompt?.labels?.length}>
+                <LabelGroup>
+                  {prompt?.labels?.map((label) => <Label key={label.id}>{label.name}</Label>)}
+                </LabelGroup>
+              </PageDetail>
+            </>
           )}
-          {hasPromptDetails ? <PromptReviewDetails /> : null}
+          {hasPromptDetails ? <PromptReviewDetails labels={reviewLabels} /> : null}
         </PageDetails>
         <PageDetail fullWidth label={t('Toggle timezone')}>
           <TimezoneToggle isLocal={isLocal} setIsLocal={setIsLocal} localTimezone={timezone} />

--- a/frontend/awx/views/schedules/wizard/ScheduleSelectStep.test.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleSelectStep.test.tsx
@@ -17,10 +17,16 @@ const { mockGetSchedulePromptValues } = vi.hoisted(() => ({
   mockGetSchedulePromptValues: vi.fn(),
 }));
 
-const { mockAlertToaster } = vi.hoisted(() => ({
+const { mockAlertToaster, mockScheduleParams } = vi.hoisted(() => ({
   mockAlertToaster: {
     addAlert: vi.fn(),
   },
+  mockScheduleParams: {} as { id?: string; schedule_id?: string },
+}));
+
+vi.mock('react-router', async () => ({
+  ...(await vi.importActual<typeof import('react-router')>('react-router')),
+  useParams: () => mockScheduleParams,
 }));
 
 vi.mock('@ansible/ansible-ui-framework/PageWizard/PageWizardProvider', () => ({
@@ -120,6 +126,8 @@ describe('ScheduleSelectStep', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockScheduleParams.id = undefined;
+    mockScheduleParams.schedule_id = undefined;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     mockSetStepData.mockImplementation((fn) => (typeof fn === 'function' ? fn({}) : fn));
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -497,6 +505,58 @@ describe('ScheduleSelectStep', () => {
       });
     });
 
+    it('should include schedule labels when labels are not prompted on launch', async () => {
+      const resourceRequest = vi.fn();
+      const launchRequest = vi.fn();
+      const labelsRequest = vi.fn();
+      server.use(
+        http.get(awxAPI`/job_templates/123/`, () => {
+          resourceRequest();
+          return HttpResponse.json({ id: 123, type: 'job_template', name: 'Test Template' });
+        }),
+        http.get(awxAPI`/job_templates/123/launch/`, () => {
+          launchRequest();
+          return HttpResponse.json({
+            ask_credential_on_launch: false,
+            ask_instance_groups_on_launch: false,
+            ask_labels_on_launch: false,
+            survey_enabled: false,
+            defaults: { labels: [{ id: 99, name: 'template-label' }] },
+          });
+        }),
+        http.get(awxAPI`/schedules/789/labels/`, () => {
+          labelsRequest();
+          return HttpResponse.json({ results: [{ id: 1, name: 'schedule-label' }] });
+        })
+      );
+      mockGetSchedulePromptValues.mockResolvedValue({});
+
+      mockScheduleParams.id = '123';
+      mockScheduleParams.schedule_id = '789';
+      render(
+        <TestWrapper
+          route="/job-templates/123/schedules/789/edit"
+          path="/job-templates/:id/schedules/:schedule_id/edit"
+          defaultValues={{ resourceId: 123, schedule_type: 'job_template' }}
+        >
+          <ScheduleSelectStep />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(mockGetSchedulePromptValues).toHaveBeenCalledWith(
+          expect.anything(),
+          [],
+          [],
+          [{ id: 1, name: 'schedule-label' }],
+          undefined
+        );
+      });
+      expect(resourceRequest).toHaveBeenCalled();
+      expect(launchRequest).toHaveBeenCalled();
+      expect(labelsRequest).toHaveBeenCalled();
+    });
+
     it('should fetch survey spec and schedule data when schedule_id is provided and survey_enabled is true', async () => {
       server.use(
         http.get(awxAPI`/job_templates/123/`, () => {
@@ -588,6 +648,7 @@ describe('ScheduleSelectStep', () => {
             ask_instance_groups_on_launch: false,
             ask_labels_on_launch: false,
             survey_enabled: false,
+            defaults: { labels: [] },
           }),
           [],
           [],

--- a/frontend/awx/views/schedules/wizard/ScheduleSelectStep.tsx
+++ b/frontend/awx/views/schedules/wizard/ScheduleSelectStep.tsx
@@ -23,6 +23,17 @@ import { Label } from '../../../interfaces/Label';
 import { PromptFormValues } from '../../../resources/templates/WorkflowVisualizer/types';
 import { LoadingState } from '@ansible/ansible-ui-framework/components/LoadingState';
 
+async function getScheduleLabels(scheduleId: string): Promise<Label[]> {
+  const labels: Label[] = [];
+  let url: string | undefined = awxAPI`/schedules/${scheduleId}/labels/`;
+  while (url) {
+    const response: AwxItemsResponse<Label> = await requestGet<AwxItemsResponse<Label>>(url);
+    labels.push(...response.results);
+    url = response.next ?? undefined;
+  }
+  return labels;
+}
+
 /**
  *
  * @param {string}[resourceEndPoint] This used to fetch the resource to which the schedule belongs
@@ -113,12 +124,19 @@ export function ScheduleSelectStep(props: {
       }
       const urlId = resourceId || Number(id);
       try {
+        const scheduleLabelsRequest = schedule_id
+          ? getScheduleLabels(schedule_id).then((results) => ({ count: results.length, results }))
+          : Promise.resolve<AwxItemsResponse<Label>>({ count: 0, results: [] });
         const endPoint =
           scheduleType === 'job_template'
             ? awxAPI`/job_templates/${urlId?.toString()}/`
             : awxAPI`/workflow_job_templates/${urlId.toString()}/`;
         const resource = await requestGet<ScheduleResources>(endPoint);
-        const launchConfig = await requestGet<LaunchConfiguration>(`${endPoint}launch/`);
+        const launchConfigRequest = requestGet<LaunchConfiguration>(`${endPoint}launch/`);
+        const launchConfig = await launchConfigRequest;
+        // Render the resource fields as soon as prompt configuration is known; accessory values
+        // are loaded below and applied without replacing the launch configuration.
+        setValue('launch_config', launchConfig);
         let credentials: Credential[] = [];
         let instanceGroups: InstanceGroup[] = [];
         let scheduleLabels: Label[] = [];
@@ -137,12 +155,10 @@ export function ScheduleSelectStep(props: {
             );
             instanceGroups = igs.results;
           }
-          if (launchConfig.ask_labels_on_launch) {
-            const labels = await requestGet<AwxItemsResponse<Label>>(
-              awxAPI`/schedules/${schedule_id}/labels/`
-            );
-            scheduleLabels = labels.results;
-          }
+          const labels = await scheduleLabelsRequest;
+          scheduleLabels = labels.results;
+          // Populate the Details field before the full prompt-value request completes.
+          setValue('prompt.labels', scheduleLabels);
           if (launchConfig.survey_enabled) {
             surveySpec = await requestGet<Survey>(`${endPoint}survey_spec/`);
             // Fetch the schedule to get extra_data with survey answers
@@ -162,8 +178,16 @@ export function ScheduleSelectStep(props: {
             }
           }
         }
+        const scheduleLaunchConfig: LaunchConfiguration = {
+          ...launchConfig,
+          defaults: {
+            ...launchConfig.defaults,
+            // Schedule labels are independent of the template's launch prompts.
+            labels: schedule_id ? scheduleLabels : [],
+          },
+        };
         const promptValues: PromptFormValues = await getSchedulePromptValues(
-          launchConfig,
+          scheduleLaunchConfig,
           credentials,
           instanceGroups,
           scheduleLabels,
@@ -178,17 +202,18 @@ export function ScheduleSelectStep(props: {
               ...promptValues,
             },
             resource,
-            launch_config: launchConfig,
+            launch_config: scheduleLaunchConfig,
           },
           survey: Object.keys(surveyAnswers).length > 0 ? { survey: surveyAnswers } : prev.survey,
           details: { ...prev.details, resourceId: urlId, resource },
         }));
         setWizardData((prev) => ({
           ...prev,
-          launch_config: launchConfig,
+          launch_config: scheduleLaunchConfig,
         }));
         setValue('schedule_type', scheduleType);
-        setValue('launch_config', launchConfig);
+        setValue('launch_config', scheduleLaunchConfig);
+        setValue('prompt.labels', promptValues.labels);
       } catch (error) {
         HandleErrors(error as Error);
       }


### PR DESCRIPTION
## Summary

Added schedule label support across schedule creation/editing, review, and details views. Users can select labels for job and workflow schedules, existing schedule labels are loaded when editing, and labels are correctly associated/disassociated when schedules are saved. Schedule details now display associated labels, and schedules with more than 80 labels show a warning while respecting the AWX limit of 100 labels.

The label processing also handles paginated label responses, resolves existing labels and organizations, performs label updates sequentially to avoid AWX update races, and tolerates already-removed labels during cleanup.

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] Tests
- [ ] Documentation
- [ ] Other (please specify)

## Risk Analysis - REQUIRED

- [ ] **High** — Broad platform impact (e.g., SWR config, shared framework components, authentication, routing, API wrappers, build/bundler config). Changes affect multiple workspaces or could cause widespread regressions.
- [x] **Medium** — Scoped but cross-cutting (e.g., shared utility functions, changes to multiple pages within one workspace, component library updates, test infrastructure). Limited blast radius but touches common code paths.
- [ ] **Low** — Narrowly scoped (e.g., single page fix, styling tweak, documentation, test-only changes, copy/string updates). Minimal risk of unintended side effects.

## Dependencies

None. The change uses the existing AWX schedule labels endpoints; no backend changes or manual setup are required.

## Testing

### Ephemeral E2E Tests

Once PR is ready and preliminary checks pass, trigger tests by posting a comment `/run-playwright` on this PR.

### External Server E2E Runs

Not applicable.

### Manual Testing

All manual checks below were completed successfully.

#### P0 — Must pass

- [x] **Create a schedule with an existing label**
  - Open the schedule creation wizard for a job or workflow job template.
  - On the **Details** step, select an existing label.
  - Complete and save the schedule.
  - Open the saved schedule details and verify the label is displayed.

- [x] **Create a schedule with a new label**
  - Open the schedule creation wizard.
  - On the **Details** step, enter and create a label that does not already exist.
  - Save the schedule.
  - Verify the new label appears on the saved schedule details page.

- [x] **Edit a schedule: add, remove, and preserve labels**
  - Open a schedule that already has labels.
  - Edit the schedule and add a second label.
  - Remove the original label while leaving the second label selected.
  - Save the schedule and verify that the saved schedule contains exactly the expected labels.

- [x] **Edit a schedule with `ask_labels_on_launch: true`**
  - Open a template configured to prompt for labels on launch and create or edit its schedule.
  - Confirm labels are managed in the **Prompts** step.
  - Confirm the label selector is not duplicated on the **Details** step.
  - Save the schedule and verify the selected labels are preserved.

- [x] **Confirm schedules without labels still work**
  - Create or edit a schedule without selecting any labels.
  - Complete and save the schedule.
  - Verify the schedule saves successfully and its details page works as expected.

#### P1 — Additional manual checks

##### Workflow job template schedules

- [x] Create or select a workflow job template and create a schedule for it.
  - On the **Details** step, select an existing label.
  - Complete the wizard and verify the label appears on both the **Review** page and the saved schedule details page.
  - Edit the schedule, add a second label, remove the original label, and save.
  - Confirm the saved schedule contains exactly the expected labels.
  - Repeat with `ask_labels_on_launch: true` and verify labels appear in **Prompts**, are not duplicated on **Details**, and remain preserved after saving.

##### Organization-specific new labels

- [x] Create a schedule for a job template associated with an organization other than the default organization.
  - On the **Details** step, create a new label that does not already exist.
  - Save the schedule and verify the label appears on the schedule details page.
  - Verify the label is associated with the template's organization rather than the default organization.
  - Edit the schedule, add another new label, save, and confirm both labels are preserved.

##### Survey-enabled schedules

- [x] Create a schedule for a job template with surveys enabled.
  - Complete the schedule details and provide valid survey answers.
  - Add an existing or new label.
  - On the **Review** page, verify the survey answers and selected label are shown correctly.
  - Save and confirm both the survey values and expected labels are present on the saved schedule.
  - Edit the schedule, change a survey answer, and add or remove a label.
  - Save and verify both the survey change and label changes persist.

##### Credentials and instance groups

- [x] Create a schedule for a job template that prompts for credentials and instance groups.
  - Select one or more credentials, instance groups, and labels.
  - On the **Review** page, confirm all selected values are shown.
  - Save and verify credentials, instance groups, and labels on the saved schedule details page.
  - Edit the schedule by adding and removing a credential, instance group, and label.
  - Save and confirm each change is reflected without affecting the other selections.
  - Repeat with no credentials or instance groups selected and verify empty values still work.

##### Keyboard navigation

- [x] Navigate the schedule creation and editing flows using only the keyboard.
  - Confirm every field can receive focus.
  - Open and select label options with the keyboard.
  - Create a new label using keyboard input.
  - Remove selected labels using the keyboard.
  - Confirm wizard navigation and **Save**/**Cancel** controls are reachable.
  - Repeat while editing a schedule with existing labels.

##### Narrow viewport

- [x] Test schedule creation and editing at a narrow mobile-sized viewport, such as 375 × 667.
  - Confirm the label field remains visible and usable.
  - Confirm labels wrap or scroll without breaking the form layout.
  - Confirm dropdown options are not clipped outside the viewport.
  - Confirm wizard navigation remains accessible.
  - Confirm the Review and Details pages do not introduce horizontal scrolling.
  - Repeat with multiple labels, long label names, credentials, instance groups, and survey fields.

#### P2 — Additional checks

- [x] Verified label API failure behavior.
- [x] Verified very large label lists, including pagination and search behavior.
- [x] Refreshed the schedule details page immediately after saving labels and verified the saved labels remained correct.

### Automated Tests

Added coverage for label resolution, pagination, association/disassociation, missing-label cleanup, schedule label loading, schedule review display, resource input behavior, and schedule details rendering.

Run the repository test suite with:

```text
npm test
```

### Screenshots

N/A